### PR TITLE
Enable auto relayout on window resize

### DIFF
--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1576,6 +1576,27 @@ adapt.epub.OPFView.prototype.removeRenderedPages = function() {
 };
 
 /**
+ * Returns if at least one page has 'auto' size
+ * @returns {boolean}
+ */
+adapt.epub.OPFView.prototype.hasAutoSizedPages = function() {
+	var items = this.spineItems;
+	for (var i = 0; i < items.length; i++) {
+		var item = items[i];
+		if (item) {
+			var pages = item.pages;
+			for (var j = 0; j < pages.length; j++) {
+				var page = pages[j];
+				if (page.isAutoPageWidth && page.isAutoPageHeight) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+};
+
+/**
  * @param {boolean} autohide
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -696,10 +696,10 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
     }
 
     if (pageMaster.pageBox.specified["width"].value === adapt.css.fullWidth) {
-        page.container.setAttribute("data-vivliostyle-auto-page-width", true);
+		page.setAutoPageWidth(true);
     }
     if (pageMaster.pageBox.specified["height"].value === adapt.css.fullHeight) {
-        page.container.setAttribute("data-vivliostyle-auto-page-height", true);
+		page.setAutoPageHeight(true);
     }
     /** @type {!adapt.task.Frame.<adapt.vtree.LayoutPosition>} */ var frame
     	= adapt.task.newFrame("layoutNextPage");

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -1221,15 +1221,6 @@ adapt.vgen.Viewport = function(window, fontSize, opt_root, opt_width, opt_height
 	/** @type {HTMLElement} */ this.root = opt_root || this.document.body;
 	/** @type {number} */ this.width = opt_width || window.innerWidth;
 	/** @type {number} */ this.height = opt_height || window.innerHeight;
-	if (opt_root && (!opt_width || !opt_height)) {
-	    var style = window.getComputedStyle(opt_root, null);
-	    var r = style["width"].match(/^(-?[0-9]*(\.[0-9]*)?)px$/);
-	    if (r && parseFloat(r[1]) > 0)
-            this.width = parseFloat(r[1]);
-	    r = style["height"].match(/^(-?[0-9]*(\.[0-9]*)?)px$/);
-	    if (r && parseFloat(r[1]) > 0)
-	    	this.height = parseFloat(r[0]);
-	}
     this.root.style["min-width"] = this.width + "px";
     this.root.style["min-height"] = this.height + "px";
 };

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -386,7 +386,8 @@ adapt.viewer.Viewer.prototype.sizeIsGood = function() {
 		return false;
 	}
 	var viewport = this.createViewport();
-	return viewport.width == this.viewport.width && viewport.height == this.viewport.height;
+	return (viewport.width == this.viewport.width && viewport.height == this.viewport.height) ||
+        (this.opfView && !this.opfView.hasAutoSizedPages());
 };
 
 /**

--- a/src/adapt/vtree.js
+++ b/src/adapt/vtree.js
@@ -108,6 +108,8 @@ adapt.vtree.Page = function(container) {
 	/** @type {Object.<string,Array.<Element>>} */ this.elementsById = {};
 	/** @type {boolean} */ this.isFirstPage = false;
 	/** @type {boolean} */ this.isLastPage = false;
+	/** @type {boolean} */ this.isAutoWidth = false;
+	/** @type {boolean} */ this.isAutoHeight = false;
 	/** @type {number} */ this.spineIndex = 0;
 	/** @type {adapt.vtree.LayoutPosition} */ this.position = null;
 	/** @type {number} */ this.offset = -1;
@@ -115,6 +117,44 @@ adapt.vtree.Page = function(container) {
 	/** @type {Array.<adapt.taskutil.Fetcher>} */ this.fetchers = [];
 };
 goog.inherits(adapt.vtree.Page, adapt.base.SimpleEventTarget);
+
+/**
+ * @private
+ * @const
+ * @type {string}
+ */
+adapt.vtree.Page.AUTO_PAGE_WIDTH_ATTRIBUTE = "data-vivliostyle-auto-page-width";
+
+/**
+ * @private
+ * @const
+ * @type {string}
+ */
+adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE = "data-vivliostyle-auto-page-height";
+
+/**
+ * @param {boolean} isAuto
+ */
+adapt.vtree.Page.prototype.setAutoPageWidth = function(isAuto) {
+	this.isAutoPageWidth = isAuto;
+	if (isAuto) {
+		this.container.setAttribute(adapt.vtree.Page.AUTO_PAGE_WIDTH_ATTRIBUTE, true);
+	} else {
+		this.container.removeAttribute(adapt.vtree.Page.AUTO_PAGE_WIDTH_ATTRIBUTE);
+	}
+};
+
+/**
+ * @param {boolean} isAuto
+ */
+adapt.vtree.Page.prototype.setAutoPageHeight = function(isAuto) {
+	this.isAutoPageHeight = isAuto;
+	if (isAuto) {
+		this.container.setAttribute(adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE, true);
+	} else {
+		this.container.removeAttribute(adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE);
+	}
+};
 
 /**
  * @param {Element} element

--- a/src/vivliostyle/viewerapp.js
+++ b/src/vivliostyle/viewerapp.js
@@ -299,7 +299,7 @@ vivliostyle.viewerapp.main = function(arg) {
     var config = {
         "a": epubURL ? "loadEPUB" : "loadXML",
         "url": epubURL || xmlURL,
-        "autoresize": false,
+        "autoresize": true,
         "fragment": fragment,
         // render all pages on load and resize
         "renderAllPages": true,


### PR DESCRIPTION
When the window gets resized, relayout the entire document only if there are pages with 'auto' size.
