### PR TITLE
Copy 'size' property in page at-rules to the DOM #3

### DIFF
--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -830,7 +830,7 @@ adapt.ops.BaseParserHandler.prototype.startPageRule = function() {
     var pageHandler = new vivliostyle.page.PageParserHandler(this.masterHandler.pageScope,
         this.masterHandler, this, this.validatorSet);
     this.masterHandler.pushHandler(pageHandler);
-    pageHandler.startSelectorRule();
+    pageHandler.startPageRule();
 };
 
 /**

--- a/viewer/res-dev/scss/vivliostyle-viewer.scss
+++ b/viewer/res-dev/scss/vivliostyle-viewer.scss
@@ -15,15 +15,20 @@ html[data-vivliostyle-paginated] {
         height: 100%;
         width: 100%;
 
-        .ui-arrow {
+        body > * {
             display: none;
+        }
+
+        #vivliostyle-viewer-viewport {
+            display: block;
         }
 
         body, #vivliostyle-viewer-viewport {
             /* workaround for Chrome calculating page height incorrectly */
             max-height: 100%;
             height: 100% !important;
-            min-width: 100%;
+            min-width: 100% !important;
+            min-height: 100% !important;
         }
         #vivliostyle-viewer-viewport > div {
             display: block !important;

--- a/viewer/vivliostyle-viewer.xhtml
+++ b/viewer/vivliostyle-viewer.xhtml
@@ -64,6 +64,7 @@ MathJax.Hub.Config({
 </script>
 <link rel="stylesheet" href="res/css/vivliostyle-viewer.css"/>
 <link rel="stylesheet" href="res/css/ui.arrows.css"/>
+<style id="vivliostyle-page-rules"></style>
 </head>
 <body style="position:absolute;left:0px;top:0px;margin:0px;padding:0px">
 <div id="vivliostyle-viewer-viewport"></div>


### PR DESCRIPTION
so that the PDF page size is automatically adjusted in Chrome's "Save As PDF" feature.
TODO Writing the rules to the style element should be done in an upper (view) layer. We should not refer UI DOM elements from this layer.
