### PR TITLE
Support page and document canvas background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+- [core] Support page background and document canvas background color 
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/33>
+  - Node: only simple background color is supported.
+
 ### Fixed
 - [core] Avoid incorrect margin collapse of the page area
   - <https://github.com/vivliostyle/vivliostyle.js/pull/32>

--- a/build/wpt-sauce.sh
+++ b/build/wpt-sauce.sh
@@ -34,4 +34,4 @@ pip install -e wptrunner
 pip install -r wptrunner/requirements_sauce.txt
 
 # run tests
-wptrunner --metadata=csswg-test/vivliostyle.js/test/wpt/metadata --tests=csswg-test --product=sauceconnect --ssl-type=none --run-vivliostyle --log-mach - --sauce-config=csswg-test/vivliostyle.js/test/wpt/sauce.ini --processes=3 --no-pause-after-test
+wptrunner --metadata=csswg-test/vivliostyle.js/test/wpt/metadata --tests=csswg-test --product=sauceconnect --ssl-type=none --run-vivliostyle --log-mach - --sauce-config=csswg-test/vivliostyle.js/test/wpt/sauce.ini --processes=2 --no-pause-after-test

--- a/src/adapt/cssstyler.js
+++ b/src/adapt/cssstyler.js
@@ -234,8 +234,14 @@ adapt.cssstyler.Styler.prototype.postprocessTopStyle = function(elemStyle, isBod
         }, this);
     }
 	if (!this.rootBackgroundAssigned) {
-		if (this.hasProp(elemStyle, this.validatorSet.backgroundProps, "background-color")
-			|| this.hasProp(elemStyle, this.validatorSet.backgroundProps, "background-image")) {
+        var backgroundColor = /** @type {adapt.css.Val} */
+            (this.hasProp(elemStyle, this.validatorSet.backgroundProps, "background-color") ?
+                elemStyle["background-color"].evaluate(this.context) : null);
+        var backgroundImage = /** @type {adapt.css.Val} */
+            (this.hasProp(elemStyle, this.validatorSet.backgroundProps, "background-image") ?
+                elemStyle["background-image"].evaluate(this.context) : null);
+		if ((backgroundColor && backgroundColor !== adapt.css.ident.inherit) ||
+            (backgroundImage && backgroundImage !== adapt.css.ident.inherit)) {
 			this.transferPropsToRoot(elemStyle, this.validatorSet.backgroundProps);
 			this.rootBackgroundAssigned = true;
 		}

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -126,13 +126,18 @@ vivliostyle.page.pageRuleMasterPseudoName = "vivliostyle-page-rule-master";
 vivliostyle.page.PageRuleMaster = function(scope, parent, style) {
     adapt.pm.PageMaster.call(this, scope, null, vivliostyle.page.pageRuleMasterPseudoName, [],
         parent, null, 0);
-    /** @const @private */ this.style = style;
     var pageSize = vivliostyle.page.resolvePageSize(style);
     var partition = new vivliostyle.page.PageRulePartition(this.scope, this, style, pageSize);
     /** @const @private */ this.bodyPartitionKey = partition.key;
     this.specified["position"] = new adapt.csscasc.CascadeValue(adapt.css.ident.relative, 0);
     this.specified["width"] = new adapt.csscasc.CascadeValue(pageSize.width, 0);
     this.specified["height"] = new adapt.csscasc.CascadeValue(pageSize.height, 0);
+    for (var name in style) {
+        if (name.match(/^background-/)
+            && name !== "background-clip") {
+            this.specified[name] = style[name];
+        }
+    }
 };
 goog.inherits(vivliostyle.page.PageRuleMaster, adapt.pm.PageMaster);
 
@@ -149,7 +154,7 @@ vivliostyle.page.PageRuleMaster.prototype.createInstance = function(parentInstan
  * @param {adapt.expr.LexicalScope} scope
  * @param {vivliostyle.page.PageRuleMaster} parent
  * @param {!adapt.csscasc.ElementStyle} style Cascaded style for @page rules
- * !param {!vivliostyle.page.PageSize} pageSize
+ * @param {!vivliostyle.page.PageSize} pageSize
  * @constructor
  * @extends {adapt.pm.Partition}
  */
@@ -308,7 +313,8 @@ vivliostyle.page.PageRulePartitionInstance.prototype.applyCascadeAndInit = funct
     var style = this.cascaded;
     for (var name in docElementStyle) {
         if (Object.prototype.hasOwnProperty.call(docElementStyle, name)) {
-            if (name.match(/^column.*$/)) {
+            if (name.match(/^column.*$/) ||
+                name.match(/^background-/)) {
                 style[name] = docElementStyle[name];
             }
         }

--- a/test/wpt/metadata/MANIFEST.json
+++ b/test/wpt/metadata/MANIFEST.json
@@ -212,11 +212,46 @@
     ],
     "reftest": [
       {
+        "path": "css21/page-box/at-page-rule-002-a.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/at-page-rule-002-a-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/at-page-rule-002-a.xht"
+      },
+      {
+        "path": "css21/page-box/at-page-rule-002-b.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/at-page-rule-002-b-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/at-page-rule-002-b.xht"
+      },
+      {
+        "path": "css21/page-box/at-page-rule-002-c.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/at-page-rule-002-c-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/at-page-rule-002-c.xht"
+      },
+      {
         "path": "css21/page-box/first-page-selectors-001.xht",
         "references": [
           ["/css21/page-box/vivliostyle/first-page-selectors-ltr-ref.html", "=="]
         ],
         "url": "/css21/page-box/first-page-selectors-001.xht"
+      },
+      {
+        "path": "css21/page-box/page-container-000.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-container-000-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-container-000.xht"
+      },
+      {
+        "path": "css21/page-box/page-container-001.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-container-001-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-container-001.xht"
       },
       {
         "path": "css21/page-box/page-container-002.xht",
@@ -233,11 +268,46 @@
         "url": "/css21/page-box/page-container-006.xht"
       },
       {
+        "path": "css21/page-box/page-container-008.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-container-008.xht"
+      },
+      {
+        "path": "css21/page-box/page-container-009.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-container-009.xht"
+      },
+      {
         "path": "css21/page-box/page-container-010.xht",
         "references": [
           ["css21/page-box/vivliostyle/page-container-010-ref.html", "=="]
         ],
         "url": "/css21/page-box/page-container-010.xht"
+      },
+      {
+        "path": "css21/page-box/page-margin-000.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-margin-000-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-margin-000.xht"
+      },
+      {
+        "path": "css21/page-box/page-margin-001.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-margin-001-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-margin-001.xht"
+      },
+      {
+        "path": "css21/page-box/page-margin-002.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-margin-002-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-margin-002.xht"
       },
       {
         "path": "css21/page-box/page-selectors-004.xht",
@@ -287,6 +357,15 @@
           ["/css-page-3/vivliostyle/page-size-010-ref.html", "=="]
         ],
         "url": "/css-page-3/page-size-010.xht"
+      },
+      {
+        "path": "css-page-3/page-background-000.xht",
+        "references": [
+          [
+            "/css-page-3/vivliostyle/page-background-000-ref.html", "=="
+          ]
+        ],
+        "url": "/css-page-3/page-background-000.xht"
       },
       {
         "path": "css-page-3/page-borders-000.xht",

--- a/test/wpt/metadata/MANIFEST.json
+++ b/test/wpt/metadata/MANIFEST.json
@@ -275,6 +275,13 @@
         "url": "/css21/page-box/page-container-008.xht"
       },
       {
+        "path": "css21/page-box/page-container-009.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-container-009.xht"
+      },
+      {
         "path": "css21/page-box/page-container-010.xht",
         "references": [
           ["css21/page-box/vivliostyle/page-container-010-ref.html", "=="]

--- a/test/wpt/metadata/MANIFEST.json
+++ b/test/wpt/metadata/MANIFEST.json
@@ -275,13 +275,6 @@
         "url": "/css21/page-box/page-container-008.xht"
       },
       {
-        "path": "css21/page-box/page-container-009.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/page-container-009.xht"
-      },
-      {
         "path": "css21/page-box/page-container-010.xht",
         "references": [
           ["css21/page-box/vivliostyle/page-container-010-ref.html", "=="]

--- a/test/wpt/metadata/MANIFEST_failing.json
+++ b/test/wpt/metadata/MANIFEST_failing.json
@@ -171,13 +171,6 @@
         "url": "/css21/page-box/page-container-001.xht"
       },
       {
-        "path": "css21/page-box/page-container-009.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/page-container-009.xht"
-      },
-      {
         "path": "css21/positioning/abspos-paged-001.xht",
         "references": [
           [

--- a/test/wpt/metadata/MANIFEST_failing.json
+++ b/test/wpt/metadata/MANIFEST_failing.json
@@ -171,6 +171,13 @@
         "url": "/css21/page-box/page-container-001.xht"
       },
       {
+        "path": "css21/page-box/page-container-009.xht",
+        "references": [
+          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
+        ],
+        "url": "/css21/page-box/page-container-009.xht"
+      },
+      {
         "path": "css21/positioning/abspos-paged-001.xht",
         "references": [
           [

--- a/test/wpt/metadata/MANIFEST_failing.json
+++ b/test/wpt/metadata/MANIFEST_failing.json
@@ -145,27 +145,6 @@
         "url": "/css21/page-box/at-page-rule-001.xht"
       },
       {
-        "path": "css21/page-box/at-page-rule-002-a.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/at-page-rule-002-a-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/at-page-rule-002-a.xht"
-      },
-      {
-        "path": "css21/page-box/at-page-rule-002-b.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/at-page-rule-002-b-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/at-page-rule-002-b.xht"
-      },
-      {
-        "path": "css21/page-box/at-page-rule-002-c.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/at-page-rule-002-c-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/at-page-rule-002-c.xht"
-      },
-      {
         "path": "css21/page-box/first-page-selectors-002.xht",
         "references": [
           ["/css21/page-box/vivliostyle/first-page-selectors-rtl-ref.html", "=="]
@@ -187,49 +166,9 @@
         "url": "/css21/page-box/first-page-selectors-004.xht"
       },
       {
-        "path": "css21/page-box/page-container-000.xht",
-        "references": [],
-        "url": "/css21/page-box/page-container-000.xht"
-      },
-      {
         "path": "css21/page-box/page-container-001.xht",
         "references": [],
         "url": "/css21/page-box/page-container-001.xht"
-      },
-      {
-        "path": "css21/page-box/page-container-008.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/page-container-008.xht"
-      },
-      {
-        "path": "css21/page-box/page-container-009.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/page-container-008-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/page-container-009.xht"
-      },
-      {
-        "path": "css21/page-box/page-margin-000.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/page-margin-000-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/page-margin-000.xht"
-      },
-      {
-        "path": "css21/page-box/page-margin-001.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/page-margin-001-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/page-margin-001.xht"
-      },
-      {
-        "path": "css21/page-box/page-margin-002.xht",
-        "references": [
-          ["/css21/page-box/vivliostyle/page-margin-002-ref.html", "=="]
-        ],
-        "url": "/css21/page-box/page-margin-002.xht"
       },
       {
         "path": "css21/positioning/abspos-paged-001.xht",
@@ -239,15 +178,6 @@
           ]
         ],
         "url": "/css21/positioning/abspos-paged-001.xht"
-      },
-      {
-        "path": "css-page-3/page-background-000.xht",
-        "references": [
-          [
-            "/css-page-3/vivliostyle/page-background-000-ref.html", "=="
-          ]
-        ],
-        "url": "/css-page-3/page-background-000.xht"
       },
       {
         "path": "css-page-3/page-margin-003.xht",


### PR DESCRIPTION
Issue: #22

Note: this PR only adds support for simple background color. Though background-image is also effective, behavior such as background position and background anchor might be different from that specified in CSS specs.
