### PR TITLE
Allow an EPUB directory URL not followed by a slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/116>
 - Fix bug that rules above footnotes disappear
   - <https://github.com/vivliostyle/vivliostyle.js/pull/118>
+- Allow an EPUB directory URL not followed by a slash
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/120>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -94,6 +94,9 @@ adapt.epub.EPUBDocStore.prototype.loadEPUBDoc = function(url, haveZipMetadata) {
 	var self = this;
 	/** @type {!adapt.task.Frame.<adapt.epub.OPFDoc>} */ var frame
 		= adapt.task.newFrame("loadEPUBDoc");
+	if (url.substring(url.length - 1) !== "/") {
+		url = url + "/";
+	}
 	if (haveZipMetadata) {
 		self.startLoadingAsJSON(url + "?r=list");
 	}


### PR DESCRIPTION
Previously, specifying an EPUB directory URL not followed by a slash resulted in an error. The implementation now adds one if the URL lacks the trailing slash.
