### PR TITLE
Some small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
 - Fix initial value of `unicode-bidi`
   - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
+- Fix support for `q` unit
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@
   - Note that this behavior is incorrect for XML documents. This issue will be tracked at <https://github.com/vivliostyle/vivliostyle.js/issues/106>.
 - Fix incorrect positioning of floats and clearance
   - <https://github.com/vivliostyle/vivliostyle.js/pull/135>
+- Fix attribute selector `~=`
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/135>
 - Fix attribute selector `~=`
   - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
+- Fix initial value of `unicode-bidi`
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/doc/property-doc-generated.md
+++ b/doc/property-doc-generated.md
@@ -45,7 +45,7 @@
       - [CSS 2.1 - background-position](https://drafts.csswg.org/css2/colors.html#propdef-background-position)
       - [CSS Backgrounds 3 - background-position](https://drafts.csswg.org/css-backgrounds-3/#background-position)
       - [CSS Backgrounds 4 - background-position](https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position)
-  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,2})+ ); /* relaxed */`
+  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
 - [background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
   - TR
       - [CSS 2.1 - background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
@@ -945,7 +945,7 @@
       - [CSS 2.1 - background-position](https://drafts.csswg.org/css2/colors.html#propdef-background-position)
       - [CSS Backgrounds 3 - background-position](https://drafts.csswg.org/css-backgrounds-3/#background-position)
       - [CSS Backgrounds 4 - background-position](https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position)
-  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,2})+ ); /* relaxed */`
+  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
 - [background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
   - TR
       - [CSS 2.1 - background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
@@ -1205,7 +1205,7 @@
       - [CSS 2.1 - background-position](https://drafts.csswg.org/css2/colors.html#propdef-background-position)
       - [CSS Backgrounds 3 - background-position](https://drafts.csswg.org/css-backgrounds-3/#background-position)
       - [CSS Backgrounds 4 - background-position](https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position)
-  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,2})+ ); /* relaxed */`
+  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
 - [border-radius](http://www.w3.org/TR/css3-background/#border-radius)
   - TR
       - [CSS Backgrounds 3 - border-radius](http://www.w3.org/TR/css3-background/#border-radius)
@@ -1228,7 +1228,7 @@
       - [CSS Images 4 - object-position](http://www.w3.org/TR/css4-images/#object-position)
   - Drafts
       - [CSS Images 3 - object-position](https://drafts.csswg.org/css-images-3/#propdef-object-position)
-  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,2})+ ); /* relaxed */`
+  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
 
 ## [CSS Images 4](http://www.w3.org/TR/css4-images/)
 - [object-fit](http://www.w3.org/TR/css3-images/#object-fit)
@@ -1244,7 +1244,7 @@
       - [CSS Images 4 - object-position](http://www.w3.org/TR/css4-images/#object-position)
   - Drafts
       - [CSS Images 3 - object-position](https://drafts.csswg.org/css-images-3/#propdef-object-position)
-  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,2})+ ); /* relaxed */`
+  - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
 
 ## [CSS Fonts 3](http://www.w3.org/TR/css-fonts-3/)
 - [font](http://www.w3.org/TR/CSS21/fonts.html#propdef-font)
@@ -1310,7 +1310,7 @@
       - [CSS Text 3 - hyphens](http://www.w3.org/TR/css-text-3/#hyphens)
   - Drafts
       - [CSS Text 3 - hyphens](https://drafts.csswg.org/css-text-3/#propdef-hyphens)
-  - Values: `auto | none;`
+  - Values: `auto | manual | none;`
 - [letter-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
   - TR
       - [CSS 2.1 - letter-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
@@ -1550,6 +1550,7 @@
       - [CSS Multicol 1 - column-gap](https://drafts.csswg.org/css-multicol-1/#propdef-column-gap)
   - Values: `LENGTH | normal;`
 - [column-rule](http://www.w3.org/TR/css3-multicol/#column-rule0)
+    - Allowed prefixes: moz, webkit
   - TR
       - [CSS Multicol 1 - column-rule](http://www.w3.org/TR/css3-multicol/#column-rule0)
   - Drafts
@@ -1592,6 +1593,7 @@
       - [CSS Multicol 1 - column-width](https://drafts.csswg.org/css-multicol-1/#propdef-column-width)
   - Values: `LENGTH | auto;`
 - [columns](http://www.w3.org/TR/css3-multicol/#columns0)
+    - Allowed prefixes: moz, webkit
   - TR
       - [CSS Multicol 1 - columns](http://www.w3.org/TR/css3-multicol/#columns0)
   - Drafts

--- a/resources/user-agent-base.css
+++ b/resources/user-agent-base.css
@@ -7,7 +7,7 @@ html|ol, html|p, html|ul, html|center, html|dir, html|hr, html|menu, html|pre,
 html|article, html|section, html|nav, html|aside, html|hgroup, html|footer, html|header,
 html|figure, html|figcaption, html|main {
      display: block;
-     unicode-bidi: embed;
+     unicode-bidi: normal;
 }
 html|li { 
     display: list-item;

--- a/resources/validation.txt
+++ b/resources/validation.txt
@@ -43,7 +43,7 @@ SCOLOR = HASHCOLOR | aliceblue: #F0F8FF | antiquewhite: #FAEBD7 | aqua: #00FFFF 
 	silver: #C0C0C0 | skyblue: #87CEEB | slateblue: #6A5ACD | slategray: #708090 | slategrey: #708090 | snow: #FFFAFA |
 	springgreen: #00FF7F | steelblue: #4682B4 | tan: #D2B48C | teal: #008080 | thistle: #D8BFD8 | tomato: #FF6347 |
 	turquoise: #40E0D0 | violet: #EE82EE | wheat: #F5DEB3 | white: #FFFFFF | whitesmoke: #F5F5F5 | yellow: #FFFF00 |
-	yellowgreen: #9ACD32 | transparent | currentColor;
+	yellowgreen: #9ACD32 | transparent | currentcolor;
 RGBCOLOR = rgb(INT{3}) | rgb(STRICT_PERCENTAGE{3});
 RGBACOLOR = rgba(NUM{4}) | rgba(STRICT_PERCENTAGE{3} NUM);
 HSLCOLOR = hsl(NUM PERCENTAGE{2});
@@ -55,7 +55,7 @@ background-attachment = COMMA( [scroll | fixed | local]+ );
 background-color = COLOR;
 background-image = COMMA( URI_OR_NONE+ );
 BG_POSITION_TERM = PLENGTH | left | center | right | top | bottom;
-background-position = COMMA( SPACE(BG_POSITION_TERM{1,2})+ ); /* relaxed */
+background-position = COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */
 background-repeat = COMMA( [repeat | repeat-x | repeat-y | no-repeat]+ );
 border-collapse = collapse | separate;
 BORDER_SIDE_COLOR = COLOR;
@@ -179,7 +179,7 @@ width = PAPLENGTH;
 word-spacing = normal | LENGTH; 
 z-index = auto | INT;
 
-[epub,moz,ms,webkit]hyphens = auto | none;
+[epub,moz,ms,webkit]hyphens = auto | manual | none;
 [adapt,webkit]margin-before = APLENGTH;
 [adapt,webkit]margin-after = APLENGTH;
 [adapt,webkit]margin-start = APLENGTH;
@@ -264,7 +264,7 @@ src = COMMA([SPACE(URI format(STRING+)?) | local(FAMILY)]+); /* for font-face */
 
 /* CSS Images */
 object-fit = fill | contain | cover | none | scale-down;
-object-position = COMMA( SPACE(BG_POSITION_TERM{1,2})+ ); /* relaxed */
+object-position = COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */
 
 /* CSS Paged Media */
 PAGE_SIZE = a5 | a4 | a3 | b5 | b4 | jis-b5 | jis-b4 | letter | legal | ledger;
@@ -411,8 +411,8 @@ border-image = border-image-source border-image-slice [ / border-image-width [ /
      border-image-repeat;
 border-radius = INSETS_SLASH border-top-left-radius border-top-right-radius
      border-bottom-right-radius border-bottom-left-radius;
-columns = column-width column-count;
-column-rule = column-rule-width column-rule-style column-rule-color;
+[moz,webkit]columns = column-width column-count;
+[moz,webkit]column-rule = column-rule-width column-rule-style column-rule-color;
 flex-flow = flex-direction flex-wrap;
 oeb-column-number = column-count;
 outline = outline-width outline-style outline-color;

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2472,6 +2472,7 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
             this.pseudoelementSelector(name, params);
             return;
         default:
+			vivliostyle.logging.logger.warn("unknown pseudo-class selector: " + name);
             this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
             break;
     }

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2542,7 +2542,7 @@ adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, na
             break;
         case adapt.csstok.TokenType.TILDE_EQ:
             this.chain.push(new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
-                new RegExp("(^|\s)" + adapt.base.escapeRegExp(value) + "($|\s)")));
+                new RegExp("(^|\\s)" + adapt.base.escapeRegExp(value) + "($|\\s)")));
             break;
         case adapt.csstok.TokenType.BAR_EQ:
             this.chain.push(new adapt.csscasc.CheckAttributeRegExpAction(ns, name,

--- a/src/adapt/cssvalid.js
+++ b/src/adapt/cssvalid.js
@@ -1710,7 +1710,8 @@ adapt.cssvalid.ValidatorSet.prototype.initBuiltInValidators = function() {
 		        "in": adapt.css.empty,
 		        "px": adapt.css.empty,
 		        "pt": adapt.css.empty,
-		        "pc": adapt.css.empty
+		        "pc": adapt.css.empty,
+                "q": adapt.css.empty
 		    }));
     this.namedValidators["POS_ANGLE"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
     		adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -1104,7 +1104,7 @@ adapt.vgen.ViewFactory.prototype.applyComputedStyles = function(target, computed
 				continue;
 			}
 		}
-		if (value.isNumeric() && value.unit === "rem") {
+		if (value.isNumeric() && (value.unit === "rem" || value.unit === "q")) {
 			// font-size for the root element is already converted to px
 			value = new adapt.css.Numeric(adapt.css.toNumber(value, this.context), "px");
 		}

--- a/test/files/attr_selectors.html
+++ b/test/files/attr_selectors.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Attribute selectors</title>
+    <style>
+        p {
+            color: red;
+        }
+        [data-foo~="baz"] {
+            color: green;
+        }
+    </style>
+</head>
+<body>
+<p data-foo="bar baz">This paragraph should be green. (using <code>~=</code> selector)</p>
+</body>
+</html>

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -11,6 +11,7 @@
     <li><a href="case_sensitivity/html.html">HTML case sensitivity</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/case_sensitivity/html.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/case_sensitivity/html.html">prod</a>]</li>
     <li><a href="break-inside_values.html">break-inside values</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/break-inside_values.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/break-inside_values.html">prod</a>]</li>
     <li><a href="break_values.html">break values</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/break_values.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/break_values.html">prod</a>]</li>
+    <li><a href="attr_selectors.html">Attribute selectors</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/attr_selectors.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/attr_selectors.html">prod</a>]</li>
 </ul>
 </body>
 </html>


### PR DESCRIPTION
- Fix attribute selectors (`~=`)
- Warn when an unknown pseudo-class selector is used
- Fix initial value of `unicode-bidi`
- Fix support for `q` unit
- Some minor fixes for supported properties
  - `currentColor` should be spelled in lower case in validation.txt. Otherwise, it does not pass validation.
  - Fixed background position value syntax (for `background-position` and `object-position`)
  - Add `manual` value to `hyphens` property
  - Allow prefixes for `columns` and `column-rule` properties
