### PR TITLE
Convert length in rem specified in page context to px value

### DIFF
--- a/src/adapt/css.js
+++ b/src/adapt/css.js
@@ -863,6 +863,16 @@ adapt.css.toNumber = function(val, context) {
 	return 0;
 };
 
+/**
+ * Convert numeric value to px
+ * @param {!adapt.css.Val} val
+ * @param {adapt.expr.Context} context
+ * @returns {!adapt.css.Numeric}
+ */
+adapt.css.convertNumericToPx = function(val, context) {
+    return new adapt.css.Numeric(adapt.css.toNumber(val, context), "px");
+};
+
 
 /**
  * @const

--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -228,6 +228,22 @@ adapt.expr.defaultUnitSizes = {
 };
 
 /**
+ * Returns if a unit should be converted to px before applied to the raw DOM.
+ * @param {string} unit
+ * @returns {boolean}
+ */
+adapt.expr.needUnitConversion = function(unit) {
+    switch (unit) {
+        case "q":
+        case "rem":
+        case "rex":
+            return true;
+        default:
+            return false;
+    }
+};
+
+/**
  * @typedef {Object.<string,adapt.expr.Result>}
  */
 adapt.expr.ScopeContext;

--- a/src/adapt/pm.js
+++ b/src/adapt/pm.js
@@ -912,8 +912,12 @@ adapt.pm.PageBoxInstance.prototype.getActiveRegions = function(context) {
  */
 adapt.pm.PageBoxInstance.prototype.propagateProperty = function(context, container, name) {
     var val = this.getProp(context, name);
-    if (val)
+    if (val) {
+        if (val.isNumeric() && adapt.expr.needUnitConversion(val.unit)) {
+            val = adapt.css.convertNumericToPx(val, context);
+        }
         adapt.base.setCSSProperty(container.element, name, val.toString());
+    }
 };
 
 /**

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -1104,9 +1104,9 @@ adapt.vgen.ViewFactory.prototype.applyComputedStyles = function(target, computed
 				continue;
 			}
 		}
-		if (value.isNumeric() && (value.unit === "rem" || value.unit === "q")) {
+		if (value.isNumeric() && adapt.expr.needUnitConversion(value.unit)) {
 			// font-size for the root element is already converted to px
-			value = new adapt.css.Numeric(adapt.css.toNumber(value, this.context), "px");
+			value = adapt.css.convertNumericToPx(value, this.context);
 		}
 	    adapt.base.setCSSProperty(target, propName, value.toString());
 	}	

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -14,6 +14,7 @@
     <li><a href="attr_selectors.html">Attribute selectors</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/attr_selectors.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/attr_selectors.html">prod</a>]</li>
     <li><a href="ruby-broken-pagination.html">Ruby broken pagination</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/ruby-broken-pagination.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/ruby-broken-pagination.html">prod</a>]</li>
     <li><a href="css-parse-error/gradient-background-image.html">Gradient background-image</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/css-parse-error/gradient-background-image.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/css-parse-error/gradient-background-image.html">prod</a>]</li>
+    <li><a href="rem_in_page_margin.html">rem in page margin</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/rem_in_page_margin.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/rem_in_page_margin.html">prod</a>]</li>
 </ul>
 </body>
 </html>

--- a/test/files/rem_in_page_margin.html
+++ b/test/files/rem_in_page_margin.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>rem in page margin</title>
+    <style>
+        @page {
+            margin-top: 50px;
+            @top-left {
+                font-size: 2rem;
+                content: "This should be rendered with 2rem(=20px) font too.";
+            }
+        }
+        :root {
+            font-size: 10px;
+        }
+        span {
+            font-size: 2rem;
+        }
+    </style>
+</head>
+<body>
+<span>This text is rendered with 2rem(=20px) font.</span>
+</body>
+</html>


### PR DESCRIPTION
- Issue: #109
- This fix only addresses a case where the value is a simple length value.
  If the property value contains a rem length as a part (e.g. space-delimited list of length), the value is not converted.
