### PR TITLE
Fix internal hyperlinks to elements with 'name' attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/issues/30>
 - Allow page/column break inside tables
   - <https://github.com/vivliostyle/vivliostyle.js/issues/101>
+- Fix internal hyperlinks to elements with 'name' attributes
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/94>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/src/adapt/xmldoc.js
+++ b/src/adapt/xmldoc.js
@@ -283,7 +283,7 @@ adapt.xmldoc.XMLDocHolder.prototype.getElement = function(url) {
 		return null;
 	}
 	var id = m[2];
-	var r = this.document.getElementById(id);
+	var r = this.document.getElementById(id) || this.document.getElementsByName(id)[0];
 	if (!r) {
 		if (!this.idMap) {
 			this.idMap = {};


### PR DESCRIPTION
- Issue: #94
- Note that the behavior is slightly different from browsers. While browsers do not jump to elements other than `a`, `img` or form elements even if a `name` attribute is specified (`name` attribute is only applicable to those elements), Vivliostyle.js jumps to such elements too.
