### PR TITLE
Page-based counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - Node: only simple background color is supported.
 - [core, viewer] Layout is automatically updated when the window size is changed
   - <https://github.com/vivliostyle/vivliostyle.js/pull/37>
+- [core] Support page-based counters
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/39>
+  - Spec: [CSS Paged Media Module Level 3 - Page-based counters](http://dev.w3.org/csswg/css-page/#page-based-counters)
+  - See [the above pull request](https://github.com/vivliostyle/vivliostyle.js/pull/39) for a detailed description of its behavior and limitation.
 
 ### Fixed
 - [core] Avoid incorrect margin collapse of the page area

--- a/src/adapt/cssstyler.js
+++ b/src/adapt/cssstyler.js
@@ -137,10 +137,11 @@ adapt.cssstyler.AbstractStyler.prototype.getStyle = function(element, deep) {};
  * @param {adapt.expr.Context} context
  * @param {Object.<string,boolean>} primaryFlows
  * @param {adapt.cssvalid.ValidatorSet} validatorSet
+ * @param {adapt.csscasc.PageCounterResolver} pageCounterResolver
  * @constructor
  * @implements {adapt.cssstyler.AbstractStyler}
  */
-adapt.cssstyler.Styler = function(xmldoc, cascade, scope, context, primaryFlows, validatorSet) {
+adapt.cssstyler.Styler = function(xmldoc, cascade, scope, context, primaryFlows, validatorSet, pageCounterResolver) {
 	/** @const */ this.xmldoc = xmldoc;
 	/** @const */ this.root = xmldoc.root;
 	/** @const */ this.cascadeHolder = cascade;
@@ -153,7 +154,7 @@ adapt.cssstyler.Styler = function(xmldoc, cascade, scope, context, primaryFlows,
     /** @const */ this.flowChunks = /** @type {Array.<adapt.vtree.FlowChunk>} */ ([]);
     /** @type {adapt.cssstyler.FlowListener} */ this.flowListener = null;
     /** @type {?string} */ this.flowToReach = null;
-    /** @const */ this.cascade = cascade.createInstance(context, xmldoc.lang);
+    /** @const */ this.cascade = cascade.createInstance(context, pageCounterResolver, xmldoc.lang);
     /** @const */ this.offsetMap = new adapt.cssstyler.SlipMap();
     /** @type {boolean} */ this.primary = true;
     /** @const */ this.primaryStack = /** @type {Array.<boolean>} */ ([]);

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -476,7 +476,7 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
 	    var contentVal = boxInstance.getProp(self, "content");
 	    if (contentVal) {
 	    	if (adapt.vtree.nonTrivialContent(contentVal)) {
-	    		contentVal.visit(new adapt.vtree.ContentPropertyHandler(boxContainer));
+	    		contentVal.visit(new adapt.vtree.ContentPropertyHandler(boxContainer, self));
 	    		boxInstance.transferContentProps(self, layoutContainer, page);
 	    	}
 	    } 	

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -134,6 +134,7 @@ adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientL
     /** @const */ this.faces = new adapt.font.DocumentFaces(this.style.fontDeobfuscator);
     /** @type {Object.<string,adapt.pm.PageBoxInstance>} */ this.pageBoxInstances = {};
     /** @type {vivliostyle.page.PageManager} */ this.pageManager = null;
+	/** @const @type {vivliostyle.page.PageCounterStore} */ this.pageCounterStore = new vivliostyle.page.PageCounterStore(style.pageScope);
     /** @type {boolean} */ this.regionBreak = false;
     /** @type {!Object.<string,boolean>} */ this.pageBreaks = {};
     /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
@@ -162,7 +163,7 @@ adapt.ops.StyleInstance.prototype.init = function() {
     /** @type {!adapt.task.Frame.<boolean>} */ var frame
     	= adapt.task.newFrame("StyleInstance.init");
     self.styler = new adapt.cssstyler.Styler(self.xmldoc, self.style.cascade, 
-    		self.style.rootScope, self, this.primaryFlows, self.style.validatorSet);
+    		self.style.rootScope, self, this.primaryFlows, self.style.validatorSet, this.pageCounterStore);
     self.styler.resetFlowChunkStream(self);
     self.stylerMap = {};
     self.stylerMap[self.xmldoc.url] = self.styler;
@@ -170,7 +171,7 @@ adapt.ops.StyleInstance.prototype.init = function() {
     self.pageProgression = vivliostyle.page.resolvePageProgression(docElementStyle);
     var rootBox = this.style.rootBox;
     this.rootPageBoxInstance = new adapt.pm.RootPageBoxInstance(rootBox);
-    var cascadeInstance = this.style.cascade.createInstance(self, this.lang);
+    var cascadeInstance = this.style.cascade.createInstance(self, this.pageCounterStore, this.lang);
     this.rootPageBoxInstance.applyCascadeAndInit(cascadeInstance, docElementStyle);
     this.rootPageBoxInstance.resolveAutoSizing(self);
     this.pageManager = new vivliostyle.page.PageManager(cascadeInstance, this.style.pageScope, this.rootPageBoxInstance, self, docElementStyle);
@@ -197,7 +198,7 @@ adapt.ops.StyleInstance.prototype.getStylerForDoc = function(xmldoc) {
 		// We need a separate content, so that variables can get potentially different values.
 		var context = new adapt.expr.Context(style.rootScope, this.pageWidth(), this.pageHeight(), this.fontSize);
 		styler = new adapt.cssstyler.Styler(xmldoc, style.cascade, 
-        		style.rootScope, context, this.primaryFlows, style.validatorSet);
+        		style.rootScope, context, this.primaryFlows, style.validatorSet, this.pageCounterStore);
 		this.stylerMap[xmldoc.url] = styler;
 	}
 	return styler;

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -702,6 +702,8 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
     if (pageMaster.pageBox.specified["height"].value === adapt.css.fullHeight) {
 		page.setAutoPageHeight(true);
     }
+	self.pageCounterStore.updatePageCounters(cascadedPageStyle, self);
+
     /** @type {!adapt.task.Frame.<adapt.vtree.LayoutPosition>} */ var frame
     	= adapt.task.newFrame("layoutNextPage");
     self.layoutContainer(page, pageMaster, page.container, 0, 0, []).then(function() {

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -150,7 +150,7 @@ adapt.vgen.PseudoelementStyler.prototype.getStyle = function(element, deep) {
 	    if (content) {
 	    	var contentVal = content.evaluate(this.context);
 	    	if (adapt.vtree.nonTrivialContent(contentVal))
-	    		contentVal.visit(new adapt.vtree.ContentPropertyHandler(element));
+	    		contentVal.visit(new adapt.vtree.ContentPropertyHandler(element, this.context));
 	    }    	
 	}
 	if (className.match(/^first-/) && !style["x-first-pseudo"]) {
@@ -1086,7 +1086,7 @@ adapt.vgen.ViewFactory.prototype.applyPseudoelementStyle = function(nodeContext,
 	nodeContext.vertical = this.computeStyle(nodeContext.vertical, elementStyle, computedStyle);
     var content = computedStyle["content"];
     if (adapt.vtree.nonTrivialContent(content)) {
-        content.visit(new adapt.vtree.ContentPropertyHandler(target));
+        content.visit(new adapt.vtree.ContentPropertyHandler(target, this.context));
         delete computedStyle["content"];
     }
     this.applyComputedStyles(target, computedStyle);

--- a/src/adapt/vtree.js
+++ b/src/adapt/vtree.js
@@ -981,17 +981,27 @@ adapt.vtree.Container.prototype.getInnerShape = function() {
 /**
  * @constructor
  * @param {Element} elem
+ * @param {adapt.expr.Context} context
  * @extends {adapt.css.Visitor}
  */
-adapt.vtree.ContentPropertyHandler = function(elem) {
+adapt.vtree.ContentPropertyHandler = function(elem, context) {
 	adapt.css.Visitor.call(this);
     /** @const */ this.elem = elem;
+	/** @const */ this.context = context;
 };
 goog.inherits(adapt.vtree.ContentPropertyHandler, adapt.css.Visitor);
 
+/**
+ * @private
+ * @param {string} str
+ */
+adapt.vtree.ContentPropertyHandler.prototype.visitStrInner = function(str) {
+	this.elem.appendChild(this.elem.ownerDocument.createTextNode(str));
+};
+
 /** @override */
 adapt.vtree.ContentPropertyHandler.prototype.visitStr = function(str) {
-    this.elem.appendChild(this.elem.ownerDocument.createTextNode(str.str));
+	this.visitStrInner(str.str);
     return null;
 };
     
@@ -1007,6 +1017,15 @@ adapt.vtree.ContentPropertyHandler.prototype.visitURL = function(url) {
 adapt.vtree.ContentPropertyHandler.prototype.visitSpaceList = function(list) {
     this.visitValues(list.values);
     return null;
+};
+
+/** @override */
+adapt.vtree.ContentPropertyHandler.prototype.visitExpr = function(expr) {
+	var val = expr.toExpr().evaluate(this.context);
+	if (typeof val === "string") {
+		this.visitStrInner(val);
+	}
+	return null;
 };
 
 /**

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -857,3 +857,42 @@ vivliostyle.page.PageParserHandler.prototype.insertNonPrimary = function(action)
     // We represent page rules without selectors by *, though it is illegal in CSS
     this.cascade.insertInTable(this.cascade.pagetypes, "*", action);
 };
+
+/**
+ * Object storing page-based counters.
+ * @param {adapt.expr.LexicalScope} pageScope Scope in which a page-based counter's adapt.expr.Val is defined. Since the page-based counters are updated per page, the scope should be a page scope, which is cleared per page.
+ * @constructor
+ * @implements {adapt.csscasc.PageCounterResolver}
+ */
+vivliostyle.page.PageCounterStore = function(pageScope) {
+    /** @const */ this.pageScope = pageScope;
+    /** @const @type {Object.<string,!Array.<number>>} */ this.counters = {};
+    this.counters["page"] = [0];
+};
+
+/**
+ * @override
+ */
+vivliostyle.page.PageCounterStore.prototype.getCounterVal = function(name, format) {
+    var self = this;
+    function getCounterNumber() {
+        var values = self.counters[name];
+        return (values && values.length) ? values[values.length - 1] : null;
+    }
+    return new adapt.expr.Native(this.pageScope, function() {
+        return format(getCounterNumber());
+    }, "page-counter-" + name);
+};
+
+/**
+ * @override
+ */
+vivliostyle.page.PageCounterStore.prototype.getCountersVal = function(name, format) {
+    var self = this;
+    function getCounterNumbers() {
+        return self.counters[name] || [];
+    }
+    return new adapt.expr.Native(this.pageScope, function() {
+        return format(getCounterNumbers());
+    }, "page-counters-" + name)
+};


### PR DESCRIPTION
Spec: [CSS Paged Media 3 - Page-based counters](http://dev.w3.org/csswg/css-page/#page-based-counters)

Add a store for page-based counters and make it available for referencing by `counter()` and `counters()` functions from style declarations on elements. These page-based counters are defined and operated by `counter-reset` and `counter-increment` properties within the page context.

A builtin counter `page` is defined, and incremented by 1 on pages where `counter-increment` for `page` is not specified. Note that it is not implemented as a user-agent style sheet, since in that way the specification would be overridden by `counter-increment` user styles even if they are not for `page` and the default increment for `page` would then get ineffective.

When referencing a counter from a style declaration on an element, if there exist both page-based counters and usual counters on the element with the same name, the usual counters on the element are treated as being nested inside the page-based counters. Therefore, the innermost usual counter on the element is used with `counter()` function, and the counters are ordered with the page-based counters first and the usual counters on the element last when `counters()` function is called.

It is not possible to manipulate (by `counter-reset` or `counter-increment`) page-based counters from style declarations on elements, or to manipulate usual counters on elements from the page context.
