### PR TITLE
Support some EPUB features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Support EPUB loading
   - <https://github.com/vivliostyle/vivliostyle.js/pull/60>
   - `loadEPUB` method of `Viewer` class loads an unzipped EPUB directory.
+- Support some EPUB features
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/62>
+  - Support `page-progression-direction` attribute of `spine` element in OPF
+  - Accept `-epub-` prefixed `text-emphasis-*` properties
 
 ### Fixed
 - Fix zoom problem when viewport is specified by the document

--- a/resources/validation.txt
+++ b/resources/validation.txt
@@ -292,9 +292,9 @@ overflow-wrap = normal | break-word;
 [webkit]text-decoration-line = none | [ underline || overline || line-through || blink ];
 [webkit]text-decoration-skip = none | [ objects || spaces || ink || edges || box-decoration ];
 [webkit]text-decoration-style = solid | double | dotted | dashed | wavy;
-[webkit]text-emphasis-color = COLOR;
+[epub,webkit]text-emphasis-color = COLOR;
 [webkit]text-emphasis-position = [ over | under ] [ right | left ];
-[webkit]text-emphasis-style = none | [[ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]] | STRING;
+[epub,webkit]text-emphasis-style = none | [[ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]] | STRING;
 [ms,webkit]text-underline-position = auto | [ under || [ left | right ]];
 
 /* CSS Transforms */
@@ -401,4 +401,4 @@ margin = INSETS margin-top margin-right margin-bottom margin-left;
 padding = INSETS padding-top padding-right padding-bottom padding-left;
 pause = INSETS pause-before pause-after;
 font = FONT font-style font-variant font-weight /* font-size line-height font-family are special-cased */;
-[webkit]text-emphasis = text-emphasis-style text-emphasis-color;
+[epub,webkit]text-emphasis = text-emphasis-style text-emphasis-color;

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -495,6 +495,7 @@ adapt.epub.OPFDoc = function(store, epubURL) {
 	/** @type {adapt.epub.OPFItem} */ this.xhtmlToc = null;
 	/** @type {adapt.epub.OPFItem} */ this.cover = null;
 	/** @type {Object.<string,string>} */ this.fallbackMap = {};
+	/** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
 	adapt.epub.checkMathJax();
 };
 
@@ -596,6 +597,10 @@ adapt.epub.OPFDoc.prototype.initWithXMLDoc = function(opfXML, encXML, zipMetadat
 	var tocAttr = pkg.child("spine").attribute("toc")[0];
 	if (tocAttr) {
 		this.ncxToc = this.itemMap[tocAttr];
+	}
+	var pageProgressionAttr = pkg.child("spine").attribute("page-progression-direction")[0];
+	if (pageProgressionAttr) {
+		this.pageProgression = vivliostyle.constants.PageProgression.of(pageProgressionAttr);
 	}
 	var idpfObfURLs = encXML.doc().child("encryption").child("EncryptedData")
 		.predicate(adapt.xmldoc.predicate.withChild("EncryptionMethod",
@@ -911,8 +916,12 @@ adapt.epub.OPFView.prototype.getCurrentPage = function() {
  * @returns {?vivliostyle.constants.PageProgression}
  */
 adapt.epub.OPFView.prototype.getCurrentPageProgression = function() {
-    var viewItem = this.spineItems[this.spineIndex];
-    return viewItem ? viewItem.instance.pageProgression : null;
+	if (this.opf.pageProgression) {
+		return this.opf.pageProgression;
+	} else {
+		var viewItem = this.spineItems[this.spineIndex];
+		return viewItem ? viewItem.instance.pageProgression : null;
+	}
 };
 
 /**

--- a/src/vivliostyle/constants.js
+++ b/src/vivliostyle/constants.js
@@ -16,6 +16,23 @@ goog.scope(function() {
         RTL: "rtl"
     };
     var PageProgression = vivliostyle.constants.PageProgression;
+
+    /**
+     * Return PageProgressino corresponding to the specified string
+     * @param {string} str
+     * @returns {vivliostyle.constants.PageProgression}
+     */
+    vivliostyle.constants.PageProgression.of = function(str) {
+        switch (str) {
+            case "ltr":
+                return PageProgression.LTR;
+            case "rtl":
+                return PageProgression.RTL;
+            default:
+                throw new Error("unknown PageProgression: " + str);
+        }
+    };
+
     vivliostyle.namespace.exportSymbol("vivliostyle.constants.PageProgression", PageProgression);
     goog.exportProperty(PageProgression, "LTR", PageProgression.LTR);
     goog.exportProperty(PageProgression, "RTL", PageProgression.RTL);


### PR DESCRIPTION
- Support `page-progression-direction` attribute of `spine` element in OPF
  - `getCurrentPageProgression` method now returns the page progression in OPF if it is specified
- Accept `-epub-` prefixed `text-emphasis-*` properties
  - `-epub-text-emphasis-color`, `-epub-text-emphasis-style` and the shorthand `-epub-text-emphasis` are now accepted
  - cf. http://www.idpf.org/accessibility/guidelines/content/style/reference.php#css025-css3text
