### PR TITLE
Apply web fonts correctly to content of page margin boxes

### DIFF
--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -472,7 +472,7 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
     parentContainer.insertBefore(boxContainer, parentContainer.firstChild);
     var layoutContainer = new adapt.vtree.Container(boxContainer);
     layoutContainer.vertical = boxInstance.vertical;
-    boxInstance.prepareContainer(self, layoutContainer, page);
+    boxInstance.prepareContainer(self, layoutContainer, page, self.faces);
     layoutContainer.originX = offsetX;
     layoutContainer.originY = offsetY;
     offsetX += layoutContainer.left + layoutContainer.marginLeft + layoutContainer.borderLeft;
@@ -485,13 +485,13 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
 			var innerContainer = self.viewport.document.createElement("span");
 			contentVal.visit(new adapt.vtree.ContentPropertyHandler(innerContainer, self));
 			boxContainer.appendChild(innerContainer);
-			boxInstance.transferContentProps(self, layoutContainer, page);
+			boxInstance.transferContentProps(self, layoutContainer, page, self.faces);
 		} else if (boxInstance.suppressEmptyBoxGeneration) {
 			parentContainer.removeChild(boxContainer);
 			removed = true;
 		}
 		if (!removed) {
-			boxInstance.finishContainer(self, layoutContainer, page, null, 1, self.clientLayout);
+			boxInstance.finishContainer(self, layoutContainer, page, null, 1, self.clientLayout, self.faces);
 		}
     	cont = adapt.task.newResult(true);
     } else if (!self.pageBreaks[flowName.toString()]) {
@@ -586,12 +586,12 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
         }).then(function() {
 	        layoutContainer.computedBlockSize = computedBlockSize;
 	        boxInstance.finishContainer(self, layoutContainer, page, region, 
-	        		columnCount, self.clientLayout);
+	        		columnCount, self.clientLayout, self.faces);
 	        innerFrame.finish(true);
         });
         cont = innerFrame.result();
     } else {
-        boxInstance.finishContainer(self, layoutContainer, page, null, 1, self.clientLayout);	    		
+        boxInstance.finishContainer(self, layoutContainer, page, null, 1, self.clientLayout, self.faces);
     	cont = adapt.task.newResult(true);
     }
     cont.then(function() {

--- a/src/adapt/pm.js
+++ b/src/adapt/pm.js
@@ -908,13 +908,17 @@ adapt.pm.PageBoxInstance.prototype.getActiveRegions = function(context) {
  * @param {adapt.expr.Context} context
  * @param {adapt.vtree.Container} container
  * @param {string} name
+ * @param {adapt.font.DocumentFaces} docFaces
  * @return {void}
  */
-adapt.pm.PageBoxInstance.prototype.propagateProperty = function(context, container, name) {
+adapt.pm.PageBoxInstance.prototype.propagateProperty = function(context, container, name, docFaces) {
     var val = this.getProp(context, name);
     if (val) {
         if (val.isNumeric() && adapt.expr.needUnitConversion(val.unit)) {
             val = adapt.css.convertNumericToPx(val, context);
+        }
+        if (name === "font-family") {
+            val = docFaces.filterFontFamily(val);
         }
         adapt.base.setCSSProperty(container.element, name, val.toString());
     }
@@ -1189,9 +1193,10 @@ adapt.pm.delayedProperties = [
  * @param {adapt.expr.Context} context
  * @param {adapt.vtree.Container} container
  * @param {adapt.vtree.Page} page
+ * @param {adapt.font.DocumentFaces} docFaces
  * @return {void}
  */
-adapt.pm.PageBoxInstance.prototype.prepareContainer = function(context, container, page) {
+adapt.pm.PageBoxInstance.prototype.prepareContainer = function(context, container, page, docFaces) {
 	if (!this.parentInstance || this.vertical != this.parentInstance.vertical) {
 		adapt.base.setCSSProperty(container.element, "writing-mode", (this.vertical ? "vertical-rl" : "horizontal-tb"));
 	}
@@ -1213,7 +1218,7 @@ adapt.pm.PageBoxInstance.prototype.prepareContainer = function(context, containe
         this.assignStartEndPosition(context, container);
     }
     for (var i = 0; i < adapt.pm.passPreProperties.length; i++) {
-        this.propagateProperty(context, container, adapt.pm.passPreProperties[i]);    	
+        this.propagateProperty(context, container, adapt.pm.passPreProperties[i], docFaces);
     }
 };
 
@@ -1221,11 +1226,12 @@ adapt.pm.PageBoxInstance.prototype.prepareContainer = function(context, containe
  * @param {adapt.expr.Context} context
  * @param {adapt.vtree.Container} container
  * @param {adapt.vtree.Page} page
+ * @param {adapt.font.DocumentFaces} docFaces
  * @return {void}
  */
-adapt.pm.PageBoxInstance.prototype.transferContentProps = function(context, container, page) {
+adapt.pm.PageBoxInstance.prototype.transferContentProps = function(context, container, page, docFaces) {
     for (var i = 0; i < adapt.pm.passContentProperties.length; i++) {
-        this.propagateProperty(context, container, adapt.pm.passContentProperties[i]);    	
+        this.propagateProperty(context, container, adapt.pm.passContentProperties[i], docFaces);
     }
 };
 
@@ -1236,10 +1242,11 @@ adapt.pm.PageBoxInstance.prototype.transferContentProps = function(context, cont
  * @param {adapt.vtree.Container} column (null when content comes from the content property)
  * @param {number} columnCount
  * @param {adapt.vtree.ClientLayout} clientLayout
+ * @param {adapt.font.DocumentFaces} docFaces
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.finishContainer = function(
-		context, container, page, column, columnCount, clientLayout) {
+		context, container, page, column, columnCount, clientLayout, docFaces) {
 	if (this.vertical)
 	    this.calculatedWidth = container.computedBlockSize + container.snapOffsetX;
 	else
@@ -1304,7 +1311,7 @@ adapt.pm.PageBoxInstance.prototype.finishContainer = function(
     	}
     }
     for (var i = 0; i < adapt.pm.passPostProperties.length; i++) {
-        this.propagateProperty(context, container, adapt.pm.passPostProperties[i]);    	
+        this.propagateProperty(context, container, adapt.pm.passPostProperties[i], docFaces);
     }
     for (var i = 0; i < adapt.pm.delayedProperties.length; i++) {
         this.propagateDelayedProperty(context, container, adapt.pm.delayedProperties[i], page.delayedItems);    	
@@ -1523,9 +1530,9 @@ adapt.pm.PartitionInstance.prototype.boxSpecificEnabled = function(enabled) {
 /**
  * @override
  */
-adapt.pm.PartitionInstance.prototype.prepareContainer = function(context, container, delayedItems) {
+adapt.pm.PartitionInstance.prototype.prepareContainer = function(context, container, delayedItems, docFaces) {
 	adapt.base.setCSSProperty(container.element, "overflow", "hidden");  // default value
-	adapt.pm.PageBoxInstance.prototype.prepareContainer.call(this, context, container, delayedItems);
+	adapt.pm.PageBoxInstance.prototype.prepareContainer.call(this, context, container, delayedItems, docFaces);
 };
 
 

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -1016,8 +1016,8 @@ vivliostyle.page.PageRuleMasterInstance.prototype.distributeAutoMarginBoxSizes =
 /**
  * @override
  */
-vivliostyle.page.PageRuleMasterInstance.prototype.prepareContainer = function(context, container, page) {
-    vivliostyle.page.PageRuleMasterInstance.superClass_.prepareContainer.call(this, context, container, page);
+vivliostyle.page.PageRuleMasterInstance.prototype.prepareContainer = function(context, container, page, docFaces) {
+    vivliostyle.page.PageRuleMasterInstance.superClass_.prepareContainer.call(this, context, container, page, docFaces);
     // Add an attribute to the element so that it can be refered from external style sheets.
     container.element.setAttribute("data-vivliostyle-page-box", true);
 };
@@ -1166,8 +1166,8 @@ vivliostyle.page.PageRulePartitionInstance.prototype.resolvePageBoxDimensions = 
 /**
  * @override
  */
-vivliostyle.page.PageRulePartitionInstance.prototype.prepareContainer = function(context, container, page) {
-    adapt.pm.PartitionInstance.prototype.prepareContainer.call(this, context, container, page);
+vivliostyle.page.PageRulePartitionInstance.prototype.prepareContainer = function(context, container, page, docFaces) {
+    adapt.pm.PartitionInstance.prototype.prepareContainer.call(this, context, container, page, docFaces);
     page.pageAreaElement = /** @type {HTMLElement} */ (container.element);
 };
 
@@ -1191,9 +1191,9 @@ goog.inherits(vivliostyle.page.PageMarginBoxPartitionInstance, adapt.pm.Partitio
 /**
  * @override
  */
-vivliostyle.page.PageMarginBoxPartitionInstance.prototype.prepareContainer = function(context, container, page) {
+vivliostyle.page.PageMarginBoxPartitionInstance.prototype.prepareContainer = function(context, container, page, docFaces) {
     this.applyVerticalAlign(context, container.element);
-    adapt.pm.PartitionInstance.prototype.prepareContainer.call(this, context, container, page);
+    adapt.pm.PartitionInstance.prototype.prepareContainer.call(this, context, container, page, docFaces);
 };
 
 /**
@@ -1405,9 +1405,9 @@ vivliostyle.page.PageMarginBoxPartitionInstance.prototype.initVertical = functio
  * @override
  */
 vivliostyle.page.PageMarginBoxPartitionInstance.prototype.finishContainer = function(
-    context, container, page, column, columnCount, clientLayout) {
+    context, container, page, column, columnCount, clientLayout, docFaces) {
     adapt.pm.PartitionInstance.prototype.finishContainer.call(this,
-        context, container, page, column, columnCount, clientLayout);
+        context, container, page, column, columnCount, clientLayout, docFaces);
 
     // finishContainer is called only when the margin box is generated.
     // In this case, store the generated container for the margin box in the page object.

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -15,6 +15,7 @@
     <li><a href="ruby-broken-pagination.html">Ruby broken pagination</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/ruby-broken-pagination.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/ruby-broken-pagination.html">prod</a>]</li>
     <li><a href="css-parse-error/gradient-background-image.html">Gradient background-image</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/css-parse-error/gradient-background-image.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/css-parse-error/gradient-background-image.html">prod</a>]</li>
     <li><a href="rem_in_page_margin.html">rem in page margin</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/rem_in_page_margin.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/rem_in_page_margin.html">prod</a>]</li>
+    <li><a href="web_font_in_page_margin.html">Web font in page margin</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/web_font_in_page_margin.html">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/web_font_in_page_margin.html">prod</a>]</li>
 </ul>
 </body>
 </html>

--- a/test/files/web_font_in_page_margin.html
+++ b/test/files/web_font_in_page_margin.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Web font in page margin</title>
+    <style>
+        @font-face {
+            font-family: "foo";
+            src: local(Georgia);
+        }
+        @page {
+            @top-left {
+                font-family: "foo";
+                content: "This should be rendered with Georgia too.";
+            }
+        }
+        span {
+            font-family: "foo";
+        }
+    </style>
+</head>
+<body>
+<span>This text is rendered with Georgia.</span>
+</body>
+</html>


### PR DESCRIPTION
- Issue: #58
- This fix also applies to cases where `content` property is specified to Adaptive Layout partitions.
