### PR TITLE
Avoid unnecessary and incorrect CSS parsing when a viewport meta element is present

### DIFF
--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -1157,7 +1157,7 @@ adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
 		            if (index < sources.length) {
 		                var source = sources[index++];
 		                sph.startStylesheet(source.flavor);
-		                if (source.text) {
+		                if (source.text !== null) {
 		                    return adapt.cssparse.parseStylesheetFromText(source.text, sph, source.url, source.classes, source.media);
 		                } else {
 		                    return adapt.cssparse.parseStylesheetFromURL(source.url, sph, source.classes, source.media);


### PR DESCRIPTION
- When the style sheet text is an empty string and not null, it should be parsed as a style sheet text.
