### PR TITLE
Avoid page break between ruby base and annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
 - Fix support for `q` unit
   - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
+- Avoid page break between ruby base and annotation
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/139>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/doc/property-doc-generated.md
+++ b/doc/property-doc-generated.md
@@ -333,7 +333,7 @@
       - [CSS Display 3 - display](https://drafts.csswg.org/css-display-3/#propdef-display)
       - [CSS 2.1 - display](https://drafts.csswg.org/css2/visuren.html#propdef-display)
       - [CSS Ruby 1 - display](https://drafts.csswg.org/css-ruby-1/#propdef-display)
-  - Values: `inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex;`
+  - Values: `inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex | ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container;`
 - [elevation](http://www.w3.org/TR/CSS21/aural.html#propdef-elevation)
   - TR
       - [CSS 2.1 - elevation](http://www.w3.org/TR/CSS21/aural.html#propdef-elevation)
@@ -771,7 +771,7 @@
   - Drafts
       - [CSS 2.1 - unicode-bidi](https://drafts.csswg.org/css2/visuren.html#propdef-unicode-bidi)
       - [CSS Writing Modes 3 - unicode-bidi](https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi)
-  - Values: `normal | embed | bidi-override;`
+  - Values: `normal | embed | isolate | bidi-override | isolate-override | plaintext;`
 - [vertical-align](http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
   - TR
       - [CSS 2.1 - vertical-align](http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
@@ -1294,6 +1294,12 @@
       - [CSS 2.1 - font-variant](https://drafts.csswg.org/css2/fonts.html#propdef-font-variant)
       - [CSS Fonts 3 - font-variant](https://drafts.csswg.org/css-fonts-3/#propdef-font-variant)
   - Values: `normal | small-caps;`
+- [font-variant-east-asian](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
+  - TR
+      - [CSS Fonts 3 - font-variant-east-asian](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
+  - Drafts
+      - [CSS Fonts 3 - font-variant-east-asian](https://drafts.csswg.org/css-fonts-3/#propdef-font-variant-east-asian)
+  - Values: `normal | [[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ] || [ full-width | proportional-width ] || ruby];`
 - [font-weight](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
   - TR
       - [CSS 2.1 - font-weight](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
@@ -1694,7 +1700,7 @@
   - Drafts
       - [CSS 2.1 - unicode-bidi](https://drafts.csswg.org/css2/visuren.html#propdef-unicode-bidi)
       - [CSS Writing Modes 3 - unicode-bidi](https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi)
-  - Values: `normal | embed | bidi-override;`
+  - Values: `normal | embed | isolate | bidi-override | isolate-override | plaintext;`
 - [writing-mode](http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
     - Allowed prefixes: epub, webkit
   - TR
@@ -2021,7 +2027,7 @@
       - [CSS Display 3 - display](https://drafts.csswg.org/css-display-3/#propdef-display)
       - [CSS 2.1 - display](https://drafts.csswg.org/css2/visuren.html#propdef-display)
       - [CSS Ruby 1 - display](https://drafts.csswg.org/css-ruby-1/#propdef-display)
-  - Values: `inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex;`
+  - Values: `inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex | ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container;`
 - [ruby-align](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
   - TR
       - [CSS Ruby 1 - ruby-align](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)

--- a/doc/supported-features.md
+++ b/doc/supported-features.md
@@ -246,7 +246,7 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Depends on browser's capability: Yes
 - [display](http://www.w3.org/TR/CSS2/visuren.html#propdef-display)
   - Depends on browser's capability: Yes
-  - Supports [`flex` and `inline-flex` values](https://www.w3.org/TR/css-flexbox-1/#flex-containers)
+  - Supports [`flex`, `inline-flex`](https://www.w3.org/TR/css-flexbox-1/#flex-containers), [`ruby`, `ruby-base`, `ruby-text`, `ruby-base-container` and `ruby-text-container`](https://www.w3.org/TR/css-ruby-1/#propdef-display) values.
 - [empty-cells](http://www.w3.org/TR/CSS2/tables.html#propdef-empty-cells)
   - Depends on browser's capability: Yes
 - [float](http://www.w3.org/TR/CSS2/visuren.html#propdef-float)
@@ -346,6 +346,7 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Depends on browser's capability: Yes
 - [unicode-bidi](http://www.w3.org/TR/CSS2/visuren.html#propdef-unicode-bidi)
   - Depends on browser's capability: Yes
+  - Supports [new values (`isolate`, `isolate-override`, `plaintext`) in CSS Writing Modes 3](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
 - [vertical-align](http://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align)
   - Depends on browser's capability: Yes
 - [visibility](http://www.w3.org/TR/CSS2/visufx.html#propdef-visibility)
@@ -488,6 +489,8 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Depends on browser's capability: Yes
 - [font-style](http://www.w3.org/TR/css-fonts-3/#propdef-font-style)
   - Depends on browser's capability: Yes
+- [font-variant-east-asian](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
+  - Depends on browser's capability: Yes
 - [font-weight](http://www.w3.org/TR/css-fonts-3/#propdef-font-weight)
   - Depends on browser's capability: Yes
 
@@ -629,6 +632,9 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Allowed prefixes: epub, webkit
   - Depends on browser's capability: Yes
   - Note: supported values are [those defined in 20 March 2014 Candidate Recommendation](https://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#propdef-text-orientation), not those in the latest spec.
+- [unicode-bidi](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
+  - Depends on browser's capability: Yes
+  - Supports [new values (`isolate`, `isolate-override`, `plaintext`) in CSS Writing Modes 3](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
 - [writing-mode](http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
   - Allowed prefixes: epub, webkit
   - Depends on browser's capability: Yes
@@ -644,7 +650,7 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Depends on browser's capability: Yes
 - [display](https://www.w3.org/TR/css-flexbox-1/#flex-containers)
   - Depends on browser's capability: Yes
-  - Supports [`flex` and `inline-flex` values](https://www.w3.org/TR/css-flexbox-1/#flex-containers)
+  - Supports [`flex`, `inline-flex`](https://www.w3.org/TR/css-flexbox-1/#flex-containers), [`ruby`, `ruby-base`, `ruby-text`, `ruby-base-container` and `ruby-text-container`](https://www.w3.org/TR/css-ruby-1/#propdef-display) values.
 - [flex](http://www.w3.org/TR/css-flexbox-1/#propdef-flex)
   - Depends on browser's capability: Yes
 - [flex-basis](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis)
@@ -694,6 +700,9 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 
 ### [CSS Ruby Layout 1](http://www.w3.org/TR/css-ruby-1/)
 
+- [display](https://www.w3.org/TR/css-ruby-1/#propdef-display)
+  - Depends on browser's capability: Yes
+  - Supports [`flex`, `inline-flex`](https://www.w3.org/TR/css-flexbox-1/#flex-containers), [`ruby`, `ruby-base`, `ruby-text`, `ruby-base-container` and `ruby-text-container`](https://www.w3.org/TR/css-ruby-1/#propdef-display) values.
 - [ruby-align](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
   - Depends on browser's capability: Yes
 - [ruby-position](https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position)

--- a/resources/user-agent-base.css
+++ b/resources/user-agent-base.css
@@ -160,6 +160,52 @@ html|audio, html|video {
     page-break-inside: avoid;
 }
 
+html|ruby {
+    display: ruby;
+}
+html|rp {
+    display: none;
+}
+html|rbc {
+    display: ruby-base-container;
+}
+html|rtc {
+    display: ruby-text-container;
+}
+html|rb {
+    display: ruby-base;
+    white-space: nowrap;
+}
+html|rt {
+    display: ruby-text;
+}
+html|ruby, html|rb, html|rt, html|rbc, html|rtc {
+    unicode-bidi: isolate;
+}
+
+html|rtc, html|rt {
+    font-variant-east-asian: ruby;
+    text-emphasis: none;
+    white-space: nowrap;
+    line-height: 1;
+}
+
+html|rtc:lang(zh), html|rt:lang(zh) {
+    ruby-align: center;
+}
+
+html|rtc, html|rt {
+    font-size: 50%;
+}
+
+html|rtc:lang(zh-TW), html|rt:lang(zh-TW) {
+    font-size: 30%;
+}
+
+html|rtc > html|rt, html|rtc > html|rt:lang(zh-TW) {
+    font-size: 100%;
+}
+
 /*------------------ epub-specific ---------------------*/
 
 @namespace epub "http://www.idpf.org/2007/ops";

--- a/resources/validation.txt
+++ b/resources/validation.txt
@@ -108,7 +108,8 @@ cursor = COMMA(URI* [ auto | crosshair | default | pointer | move | e-resize | n
 direction = ltr | rtl;
 display = inline | block | list-item | inline-block | table | inline-table | table-row-group |
     table-header-group | table-footer-group | table-row | table-column-group | table-column |
-    table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex;
+    table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex |
+    ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container;
 elevation = ANGLE | below | level | above | higher | lower;
 empty-cells = show | hide;
 FAMILY = SPACE(IDENT+) | STRING;
@@ -168,7 +169,6 @@ text-decoration = none | [ underline || overline || line-through || blink ];
 text-indent = PLENGTH;
 text-transform = capitalize | uppercase | lowercase | none;
 top = APLENGTH;
-unicode-bidi = normal | embed | bidi-override;
 vertical-align = baseline | sub | super | top | text-top | middle | bottom | text-bottom | PLENGTH;
 visibility = visible | hidden | collapse;
 voice-family = FAMILY_LIST;
@@ -261,6 +261,7 @@ src = COMMA([SPACE(URI format(STRING+)?) | local(FAMILY)]+); /* for font-face */
 
 /* CSS Fonts */
 [webkit]font-kerning = auto | normal | none;
+font-variant-east-asian = normal | [[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ] || [ full-width | proportional-width ] || ruby];
 
 /* CSS Images */
 object-fit = fill | contain | cover | none | scale-down;
@@ -312,6 +313,7 @@ box-sizing = content-box | padding-box | border-box;
 [epub,ms]text-combine-horizontal = none | all | [ digits POS_INT? ]; /* relaxed */
 text-combine-upright = none | all | [ digits POS_INT? ]; /* relaxed */
 [epub,webkit]text-orientation = mixed | upright | sideways-right | sideways-left | sideways | use-glyph-orientation /* the following values are kept for backward-compatibility */ | vertical-right | rotate-right | rotate-left | rotate-normal | auto;
+unicode-bidi = normal | embed | isolate | bidi-override | isolate-override | plaintext;
 [epub,webkit]writing-mode = horizontal-tb | vertical-rl;
 
 /* CSS Flex box */

--- a/test/files/ruby-broken-pagination.html
+++ b/test/files/ruby-broken-pagination.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Ruby broken pagination</title>
+    <style>
+        @page {
+            size: 217px 217px;
+            margin: 10px;
+        }
+        * {
+            margin: 0;
+            padding: 0;
+        }
+        :root {
+            writing-mode: vertical-rl;
+            font-size: 20px;
+            line-height: 30px;
+            orphans: 1;
+            widows: 1;
+        }
+        rt {
+            font-size: 10px;
+        }
+    </style>
+</head>
+<body>
+<p>
+    <ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby><ruby><rb>高瀬舟</rb><rp>（</rp><rt>たかせぶね</rt><rp>）</rp></ruby>
+</p>
+</body>
+</html>


### PR DESCRIPTION
- Issue: #67
- Add default style sheet based on [the current editor's draft of CSS Ruby](https://drafts.csswg.org/css-ruby/#default-ua-ruby). Since `display` values other than `inline` are assigned to ruby elements, the implementation does not attempt to break page inside the elements.
- Add new values for `display`: `ruby`, `ruby-base`, `ruby-text`, `ruby-base-container` and `ruby-text-container`
- Add new values for `unicode-bidi`: `isolate`, isolate-override`and`plaintext`
- Add new property `font-variant-east-asian` from CSS Fonts 3
