### PR TITLE
Fix incorrect positioning of floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixed
 - [core] Avoid incorrect margin collapse of the page area
   - <https://github.com/vivliostyle/vivliostyle.js/pull/32>
+- [core] Fix incorrect positioning of floats
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/35>
 
 ## [0.1.1](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.1.1) - 2015-05-06
 Minor update with several changes and bug fixes.


### PR DESCRIPTION
When calculating position of a float, the current position of the float should be measured from edges of the page instead of edges of the browser window.
Added `getElementRelativeClientRect` method to `Column` class, which returns the element position measured from edges of the page.
Calls of `clientLayout.getElementClientRect` in the calculation of float position are replaced with calls of `getElementRelativeClientRect`.
Note that since calls of `clientLayout.getElementClientRect` in parts other than float position calculation are not replaced, there might be similar problems in these parts too.
