### PR TITLE
Use a unique page-number counter across entire EPUB document

### DIFF
--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1542,8 +1542,16 @@ adapt.epub.OPFView.prototype.getPageViewItem = function() {
     		viewport = new adapt.vgen.Viewport(viewport.window, viewportSize.fontSize, viewport.root,
     				viewportSize.width, viewportSize.height);
     	}
+		var previousViewItem = self.spineItems[self.spineIndex - 1];
+		var pageNumberOffset = previousViewItem ?
+			previousViewItem.instance.pageNumberOffset + previousViewItem.pages.length : 0;
+
         var instance = new adapt.ops.StyleInstance(style, xmldoc, self.opf.lang,
-        		viewport, self.clientLayout, self.fontMapper, customRenderer, self.opf.fallbackMap);
+			viewport, self.clientLayout, self.fontMapper, customRenderer, self.opf.fallbackMap, pageNumberOffset);
+
+		if (previousViewItem) {
+			instance.pageCounterStore.copyFrom(previousViewItem.instance.pageCounterStore);
+		}
         instance.pref = self.pref;
         instance.init().then(function() {
 			viewItem = {item: item, xmldoc: xmldoc, instance: instance,

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -59,7 +59,7 @@ adapt.ops.Style = function(store, rootScope, pageScope, cascade, rootBox,
     });  
     this.pageScope.defineName("page-number", new adapt.expr.Native(this.pageScope, function() {    	
     	var styleInstance = /** @type {adapt.ops.StyleInstance} */ (this);
-    	return styleInstance.currentLayoutPosition.page;
+    	return styleInstance.pageNumberOffset + styleInstance.currentLayoutPosition.page;
     }, "page-number"));
 };
 
@@ -110,6 +110,7 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @param {adapt.font.Mapper} fontMapper
  * @param {adapt.vgen.CustomRenderer} customRenderer
  * @param {Object.<string,string>} fallbackMap
+ * @param {number} pageNumberOffset
  * @constructor
  * @extends {adapt.expr.Context}
  * @implements {adapt.cssstyler.FlowListener}
@@ -117,7 +118,7 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @implements {adapt.vgen.StylerProducer}
  */
 adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientLayout, 
-		fontMapper, customRenderer, fallbackMap) {
+		fontMapper, customRenderer, fallbackMap, pageNumberOffset) {
 	adapt.expr.Context.call(this, style.rootScope, viewport.width, viewport.height, viewport.fontSize);
 	/** @const */ this.style = style;
 	/** @const */ this.xmldoc = xmldoc;
@@ -134,12 +135,13 @@ adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientL
     /** @const */ this.faces = new adapt.font.DocumentFaces(this.style.fontDeobfuscator);
     /** @type {Object.<string,adapt.pm.PageBoxInstance>} */ this.pageBoxInstances = {};
     /** @type {vivliostyle.page.PageManager} */ this.pageManager = null;
-	/** @const @type {vivliostyle.page.PageCounterStore} */ this.pageCounterStore = new vivliostyle.page.PageCounterStore(style.pageScope);
+	/** @const @type {!vivliostyle.page.PageCounterStore} */ this.pageCounterStore = new vivliostyle.page.PageCounterStore(style.pageScope);
     /** @type {boolean} */ this.regionBreak = false;
     /** @type {!Object.<string,boolean>} */ this.pageBreaks = {};
     /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
     /** @const */ this.customRenderer = customRenderer;
     /** @const */ this.fallbackMap = fallbackMap;
+	/** @const @type {number} */ this.pageNumberOffset = pageNumberOffset;
     for (var flowName in style.flowProps) {
     	var flowStyle = style.flowProps[flowName];
     	var consume = adapt.csscasc.getProp(flowStyle, "flow-consume");

--- a/src/adapt/toc.js
+++ b/src/adapt/toc.js
@@ -174,7 +174,7 @@ adapt.toc.TOCView.prototype.showTOC = function(elem, viewport, width, height, fo
     				viewportSize.width, viewportSize.height);
     	var customRenderer = self.makeCustomRenderer(xmldoc);
         var instance = new adapt.ops.StyleInstance(style, xmldoc, self.lang,
-        		viewport, self.clientLayout, self.fontMapper, customRenderer, self.fallbackMap);
+        		viewport, self.clientLayout, self.fontMapper, customRenderer, self.fallbackMap, 0);
         self.instance = instance;
         instance.pref = self.pref;
         instance.init().then(function() {

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -1990,8 +1990,18 @@ vivliostyle.page.PageMarginBoxParserHandler.prototype.simpleProperty = function(
  */
 vivliostyle.page.PageCounterStore = function(pageScope) {
     /** @const */ this.pageScope = pageScope;
-    /** @const @type {Object.<string,!Array.<number>>} */ this.counters = {};
+    /** @const @type {!Object.<string,!Array.<number>>} */ this.counters = {};
     this.counters["page"] = [0];
+};
+
+/**
+ * Copy (and override) counter states from another PageCounterstore.
+ * @param {!vivliostyle.page.PageCounterStore} pageCounterStore
+ */
+vivliostyle.page.PageCounterStore.prototype.copyFrom = function(pageCounterStore) {
+    Object.keys(pageCounterStore.counters).forEach(function(key) {
+        this.counters[key] = Array.from(pageCounterStore.counters[key]);
+    }, this);
 };
 
 /**

--- a/src/vivliostyle/util.js
+++ b/src/vivliostyle/util.js
@@ -5,6 +5,27 @@
 goog.provide("vivliostyle.util");
 
 (function() {
+    if (!Array.from) {
+        /**
+         * Very simple polyfill of Array.from.
+         * @param {!Object} arrayLike
+         * @param {function(*)=} mapFn
+         * @param {Object=} thisArg
+         * @returns {!Array}
+         */
+        Array.from = function(arrayLike, mapFn, thisArg) {
+            if (mapFn && thisArg) {
+                mapFn = mapFn.bind(thisArg);
+            }
+            var to = [];
+            var len = arrayLike.length;
+            for (var i = 0; i < len; i++) {
+                to[i] = mapFn ? mapFn(arrayLike[i]) : arrayLike[i];
+            }
+            return to;
+        };
+    }
+
     if (!Object.assign) {
         /**
          * Very simple polyfill of Object.assign.


### PR DESCRIPTION
- Always render all spine items before the specified spine item.
- `StyleInstance` now holds `pageNumberOffset`, which indicates the last page number of the previous spine item (0 for a `StyleInstance` of the first spine item).
- The offset is added when calculating the page number.
- State of page-based counters is preserved (copied from old `StyleInstance` to new one) when proceeding to the next spine item.
- Issue: #70
