### PR TITLE
Fix bug that rules above footnotes disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/82>
 - Improve MathJax performance
   - <https://github.com/vivliostyle/vivliostyle.js/pull/116>
+- Fix bug that rules above footnotes disappear
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/118>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -2190,8 +2190,13 @@ adapt.layout.Column.prototype.layout = function(chunkPosition) {
  */
 adapt.layout.Column.prototype.redoLayout = function() {
 	var chunkPositions = this.chunkPositions;
-	while (this.element.lastChild != this.last) {
-		this.element.removeChild(this.element.lastChild);
+	var last = this.element.lastChild;
+	while (last != this.last) {
+		var prev = last.previousSibling;
+		if (!(this.element.isSameNode(last.parentNode) && this.layoutContext.isPseudoelement(last))) {
+			this.element.removeChild(last);
+		}
+		last = prev;
 	}
 	this.killFloats();
 	this.init();

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -115,12 +115,14 @@ adapt.vgen.pseudoNames = ["footnote-marker", "first-5-lines", "first-4-lines",
                           "first-3-lines", "first-2-lines", "first-line", "first-letter", "before",
                              "" /* content */, "after"];
 
+adapt.vgen.PSEUDO_ATTR = "data-adapt-pseudo";
+
 /**
  * @param {Element} element
  * @returns {string}
  */
 adapt.vgen.getPseudoName = function(element) {
-	return element.getAttribute("class") || "";
+	return element.getAttribute(adapt.vgen.PSEUDO_ATTR) || "";
 };
 
 /**
@@ -128,7 +130,7 @@ adapt.vgen.getPseudoName = function(element) {
  * @param {string} name
  */
 adapt.vgen.setPseudoName = function(element, name) {
-	element.setAttribute("class", name);
+	element.setAttribute(adapt.vgen.PSEUDO_ATTR, name);
 };
 
 /**
@@ -1192,7 +1194,7 @@ adapt.vgen.ViewFactory.prototype.peelOff = function(nodeContext, nodeOffset) {
 /**
  * @param {string} ns
  * @param {string} tag
- * @return {Element}
+ * @return {!Element}
  */
 adapt.vgen.ViewFactory.prototype.createElement = function(ns, tag) {
 	if (ns == adapt.base.NS.XHTML)
@@ -1210,6 +1212,7 @@ adapt.vgen.ViewFactory.prototype.applyFootnoteStyle = function(vertical, target)
     if (pseudoMap && pseudoMap["before"]) {
     	var childComputedStyle = {};
     	var span = this.createElement(adapt.base.NS.XHTML, "span");
+		adapt.vgen.setPseudoName(span, "before");
     	target.appendChild(span);
     	this.computeStyle(vertical, pseudoMap["before"], childComputedStyle);
     	delete childComputedStyle["content"];
@@ -1258,6 +1261,10 @@ adapt.vgen.ViewFactory.prototype.isSameNodePosition = function(nodePosition1, no
  */
 adapt.vgen.ViewFactory.prototype.getPageFloatHolder = function() {
 	return this.pageFloatHolder;
+};
+
+adapt.vgen.ViewFactory.prototype.isPseudoelement = function(elem) {
+	return !!adapt.vgen.getPseudoName(elem);
 };
 
 /**


### PR DESCRIPTION
- When redoing footnote layout, view elements corresponding to pseudo elements are removed and not created again. We now detect the pseudo elements and do not remove them.
