### PR TITLE
Suppress extra blank page

### DIFF
--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -18,7 +18,7 @@
     /* Workaround for Chrome printing problem */
     [data-vivliostyle-viewer-viewport] > div > div > div {
         display: block !important;
-        height: 99.99% !important;
+        page-break-after: always;
     }
 }
 

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -585,7 +585,12 @@ vivliostyle.page.PageRuleMasterInstance.prototype.setPageAreaDimension = functio
     style["padding-left"] = new adapt.css.Expr(dim.marginLeft);
     style["padding-right"] = new adapt.css.Expr(dim.marginRight);
     style["padding-top"] = new adapt.css.Expr(dim.marginTop);
-    style["padding-bottom"] = new adapt.css.Expr(dim.marginBottom);
+
+    // Rounding errors in vertical dimension calculations sometimes make the page size too large
+    // to fit within the actual page in printing (PDF) and cause extra blank pages.
+    // We subtract a small length from the padding-bottom value to avoid this problem.
+    var scope = dim.marginBottom.scope;
+    style["padding-bottom"] = new adapt.css.Expr(adapt.expr.sub(scope, dim.marginBottom, new adapt.expr.Const(scope, 0.75)));
 };
 
 /**

--- a/test/wpt/metadata/MANIFEST.json
+++ b/test/wpt/metadata/MANIFEST.json
@@ -331,15 +331,6 @@
         "url": "/css-page-3/page-size-010.xht"
       },
       {
-        "path": "css-page-3/page-background-000.xht",
-        "references": [
-          [
-            "/css-page-3/vivliostyle/page-background-000-ref.html", "=="
-          ]
-        ],
-        "url": "/css-page-3/page-background-000.xht"
-      },
-      {
         "path": "css-page-3/page-borders-000.xht",
         "references": [
           ["/css-page-3/vivliostyle/page-borders-000-ref.html", "=="]

--- a/test/wpt/metadata/MANIFEST_failing.json
+++ b/test/wpt/metadata/MANIFEST_failing.json
@@ -208,6 +208,15 @@
         "url": "/css21/page-box/page-margin-002.xht"
       },
       {
+        "path": "css-page-3/page-background-000.xht",
+        "references": [
+          [
+            "/css-page-3/vivliostyle/page-background-000-ref.html", "=="
+          ]
+        ],
+        "url": "/css-page-3/page-background-000.xht"
+      },
+      {
         "path": "css-page-3/page-margin-003.xht",
         "references": [
           [


### PR DESCRIPTION
Issue: #97

Rounding errors in vertical page dimension calculations sometimes make the page size too large to fit within the actual page in printing (PDF) and cause extra blank pages.

This PR resolves this issue by subtracting a small length (0.75px) from `padding-bottom` value of the element that corresponds to the entire page. By doing so, the entire page height (top margin + page area height + bottom margin) is likely to fit within the actual page in printing.

Note that this method is rather ad hoc and causes another problem on page background. The problem will be tracked by another issue.
