### PR TITLE
Cascade page size specified in @page rules to page masters defined by @-epubx-page-master rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+### Added
+- [core] Cascade page size specified in @page rules to page masters defined by @-epubx-page-master rules
+  - When @page rules and @-epubx-page-master rules are both specified, the page size specified by 'size' property in @page rules is applied to the selected page master. This behavior is not defined in the related specs. We added this behavior for a use case in which one wants to print content styled with Adaptive Layout on a paper sheet and wants to specify the sheet size by adding a (user) stylesheet containing @page rules with 'size' property.
+
 ### Fixed
+- [core] 'page-width', 'page-height' variables (used in -epubx-expr) are now correctly reflect the page size specified by @page rules
 - [viewer] Fixed incorrect page size calculation when content with 'auto' page size is viewed in the spread view mode.
 
 ## [0.1.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.1.0) - 2015-04-28

--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -242,12 +242,22 @@ adapt.expr.ScopeContext;
  */
 adapt.expr.Context = function(rootScope, viewportWidth, viewportHeight, fontSize) {
 	/** @const */ this.rootScope = rootScope;
+    /** @protected @type {?number} */ this.actualPageWidth = null;
     /** @const @type {function(this:adapt.expr.Context): number} */
     this.pageWidth = function() {
-        return this.pref.spreadView ? Math.floor(viewportWidth / 2) : viewportWidth;
+        if (this.actualPageWidth)
+            return this.actualPageWidth;
+        else
+            return this.pref.spreadView ? Math.floor(viewportWidth / 2) : viewportWidth;
     };
+    /** @protected @type {?number} */ this.actualPageHeight = null;
     /** @const @type {function(this:adapt.expr.Context): number} */
-    this.pageHeight = function() { return viewportHeight; };
+    this.pageHeight = function() {
+        if (this.actualPageHeight)
+            return this.actualPageHeight;
+        else
+            return viewportHeight;
+    };
 	/** @const */ this.fontSize = fontSize;
 	this.pref = adapt.expr.defaultPreferencesInstance;
 	/** @type {Object.<string,adapt.expr.ScopeContext>} */ this.scopes = {};

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -33,7 +33,7 @@ adapt.ops.FontFace;
  * @param {adapt.expr.LexicalScope} rootScope
  * @param {adapt.expr.LexicalScope} pageScope
  * @param {adapt.csscasc.Cascade} cascade
- * @param {adapt.pm.RootPageBox} rootBox
+ * @param {!adapt.pm.RootPageBox} rootBox
  * @param {Array.<adapt.ops.FontFace>} fontFaces
  * @param {adapt.csscasc.ElementStyle} footnoteProps
  * @param {Object.<string,adapt.csscasc.ElementStyle>} flowProps
@@ -317,13 +317,9 @@ adapt.ops.StyleInstance.prototype.selectPageMaster = function() {
     	// end of primary content is reached
     	return null;
     }
-    // If there is a page master generated for @page rules, use it.
-    var pageMaster = this.pageManager.getPageRulePageMaster();
-    if (pageMaster) {
-        return pageMaster;
-    }
     // 2. Page master selection: for each page master:
     var pageMasters = /** @type {Array.<adapt.pm.PageMasterInstance>} */ (this.rootPageBoxInstance.children);
+    var pageMaster;
     for (var i = 0; i < pageMasters.length; i++) {
         pageMaster = pageMasters[i];
         // Skip a page master generated for @page rules
@@ -352,7 +348,8 @@ adapt.ops.StyleInstance.prototype.selectPageMaster = function() {
             if (goog.DEBUG) {
             	this.dumpLocation(currentPosition);
             }
-            return pageMaster;
+            // Apply @page rules
+            return this.pageManager.getPageRulePageMaster(pageMaster);
         }
     }
     throw new Error("No enabled page masters");

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -63,7 +63,6 @@ vivliostyle.page.fitToViewportSize = {
 };
 
 /**
- * @private
  * @param {!Object.<string, adapt.css.Val>} style
  * @return {!vivliostyle.page.PageSize}
  */
@@ -459,33 +458,41 @@ vivliostyle.page.PageManager.prototype.definePageProgression = function() {
 };
 
 /**
+ * Get cascaded page style specified in page context for the current page.
+ * @returns {!adapt.csscasc.ElementStyle}
+ */
+vivliostyle.page.PageManager.prototype.getCascadedPageStyle = function() {
+    var style = /** @type {!adapt.csscasc.ElementStyle} */ ({});
+    this.cascadeInstance.pushRule([], "", style);
+    return style;
+};
+
+/**
  * Return a PageMasterInstance with page rules applied. Return a cached instance if there already exists one with the same styles.
- * @param {!adapt.pm.PageMasterInstance} pageMasterInstance
+ * @param {!adapt.pm.PageMasterInstance} pageMasterInstance The original page master instance.
+ * @param {!adapt.csscasc.ElementStyle} cascadedPageStyle Cascaded page style specified in page context.
  * @return {!adapt.pm.PageMasterInstance}
  */
-vivliostyle.page.PageManager.prototype.getPageRulePageMaster = function(pageMasterInstance) {
+vivliostyle.page.PageManager.prototype.getPageRulePageMaster = function(pageMasterInstance, cascadedPageStyle) {
     var pageMaster = /** @type {!adapt.pm.PageMaster} */ (pageMasterInstance.pageBox);
 
-    /** @const */ var style = /** @type {!adapt.csscasc.ElementStyle} */ ({});
-    this.cascadeInstance.pushRule([], "", style);
-
     // If no properies are specified in @page rules, use the original page master.
-    if (Object.keys(style).length === 0) {
+    if (Object.keys(cascadedPageStyle).length === 0) {
         pageMaster.resetScope();
         return pageMasterInstance;
     }
 
-    /** @const */ var key = this.makeCacheKey(style, pageMaster);
+    /** @const */ var key = this.makeCacheKey(cascadedPageStyle, pageMaster);
     var applied = this.pageMasterCache[key];
 
     if (!applied) {
         if (pageMaster.pseudoName === adapt.pm.userAgentPageMasterPseudo) {
             // If the passed page master is a UA page master,
             // ignore it and generate a new page master from @page rules.
-            applied = this.generatePageRuleMaster(style);
+            applied = this.generatePageRuleMaster(cascadedPageStyle);
         } else {
             // Otherwise cascade some properties from @page rules to the page master.
-            applied = this.generateCascadedPageMaster(style, pageMaster);
+            applied = this.generateCascadedPageMaster(cascadedPageStyle, pageMaster);
         }
         this.pageMasterCache[key] = applied;
     }


### PR DESCRIPTION
When @page rules and @-epubx-page-master rules are both specified, a page master defined by an @-epubx-page-master rule is used (selected by the original algorithm specified in [Adaptive Layout spec](http://www.idpf.org/epub/pgt/)) and the page size specified by 'size' property in page context is applied to the page master for that page.

We want to add this behavior for a use case in which one wants to print content styled with Adaptive Layout on a paper sheet and wants to specify the sheet size by adding a (user) stylesheet containing @page rules with 'size' property.

For the time being, the interaction between @page rules and @-epubx-page-master rules (or [CSS Pagination Templates](http://dev.w3.org/csswg/css-page-template-1/)) is not defined in the specs. As the specs' development progresses, we might need to modify (or drop) this behavior to make the implementation in line with the specs in the future.
