### PR TITLE
Automatically publish to npm on push to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .sass-cache
 node_modules
 
-build/vivliostyle.min.js
+lib/vivliostyle.min.js
 test/wpt/sauce-credentials.ini
 viewer/res/css/*

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install
 npm run build
 ```
 
-Then the compiled JavaScript file appears at `build/vivliostyle.min.js`.
+Then the compiled JavaScript file appears at `lib/vivliostyle.min.js`.
 Modify vivliostyle-viewer.html to reference only vivliostyle-viewer.min.js
 (goog/base.js is not needed, but MathJax-related files can be kept if desired).
 You might need to modify `uaRoot` parameter in vivliostyle-viewer.html to

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -18,7 +18,7 @@ if [ "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_BRANCH}" = "master" ]; then
 
     # update gh-pages branch
     master=../vivliostyle/vivliostyle.js
-    cp -R ${master}/build/vivliostyle.min.js ${master}/resources ${master}/viewer/res viewer/
+    cp -R ${master}/lib/vivliostyle.min.js ${master}/resources ${master}/viewer/res viewer/
     git add viewer
     git commit -m "Update built vivliostyle.min.js (original commit: $TRAVIS_COMMIT)"
     git push origin gh-pages

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -2,6 +2,12 @@
 set -ev
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_BRANCH}" = "master" ]; then
+    # publish to npm
+    echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+    npm --no-git-tag-version version minor
+    npm --no-git-tag-version version $(grep '^ *"version":' package.json | sed -e 's/^.*"\([^"]*\)",$/\1/')-pre.$(date -u "+%Y%m%d%H%M%S")
+    npm publish --tag next
+
     # setup ssh key
     echo -e "Host github.com\n\tStrictHostKeyChecking no\nIdentityFile ~/.ssh/deploy.key\n" >> ~/.ssh/config
     echo -e "$GITHUB_DEPLOY_KEY" | base64 -d > ~/.ssh/deploy.key

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Library for web sites with rich paged viewing and EPUB support, shared with Vivliostyle Formatter & Browser",
   "scripts": {
-    "build": "java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level ADVANCED_OPTIMIZATIONS --warning_level VERBOSE --output_wrapper_file src/wrapper.js --externs src/externs.js --js_output_file build/vivliostyle.min.js src/closure/goog/base.js src/adapt/*.js src/vivliostyle/*.js",
+    "build": "mkdirp lib && java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level ADVANCED_OPTIMIZATIONS --warning_level VERBOSE --output_wrapper_file src/wrapper.js --externs src/externs.js --js_output_file lib/vivliostyle.min.js src/closure/goog/base.js src/adapt/*.js src/vivliostyle/*.js",
     "build-css": "cd viewer/res-dev && compass compile -e production",
     "test": "karma start test/conf/karma-sauce.conf.js",
     "test:local": "karma start test/conf/karma-local.conf.js"
@@ -16,6 +16,11 @@
   "bugs": {
     "url": "https://github.com/vivliostyle/vivliostyle.js/issues"
   },
+  "license": "Apache-2.0",
+  "files": [
+    "lib",
+    "resources"
+  ],
   "homepage": "https://github.com/vivliostyle/vivliostyle.js",
   "devDependencies": {
     "font-awesome": "^4.3.0",
@@ -25,6 +30,7 @@
     "karma-cli": "^0.1.0",
     "karma-jasmine": "^0.3.6",
     "karma-sauce-launcher": "^0.2.14",
-    "karma-verbose-reporter": "0.0.3"
+    "karma-verbose-reporter": "0.0.3",
+    "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
Push to master triggers a build on Travis CI and the built package is published to npm if all tests pass.
The package is published with semver `(next minor version)-pre.YYmmddHHMMSS` and with `next` tag.
SInce `npm install` uses `latest` tag by default, the package automatically published by this script will not be installed by `npm install` without specifying any tag.
For details on npm tag, see https://docs.npmjs.com/cli/dist-tag.
For details on semver, see http://semver.org.
