### PR TITLE
Use document.getElementsByName only when available

### DIFF
--- a/src/adapt/xmldoc.js
+++ b/src/adapt/xmldoc.js
@@ -283,7 +283,10 @@ adapt.xmldoc.XMLDocHolder.prototype.getElement = function(url) {
 		return null;
 	}
 	var id = m[2];
-	var r = this.document.getElementById(id) || this.document.getElementsByName(id)[0];
+	var r = this.document.getElementById(id);
+	if (!r && this.document.getElementsByName) {
+		r = this.document.getElementsByName(id)[0];
+	}
 	if (!r) {
 		if (!this.idMap) {
 			this.idMap = {};

--- a/test/spec/adapt/xmldoc-spec.js
+++ b/test/spec/adapt/xmldoc-spec.js
@@ -1,5 +1,35 @@
 describe("xmldoc", function() {
 
+    describe("XMLDocHolder", function() {
+        var url = "foobar";
+
+        describe("getElement", function() {
+            it("returns an element if there is one with the specified ID", function() {
+                var doc = new DOMParser().parseFromString("<foo><bar id='baz'></bar></foo>", "text/xml");
+                var holder = new adapt.xmldoc.XMLDocHolder(null, url, doc);
+
+                var e = holder.getElement("foobar#baz");
+                expect(e instanceof Element).toBe(true);
+            });
+
+            it("returns an element if there is one with the specified name", function() {
+                var doc = new DOMParser().parseFromString("<html><head></head><body><bar name='baz'></bar></body></html>", "text/html");
+                var holder = new adapt.xmldoc.XMLDocHolder(null, url, doc);
+
+                var e = holder.getElement("foobar#baz");
+                expect(e instanceof Element).toBe(true);
+            });
+
+            it("returns null if nothing found", function() {
+                var doc = new DOMParser().parseFromString("<foo><bar></bar></foo>", "text/xml");
+                var holder = new adapt.xmldoc.XMLDocHolder(null, url, doc);
+
+                var e = holder.getElement("foobar#baz");
+                expect(e).toBeFalsy();
+            });
+        });
+    });
+
     describe("parseAndReturnNullIfError", function() {
         it("uses a parser passed by an optional argument", function() {
             var parser = {parseFromString: function() {}};


### PR DESCRIPTION
- Calling document.getElementsByName throws on Firefox when the document is a non-HTML document
- This bug was introduced by #125 (fix for #94)
