### PR TITLE
Fix HTML parsing

### DIFF
--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -151,7 +151,7 @@ adapt.epub.EPUBDocStore.prototype.addDocument = function(url, doc) {
     var frame = adapt.task.newFrame("EPUBDocStore.load");
     var docURL = adapt.base.stripFragment(url);
     var r = this.documents[docURL] = this.parseOPSResource(
-        {status: 200, url: docURL, responseText: null, responseXML: doc, responseBlob: null}
+        {status: 200, url: docURL, contentType: doc.contentType, responseText: null, responseXML: doc, responseBlob: null}
     );
     r.thenFinish(frame);
     return frame.result();

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -6,6 +6,7 @@
 goog.provide('adapt.epub');
 
 goog.require("vivliostyle.constants");
+goog.require('adapt.net');
 goog.require('adapt.csscasc');
 goog.require('adapt.font');
 goog.require('adapt.ops');
@@ -666,7 +667,7 @@ adapt.epub.OPFDoc.prototype.initWithXMLDoc = function(opfXML, encXML, zipMetadat
 		}
 	}
 	self.assignAutoPages();
-	return adapt.net.ajax(manifestURL, false, "POST", manifestText.toString(), "text/plain");
+	return adapt.net.ajax(manifestURL, adapt.net.XMLHttpRequestResponseType.DEFAULT, "POST", manifestText.toString(), "text/plain");
 };
 
 /**

--- a/src/adapt/font.js
+++ b/src/adapt/font.js
@@ -307,7 +307,7 @@ adapt.font.Mapper.prototype.loadFont = function(srcFace, documentFaces) {
 				adapt.task.newFrame("loadFont");
 			var deobfuscator = documentFaces.deobfuscator ? documentFaces.deobfuscator(src) : null;
 			if (deobfuscator) {
-				adapt.net.ajax(src, true).then(function(xhr) {
+				adapt.net.ajax(src, adapt.net.XMLHttpRequestResponseType.BLOB).then(function(xhr) {
 					if (!xhr.responseBlob) {
 						frame.finish(null);
 						return;

--- a/src/adapt/net.js
+++ b/src/adapt/net.js
@@ -18,7 +18,7 @@ adapt.net.XMLHttpRequestResponseType = {
 	TEXT: "text"
 };
 
-/** @typedef {{status:number, url:string, responseText:?string, responseXML:Document, responseBlob:Blob}} */
+/** @typedef {{status:number, url:string, contentType:?string, responseText:?string, responseXML:Document, responseBlob:Blob}} */
 adapt.net.Response;
 
 /**
@@ -35,7 +35,7 @@ adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) 
     var request = new XMLHttpRequest();
     var continuation = frame.suspend(request);
     /** @type {adapt.net.Response} */ var response =
-    	{status: 0, url: url, responseText: null, responseXML: null, responseBlob: null};
+    	{status: 0, url: url, contentType: null, responseText: null, responseXML: null, responseBlob: null};
     request.open(opt_method || "GET", url, true);
     if (opt_type) {
     	request.responseType = opt_type;
@@ -46,6 +46,7 @@ adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) 
         	if (response.status == 200 || response.status == 0) {
 	        	if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.DOCUMENT) && request.responseXML) {
 	        		response.responseXML = request.responseXML;
+					response.contentType = request.responseXML.contentType;
 	        	} else {
 	        		var text = request.response;
 	        		if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.TEXT) && typeof text == "string") {
@@ -59,6 +60,10 @@ adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) 
         					response.responseBlob = /** @type {Blob} */ (text);
         				}
         			}
+					var contentTypeHeader = request.getResponseHeader("Content-Type");
+					if (contentTypeHeader) {
+						response.contentType = contentTypeHeader.replace(/(.*);.*$/, "$1");
+					}
 	        	}
         	}
             continuation.schedule(response);

--- a/src/adapt/net.js
+++ b/src/adapt/net.js
@@ -6,18 +6,30 @@ goog.provide('adapt.net');
 
 goog.require('adapt.task');
 
