### PR TITLE
Fix media queries behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   - https://github.com/vivliostyle/vivliostyle.js/issues/65
 - Fix viewport blinking while loading
   - <https://github.com/vivliostyle/vivliostyle.js/pull/77>
+- Fix media queries behavior
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/78>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -1240,6 +1240,9 @@ adapt.cssparse.Parser.prototype.exprStackReduce = function(op, token) {
                 }
             }
             if (tok == adapt.csstok.TokenType.O_PAR) {
+                if (val.isMediaName()) {
+                    val = new adapt.expr.MediaTest(handler.getScope(), /** @type {!adapt.expr.MediaName} */(val), null);
+                }
                 op = adapt.csstok.TokenType.EOF;
                 continue;
             }

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -2009,6 +2009,8 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     	this.importCondition = /** @type {adapt.css.Expr} */ (valStack.pop());
                     	this.importReady = true;
                         this.actions = adapt.cssparse.actionsBase;
+                        tokenizer.consume();
+                        return false;
                     }
                 }
                 tokenizer.consume();

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -1386,14 +1386,14 @@ adapt.cssparse.Parser.prototype.readPseudoParams = function() {
 
 /**
  * @param {?string} classes
- * @param {?string} media
+ * @param {adapt.expr.Val} condition
  * @return {adapt.css.Expr}
  */
-adapt.cssparse.Parser.prototype.makeCondition = function(classes, media) {
+adapt.cssparse.Parser.prototype.makeCondition = function(classes, condition) {
 	var scope = this.handler.getScope();
 	if (!scope)
 		return null;
-	var condition = scope._true;
+	condition = condition || scope._true;
 	if (classes) {
 		var classList = classes.split(/\s+/);
 		for (var i = 0; i < classList.length; i++) {
@@ -1443,7 +1443,7 @@ adapt.cssparse.Parser.prototype.isInsidePropertyOnlyRule = function() {
  * @param {boolean} parsingStyleAttr
  * @return {boolean} 
  */
-adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsingStyleAttr) {
+adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsingStyleAttr, parsingMediaQuery) {
 	var handler = this.handler;
 	var tokenizer = this.tokenizer;
     var valStack = this.valStack;
@@ -1455,6 +1455,11 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
     /** @type {number} */ var num;
     /** @type {adapt.css.Val} */ var val;
     /** @type {Array.<number|string>} */ var params;
+
+    if (parsingMediaQuery) {
+        this.exprContext = adapt.cssparse.ExprContext.MEDIA;
+        this.valStack.push("{");
+    }
     
     for(; count > 0; --count) {
         token = tokenizer.token();
@@ -2319,6 +2324,13 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
             default:
             	if (parsingValue || parsingStyleAttr)
             		return true;
+                if (parsingMediaQuery) {
+                    if (this.exprStackReduce(adapt.csstok.TokenType.C_PAR, token)) {
+                        this.result = /** @type {adapt.css.Val} */ (valStack.pop());
+                        return true;
+                    }
+                    return false;
+                }
                 if (this.actions === adapt.cssparse.actionsPropVal && tokenizer.hasMark()) {
                     tokenizer.reset();
                     this.actions = adapt.cssparse.actionsSelectorStart;
@@ -2384,13 +2396,18 @@ adapt.cssparse.parseStylesheet = function(tokenizer, handler, baseURL, classes, 
 	/** @type {adapt.task.Frame.<boolean>} */ var frame =
 		adapt.task.newFrame("parseStylesheet");
 	var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsBase, tokenizer, handler, baseURL);
-	var condition = parser.makeCondition(classes, media);
+
+    var condition = null;
+    if (media) {
+        condition = adapt.cssparse.parseMediaQuery(new adapt.csstok.Tokenizer(media, handler), handler, baseURL);
+    }
+    condition = parser.makeCondition(classes, condition && condition.toExpr());
 	if (condition) {
 		handler.startMediaRule(condition);
 		handler.startRuleBody();		
 	}
 	frame.loop(function() {
-		while (!parser.runParser(100, false, false)) {
+		while (!parser.runParser(100, false, false, false)) {
 			if (parser.importReady) {
 				var resolvedURL = adapt.base.resolveURL(/** @type {string} */ (parser.importURL), baseURL);
 				if (parser.importCondition) {
@@ -2481,7 +2498,7 @@ adapt.cssparse.parseStylesheetFromURL = function(url, handler, classes, media) {
 adapt.cssparse.parseValue = function(scope, tokenizer, baseURL) {
 	var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsPropVal, tokenizer, 
     		new adapt.cssparse.ErrorHandler(scope), baseURL);
-	parser.runParser(Number.POSITIVE_INFINITY, true, false);
+	parser.runParser(Number.POSITIVE_INFINITY, true, false, false);
 	return parser.result;
 };
 
@@ -2494,7 +2511,19 @@ adapt.cssparse.parseValue = function(scope, tokenizer, baseURL) {
 adapt.cssparse.parseStyleAttribute = function(tokenizer, handler, baseURL) {
 	var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsStyleAttribute, tokenizer, 
     		handler, baseURL);
-	parser.runParser(Number.POSITIVE_INFINITY, false, true);
+	parser.runParser(Number.POSITIVE_INFINITY, false, true, false);
+};
+
+/**
+ * @param {adapt.csstok.Tokenizer} tokenizer
+ * @param {adapt.cssparse.ParserHandler} handler
+ * @param {string} baseURL
+ * @return {adapt.css.Expr}
+ */
+adapt.cssparse.parseMediaQuery = function(tokenizer, handler, baseURL) {
+    var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsExprVal, tokenizer, handler, baseURL);
+    parser.runParser(Number.POSITIVE_INFINITY, false, false, true);
+    return /** @type {adapt.css.Expr} */ (parser.result);
 };
 
 /**

--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -408,6 +408,8 @@ adapt.expr.Context.prototype.evalMediaTest = function(feature, value) {
             default:
                 return actual == req;
         }
+    } else if (actual != null && value == null) {
+        return actual !== 0;
     }
     return false;
 };

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test cases</title>
+</head>
+<body>
+<ul>
+    <li><a href="print_media/">Print media</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/print_media/">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/print_media/">prod</a>]</li>
+</ul>
+</body>
+</html>

--- a/test/files/print_media/import_all.css
+++ b/test/files/print_media/import_all.css
@@ -1,0 +1,3 @@
+.import_all {
+    color: green;
+}

--- a/test/files/print_media/import_print.css
+++ b/test/files/print_media/import_print.css
@@ -1,0 +1,3 @@
+.import_print {
+    color: green;
+}

--- a/test/files/print_media/import_tv.css
+++ b/test/files/print_media/import_tv.css
@@ -1,0 +1,3 @@
+.import_tv {
+    color: red;
+}

--- a/test/files/print_media/import_tv_or_print.css
+++ b/test/files/print_media/import_tv_or_print.css
@@ -1,0 +1,3 @@
+.import_tv_or_print {
+    color: green;
+}

--- a/test/files/print_media/import_tv_or_print_nocolor.css
+++ b/test/files/print_media/import_tv_or_print_nocolor.css
@@ -1,0 +1,3 @@
+.import_tv_or_print_nocolor {
+    color: red;
+}

--- a/test/files/print_media/index.html
+++ b/test/files/print_media/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" media="tv" href="link_tv.css">
     <link rel="stylesheet" type="text/css" media="tv, print" href="link_tv_or_print.css">
     <style>
-        @import url(import_all.css) all;
+        @import url(import_all.css) all and (color);
         @import url(import_print.css) print;
         @import url(import_tv.css) tv;
         @import url(import_tv_or_print.css) tv, print;

--- a/test/files/print_media/index.html
+++ b/test/files/print_media/index.html
@@ -3,15 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <title>Print media test</title>
-    <link rel="stylesheet" type="text/css" media="all" href="link_all.css">
-    <link rel="stylesheet" type="text/css" media="print" href="link_print.css">
-    <link rel="stylesheet" type="text/css" media="tv" href="link_tv.css">
-    <link rel="stylesheet" type="text/css" media="tv, print" href="link_tv_or_print.css">
     <style>
-        @import url(import_all.css) all and (color);
+        .link_all, .link_print, .link_tv_or_print,
+        .import_all, .import_print, .import_tv_or_print,
+        .at_media_all, .at_media_print, .at_media_tv_or_print {
+            color: red;
+        }
+        .link_tv, .link_tv_or_print_nocolor, .import_tv, .import_tv_or_print_nocolor, .at_media_tv, .at_media_tv_or_print_nocolor {
+            color: green;
+        }
+
+        @import url(import_all.css) all;
         @import url(import_print.css) print;
         @import url(import_tv.css) tv;
         @import url(import_tv_or_print.css) tv, print;
+        @import url(import_tv_or_print_nocolor.css) tv, print and (color:0);
 
         @media all {
             .at_media_all {
@@ -33,22 +39,35 @@
                 color: green;
             }
         }
+        @media tv, print and (color:0) {
+            .at_media_tv_or_print_nocolor {
+                color: red;
+            }
+        }
     </style>
+    <link rel="stylesheet" type="text/css" media="all" href="link_all.css">
+    <link rel="stylesheet" type="text/css" media="print" href="link_print.css">
+    <link rel="stylesheet" type="text/css" media="tv" href="link_tv.css">
+    <link rel="stylesheet" type="text/css" media="tv, print" href="link_tv_or_print.css">
+    <link rel="stylesheet" type="text/css" media="tv, print and (color:0)" href="link_tv_or_print_nocolor.css">
 </head>
 <body>
 <p class="link_all">This text should be green. (<code>link</code> element with <code>media="all"</code>)</p>
 <p class="link_print">This text should be green. (<code>link</code> element with <code>media="print"</code>)</p>
 <p class="link_tv">This text should not be red. (<code>link</code> element with <code>media="tv"</code>)</p>
 <p class="link_tv_or_print">This text should be green. (<code>link</code> element with <code>media="tv, print"</code>)</p>
+<p class="link_tv_or_print_nocolor">This text should not be red. (<code>link</code> element with <code>media="tv, print and (color:0)"</code>)</p>
 
 <p class="import_all">This text should be green. (<code>@import all</code> from <code>style</code> element)</p>
 <p class="import_print">This text should be green. (<code>@import print</code> from <code>style</code> element)</p>
 <p class="import_tv">This text should not be red. (<code>@import tv</code> from <code>style</code> element)</p>
 <p class="import_tv_or_print">This text should be green. (<code>@import tv, print</code> from <code>style</code> element)</p>
+<p class="import_tv_or_print_nocolor">This text should not be red. (<code>@import tv, print and (color:0)</code> from <code>style</code> element)</p>
 
 <p class="at_media_all">This text should be green. (<code>@media all</code> in <code>style</code> element)</p>
 <p class="at_media_print">This text should be green. (<code>@media print</code> in <code>style</code> element)</p>
 <p class="at_media_tv">This text should not be red. (<code>@media tv</code> in <code>style</code> element)</p>
 <p class="at_media_tv_or_print">This text should be green. (<code>@media tv, print</code> in <code>style</code> element)</p>
+<p class="at_media_tv_or_print_nocolor">This text should not be red. (<code>@media tv, print and (color:0)</code> in <code>style</code> element)</p>
 </body>
 </html>

--- a/test/files/print_media/index.html
+++ b/test/files/print_media/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Print media test</title>
+    <link rel="stylesheet" type="text/css" media="all" href="link_all.css">
+    <link rel="stylesheet" type="text/css" media="print" href="link_print.css">
+    <link rel="stylesheet" type="text/css" media="tv" href="link_tv.css">
+    <link rel="stylesheet" type="text/css" media="tv, print" href="link_tv_or_print.css">
+    <style>
+        @import url(import_all.css) all;
+        @import url(import_print.css) print;
+        @import url(import_tv.css) tv;
+        @import url(import_tv_or_print.css) tv, print;
+
+        @media all {
+            .at_media_all {
+                color: green;
+            }
+        }
+        @media print {
+            .at_media_print {
+                color: green;
+            }
+        }
+        @media tv {
+            .at_media_tv {
+                color: red;
+            }
+        }
+        @media tv, print {
+            .at_media_tv_or_print {
+                color: green;
+            }
+        }
+    </style>
+</head>
+<body>
+<p class="link_all">This text should be green. (<code>link</code> element with <code>media="all"</code>)</p>
+<p class="link_print">This text should be green. (<code>link</code> element with <code>media="print"</code>)</p>
+<p class="link_tv">This text should not be red. (<code>link</code> element with <code>media="tv"</code>)</p>
+<p class="link_tv_or_print">This text should be green. (<code>link</code> element with <code>media="tv, print"</code>)</p>
+
+<p class="import_all">This text should be green. (<code>@import all</code> from <code>style</code> element)</p>
+<p class="import_print">This text should be green. (<code>@import print</code> from <code>style</code> element)</p>
+<p class="import_tv">This text should not be red. (<code>@import tv</code> from <code>style</code> element)</p>
+<p class="import_tv_or_print">This text should be green. (<code>@import tv, print</code> from <code>style</code> element)</p>
+
+<p class="at_media_all">This text should be green. (<code>@media all</code> in <code>style</code> element)</p>
+<p class="at_media_print">This text should be green. (<code>@media print</code> in <code>style</code> element)</p>
+<p class="at_media_tv">This text should not be red. (<code>@media tv</code> in <code>style</code> element)</p>
+<p class="at_media_tv_or_print">This text should be green. (<code>@media tv, print</code> in <code>style</code> element)</p>
+</body>
+</html>

--- a/test/files/print_media/link_all.css
+++ b/test/files/print_media/link_all.css
@@ -1,0 +1,3 @@
+.link_all {
+    color: green;
+}

--- a/test/files/print_media/link_print.css
+++ b/test/files/print_media/link_print.css
@@ -1,0 +1,3 @@
+.link_print {
+    color: green;
+}

--- a/test/files/print_media/link_tv.css
+++ b/test/files/print_media/link_tv.css
@@ -1,0 +1,3 @@
+.link_tv {
+    color: red;
+}

--- a/test/files/print_media/link_tv_or_print.css
+++ b/test/files/print_media/link_tv_or_print.css
@@ -1,0 +1,3 @@
+.link_tv_or_print {
+    color: green;
+}

--- a/test/files/print_media/link_tv_or_print_nocolor.css
+++ b/test/files/print_media/link_tv_or_print_nocolor.css
@@ -1,0 +1,3 @@
+.link_tv_or_print_nocolor {
+    color: red;
+}


### PR DESCRIPTION
- Media queries specified in `media` attribute of `link` elements, `@import` statements and `@media` rules, which were ignored before (always treated as true), are now interpreted and applied correctly.
- Currently, media types of `print`, `projection` and `screen` (as well as `all`) are evaluated as true. We will consider adding some UI allowing a user to specify which media types are enabled. Until we implement it, those three media types are enabled by default.
- Fix behavior for a media feature without a value
  - Spec: [Media Queries - Media features](http://www.w3.org/TR/css3-mediaqueries/#media1)
