### PR TITLE
Do not block entire process when stylesheets cannot be fetched or parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/137>
 - Avoid page break between ruby base and annotation
   - <https://github.com/vivliostyle/vivliostyle.js/pull/139>
+- Do not block entire process when stylesheets cannot be fetched or parsed
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/141>
 
 ## [0.2.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/0.2.0) - 2015-09-16
 Beta release.

--- a/src/adapt/net.js
+++ b/src/adapt/net.js
@@ -71,13 +71,18 @@ adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) 
             continuation.schedule(response);
         }
     };
-    if (opt_data) {
-        request.setRequestHeader("Content-Type",
-        		opt_contentType || "text/plain; charset=UTF-8");
-        request.send(opt_data);
-    }
-    else
-        request.send(null);
+	try {
+		if (opt_data) {
+			request.setRequestHeader("Content-Type",
+				opt_contentType || "text/plain; charset=UTF-8");
+			request.send(opt_data);
+		}
+		else
+			request.send(null);
+	} catch (e) {
+		vivliostyle.logging.logger.warn(e, "Error fetching " + url);
+		continuation.schedule(response);
+	}
     return frame.result();
 };
 

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -1163,7 +1163,7 @@ adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
 		                var source = sources[index++];
 		                sph.startStylesheet(source.flavor);
 		                if (source.text !== null) {
-		                    return adapt.cssparse.parseStylesheetFromText(source.text, sph, source.url, source.classes, source.media);
+							return adapt.cssparse.parseStylesheetFromText(source.text, sph, source.url, source.classes, source.media).thenReturn(true);
 		                } else {
 		                    return adapt.cssparse.parseStylesheetFromURL(source.url, sph, source.classes, source.media);
 		                }

--- a/test/files/css-parse-error/gradient-background-image.css
+++ b/test/files/css-parse-error/gradient-background-image.css
@@ -1,0 +1,5 @@
+.alert-container {
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    background-image:linear-gradient(bottom, rgb(215,215,215) 4%, rgb(230,230,230) 55%, rgb(255,255,255) 100%);
+}

--- a/test/files/css-parse-error/gradient-background-image.html
+++ b/test/files/css-parse-error/gradient-background-image.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Gradient background-image</title>
+    <style>
+        .alert-container {
+            -moz-border-radius: 3px;
+            border-radius: 3px;
+            background-image:linear-gradient(bottom, rgb(215,215,215) 4%, rgb(230,230,230) 55%, rgb(255,255,255) 100%);
+        }
+    </style>
+    <link rel="stylesheet" href="gradient-background-image.css">
+    <style>
+        p {
+            color: green;
+        }
+    </style>
+</head>
+<body>
+<p>This paragraph should be green.</p>
+</body>
+</html>

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -13,6 +13,7 @@
     <li><a href="break_values.html">break values</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/break_values.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/break_values.html">prod</a>]</li>
     <li><a href="attr_selectors.html">Attribute selectors</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/attr_selectors.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/attr_selectors.html">prod</a>]</li>
     <li><a href="ruby-broken-pagination.html">Ruby broken pagination</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/ruby-broken-pagination.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/ruby-broken-pagination.html">prod</a>]</li>
+    <li><a href="css-parse-error/gradient-background-image.html">Gradient background-image</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/css-parse-error/gradient-background-image.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/css-parse-error/gradient-background-image.html">prod</a>]</li>
 </ul>
 </body>
 </html>


### PR DESCRIPTION
- Issue: #141
- Do not stop when XMLHttpRequest threw an exception. The exception is catched, a warning message is logged, and the entire process continues.
  - This is effective for Firefox, which throws an exception when an XMLHttpRequest is blocked due to a security reason, but not for Chrome ([See this bug](https://code.google.com/p/chromium/issues/detail?id=389326)).
  - WebKit does not have the same problem since it returns a response with a status code 0 when it blocks the request.
- Do not stop when CSS parsing threw an exception. The exception is catched, a warning message is logged, and the entire process continues.
