### PR TITLE
Fix calculation of `rem` unit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Fix media queries behavior
   - <https://github.com/vivliostyle/vivliostyle.js/pull/78>
   - <https://github.com/vivliostyle/vivliostyle.js/pull/80>
+- Fix calculation of `rem` unit values
+  - Spec: [CSS Values and Units Module Level 3 - rem unit](https://drafts.csswg.org/css-values/#rem)
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/82>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/src/adapt/css.js
+++ b/src/adapt/css.js
@@ -854,7 +854,7 @@ adapt.css.toNumber = function(val, context) {
 	if (val) {
 	    if (val.isNumeric()) {
 	        var numeric = /** @type {adapt.css.Numeric} */ (val);
-	        return context.queryUnitSize(numeric.unit) * numeric.num;
+	        return context.queryUnitSize(numeric.unit, false) * numeric.num;
 	    }
 	    if (val.isNum()) {
 	        return (/** @type {adapt.css.Num} */ (val)).num;

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -461,7 +461,7 @@ adapt.csscasc.InheritanceVisitor.prototype.getFontSize = function() {
  */
 adapt.csscasc.InheritanceVisitor.prototype.visitNumeric = function(numeric) {
 	if (numeric.unit == "em" || numeric.unit == "ex") {
-		var ratio = this.context.queryUnitSize(numeric.unit) / this.context.queryUnitSize("em");
+		var ratio = this.context.queryUnitSize(numeric.unit, false) / this.context.queryUnitSize("em", false);
 		return new adapt.css.Numeric(numeric.num * ratio * this.getFontSize(), "px");
 	} else if (numeric.unit == "%") {
         if (this.propName === "font-size") {

--- a/src/adapt/cssprop.js
+++ b/src/adapt/cssprop.js
@@ -168,7 +168,7 @@ adapt.cssprop.ShapeVisitor.prototype.getShape = function(x, y, width, height, co
                     ref = Math.sqrt((width * width + height * height) / 2);
                 numbers.push(coord.num * ref / 100);
             } else {
-                numbers.push(coord.num * context.queryUnitSize(coord.unit));
+                numbers.push(coord.num * context.queryUnitSize(coord.unit, false));
             }
         }
         switch (this.name) {

--- a/src/adapt/cssstyler.js
+++ b/src/adapt/cssstyler.js
@@ -256,6 +256,30 @@ adapt.cssstyler.Styler.prototype.postprocessTopStyle = function(elemStyle, isBod
 			}
 		}
 	}
+    var fontSize = elemStyle["font-size"];
+    if (fontSize) {
+        var val = fontSize.evaluate(this.context);
+        var px = val.num;
+        switch (val.unit) {
+            case "em":
+            case "rem":
+                px *= this.context.initialFontSize;
+                break;
+            case "ex":
+            case "rex":
+                px *= this.context.initialFontSize * adapt.expr.defaultUnitSizes["ex"] / adapt.expr.defaultUnitSizes["em"];
+                break;
+            case "%":
+                px *= this.context.initialFontSize / 100;
+                break;
+            default:
+                var unitSize = adapt.expr.defaultUnitSizes[val.unit];
+                if (unitSize) {
+                    px *= unitSize;
+                }
+        }
+        this.context.rootFontSize = px;
+    }
 };
 
 /**

--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -260,7 +260,14 @@ adapt.expr.Context = function(rootScope, viewportWidth, viewportHeight, fontSize
         else
             return viewportHeight;
     };
-	/** @const */ this.fontSize = fontSize;
+    /** @const */ this.initialFontSize = fontSize;
+    /** @type {?number} */ this.rootFontSize = null;
+	this.fontSize = function() {
+        if (this.rootFontSize)
+            return this.rootFontSize;
+        else
+            return fontSize;
+    };
 	this.pref = adapt.expr.defaultPreferencesInstance;
 	/** @type {Object.<string,adapt.expr.ScopeContext>} */ this.scopes = {};
 };
@@ -292,17 +299,18 @@ adapt.expr.Context.prototype.clearScope = function(scope) {
 
 /**
  * @param {string} unit
+ * @param {boolean} isRoot
  * @return {number}
  */
-adapt.expr.Context.prototype.queryUnitSize = function(unit) {
+adapt.expr.Context.prototype.queryUnitSize = function(unit, isRoot) {
     if (unit == "vw")
         return this.pageWidth() / 100;
     if (unit == "vh")
         return this.pageHeight() / 100;
     if (unit == "em" || unit == "rem")
-        return this.fontSize;
+        return isRoot ? this.initialFontSize : this.fontSize();
     if (unit == "ex" || unit == "rex")
-        return adapt.expr.defaultUnitSizes["ex"] * this.fontSize / adapt.expr.defaultUnitSizes["em"];
+        return adapt.expr.defaultUnitSizes["ex"] * (isRoot ? this.initialFontSize : this.fontSize()) / adapt.expr.defaultUnitSizes["em"];
     return adapt.expr.defaultUnitSizes[unit];
 };
 
@@ -1259,7 +1267,7 @@ adapt.expr.Numeric.prototype.appendTo = function(buf, priority) {
  * @override
  */
 adapt.expr.Numeric.prototype.evaluateCore = function(context) {
-    return this.num * context.queryUnitSize(this.unit);
+    return this.num * context.queryUnitSize(this.unit, false);
 };
 
 

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -199,7 +199,7 @@ adapt.ops.StyleInstance.prototype.getStylerForDoc = function(xmldoc) {
 	if (!styler) {
 		var style = this.style.store.getStyleForDoc(xmldoc);
 		// We need a separate content, so that variables can get potentially different values.
-		var context = new adapt.expr.Context(style.rootScope, this.pageWidth(), this.pageHeight(), this.fontSize);
+		var context = new adapt.expr.Context(style.rootScope, this.pageWidth(), this.pageHeight(), this.initialFontSize);
 		styler = new adapt.cssstyler.Styler(xmldoc, style.cascade, 
         		style.rootScope, context, this.primaryFlows, style.validatorSet, this.pageCounterStore);
 		this.stylerMap[xmldoc.url] = styler;
@@ -336,7 +336,7 @@ adapt.ops.StyleInstance.prototype.selectPageMaster = function(cascadedPageStyle)
         var utilization = pageMaster.getProp(self, "utilization");
         if (utilization && utilization.isNum())
             coeff = (/** @type {adapt.css.Num} */ (utilization)).num;
-        var em = self.queryUnitSize("em");
+        var em = self.queryUnitSize("em", false);
         var pageArea = self.pageWidth() * self.pageHeight();
         var lookup = Math.ceil(coeff * pageArea / (em * em));
         // B. Determine element eligibility. Each element in a flow is considered eligible if
@@ -603,7 +603,7 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
 	            		outerWidth, outerHeight, self);
 	            if (adapt.base.checkLShapeFloatBug(self.viewport.root)) {
 	            	// Simplistic bug workaround: add a copy of the shape translated up.
-		            exclusions.push(outerShape.withOffset(0, -1.25 * self.queryUnitSize("em")));
+		            exclusions.push(outerShape.withOffset(0, -1.25 * self.queryUnitSize("em", false)));
 	            }
 	            exclusions.push(outerShape);
         	}
@@ -767,13 +767,13 @@ adapt.ops.StyleInstance.prototype.setPageSize = function(cascadedPageStyle) {
     if (width === adapt.css.fullWidth) {
         this.actualPageWidth = null;
     } else {
-        this.actualPageWidth = width.num * this.queryUnitSize(width.unit);
+        this.actualPageWidth = width.num * this.queryUnitSize(width.unit, false);
     }
     var height = pageSize.height;
     if (height === adapt.css.fullHeight) {
         this.actualPageHeight = null;
     } else {
-        this.actualPageHeight = height.num * this.queryUnitSize(height.unit);
+        this.actualPageHeight = height.num * this.queryUnitSize(height.unit, false);
     }
 };
 

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -414,6 +414,7 @@ adapt.vgen.ViewFactory.prototype.inheritFromSourceParent = function(elementStyle
 	// have the full shadow tree structure at this point. This code handles coming out of the
 	// shadow trees, but does not go back in (through shadow:content element).
 	var shadowContext = this.nodeContext.shadowContext;
+	var steps = -1;
 	while (node && node.nodeType == 1) {
 		var shadowRoot = shadowContext && shadowContext.root == node;
 		if (!shadowRoot || shadowContext.type == adapt.vtree.ShadowType.ROOTLESS) {
@@ -427,9 +428,11 @@ adapt.vgen.ViewFactory.prototype.inheritFromSourceParent = function(elementStyle
 			shadowContext = shadowContext.parentShadow;
 		} else {
 			node = node.parentNode;
+			steps++;
 		}
 	}
-	var fontSize = this.context.queryUnitSize("em");
+	var isRoot = steps === 0;
+	var fontSize = this.context.queryUnitSize("em", isRoot);
 	var props = /** @type {adapt.csscasc.ElementStyle} */
 		({"font-size": new adapt.csscasc.CascadeValue(new adapt.css.Numeric(fontSize, "px"), 0)});
 	var inheritanceVisitor = new adapt.csscasc.InheritanceVisitor(props, this.context);
@@ -1095,6 +1098,10 @@ adapt.vgen.ViewFactory.prototype.applyComputedStyles = function(target, computed
 						new adapt.vtree.DelayedItem(target, propName, value));
 				continue;
 			}
+		}
+		if (value.isNumeric() && value.unit === "rem") {
+			// font-size for the root element is already converted to px
+			value = new adapt.css.Numeric(adapt.css.toNumber(value, this.context), "px");
 		}
 	    adapt.base.setCSSProperty(target, propName, value.toString());
 	}	


### PR DESCRIPTION
- Spec: [CSS Values and Units Module Level 3 - rem unit](https://drafts.csswg.org/css-values/#rem)
- `rem` unit values are now calculated correctly relative to the font size of the root element
