### PR TITLE
Fix layout inside page margin boxes

### DIFF
--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -481,7 +481,9 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
 	    var contentVal = boxInstance.getProp(self, "content");
 		var removed = false;
 	    if (contentVal && adapt.vtree.nonTrivialContent(contentVal)) {
-			contentVal.visit(new adapt.vtree.ContentPropertyHandler(boxContainer, self));
+			var innerContainer = self.viewport.document.createElement("span");
+			contentVal.visit(new adapt.vtree.ContentPropertyHandler(innerContainer, self));
+			boxContainer.appendChild(innerContainer);
 			boxInstance.transferContentProps(self, layoutContainer, page);
 		} else if (boxInstance.suppressEmptyBoxGeneration) {
 			parentContainer.removeChild(boxContainer);


### PR DESCRIPTION
- Since we use flexbox to emulate `vertical-align` behavior in page margin boxes, the content should be wrapped in an element (`span`). Otherwise, when there are a text and an image inside the box, each occupies a single row, resulting a line break between them.
