### PR TITLE
Improve MathJax config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 - Fix calculation of `rem` unit values
   - Spec: [CSS Values and Units Module Level 3 - rem unit](https://drafts.csswg.org/css-values/#rem)
   - <https://github.com/vivliostyle/vivliostyle.js/pull/82>
+- Improve MathJax performance
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/116>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/resources/mathjax-config.js
+++ b/resources/mathjax-config.js
@@ -4,5 +4,23 @@
 
 window.MathJax = {
     showProcessingMessages: false,
-    messageStyle: "none"
+    messageStyle: "none",
+    skipStartupTypeset: true,
+    CommonHTML: {
+        scale: 90,
+        linebreaks: {
+            automatic: true
+        },
+        styles: {
+            ".MJXc-display": {
+                margin: "0"
+            }
+        }
+    },
+    "fast-preview": {
+        disabled: true
+    },
+    AuthorInit: function() {
+        MathJax.Hub.processSectionDelay = 0;
+    }
 };


### PR DESCRIPTION
- Improve typesetting speed by setting `MathJax.Hub.processSectionDelay` to 0
- Automatic line breaking is enabled for better math typesetting
- Margins before and after display equations are set 0 so that they can be configured with document's CSS
