### PR TITLE
Fix incorrect positioning of floats and clearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
 - Element names and attribute names in selectors are now treated in a case-insensitive manner
   - <https://github.com/vivliostyle/vivliostyle.js/issues/95>
   - Note that this behavior is incorrect for XML documents. This issue will be tracked at <https://github.com/vivliostyle/vivliostyle.js/issues/106>.
+- Fix incorrect positioning of floats and clearance
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/135>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.


### PR DESCRIPTION
- Changes made in #35 was causing a problem that elements with `clear: left|right|both` are not placed at correct positions (overlapping preceding floats etc). This is due to inconsistency in the code, where a position of a float _relative to the page_ is used when a position _relative to the browser's viewport_ should be used.
- Fix code so that the position _relative to the page_ and the position _relative to the browser's viewport_ are appropriately used.
