### PR TITLE
Disable page navigation by swipe; remove user-scalable=no

### DIFF
--- a/src/vivliostyle/viewerapp.js
+++ b/src/vivliostyle/viewerapp.js
@@ -166,9 +166,9 @@ vivliostyle.viewerapp.callback = function(msg) {
         viewer.viewportElement.setAttribute("data-vivliostyle-spread-view", viewer.spreadView);
 
         window.addEventListener("keydown", /** @type {Function} */ (vivliostyle.viewerapp.keydown), false);
-        window.addEventListener("touchstart", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
-        window.addEventListener("touchmove", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
-        window.addEventListener("touchend", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
+//        window.addEventListener("touchstart", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
+//        window.addEventListener("touchmove", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
+//        window.addEventListener("touchend", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
 
         var leftButton = document.getElementById("vivliostyle-page-navigation-left");
         leftButton.addEventListener("click", /** @type {Function} */ (vivliostyle.viewerapp.navigateToLeftPage), false);

--- a/viewer/vivliostyle-viewer.xhtml
+++ b/viewer/vivliostyle-viewer.xhtml
@@ -3,7 +3,7 @@
    style="position:relative;left:0px;top:0px;width:100%;height:100%;margin:0px;padding:0px;text-rendering:geometricPrecision"
    data-vivliostyle-paginated="true">
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="apple-mobile-web-app-capable" content="yes"/>
 <script>
 CLOSURE_NO_DEPS = true;


### PR DESCRIPTION
- Since touch device users should be able scroll the page by touch, disable the page navigation by swipe for now.
