### PR TITLE
Support user style sheets injection

### DIFF
--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -933,6 +933,7 @@ adapt.ops.OPSDocStore = function(fontDeobfuscator) {
 	/** @type {Object.<string,adapt.ops.Style>} */ this.styleByDocURL = {};
 	/** @type {Object.<string,Array.<adapt.vtree.Trigger>>} */ this.triggersByDocURL = {};
 	/** @type {adapt.cssvalid.ValidatorSet} */ this.validatorSet = null;
+    /** @private @const @type {Array.<adapt.ops.StyleSource>} */ this.userStyleSheets = [];
 };
 goog.inherits(adapt.ops.OPSDocStore, adapt.net.ResourceStore);
 
@@ -971,6 +972,14 @@ adapt.ops.OPSDocStore.prototype.getTriggersForDoc = function(xmldoc) {
 };
 
 /**
+ * @param {{url: ?string, text: ?string}} stylesheet
+ */
+adapt.ops.OPSDocStore.prototype.addUserStyleSheet = function(stylesheet) {
+    this.userStyleSheets.push({url: stylesheet.url, text: stylesheet.text,
+        flavor: adapt.cssparse.StylesheetFlavor.USER, classes: null, media: null});
+};
+
+/**
  * @param {adapt.net.Response} response
  * @return {!adapt.task.Result.<!adapt.xmldoc.XMLDocHolder>}
  */
@@ -997,6 +1006,9 @@ adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
 	    var userAgentURL = adapt.base.resolveURL("user-agent-page.css", adapt.base.resourceBaseURL);
 		sources.push({url: userAgentURL, text:null,
 			flavor:adapt.cssparse.StylesheetFlavor.USER_AGENT, classes: null, media: null});
+        for (var i = 0; i < self.userStyleSheets.length; i++) {
+            sources.push(self.userStyleSheets[i]);
+        }
 	    var head = xmldoc.head;
 	    if (head) {
 	        for (var c = head.firstChild ; c ; c = c.nextSibling) {

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -109,9 +109,15 @@ adapt.viewer.Viewer.prototype.loadEPUB = function(command) {
 	var url = /** @type {string} */ (command["url"]);
 	var fragment = /** @type {?string} */ (command["fragment"]);
 	var haveZipMetadata = !!command["zipmeta"];
+    var userStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["userStyleSheet"]);
 	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("loadEPUB");
 	var self = this;
 	var store = new adapt.epub.EPUBDocStore();
+    if (userStyleSheet) {
+        for (var i = 0; i < userStyleSheet.length; i++) {
+            store.addUserStyleSheet(userStyleSheet[i]);
+        }
+    }
 	store.init().then(function() {
 	    var epubURL = adapt.base.resolveURL(url, self.window.location.href);
 	    self.packageURL = epubURL;

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -139,10 +139,16 @@ adapt.viewer.Viewer.prototype.loadXML = function(command) {
 	var url = /** @type {string} */ (command["url"]);
     var doc = /** @type {Document} */ (command["document"]);
 	var fragment = /** @type {?string} */ (command["fragment"]);
+    var userStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["userStyleSheet"]);
 	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("loadXML");
 	var self = this;
     self.configure(command).then(function() {
 	var store = new adapt.epub.EPUBDocStore();
+    if (userStyleSheet) {
+        for (var i = 0; i < userStyleSheet.length; i++) {
+            store.addUserStyleSheet(userStyleSheet[i]);
+        }
+    }
 	store.init().then(function() {
 	    var xmlURL = adapt.base.resolveURL(url, self.window.location.href);
 	    self.packageURL = xmlURL;

--- a/src/vivliostyle/viewerapp.js
+++ b/src/vivliostyle/viewerapp.js
@@ -222,6 +222,7 @@ vivliostyle.viewerapp.main = function(arg) {
     var orientation = (arg && arg.orientation) || adapt.base.getURLParam("orientation");
     var uaRoot = (arg && arg.uaRoot) || null;
     var doc = (arg && arg.document) || null;
+    var userStyleSheet = (arg && arg.userStyleSheet) || null;
 	var viewer = new adapt.viewer.Viewer(window, "main", vivliostyle.viewerapp.callback);
 
     var config = {
@@ -230,7 +231,8 @@ vivliostyle.viewerapp.main = function(arg) {
         // render all pages on load and resize
         "renderAllPages": true,
         "userAgentRootURL": uaRoot,
-        "document": doc
+        "document": doc,
+        "userStyleSheet": userStyleSheet
     };
     setViewportSize(width, height, size, orientation, config);
     config["a"] = epubURL ? "loadEPUB" : "loadXML";


### PR DESCRIPTION
User style sheets can be injected by passing the 'userStyleSheet' option to the viewer instance.
The 'userStyleSheet' should be an array of objects each representing a user style sheet:

``` javascript
{
  // Only one of property can be non-null
  "url": "example.css" // style sheet URL
  "text": "html { font-size: 110%; }" // style sheet text
}
```
