### PR TITLE
Suppress extra blank page on print from Google Chrome

### DIFF
--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -20,6 +20,11 @@
         display: block !important;
         page-break-after: always;
     }
+    /* Workaround for Chrome printing problem */
+    [data-vivliostyle-page-box] {
+        padding-bottom: 0 !important;
+        overflow: visible !important;
+    }
 }
 
 @media screen {

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -585,12 +585,7 @@ vivliostyle.page.PageRuleMasterInstance.prototype.setPageAreaDimension = functio
     style["padding-left"] = new adapt.css.Expr(dim.marginLeft);
     style["padding-right"] = new adapt.css.Expr(dim.marginRight);
     style["padding-top"] = new adapt.css.Expr(dim.marginTop);
-
-    // Rounding errors in vertical dimension calculations sometimes make the page size too large
-    // to fit within the actual page in printing (PDF) and cause extra blank pages.
-    // We subtract a small length from the padding-bottom value to avoid this problem.
-    var scope = dim.marginBottom.scope;
-    style["padding-bottom"] = new adapt.css.Expr(adapt.expr.sub(scope, dim.marginBottom, new adapt.expr.Const(scope, 0.75)));
+    style["padding-bottom"] = new adapt.css.Expr(dim.marginBottom);
 };
 
 /**
@@ -1019,6 +1014,15 @@ vivliostyle.page.PageRuleMasterInstance.prototype.distributeAutoMarginBoxSizes =
 };
 
 /**
+ * @override
+ */
+vivliostyle.page.PageRuleMasterInstance.prototype.prepareContainer = function(context, container, page) {
+    vivliostyle.page.PageRuleMasterInstance.superClass_.prepareContainer.call(this, context, container, page);
+    // Add an attribute to the element so that it can be refered from external style sheets.
+    container.element.setAttribute("data-vivliostyle-page-box", true);
+};
+
+/**
  * @param {!adapt.pm.PageBoxInstance} parentInstance
  * @param {!vivliostyle.page.PageRulePartition} pageRulePartition
  * @constructor
@@ -1286,7 +1290,9 @@ vivliostyle.page.PageMarginBoxPartitionInstance.prototype.positionAndSizeAlongFi
         var insideName = names.inside;
         var outsideName = names.outside;
         var extentName = names.extent;
-        var pageMargin = dim["margin" + outsideName.charAt(0).toUpperCase() + outsideName.substring(1)];
+        // Reduce page margin by 2px: workaround for Chrome printing problem.
+        // https://github.com/vivliostyle/vivliostyle.js/issues/97
+        var pageMargin = adapt.expr.sub(scope, dim["margin" + outsideName.charAt(0).toUpperCase() + outsideName.substring(1)], new adapt.expr.Const(scope, 2));
         var marginInside = adapt.pm.toExprZeroAuto(scope, style["margin-" + insideName], pageMargin);
         var marginOutside = adapt.pm.toExprZeroAuto(scope, style["margin-" + outsideName], pageMargin);
         var paddingInside = adapt.pm.toExprZero(scope, style["padding-" + insideName], pageMargin);

--- a/test/wpt/metadata/MANIFEST.json
+++ b/test/wpt/metadata/MANIFEST.json
@@ -383,6 +383,15 @@
         "url": "/css21/pagination/widows-004b.xht"
       },
       {
+        "path": "css-page-3/page-background-000.xht",
+        "references": [
+          [
+            "/css-page-3/vivliostyle/page-background-000-ref.html", "=="
+          ]
+        ],
+        "url": "/css-page-3/page-background-000.xht"
+      },
+      {
         "path": "css-page-3/page-size-010.xht",
         "references": [
           ["/css-page-3/vivliostyle/page-size-010-ref.html", "=="]

--- a/test/wpt/metadata/MANIFEST_failing.json
+++ b/test/wpt/metadata/MANIFEST_failing.json
@@ -207,15 +207,6 @@
         "url": "/css21/pagination/orphans-004a.xht"
       },
       {
-        "path": "css-page-3/page-background-000.xht",
-        "references": [
-          [
-            "/css-page-3/vivliostyle/page-background-000-ref.html", "=="
-          ]
-        ],
-        "url": "/css-page-3/page-background-000.xht"
-      },
-      {
         "path": "css-page-3/page-margin-003.xht",
         "references": [
           [


### PR DESCRIPTION
- Issue: #97
- Set the bottom padding of elements emulating page boxes to zero when printing, preventing the elements to overflow physical pages
- Reduce spaces for page-margin boxes along fixed dimension by 2px, preventing elements emulating page-margin boxes to overflow physical pages
- Both of the above are workarounds for Chrome printing bug. Applying `height: 100%; overflow: hidden;` should be sufficient, but it causes Chrome an incorrect layout (pages are incorrectly scaled and positioned at wrong position)
- These workarounds are not effective when the bottom page margin is zero.