+/**
+ * @enum {string}
+ */
+adapt.net.XMLHttpRequestResponseType = {
+	DEFAULT: "",
+	ARRAYBUFFER: "arraybuffer",
+	BLOB: "blob",
+	DOCUMENT: "document",
+	JSON: "json",
+	TEXT: "text"
+};
+
 /** @typedef {{status:number, url:string, responseText:?string, responseXML:Document, responseBlob:Blob}} */
 adapt.net.Response;
 
 /**
  * @param {string} url
- * @param {boolean=} opt_binary
+ * @param {adapt.net.XMLHttpRequestResponseType=} opt_type
  * @param {string=} opt_method
  * @param {string=} opt_data
  * @param {string=} opt_contentType 
  * @return {!adapt.task.Result.<adapt.net.Response>}
  */
-adapt.net.ajax = function(url, opt_binary, opt_method, opt_data, opt_contentType) {
+adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) {
     /** @type {!adapt.task.Frame.<adapt.net.Response>} */ var frame =
     	adapt.task.newFrame("ajax");
     var request = new XMLHttpRequest();
@@ -25,18 +37,18 @@ adapt.net.ajax = function(url, opt_binary, opt_method, opt_data, opt_contentType
     /** @type {adapt.net.Response} */ var response =
     	{status: 0, url: url, responseText: null, responseXML: null, responseBlob: null};
     request.open(opt_method || "GET", url, true);
-    if (opt_binary) {
-    	request.responseType = "blob";
+    if (opt_type) {
+    	request.responseType = opt_type;
     }
     request.onreadystatechange = function() {
         if (request.readyState === 4) {
         	response.status = request.status;
         	if (response.status == 200 || response.status == 0) {
-	        	if (!opt_binary && request.responseXML) {
+	        	if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.DOCUMENT) && request.responseXML) {
 	        		response.responseXML = request.responseXML;
 	        	} else {
 	        		var text = request.response;
-	        		if (!opt_binary && typeof text == "string") {
+	        		if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.TEXT) && typeof text == "string") {
 	        			response.responseText = text;
 	        		} else if (!text) {
         				adapt.base.log("Unexpected empty success response for " + url);
@@ -115,11 +127,11 @@ adapt.net.createObjectURL = function(blob) {
  * @template Resource
  * @constructor
  * @param {function(adapt.net.Response,adapt.net.ResourceStore.<Resource>):adapt.task.Result.<Resource>} parser
- * @param {boolean} binary
+ * @param {adapt.net.XMLHttpRequestResponseType} type
  */
-adapt.net.ResourceStore = function(parser, binary) {
+adapt.net.ResourceStore = function(parser, type) {
 	/** @const */ this.parser = parser;
-	/** @const */ this.binary = binary;
+	/** @const */ this.type = type;
 	/** @type {Object.<string,Resource>} */ this.resources = {};
 	/** @type {Object.<string,adapt.taskutil.Fetcher.<Resource>>} */ this.fetchers = {};
 };
@@ -145,7 +157,7 @@ adapt.net.ResourceStore.prototype.load = function(url) {
 adapt.net.ResourceStore.prototype.fetchInner = function(url) {
 	var self = this;
 	/** @type {adapt.task.Frame.<Resource>} */ var frame = adapt.task.newFrame("fetch");
-	adapt.net.ajax(url, self.binary).then(function(response) {
+	adapt.net.ajax(url, self.type).then(function(response) {
     	self.parser(response, self).then(function(resource) {
             delete self.fetchers[url];
             self.resources[url] = resource;
@@ -204,5 +216,5 @@ adapt.net.parseJSONResource = function(response, store) {
  * return {adapt.net.JSONStore}
  */
 adapt.net.newJSONStore = function() {
-	return new adapt.net.ResourceStore(adapt.net.parseJSONResource, false);
+	return new adapt.net.ResourceStore(adapt.net.parseJSONResource, adapt.net.XMLHttpRequestResponseType.TEXT);
 };

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -998,7 +998,7 @@ adapt.ops.parseOPSResource = function(response, store) {
  * @extends {adapt.xmldoc.XMLDocStore}
  */
 adapt.ops.OPSDocStore = function(fontDeobfuscator) {
-	adapt.net.ResourceStore.call(this, adapt.ops.parseOPSResource, false);
+	adapt.net.ResourceStore.call(this, adapt.ops.parseOPSResource, adapt.net.XMLHttpRequestResponseType.DOCUMENT);
 	/** @type {?function(string):?function(Blob):adapt.task.Result.<Blob>} */ this.fontDeobfuscator = fontDeobfuscator;
 	/** @type {Object.<string,adapt.ops.Style>} */ this.styleByKey = {};
 	/** @type {Object.<string,adapt.taskutil.Fetcher.<adapt.ops.Style>>} */ this.styleFetcherByKey = {};

--- a/src/adapt/xmldoc.js
+++ b/src/adapt/xmldoc.js
@@ -360,7 +360,7 @@ adapt.xmldoc.parseXMLResource = function(response, store) {
  * @return {adapt.xmldoc.XMLDocStore}
  */
 adapt.xmldoc.newXMLDocStore = function() {
-	return new adapt.net.ResourceStore(adapt.xmldoc.parseXMLResource, false);
+	return new adapt.net.ResourceStore(adapt.xmldoc.parseXMLResource, adapt.net.XMLHttpRequestResponseType.DOCUMENT);
 };
 
 /**

--- a/src/adapt/xmldoc.js
+++ b/src/adapt/xmldoc.js
@@ -300,7 +300,20 @@ adapt.xmldoc.XMLDocHolder.prototype.getElement = function(url) {
 adapt.xmldoc.XMLDocStore;
 
 /**
- * Parse a string with a DOMParser and returns the document.
+ * cf. https://w3c.github.io/DOM-Parsing/#the-domparser-interface
+ * @enum {string}
+ * @private
+ */
+adapt.xmldoc.DOMParserSupportedType = {
+	TEXT_HTML: "text/html",
+	TEXT_XML: "text/xml",
+	APPLICATION_XML: "application/xml",
+	APPLICATION_XHTML_XML: "application/xhtml_xml",
+	IMAGE_SVG_XML: "image/svg+xml"
+};
+
+/**
+ * Parses a string with a DOMParser and returns the document.
  * If a parse error occurs, return null.
  * @param {string} str
  * @param {string} type
@@ -333,6 +346,45 @@ adapt.xmldoc.parseAndReturnNullIfError = function(str, type, opt_parser) {
 };
 
 /**
+ * @private
+ * @param {adapt.net.Response} response
+ * @returns {?string} null if contentType cannot be inferred from HTTP header and file extension
+ */
+adapt.xmldoc.resolveContentType = function(response) {
+	var contentType = response.contentType;
+	if (contentType) {
+		var supportedKeys = Object.keys(adapt.xmldoc.DOMParserSupportedType);
+		for (var i = 0; i < supportedKeys.length; i++) {
+			if (adapt.xmldoc.DOMParserSupportedType[supportedKeys[i]] === contentType) {
+				return contentType;
+			}
+		}
+		if (contentType.match(/\+xml$/)) {
+			return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML;
+		}
+	}
+	var match = response.url.match(/\.([^./]+)$/);
+	if (match) {
+		var extension = match[1];
+		switch (extension) {
+			case "html":
+			case "htm":
+				return adapt.xmldoc.DOMParserSupportedType.TEXT_HTML;
+			case "xhtml":
+			case "xht":
+				return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XHTML_XML;
+			case "svg":
+			case "svgz":
+				return adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML;
+			case "opf":
+			case "xml":
+				return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML;
+		}
+	}
+	return null;
+};
+
+/**
  * @param {adapt.net.Response} response
  * @param {adapt.xmldoc.XMLDocStore} store
  * @return {!adapt.task.Result.<!adapt.xmldoc.XMLDocHolder>}
@@ -342,13 +394,26 @@ adapt.xmldoc.parseXMLResource = function(response, store) {
 	if (!doc) {
 		var parser = new DOMParser();
 		var text = response.responseText || "<not-found/>";
-		// If responseXML is absent, try to parse as text/xml
-		doc = adapt.xmldoc.parseAndReturnNullIfError(text, "text/xml", parser);
+		var contentType = adapt.xmldoc.resolveContentType(response);
+		doc = adapt.xmldoc.parseAndReturnNullIfError(text, contentType || adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML, parser);
+
+		// When contentType cannot be inferred from HTTP header and file extension,
+		// we use root element's tag name to infer the contentType.
+		// If it is html or svg, we re-parse the source with an appropriate contentType.
+		if (doc && !contentType) {
+			var root = doc.documentElement;
+			if (root.localName.toLowerCase() === "html" && !root.namespaceURI) {
+				doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.TEXT_HTML, parser);
+			} else if (root.localName.toLowerCase() === "svg" && doc.contentType !== adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML) {
+				doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML, parser);
+			}
+		}
+
 		if (!doc) {
-			// If HTML parsing fails, try to parse as text/html
-			doc = adapt.xmldoc.parseAndReturnNullIfError(text, "text/html", parser);
+			// Fallback to HTML parsing
+			doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.TEXT_HTML, parser);
 			if (!doc) {
-				parser.parseFromString("<error/>", "text/xml");
+				parser.parseFromString("<error/>", adapt.xmldoc.DOMParserSupportedType.TEXT_XML);
 			}
 		}
 	}

--- a/test/spec/adapt/xmldoc-spec.js
+++ b/test/spec/adapt/xmldoc-spec.js
@@ -26,4 +26,145 @@ describe("xmldoc", function() {
         });
     });
 
+    describe("parseXMLResource", function() {
+        it("returns an already parsed Document if present", function(done) {
+            var docStore = adapt.xmldoc.newXMLDocStore();
+            var result = adapt.xmldoc.parseXMLResource({responseXML: document}, docStore);
+            result.then(function(docHolder) {
+                expect(docHolder.document).toBe(document);
+                done();
+            });
+        });
+
+        it("uses given contentType to parse the source", function(done) {
+            var htmlText = "<html></html>";
+            var doneHtml = false, doneXml = false, doneSvg = false;
+            function complete() {
+                if (doneHtml && doneXml && doneSvg) {
+                    done();
+                }
+            }
+
+            var docStore = adapt.xmldoc.newXMLDocStore();
+            var result = adapt.xmldoc.parseXMLResource({responseText: htmlText, contentType: "text/html"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.documentElement.namespaceURI).toBe(adapt.base.NS.XHTML);
+                doneHtml = true;
+                complete();
+            });
+
+            docStore = adapt.xmldoc.newXMLDocStore();
+            result = adapt.xmldoc.parseXMLResource({responseText: htmlText, contentType: "text/xml"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.documentElement.namespaceURI).toBe(null);
+                expect(doc.documentElement.localName).toBe("html");
+                doneXml = true;
+                complete();
+            });
+
+            docStore = adapt.xmldoc.newXMLDocStore();
+            result = adapt.xmldoc.parseXMLResource({responseText: "<svg></svg>", contentType: "image/svg+xml"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.contentType).toBe("image/svg+xml");
+                doneSvg = true;
+                complete();
+            })
+        });
+
+        it("can parse application/*+xml source as an XML", function(done) {
+            var docStore = adapt.xmldoc.newXMLDocStore();
+            var result = adapt.xmldoc.parseXMLResource(
+                {responseText: "<foo></foo>", contentType: "application/foo+xml"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.documentElement.localName).toBe("foo");
+                done();
+            })
+        });
+
+        it("can infer contentType from file extension", function(done) {
+            var htmlText = "<html></html>";
+            var doneHtml = false, doneXml = false, doneSvg = false;
+            function complete() {
+                if (doneHtml && doneXml && doneSvg) {
+                    done();
+                }
+            }
+
+            var docStore = adapt.xmldoc.newXMLDocStore();
+            var result = adapt.xmldoc.parseXMLResource(
+                {responseText: htmlText, contentType: null, url: "foo.html"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.documentElement.namespaceURI).toBe(adapt.base.NS.XHTML);
+                doneHtml = true;
+                complete();
+            });
+
+            docStore = adapt.xmldoc.newXMLDocStore();
+            result = adapt.xmldoc.parseXMLResource({
+                responseText: htmlText, contentType: null, url: "foo.xml"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.documentElement.namespaceURI).toBe(null);
+                expect(doc.documentElement.localName).toBe("html");
+                doneXml = true;
+                complete();
+            });
+
+            docStore = adapt.xmldoc.newXMLDocStore();
+            result = adapt.xmldoc.parseXMLResource({
+                responseText: "<svg></svg>", contentType: null, url: "foo.svg"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.contentType).toBe("image/svg+xml");
+                doneSvg = true;
+                complete();
+            });
+        });
+
+        it("assumes XML if contentType and file extension are both unavailable, but treats the document as HTML or SVG if the root element's localName is html or svg and namespaceURI is absent", function(done) {
+            var doneXml = false, doneHtml = false, doneSvg = false;
+            function complete() {
+                if (doneHtml && doneXml && doneSvg) {
+                    done();
+                }
+            }
+
+            var docStore = adapt.xmldoc.newXMLDocStore();
+            var result = adapt.xmldoc.parseXMLResource(
+                {responseText: "<foo></foo>", contentType: null, url: "foo/"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.documentElement.namespaceURI).toBe(null);
+                expect(doc.documentElement.localName).toBe("foo");
+                doneXml = true;
+                complete();
+            });
+
+            docStore = adapt.xmldoc.newXMLDocStore();
+            result = adapt.xmldoc.parseXMLResource(
+                {responseText: "<html></html>", contentType: null, url: "foo/"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.documentElement.namespaceURI).toBe(adapt.base.NS.XHTML);
+                doneHtml = true;
+                complete();
+            });
+
+            docStore = adapt.xmldoc.newXMLDocStore();
+            result = adapt.xmldoc.parseXMLResource(
+                {responseText: "<svg></svg>", contentType: null, url: "foo/"}, docStore);
+            result.then(function(docHolder) {
+                var doc = docHolder.document;
+                expect(doc.contentType).toBe("image/svg+xml");
+                doneSvg = true;
+                complete();
+            });
+        });
+    });
+
 });

--- a/test/spec/adapt/xmldoc-spec.js
+++ b/test/spec/adapt/xmldoc-spec.js
@@ -68,7 +68,7 @@ describe("xmldoc", function() {
             result = adapt.xmldoc.parseXMLResource({responseText: "<svg></svg>", contentType: "image/svg+xml"}, docStore);
             result.then(function(docHolder) {
                 var doc = docHolder.document;
-                expect(doc.contentType).toBe("image/svg+xml");
+                expect(doc.documentElement.localName).toBe("svg");
                 doneSvg = true;
                 complete();
             })
@@ -120,7 +120,7 @@ describe("xmldoc", function() {
                 responseText: "<svg></svg>", contentType: null, url: "foo.svg"}, docStore);
             result.then(function(docHolder) {
                 var doc = docHolder.document;
-                expect(doc.contentType).toBe("image/svg+xml");
+                expect(doc.documentElement.localName).toBe("svg");
                 doneSvg = true;
                 complete();
             });
@@ -160,7 +160,7 @@ describe("xmldoc", function() {
                 {responseText: "<svg></svg>", contentType: null, url: "foo/"}, docStore);
             result.then(function(docHolder) {
                 var doc = docHolder.document;
-                expect(doc.contentType).toBe("image/svg+xml");
+                expect(doc.documentElement.localName).toBe("svg");
                 doneSvg = true;
                 complete();
             });


### PR DESCRIPTION
- Issue: #65
- Let XMLHttpRequest parse `text/html` documents by setting `responseType` attribute to "document"
  - cf. https://xhr.spec.whatwg.org/#response-body
- When XMLHttpRequest does not automatically parse the content, resolve Content-Type using HTTP header and file extension
  - If `Content-Type` header contains a valid MIME type
    - If it is one of types supported by `DOMParser`, use it as it is.
    - If the specified type ends with `+xml`, use `application/xml` to parse it.
  - If the file extension indicates a type that can be mapped to one of types supported by `DOMParser`, use the mapped type.
  - When `Content-Type` header and file extension are both unavailable, we infer the content type by the root element's tag name.
  - If all attempts failed, use `text/html` as the fallback.
