### PR TITLE
Support printer marks ('marks' property) and bleed area ('bleed' property)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Support even/odd arguments for :nth-child selector
   - <https://github.com/vivliostyle/vivliostyle.js/issues/87>
   - Spec: [Selectors Level 3 - :nth-child() pseudo-class](http://www.w3.org/TR/css3-selectors/#nth-child-pseudo)
-- Support Printer marks (`marks` property) and bleed area (`bleed` property)
-  - <https://github.com/vivliostyle/vivliostyle.js/issues/169>
+- Support printer marks (`marks` property) and bleed area (`bleed` property)
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/98>
   - Spec: [CSS Paged Media Module Level 3 - Crop and Registration Marks: the 'marks' property](https://drafts.csswg.org/css-page/#marks), [Bleed Area: the 'bleed' property](https://drafts.csswg.org/css-page/#bleed)
   - Only effective when specified within an `@page` rule without page selectors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Support even/odd arguments for :nth-child selector
   - <https://github.com/vivliostyle/vivliostyle.js/issues/87>
   - Spec: [Selectors Level 3 - :nth-child() pseudo-class](http://www.w3.org/TR/css3-selectors/#nth-child-pseudo)
+- Support Printer marks (`marks` property) and bleed area (`bleed` property)
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/169>
+  - Spec: [CSS Paged Media Module Level 3 - Crop and Registration Marks: the 'marks' property](https://drafts.csswg.org/css-page/#marks), [Bleed Area: the 'bleed' property](https://drafts.csswg.org/css-page/#bleed)
+  - Only effective when specified within an `@page` rule without page selectors.
 
 ### Fixed
 - Lengths in 'rem' specified within page context are now interpreted correctly.

--- a/doc/property-doc-generated.md
+++ b/doc/property-doc-generated.md
@@ -1,2061 +1,2056 @@
-## [CSS 2.1](http://www.w3.org/TR/CSS21/)
-- [azimuth](http://www.w3.org/TR/CSS21/aural.html#propdef-azimuth)
+## [CSS 2.1](https://www.w3.org/TR/CSS21/)
+- [azimuth](https://www.w3.org/TR/CSS21/aural.html#propdef-azimuth)
   - TR
-      - [CSS 2.1 - azimuth](http://www.w3.org/TR/CSS21/aural.html#propdef-azimuth)
+      - [CSS 2.1 - azimuth](https://www.w3.org/TR/CSS21/aural.html#propdef-azimuth)
   - Drafts
       - [CSS 2.1 - azimuth](https://drafts.csswg.org/css2/aural.html#propdef-azimuth)
   - Values: `ANGLE | [[ left-side | far-left | left | center-left | center | center-right | right | far-right | right-side ] || behind ] | leftwards | rightwards;`
-- [background](http://www.w3.org/TR/CSS21/colors.html#propdef-background)
+- [background](https://www.w3.org/TR/CSS21/colors.html#propdef-background)
   - TR
-      - [CSS 2.1 - background](http://www.w3.org/TR/CSS21/colors.html#propdef-background)
-      - [CSS Backgrounds 3 - background](http://www.w3.org/TR/css3-background/#background)
+      - [CSS 2.1 - background](https://www.w3.org/TR/CSS21/colors.html#propdef-background)
+      - [CSS Backgrounds 3 - background](https://www.w3.org/TR/css3-background/#background)
   - Drafts
       - [CSS 2.1 - background](https://drafts.csswg.org/css2/colors.html#propdef-background)
       - [CSS Backgrounds 3 - background](https://drafts.csswg.org/css-backgrounds-3/#background)
   - Values: `COMMA background-image [background-position [ / background-size ]] background-repeat background-attachment [background-origin background-clip] background-color; /* background-color is a special case, see the code */`
-- [background-attachment](http://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
+- [background-attachment](https://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
   - TR
-      - [CSS 2.1 - background-attachment](http://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
-      - [CSS Backgrounds 3 - background-attachment](http://www.w3.org/TR/css3-background/#background-attachment)
+      - [CSS 2.1 - background-attachment](https://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
+      - [CSS Backgrounds 3 - background-attachment](https://www.w3.org/TR/css3-background/#background-attachment)
   - Drafts
       - [CSS 2.1 - background-attachment](https://drafts.csswg.org/css2/colors.html#propdef-background-attachment)
       - [CSS Backgrounds 3 - background-attachment](https://drafts.csswg.org/css-backgrounds-3/#background-attachment)
   - Values: `COMMA( [scroll | fixed | local]+ );`
-- [background-color](http://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
+- [background-color](https://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
   - TR
-      - [CSS 2.1 - background-color](http://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
-      - [CSS Backgrounds 3 - background-color](http://www.w3.org/TR/css3-background/#background-color)
+      - [CSS 2.1 - background-color](https://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
+      - [CSS Backgrounds 3 - background-color](https://www.w3.org/TR/css3-background/#background-color)
   - Drafts
       - [CSS 2.1 - background-color](https://drafts.csswg.org/css2/colors.html#propdef-background-color)
       - [CSS Backgrounds 3 - background-color](https://drafts.csswg.org/css-backgrounds-3/#background-color)
   - Values: `COLOR;`
-- [background-image](http://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
+- [background-image](https://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
   - TR
-      - [CSS 2.1 - background-image](http://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
-      - [CSS Backgrounds 3 - background-image](http://www.w3.org/TR/css3-background/#background-image)
+      - [CSS 2.1 - background-image](https://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
+      - [CSS Backgrounds 3 - background-image](https://www.w3.org/TR/css3-background/#background-image)
   - Drafts
       - [CSS 2.1 - background-image](https://drafts.csswg.org/css2/colors.html#propdef-background-image)
       - [CSS Backgrounds 3 - background-image](https://drafts.csswg.org/css-backgrounds-3/#background-image)
   - Values: `COMMA( URI_OR_NONE+ );`
-- [background-position](http://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
+- [background-position](https://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
   - TR
-      - [CSS 2.1 - background-position](http://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
-      - [CSS Backgrounds 3 - background-position](http://www.w3.org/TR/css3-background/#background-position)
+      - [CSS 2.1 - background-position](https://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
+      - [CSS Backgrounds 3 - background-position](https://www.w3.org/TR/css3-background/#background-position)
   - Drafts
       - [CSS 2.1 - background-position](https://drafts.csswg.org/css2/colors.html#propdef-background-position)
       - [CSS Backgrounds 3 - background-position](https://drafts.csswg.org/css-backgrounds-3/#background-position)
       - [CSS Backgrounds 4 - background-position](https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position)
   - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
-- [background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
+- [background-repeat](https://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
   - TR
-      - [CSS 2.1 - background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
-      - [CSS Backgrounds 3 - background-repeat](http://www.w3.org/TR/css3-background/#background-repeat)
+      - [CSS 2.1 - background-repeat](https://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
+      - [CSS Backgrounds 3 - background-repeat](https://www.w3.org/TR/css3-background/#background-repeat)
   - Drafts
       - [CSS 2.1 - background-repeat](https://drafts.csswg.org/css2/colors.html#propdef-background-repeat)
       - [CSS Backgrounds 3 - background-repeat](https://drafts.csswg.org/css-backgrounds-3/#background-repeat)
   - Values: `COMMA( [repeat | repeat-x | repeat-y | no-repeat]+ );`
-- [border](http://www.w3.org/TR/CSS21/box.html#propdef-border)
+- [border](https://www.w3.org/TR/CSS21/box.html#propdef-border)
   - TR
-      - [CSS 2.1 - border](http://www.w3.org/TR/CSS21/box.html#propdef-border)
-      - [CSS Backgrounds 3 - border](http://www.w3.org/TR/css3-background/#border)
+      - [CSS 2.1 - border](https://www.w3.org/TR/CSS21/box.html#propdef-border)
+      - [CSS Backgrounds 3 - border](https://www.w3.org/TR/css3-background/#border)
   - Drafts
       - [CSS 2.1 - border](https://drafts.csswg.org/css2/box.html#propdef-border)
       - [CSS Backgrounds 3 - border](https://drafts.csswg.org/css-backgrounds-3/#border)
   - Values: `border-width border-style border-color;`
-- [border-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
+- [border-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
   - TR
-      - [CSS 2.1 - border-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
-      - [CSS Backgrounds 3 - border-bottom](http://www.w3.org/TR/css3-background/#border-bottom)
+      - [CSS 2.1 - border-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
+      - [CSS Backgrounds 3 - border-bottom](https://www.w3.org/TR/css3-background/#border-bottom)
   - Drafts
       - [CSS 2.1 - border-bottom](https://drafts.csswg.org/css2/box.html#propdef-border-bottom)
       - [CSS Backgrounds 3 - border-bottom](https://drafts.csswg.org/css-backgrounds-3/#border-bottom)
   - Values: `border-bottom-width border-bottom-style border-bottom-color;`
-- [border-bottom-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
+- [border-bottom-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
   - TR
-      - [CSS 2.1 - border-bottom-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
-      - [CSS Backgrounds 3 - border-bottom-color](http://www.w3.org/TR/css3-background/#border-bottom-color)
+      - [CSS 2.1 - border-bottom-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
+      - [CSS Backgrounds 3 - border-bottom-color](https://www.w3.org/TR/css3-background/#border-bottom-color)
   - Drafts
       - [CSS 2.1 - border-bottom-color](https://drafts.csswg.org/css2/box.html#propdef-border-bottom-color)
       - [CSS Backgrounds 3 - border-bottom-color](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-bottom-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
+- [border-bottom-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
   - TR
-      - [CSS 2.1 - border-bottom-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
-      - [CSS Backgrounds 3 - border-bottom-style](http://www.w3.org/TR/css3-background/#border-bottom-style)
+      - [CSS 2.1 - border-bottom-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
+      - [CSS Backgrounds 3 - border-bottom-style](https://www.w3.org/TR/css3-background/#border-bottom-style)
   - Drafts
       - [CSS 2.1 - border-bottom-style](https://drafts.csswg.org/css2/box.html#propdef-border-bottom-style)
       - [CSS Backgrounds 3 - border-bottom-style](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-bottom-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
+- [border-bottom-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
   - TR
-      - [CSS 2.1 - border-bottom-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
-      - [CSS Backgrounds 3 - border-bottom-width](http://www.w3.org/TR/css3-background/#border-bottom-width)
+      - [CSS 2.1 - border-bottom-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
+      - [CSS Backgrounds 3 - border-bottom-width](https://www.w3.org/TR/css3-background/#border-bottom-width)
   - Drafts
       - [CSS 2.1 - border-bottom-width](https://drafts.csswg.org/css2/box.html#propdef-border-bottom-width)
       - [CSS Backgrounds 3 - border-bottom-width](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-collapse](http://www.w3.org/TR/CSS21/tables.html#propdef-border-collapse)
+- [border-collapse](https://www.w3.org/TR/CSS21/tables.html#propdef-border-collapse)
   - TR
-      - [CSS 2.1 - border-collapse](http://www.w3.org/TR/CSS21/tables.html#propdef-border-collapse)
+      - [CSS 2.1 - border-collapse](https://www.w3.org/TR/CSS21/tables.html#propdef-border-collapse)
   - Drafts
-      - [CSS Tables 3 - border-collapse](https://drafts.csswg.org/css3-tables/#border-collapse)
-      - [CSS Tables 3 - border-collapse](https://drafts.csswg.org/css3-tables/??#border-collapse)
+      - [CSS Tables 3 - border-collapse](https://drafts.csswg.org/css-tables-3/#propdef-border-collapse)
       - [CSS 2.1 - border-collapse](https://drafts.csswg.org/css2/tables.html#propdef-border-collapse)
   - Values: `collapse | separate;`
-- [border-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-color)
+- [border-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-color)
   - TR
-      - [CSS 2.1 - border-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-color)
-      - [CSS Backgrounds 3 - border-color](http://www.w3.org/TR/css3-background/#border-color)
+      - [CSS 2.1 - border-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-color)
+      - [CSS Backgrounds 3 - border-color](https://www.w3.org/TR/css3-background/#border-color)
   - Drafts
       - [CSS 2.1 - border-color](https://drafts.csswg.org/css2/box.html#propdef-border-color)
       - [CSS Backgrounds 3 - border-color](https://drafts.csswg.org/css-backgrounds-3/#border-color)
   - Values: `INSETS border-top-color border-right-color border-bottom-color border-left-color;`
-- [border-left](http://www.w3.org/TR/CSS21/box.html#propdef-border-left)
+- [border-left](https://www.w3.org/TR/CSS21/box.html#propdef-border-left)
   - TR
-      - [CSS 2.1 - border-left](http://www.w3.org/TR/CSS21/box.html#propdef-border-left)
-      - [CSS Backgrounds 3 - border-left](http://www.w3.org/TR/css3-background/#border-left)
+      - [CSS 2.1 - border-left](https://www.w3.org/TR/CSS21/box.html#propdef-border-left)
+      - [CSS Backgrounds 3 - border-left](https://www.w3.org/TR/css3-background/#border-left)
   - Drafts
       - [CSS 2.1 - border-left](https://drafts.csswg.org/css2/box.html#propdef-border-left)
       - [CSS Backgrounds 3 - border-left](https://drafts.csswg.org/css-backgrounds-3/#border-left)
   - Values: `border-left-width border-left-style border-left-color;`
-- [border-left-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
+- [border-left-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
   - TR
-      - [CSS 2.1 - border-left-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
-      - [CSS Backgrounds 3 - border-left-color](http://www.w3.org/TR/css3-background/#border-left-color)
+      - [CSS 2.1 - border-left-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
+      - [CSS Backgrounds 3 - border-left-color](https://www.w3.org/TR/css3-background/#border-left-color)
   - Drafts
       - [CSS 2.1 - border-left-color](https://drafts.csswg.org/css2/box.html#propdef-border-left-color)
       - [CSS Backgrounds 3 - border-left-color](https://drafts.csswg.org/css-backgrounds-3/#border-left-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-left-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
+- [border-left-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
   - TR
-      - [CSS 2.1 - border-left-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
-      - [CSS Backgrounds 3 - border-left-style](http://www.w3.org/TR/css3-background/#border-left-style)
+      - [CSS 2.1 - border-left-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
+      - [CSS Backgrounds 3 - border-left-style](https://www.w3.org/TR/css3-background/#border-left-style)
   - Drafts
       - [CSS 2.1 - border-left-style](https://drafts.csswg.org/css2/box.html#propdef-border-left-style)
       - [CSS Backgrounds 3 - border-left-style](https://drafts.csswg.org/css-backgrounds-3/#border-left-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-left-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
+- [border-left-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
   - TR
-      - [CSS 2.1 - border-left-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
-      - [CSS Backgrounds 3 - border-left-width](http://www.w3.org/TR/css3-background/#border-left-width)
+      - [CSS 2.1 - border-left-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
+      - [CSS Backgrounds 3 - border-left-width](https://www.w3.org/TR/css3-background/#border-left-width)
   - Drafts
       - [CSS 2.1 - border-left-width](https://drafts.csswg.org/css2/box.html#propdef-border-left-width)
       - [CSS Backgrounds 3 - border-left-width](https://drafts.csswg.org/css-backgrounds-3/#border-left-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-right](http://www.w3.org/TR/CSS21/box.html#propdef-border-right)
+- [border-right](https://www.w3.org/TR/CSS21/box.html#propdef-border-right)
   - TR
-      - [CSS 2.1 - border-right](http://www.w3.org/TR/CSS21/box.html#propdef-border-right)
-      - [CSS Backgrounds 3 - border-right](http://www.w3.org/TR/css3-background/#border-right)
+      - [CSS 2.1 - border-right](https://www.w3.org/TR/CSS21/box.html#propdef-border-right)
+      - [CSS Backgrounds 3 - border-right](https://www.w3.org/TR/css3-background/#border-right)
   - Drafts
       - [CSS 2.1 - border-right](https://drafts.csswg.org/css2/box.html#propdef-border-right)
       - [CSS Backgrounds 3 - border-right](https://drafts.csswg.org/css-backgrounds-3/#border-right)
   - Values: `border-right-width border-right-style border-right-color;`
-- [border-right-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
+- [border-right-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
   - TR
-      - [CSS 2.1 - border-right-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
-      - [CSS Backgrounds 3 - border-right-color](http://www.w3.org/TR/css3-background/#border-right-color)
+      - [CSS 2.1 - border-right-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
+      - [CSS Backgrounds 3 - border-right-color](https://www.w3.org/TR/css3-background/#border-right-color)
   - Drafts
       - [CSS 2.1 - border-right-color](https://drafts.csswg.org/css2/box.html#propdef-border-right-color)
       - [CSS Backgrounds 3 - border-right-color](https://drafts.csswg.org/css-backgrounds-3/#border-right-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-right-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
+- [border-right-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
   - TR
-      - [CSS 2.1 - border-right-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
-      - [CSS Backgrounds 3 - border-right-style](http://www.w3.org/TR/css3-background/#border-right-style)
+      - [CSS 2.1 - border-right-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
+      - [CSS Backgrounds 3 - border-right-style](https://www.w3.org/TR/css3-background/#border-right-style)
   - Drafts
       - [CSS 2.1 - border-right-style](https://drafts.csswg.org/css2/box.html#propdef-border-right-style)
       - [CSS Backgrounds 3 - border-right-style](https://drafts.csswg.org/css-backgrounds-3/#border-right-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-right-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
+- [border-right-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
   - TR
-      - [CSS 2.1 - border-right-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
-      - [CSS Backgrounds 3 - border-right-width](http://www.w3.org/TR/css3-background/#border-right-width)
+      - [CSS 2.1 - border-right-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
+      - [CSS Backgrounds 3 - border-right-width](https://www.w3.org/TR/css3-background/#border-right-width)
   - Drafts
       - [CSS 2.1 - border-right-width](https://drafts.csswg.org/css2/box.html#propdef-border-right-width)
       - [CSS Backgrounds 3 - border-right-width](https://drafts.csswg.org/css-backgrounds-3/#border-right-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-spacing](http://www.w3.org/TR/CSS21/tables.html#propdef-border-spacing)
+- [border-spacing](https://www.w3.org/TR/CSS21/tables.html#propdef-border-spacing)
   - TR
-      - [CSS 2.1 - border-spacing](http://www.w3.org/TR/CSS21/tables.html#propdef-border-spacing)
+      - [CSS 2.1 - border-spacing](https://www.w3.org/TR/CSS21/tables.html#propdef-border-spacing)
   - Drafts
-      - [CSS Tables 3 - border-spacing](https://drafts.csswg.org/css3-tables/#border-spacing)
-      - [CSS Tables 3 - border-spacing](https://drafts.csswg.org/css3-tables/??#border-spacing)
+      - [CSS Tables 3 - border-spacing](https://drafts.csswg.org/css-tables-3/#propdef-border-spacing)
       - [CSS 2.1 - border-spacing](https://drafts.csswg.org/css2/tables.html#propdef-border-spacing)
   - Values: `LENGTH LENGTH?;`
-- [border-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-style)
+- [border-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-style)
   - TR
-      - [CSS 2.1 - border-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-style)
-      - [CSS Backgrounds 3 - border-style](http://www.w3.org/TR/css3-background/#border-style)
+      - [CSS 2.1 - border-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-style)
+      - [CSS Backgrounds 3 - border-style](https://www.w3.org/TR/css3-background/#border-style)
   - Drafts
       - [CSS 2.1 - border-style](https://drafts.csswg.org/css2/box.html#propdef-border-style)
       - [CSS Backgrounds 3 - border-style](https://drafts.csswg.org/css-backgrounds-3/#border-style)
   - Values: `INSETS border-top-style border-right-style border-bottom-style border-left-style;`
-- [border-top](http://www.w3.org/TR/CSS21/box.html#propdef-border-top)
+- [border-top](https://www.w3.org/TR/CSS21/box.html#propdef-border-top)
   - TR
-      - [CSS 2.1 - border-top](http://www.w3.org/TR/CSS21/box.html#propdef-border-top)
-      - [CSS Backgrounds 3 - border-top](http://www.w3.org/TR/css3-background/#border-top)
+      - [CSS 2.1 - border-top](https://www.w3.org/TR/CSS21/box.html#propdef-border-top)
+      - [CSS Backgrounds 3 - border-top](https://www.w3.org/TR/css3-background/#border-top)
   - Drafts
       - [CSS 2.1 - border-top](https://drafts.csswg.org/css2/box.html#propdef-border-top)
       - [CSS Backgrounds 3 - border-top](https://drafts.csswg.org/css-backgrounds-3/#border-top)
   - Values: `border-top-width border-top-style border-top-color;`
-- [border-top-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
+- [border-top-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
   - TR
-      - [CSS 2.1 - border-top-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
-      - [CSS Backgrounds 3 - border-top-color](http://www.w3.org/TR/css3-background/#border-top-color)
+      - [CSS 2.1 - border-top-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
+      - [CSS Backgrounds 3 - border-top-color](https://www.w3.org/TR/css3-background/#border-top-color)
   - Drafts
       - [CSS 2.1 - border-top-color](https://drafts.csswg.org/css2/box.html#propdef-border-top-color)
       - [CSS Backgrounds 3 - border-top-color](https://drafts.csswg.org/css-backgrounds-3/#border-top-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-top-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
+- [border-top-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
   - TR
-      - [CSS 2.1 - border-top-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
-      - [CSS Backgrounds 3 - border-top-style](http://www.w3.org/TR/css3-background/#border-top-style)
+      - [CSS 2.1 - border-top-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
+      - [CSS Backgrounds 3 - border-top-style](https://www.w3.org/TR/css3-background/#border-top-style)
   - Drafts
       - [CSS 2.1 - border-top-style](https://drafts.csswg.org/css2/box.html#propdef-border-top-style)
       - [CSS Backgrounds 3 - border-top-style](https://drafts.csswg.org/css-backgrounds-3/#border-top-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-top-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
+- [border-top-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
   - TR
-      - [CSS 2.1 - border-top-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
-      - [CSS Backgrounds 3 - border-top-width](http://www.w3.org/TR/css3-background/#border-top-width)
+      - [CSS 2.1 - border-top-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
+      - [CSS Backgrounds 3 - border-top-width](https://www.w3.org/TR/css3-background/#border-top-width)
   - Drafts
       - [CSS 2.1 - border-top-width](https://drafts.csswg.org/css2/box.html#propdef-border-top-width)
       - [CSS Backgrounds 3 - border-top-width](https://drafts.csswg.org/css-backgrounds-3/#border-top-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-width)
+- [border-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-width)
   - TR
-      - [CSS 2.1 - border-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-width)
-      - [CSS Backgrounds 3 - border-width](http://www.w3.org/TR/css3-background/#border-width)
+      - [CSS 2.1 - border-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-width)
+      - [CSS Backgrounds 3 - border-width](https://www.w3.org/TR/css3-background/#border-width)
   - Drafts
       - [CSS 2.1 - border-width](https://drafts.csswg.org/css2/box.html#propdef-border-width)
       - [CSS Backgrounds 3 - border-width](https://drafts.csswg.org/css-backgrounds-3/#border-width)
   - Values: `INSETS border-top-width border-right-width border-bottom-width border-left-width;`
-- [bottom](http://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
+- [bottom](https://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
   - TR
-      - [CSS 2.1 - bottom](http://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
-      - [CSS Positioned Layout 3 - bottom](http://www.w3.org/TR/css3-positioning/#propdef-bottom)
+      - [CSS 2.1 - bottom](https://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
+      - [CSS Positioned Layout 3 - bottom](https://www.w3.org/TR/css3-positioning/#propdef-bottom)
   - Drafts
       - [CSS 2.1 - bottom](https://drafts.csswg.org/css2/visuren.html#propdef-bottom)
       - [CSS Positioned Layout 3 - bottom](https://drafts.csswg.org/css-position-3/#propdef-bottom)
   - Values: `APLENGTH;`
-- [caption-side](http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side)
+- [caption-side](https://www.w3.org/TR/CSS21/tables.html#propdef-caption-side)
   - TR
-      - [CSS 2.1 - caption-side](http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side)
+      - [CSS 2.1 - caption-side](https://www.w3.org/TR/CSS21/tables.html#propdef-caption-side)
   - Drafts
-      - [CSS Tables 3 - caption-side](https://drafts.csswg.org/css3-tables/#caption-side)
-      - [CSS Tables 3 - caption-side](https://drafts.csswg.org/css3-tables/??#caption-side)
+      - [CSS Tables 3 - caption-side](https://drafts.csswg.org/css-tables-3/#propdef-caption-side)
       - [CSS 2.1 - caption-side](https://drafts.csswg.org/css2/tables.html#propdef-caption-side)
   - Values: `top | bottom;`
-- [clear](http://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
+- [clear](https://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
   - TR
-      - [CSS 2.1 - clear](http://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
+      - [CSS 2.1 - clear](https://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
   - Drafts
       - [CSS 2.1 - clear](https://drafts.csswg.org/css2/visuren.html#propdef-clear)
       - [CSS Page Floats 3 - clear](https://drafts.csswg.org/css-page-floats-3/#propdef-clear)
   - Values: `none | left | right | both;`
-- [clip](http://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
+- [clip](https://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
   - TR
-      - [CSS 2.1 - clip](http://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
-      - [CSS Masking 1 - clip](http://www.w3.org/TR/css-masking-1/#propdef-clip)
+      - [CSS 2.1 - clip](https://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
+      - [CSS Masking 1 - clip](https://www.w3.org/TR/css-masking-1/#propdef-clip)
   - Drafts
       - [CSS 2.1 - clip](https://drafts.csswg.org/css2/visufx.html#propdef-clip)
       - [CSS Masking 1 - clip](https://drafts.fxtf.org/css-masking-1/#propdef-clip)
   - Values: `rect(ALENGTH{4}) | rect(SPACE(ALENGTH{4})) | auto;`
-- [color](http://www.w3.org/TR/CSS21/colors.html#propdef-color)
+- [color](https://www.w3.org/TR/CSS21/colors.html#propdef-color)
   - TR
-      - [CSS 2.1 - color](http://www.w3.org/TR/CSS21/colors.html#propdef-color)
-      - [CSS Color 3 - color](http://www.w3.org/TR/css3-color/#color0)
+      - [CSS 2.1 - color](https://www.w3.org/TR/CSS21/colors.html#propdef-color)
+      - [CSS Color 3 - color](https://www.w3.org/TR/css3-color/#color0)
   - Drafts
       - [CSS 2.1 - color](https://drafts.csswg.org/css2/colors.html#propdef-color)
       - [CSS Color 3 - color](https://drafts.csswg.org/css-color-3/#color0)
       - [CSS Color 4 - color](https://drafts.csswg.org/css-color-4/#propdef-color)
   - Values: `COLOR;`
-- [content](http://www.w3.org/TR/CSS21/generate.html#propdef-content)
+- [content](https://www.w3.org/TR/CSS21/generate.html#propdef-content)
   - TR
-      - [CSS 2.1 - content](http://www.w3.org/TR/CSS21/generate.html#propdef-content)
+      - [CSS 2.1 - content](https://www.w3.org/TR/CSS21/generate.html#propdef-content)
   - Drafts
       - [CSS Generated Content 3 - content](https://drafts.csswg.org/css-content-3/#propdef-content)
       - [CSS 2.1 - content](https://drafts.csswg.org/css2/generate.html#propdef-content)
   - Values: `CONTENT;`
-- [counter-increment](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
+- [counter-increment](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
   - TR
-      - [CSS 2.1 - counter-increment](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
-      - [CSS Lists 3 - counter-increment](http://www.w3.org/TR/css3-lists/#propdef-counter-increment)
+      - [CSS 2.1 - counter-increment](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
+      - [CSS Lists 3 - counter-increment](https://www.w3.org/TR/css3-lists/#propdef-counter-increment)
   - Drafts
       - [CSS 2.1 - counter-increment](https://drafts.csswg.org/css2/generate.html#propdef-counter-increment)
       - [CSS Lists 3 - counter-increment](https://drafts.csswg.org/css-lists-3/#propdef-counter-increment)
   - Values: `COUNTER;`
-- [counter-reset](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
+- [counter-reset](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
   - TR
-      - [CSS 2.1 - counter-reset](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
-      - [CSS Lists 3 - counter-reset](http://www.w3.org/TR/css3-lists/#propdef-counter-reset)
+      - [CSS 2.1 - counter-reset](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
+      - [CSS Lists 3 - counter-reset](https://www.w3.org/TR/css3-lists/#propdef-counter-reset)
   - Drafts
       - [CSS 2.1 - counter-reset](https://drafts.csswg.org/css2/generate.html#propdef-counter-reset)
       - [CSS Lists 3 - counter-reset](https://drafts.csswg.org/css-lists-3/#propdef-counter-reset)
   - Values: `COUNTER;`
-- [cue-after](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
+- [cue-after](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
   - TR
-      - [CSS 2.1 - cue-after](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
-      - [CSS Speech 1 - cue-after](http://www.w3.org/TR/css3-speech/#cue-after)
+      - [CSS 2.1 - cue-after](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
+      - [CSS Speech 1 - cue-after](https://www.w3.org/TR/css3-speech/#cue-after)
   - Drafts
       - [CSS 2.1 - cue-after](https://drafts.csswg.org/css2/aural.html#propdef-cue-after)
       - [CSS Speech 1 - cue-after](https://drafts.csswg.org/css-speech-1/#cue-after)
   - Values: `URI_OR_NONE;`
-- [cue-before](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
+- [cue-before](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
   - TR
-      - [CSS 2.1 - cue-before](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
-      - [CSS Speech 1 - cue-before](http://www.w3.org/TR/css3-speech/#cue-before)
+      - [CSS 2.1 - cue-before](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
+      - [CSS Speech 1 - cue-before](https://www.w3.org/TR/css3-speech/#cue-before)
   - Drafts
       - [CSS 2.1 - cue-before](https://drafts.csswg.org/css2/aural.html#propdef-cue-before)
       - [CSS Speech 1 - cue-before](https://drafts.csswg.org/css-speech-1/#cue-before)
   - Values: `URI_OR_NONE;`
-- [cursor](http://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
+- [cursor](https://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
   - TR
-      - [CSS 2.1 - cursor](http://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
-      - [CSS User Interface 3 - cursor](http://www.w3.org/TR/css3-ui/#propdef-cursor)
+      - [CSS 2.1 - cursor](https://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
+      - [CSS User Interface 3 - cursor](https://www.w3.org/TR/css3-ui/#propdef-cursor)
   - Drafts
       - [CSS 2.1 - cursor](https://drafts.csswg.org/css2/ui.html#propdef-cursor)
       - [CSS User Interface 3 - cursor](https://drafts.csswg.org/css-ui-3/#propdef-cursor)
   - Values: `COMMA(URI* [ auto | crosshair | default | pointer | move | e-resize | ne-resize | nw-resize | n-resize | se-resize | sw-resize | s-resize | w-resize | text | wait | help | progress ]);`
-- [direction](http://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
+- [direction](https://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
   - TR
-      - [CSS 2.1 - direction](http://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
-      - [CSS Writing Modes 3 - direction](http://www.w3.org/TR/css-writing-modes-3/#propdef-direction)
+      - [CSS 2.1 - direction](https://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
+      - [CSS Writing Modes 3 - direction](https://www.w3.org/TR/css-writing-modes-3/#propdef-direction)
   - Drafts
       - [CSS 2.1 - direction](https://drafts.csswg.org/css2/visuren.html#propdef-direction)
       - [CSS Writing Modes 3 - direction](https://drafts.csswg.org/css-writing-modes-3/#propdef-direction)
   - Values: `ltr | rtl;`
-- [display](http://www.w3.org/TR/CSS21/visuren.html#propdef-display)
+- [display](https://www.w3.org/TR/CSS21/visuren.html#propdef-display)
   - TR
-      - [CSS 2.1 - display](http://www.w3.org/TR/CSS21/visuren.html#propdef-display)
-      - [CSS Ruby 1 - display](http://www.w3.org/TR/css-ruby-1/#propdef-display)
+      - [CSS 2.1 - display](https://www.w3.org/TR/CSS21/visuren.html#propdef-display)
+      - [CSS Ruby 1 - display](https://www.w3.org/TR/css-ruby-1/#propdef-display)
   - Drafts
       - [CSS Display 3 - display](https://drafts.csswg.org/css-display-3/#propdef-display)
       - [CSS 2.1 - display](https://drafts.csswg.org/css2/visuren.html#propdef-display)
       - [CSS Ruby 1 - display](https://drafts.csswg.org/css-ruby-1/#propdef-display)
   - Values: `inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex | ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container;`
-- [elevation](http://www.w3.org/TR/CSS21/aural.html#propdef-elevation)
+- [elevation](https://www.w3.org/TR/CSS21/aural.html#propdef-elevation)
   - TR
-      - [CSS 2.1 - elevation](http://www.w3.org/TR/CSS21/aural.html#propdef-elevation)
+      - [CSS 2.1 - elevation](https://www.w3.org/TR/CSS21/aural.html#propdef-elevation)
   - Drafts
       - [CSS 2.1 - elevation](https://drafts.csswg.org/css2/aural.html#propdef-elevation)
   - Values: `ANGLE | below | level | above | higher | lower;`
-- [empty-cells](http://www.w3.org/TR/CSS21/tables.html#propdef-empty-cells)
+- [empty-cells](https://www.w3.org/TR/CSS21/tables.html#propdef-empty-cells)
   - TR
-      - [CSS 2.1 - empty-cells](http://www.w3.org/TR/CSS21/tables.html#propdef-empty-cells)
+      - [CSS 2.1 - empty-cells](https://www.w3.org/TR/CSS21/tables.html#propdef-empty-cells)
   - Drafts
-      - [CSS Tables 3 - empty-cells](https://drafts.csswg.org/css3-tables/#empty-cells0)
-      - [CSS Tables 3 - empty-cells](https://drafts.csswg.org/css3-tables/??#empty-cells0)
+      - [CSS Tables 3 - empty-cells](https://drafts.csswg.org/css-tables-3/#propdef-empty-cells)
       - [CSS 2.1 - empty-cells](https://drafts.csswg.org/css2/tables.html#propdef-empty-cells)
   - Values: `show | hide;`
-- [float](http://www.w3.org/TR/CSS21/visuren.html#propdef-float)
+- [float](https://www.w3.org/TR/CSS21/visuren.html#propdef-float)
   - TR
-      - [CSS 2.1 - float](http://www.w3.org/TR/CSS21/visuren.html#propdef-float)
+      - [CSS 2.1 - float](https://www.w3.org/TR/CSS21/visuren.html#propdef-float)
   - Drafts
       - [CSS 2.1 - float](https://drafts.csswg.org/css2/visuren.html#propdef-float)
       - [CSS Page Floats 3 - float](https://drafts.csswg.org/css-page-floats-3/#propdef-float)
   - Values: `block-start | block-end | inline-start | inline-end | snap-block | snap-inline | left | right | top | bottom | none | footnote;`
-- [font](http://www.w3.org/TR/CSS21/fonts.html#propdef-font)
+- [font](https://www.w3.org/TR/CSS21/fonts.html#propdef-font)
   - TR
-      - [CSS 2.1 - font](http://www.w3.org/TR/CSS21/fonts.html#propdef-font)
-      - [CSS Fonts 3 - font](http://www.w3.org/TR/css-fonts-3/#propdef-font)
+      - [CSS 2.1 - font](https://www.w3.org/TR/CSS21/fonts.html#propdef-font)
+      - [CSS Fonts 3 - font](https://www.w3.org/TR/css-fonts-3/#propdef-font)
   - Drafts
       - [CSS 2.1 - font](https://drafts.csswg.org/css2/fonts.html#propdef-font)
       - [CSS Fonts 3 - font](https://drafts.csswg.org/css-fonts-3/#propdef-font)
   - Values: `FONT font-style font-variant font-weight /* font-size line-height font-family are special-cased */;`
-- [font-family](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
+- [font-family](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
   - TR
-      - [CSS 2.1 - font-family](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
-      - [CSS Fonts 3 - font-family](http://www.w3.org/TR/css-fonts-3/#propdef-font-family)
+      - [CSS 2.1 - font-family](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
+      - [CSS Fonts 3 - font-family](https://www.w3.org/TR/css-fonts-3/#propdef-font-family)
   - Drafts
       - [CSS 2.1 - font-family](https://drafts.csswg.org/css2/fonts.html#propdef-font-family)
       - [CSS Fonts 3 - font-family](https://drafts.csswg.org/css-fonts-3/#propdef-font-family)
   - Values: `FAMILY_LIST;`
-- [font-size](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
+- [font-size](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
   - TR
-      - [CSS 2.1 - font-size](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
-      - [CSS Fonts 3 - font-size](http://www.w3.org/TR/css-fonts-3/#propdef-font-size)
+      - [CSS 2.1 - font-size](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
+      - [CSS Fonts 3 - font-size](https://www.w3.org/TR/css-fonts-3/#propdef-font-size)
   - Drafts
       - [CSS 2.1 - font-size](https://drafts.csswg.org/css2/fonts.html#propdef-font-size)
       - [CSS Fonts 3 - font-size](https://drafts.csswg.org/css-fonts-3/#propdef-font-size)
   - Values: `xx-small | x-small | small | medium | large | x-large | xx-large | larger | smaller | PPLENGTH;`
-- [font-style](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
+- [font-style](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
   - TR
-      - [CSS 2.1 - font-style](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
-      - [CSS Fonts 3 - font-style](http://www.w3.org/TR/css-fonts-3/#propdef-font-style)
+      - [CSS 2.1 - font-style](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
+      - [CSS Fonts 3 - font-style](https://www.w3.org/TR/css-fonts-3/#propdef-font-style)
   - Drafts
       - [CSS 2.1 - font-style](https://drafts.csswg.org/css2/fonts.html#propdef-font-style)
       - [CSS Fonts 3 - font-style](https://drafts.csswg.org/css-fonts-3/#propdef-font-style)
   - Values: `normal | italic | oblique;`
-- [font-variant](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
+- [font-variant](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
   - TR
-      - [CSS 2.1 - font-variant](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
-      - [CSS Fonts 3 - font-variant](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant)
+      - [CSS 2.1 - font-variant](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
+      - [CSS Fonts 3 - font-variant](https://www.w3.org/TR/css-fonts-3/#propdef-font-variant)
   - Drafts
       - [CSS 2.1 - font-variant](https://drafts.csswg.org/css2/fonts.html#propdef-font-variant)
       - [CSS Fonts 3 - font-variant](https://drafts.csswg.org/css-fonts-3/#propdef-font-variant)
   - Values: `normal | small-caps;`
-- [font-weight](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
+- [font-weight](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
   - TR
-      - [CSS 2.1 - font-weight](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
-      - [CSS Fonts 3 - font-weight](http://www.w3.org/TR/css-fonts-3/#propdef-font-weight)
+      - [CSS 2.1 - font-weight](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
+      - [CSS Fonts 3 - font-weight](https://www.w3.org/TR/css-fonts-3/#propdef-font-weight)
   - Drafts
       - [CSS 2.1 - font-weight](https://drafts.csswg.org/css2/fonts.html#propdef-font-weight)
       - [CSS Fonts 3 - font-weight](https://drafts.csswg.org/css-fonts-3/#propdef-font-weight)
   - Values: `normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;`
-- [height](http://www.w3.org/TR/CSS21/visudet.html#propdef-height)
+- [height](https://www.w3.org/TR/CSS21/visudet.html#propdef-height)
   - TR
-      - [CSS 2.1 - height](http://www.w3.org/TR/CSS21/visudet.html#propdef-height)
+      - [CSS 2.1 - height](https://www.w3.org/TR/CSS21/visudet.html#propdef-height)
   - Drafts
       - [CSS 2.1 - height](https://drafts.csswg.org/css2/visudet.html#propdef-height)
   - Values: `PAPLENGTH;`
-- [left](http://www.w3.org/TR/CSS21/visuren.html#propdef-left)
+- [left](https://www.w3.org/TR/CSS21/visuren.html#propdef-left)
   - TR
-      - [CSS 2.1 - left](http://www.w3.org/TR/CSS21/visuren.html#propdef-left)
-      - [CSS Positioned Layout 3 - left](http://www.w3.org/TR/css3-positioning/#propdef-left)
+      - [CSS 2.1 - left](https://www.w3.org/TR/CSS21/visuren.html#propdef-left)
+      - [CSS Positioned Layout 3 - left](https://www.w3.org/TR/css3-positioning/#propdef-left)
   - Drafts
       - [CSS 2.1 - left](https://drafts.csswg.org/css2/visuren.html#propdef-left)
       - [CSS Positioned Layout 3 - left](https://drafts.csswg.org/css-position-3/#propdef-left)
   - Values: `APLENGTH;`
-- [letter-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
+- [letter-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
   - TR
-      - [CSS 2.1 - letter-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
-      - [CSS Text 3 - letter-spacing](http://www.w3.org/TR/css-text-3/#letter-spacing)
+      - [CSS 2.1 - letter-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
+      - [CSS Text 3 - letter-spacing](https://www.w3.org/TR/css-text-3/#letter-spacing)
   - Drafts
       - [CSS 2.1 - letter-spacing](https://drafts.csswg.org/css2/text.html#propdef-letter-spacing)
       - [CSS Text 3 - letter-spacing](https://drafts.csswg.org/css-text-3/#propdef-letter-spacing)
   - Values: `normal | LENGTH;`
-- [line-height](http://www.w3.org/TR/CSS21/visudet.html#propdef-line-height)
+- [line-height](https://www.w3.org/TR/CSS21/visudet.html#propdef-line-height)
   - TR
-      - [CSS 2.1 - line-height](http://www.w3.org/TR/CSS21/visudet.html#propdef-line-height)
+      - [CSS 2.1 - line-height](https://www.w3.org/TR/CSS21/visudet.html#propdef-line-height)
   - Drafts
       - [CSS 2.1 - line-height](https://drafts.csswg.org/css2/visudet.html#propdef-line-height)
   - Values: `normal | POS_NUM | PPLENGTH;`
-- [list-style](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
+- [list-style](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
   - TR
-      - [CSS 2.1 - list-style](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
-      - [CSS Lists 3 - list-style](http://www.w3.org/TR/css3-lists/#propdef-list-style)
+      - [CSS 2.1 - list-style](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
+      - [CSS Lists 3 - list-style](https://www.w3.org/TR/css3-lists/#propdef-list-style)
   - Drafts
       - [CSS 2.1 - list-style](https://drafts.csswg.org/css2/generate.html#propdef-list-style)
       - [CSS Lists 3 - list-style](https://drafts.csswg.org/css-lists-3/#propdef-list-style)
   - Values: `list-style-type list-style-position list-style-image;`
-- [list-style-image](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
+- [list-style-image](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
   - TR
-      - [CSS 2.1 - list-style-image](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
-      - [CSS Lists 3 - list-style-image](http://www.w3.org/TR/css3-lists/#propdef-list-style-image)
+      - [CSS 2.1 - list-style-image](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
+      - [CSS Lists 3 - list-style-image](https://www.w3.org/TR/css3-lists/#propdef-list-style-image)
   - Drafts
       - [CSS 2.1 - list-style-image](https://drafts.csswg.org/css2/generate.html#propdef-list-style-image)
       - [CSS Lists 3 - list-style-image](https://drafts.csswg.org/css-lists-3/#propdef-list-style-image)
   - Values: `URI_OR_NONE;`
-- [list-style-position](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
+- [list-style-position](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
   - TR
-      - [CSS 2.1 - list-style-position](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
-      - [CSS Lists 3 - list-style-position](http://www.w3.org/TR/css3-lists/#propdef-list-style-position)
+      - [CSS 2.1 - list-style-position](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
+      - [CSS Lists 3 - list-style-position](https://www.w3.org/TR/css3-lists/#propdef-list-style-position)
   - Drafts
       - [CSS 2.1 - list-style-position](https://drafts.csswg.org/css2/generate.html#propdef-list-style-position)
       - [CSS Lists 3 - list-style-position](https://drafts.csswg.org/css-lists-3/#propdef-list-style-position)
   - Values: `inside | outside;`
-- [list-style-type](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
+- [list-style-type](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
   - TR
-      - [CSS 2.1 - list-style-type](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
-      - [CSS Lists 3 - list-style-type](http://www.w3.org/TR/css3-lists/#propdef-list-style-type)
+      - [CSS 2.1 - list-style-type](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
+      - [CSS Lists 3 - list-style-type](https://www.w3.org/TR/css3-lists/#propdef-list-style-type)
   - Drafts
       - [CSS 2.1 - list-style-type](https://drafts.csswg.org/css2/generate.html#propdef-list-style-type)
       - [CSS Lists 3 - list-style-type](https://drafts.csswg.org/css-lists-3/#propdef-list-style-type)
   - Values: `LIST_STYLE_TYPE;`
-- [margin](http://www.w3.org/TR/CSS21/box.html#propdef-margin)
+- [margin](https://www.w3.org/TR/CSS21/box.html#propdef-margin)
   - TR
-      - [CSS 2.1 - margin](http://www.w3.org/TR/CSS21/box.html#propdef-margin)
+      - [CSS 2.1 - margin](https://www.w3.org/TR/CSS21/box.html#propdef-margin)
   - Drafts
       - [CSS 2.1 - margin](https://drafts.csswg.org/css2/box.html#propdef-margin)
   - Values: `INSETS margin-top margin-right margin-bottom margin-left;`
-- [margin-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-margin-bottom)
+- [margin-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-margin-bottom)
   - TR
-      - [CSS 2.1 - margin-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-margin-bottom)
+      - [CSS 2.1 - margin-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-margin-bottom)
   - Drafts
       - [CSS 2.1 - margin-bottom](https://drafts.csswg.org/css2/box.html#propdef-margin-bottom)
   - Values: `APLENGTH;`
-- [margin-left](http://www.w3.org/TR/CSS21/box.html#propdef-margin-left)
+- [margin-left](https://www.w3.org/TR/CSS21/box.html#propdef-margin-left)
   - TR
-      - [CSS 2.1 - margin-left](http://www.w3.org/TR/CSS21/box.html#propdef-margin-left)
+      - [CSS 2.1 - margin-left](https://www.w3.org/TR/CSS21/box.html#propdef-margin-left)
   - Drafts
       - [CSS 2.1 - margin-left](https://drafts.csswg.org/css2/box.html#propdef-margin-left)
   - Values: `APLENGTH;`
-- [margin-right](http://www.w3.org/TR/CSS21/box.html#propdef-margin-right)
+- [margin-right](https://www.w3.org/TR/CSS21/box.html#propdef-margin-right)
   - TR
-      - [CSS 2.1 - margin-right](http://www.w3.org/TR/CSS21/box.html#propdef-margin-right)
+      - [CSS 2.1 - margin-right](https://www.w3.org/TR/CSS21/box.html#propdef-margin-right)
   - Drafts
       - [CSS 2.1 - margin-right](https://drafts.csswg.org/css2/box.html#propdef-margin-right)
   - Values: `APLENGTH;`
-- [margin-top](http://www.w3.org/TR/CSS21/box.html#propdef-margin-top)
+- [margin-top](https://www.w3.org/TR/CSS21/box.html#propdef-margin-top)
   - TR
-      - [CSS 2.1 - margin-top](http://www.w3.org/TR/CSS21/box.html#propdef-margin-top)
+      - [CSS 2.1 - margin-top](https://www.w3.org/TR/CSS21/box.html#propdef-margin-top)
   - Drafts
       - [CSS 2.1 - margin-top](https://drafts.csswg.org/css2/box.html#propdef-margin-top)
   - Values: `APLENGTH;`
-- [max-height](http://www.w3.org/TR/CSS21/visudet.html#propdef-max-height)
+- [max-height](https://www.w3.org/TR/CSS21/visudet.html#propdef-max-height)
   - TR
-      - [CSS 2.1 - max-height](http://www.w3.org/TR/CSS21/visudet.html#propdef-max-height)
+      - [CSS 2.1 - max-height](https://www.w3.org/TR/CSS21/visudet.html#propdef-max-height)
   - Drafts
       - [CSS 2.1 - max-height](https://drafts.csswg.org/css2/visudet.html#propdef-max-height)
   - Values: `NPLENGTH;`
-- [max-width](http://www.w3.org/TR/CSS21/visudet.html#propdef-max-width)
+- [max-width](https://www.w3.org/TR/CSS21/visudet.html#propdef-max-width)
   - TR
-      - [CSS 2.1 - max-width](http://www.w3.org/TR/CSS21/visudet.html#propdef-max-width)
+      - [CSS 2.1 - max-width](https://www.w3.org/TR/CSS21/visudet.html#propdef-max-width)
   - Drafts
       - [CSS 2.1 - max-width](https://drafts.csswg.org/css2/visudet.html#propdef-max-width)
   - Values: `NPLENGTH;`
-- [min-height](http://www.w3.org/TR/CSS21/visudet.html#propdef-min-height)
+- [min-height](https://www.w3.org/TR/CSS21/visudet.html#propdef-min-height)
   - TR
-      - [CSS 2.1 - min-height](http://www.w3.org/TR/CSS21/visudet.html#propdef-min-height)
+      - [CSS 2.1 - min-height](https://www.w3.org/TR/CSS21/visudet.html#propdef-min-height)
   - Drafts
       - [CSS 2.1 - min-height](https://drafts.csswg.org/css2/visudet.html#propdef-min-height)
   - Values: `auto | PLENGTH;`
-- [min-width](http://www.w3.org/TR/CSS21/visudet.html#propdef-min-width)
+- [min-width](https://www.w3.org/TR/CSS21/visudet.html#propdef-min-width)
   - TR
-      - [CSS 2.1 - min-width](http://www.w3.org/TR/CSS21/visudet.html#propdef-min-width)
+      - [CSS 2.1 - min-width](https://www.w3.org/TR/CSS21/visudet.html#propdef-min-width)
   - Drafts
       - [CSS 2.1 - min-width](https://drafts.csswg.org/css2/visudet.html#propdef-min-width)
   - Values: `auto | PLENGTH;`
-- [orphans](http://www.w3.org/TR/CSS21/page.html#propdef-orphans)
+- [orphans](https://www.w3.org/TR/CSS21/page.html#propdef-orphans)
   - TR
-      - [CSS 2.1 - orphans](http://www.w3.org/TR/CSS21/page.html#propdef-orphans)
-      - [CSS Fragmentation 3 - orphans](http://www.w3.org/TR/css3-break/#orphans)
+      - [CSS 2.1 - orphans](https://www.w3.org/TR/CSS21/page.html#propdef-orphans)
+      - [CSS Fragmentation 3 - orphans](https://www.w3.org/TR/css3-break/#propdef-orphans)
   - Drafts
       - [CSS 2.1 - orphans](https://drafts.csswg.org/css2/page.html#propdef-orphans)
       - [CSS Fragmentation 3 - orphans](https://drafts.csswg.org/css-break-3/#propdef-orphans)
   - Values: `POS_INT;`
-- [outline](http://www.w3.org/TR/CSS21/ui.html#propdef-outline)
+- [outline](https://www.w3.org/TR/CSS21/ui.html#propdef-outline)
   - TR
-      - [CSS 2.1 - outline](http://www.w3.org/TR/CSS21/ui.html#propdef-outline)
-      - [CSS User Interface 3 - outline](http://www.w3.org/TR/css3-ui/#propdef-outline)
+      - [CSS 2.1 - outline](https://www.w3.org/TR/CSS21/ui.html#propdef-outline)
+      - [CSS User Interface 3 - outline](https://www.w3.org/TR/css3-ui/#propdef-outline)
   - Drafts
       - [CSS 2.1 - outline](https://drafts.csswg.org/css2/ui.html#propdef-outline)
       - [CSS User Interface 3 - outline](https://drafts.csswg.org/css-ui-3/#propdef-outline)
   - Values: `outline-width outline-style outline-color;`
-- [outline-color](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
+- [outline-color](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
   - TR
-      - [CSS 2.1 - outline-color](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
-      - [CSS User Interface 3 - outline-color](http://www.w3.org/TR/css3-ui/#propdef-outline-color)
+      - [CSS 2.1 - outline-color](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
+      - [CSS User Interface 3 - outline-color](https://www.w3.org/TR/css3-ui/#propdef-outline-color)
   - Drafts
       - [CSS 2.1 - outline-color](https://drafts.csswg.org/css2/ui.html#propdef-outline-color)
       - [CSS User Interface 3 - outline-color](https://drafts.csswg.org/css-ui-3/#propdef-outline-color)
   - Values: `COLOR | invert;`
-- [outline-style](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
+- [outline-style](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
   - TR
-      - [CSS 2.1 - outline-style](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
-      - [CSS User Interface 3 - outline-style](http://www.w3.org/TR/css3-ui/#propdef-outline-style)
+      - [CSS 2.1 - outline-style](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
+      - [CSS User Interface 3 - outline-style](https://www.w3.org/TR/css3-ui/#propdef-outline-style)
   - Drafts
       - [CSS 2.1 - outline-style](https://drafts.csswg.org/css2/ui.html#propdef-outline-style)
       - [CSS User Interface 3 - outline-style](https://drafts.csswg.org/css-ui-3/#propdef-outline-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [outline-width](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
+- [outline-width](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
   - TR
-      - [CSS 2.1 - outline-width](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
-      - [CSS User Interface 3 - outline-width](http://www.w3.org/TR/css3-ui/#propdef-outline-width)
+      - [CSS 2.1 - outline-width](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
+      - [CSS User Interface 3 - outline-width](https://www.w3.org/TR/css3-ui/#propdef-outline-width)
   - Drafts
       - [CSS 2.1 - outline-width](https://drafts.csswg.org/css2/ui.html#propdef-outline-width)
       - [CSS User Interface 3 - outline-width](https://drafts.csswg.org/css-ui-3/#propdef-outline-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [overflow](http://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
+- [overflow](https://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
   - TR
-      - [CSS 2.1 - overflow](http://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
-      - [CSS Overflow 3 - overflow](http://www.w3.org/TR/css-overflow-3/#overflow)
+      - [CSS 2.1 - overflow](https://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
+      - [CSS Overflow 3 - overflow](https://www.w3.org/TR/css-overflow-3/#overflow)
   - Drafts
+      - [CSS Overflow 4 - overflow](https://drafts.csswg.org/css-overflow-4/#propdef-overflow)
       - [CSS 2.1 - overflow](https://drafts.csswg.org/css2/visufx.html#propdef-overflow)
       - [CSS Overflow 3 - overflow](https://drafts.csswg.org/css-overflow-3/#propdef-overflow)
   - Values: `visible | hidden | scroll | auto;`
-- [padding](http://www.w3.org/TR/CSS21/box.html#propdef-padding)
+- [padding](https://www.w3.org/TR/CSS21/box.html#propdef-padding)
   - TR
-      - [CSS 2.1 - padding](http://www.w3.org/TR/CSS21/box.html#propdef-padding)
+      - [CSS 2.1 - padding](https://www.w3.org/TR/CSS21/box.html#propdef-padding)
   - Drafts
       - [CSS 2.1 - padding](https://drafts.csswg.org/css2/box.html#propdef-padding)
   - Values: `INSETS padding-top padding-right padding-bottom padding-left;`
-- [padding-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-padding-bottom)
+- [padding-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-padding-bottom)
   - TR
-      - [CSS 2.1 - padding-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-padding-bottom)
+      - [CSS 2.1 - padding-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-padding-bottom)
   - Drafts
       - [CSS 2.1 - padding-bottom](https://drafts.csswg.org/css2/box.html#propdef-padding-bottom)
   - Values: `PPLENGTH;`
-- [padding-left](http://www.w3.org/TR/CSS21/box.html#propdef-padding-left)
+- [padding-left](https://www.w3.org/TR/CSS21/box.html#propdef-padding-left)
   - TR
-      - [CSS 2.1 - padding-left](http://www.w3.org/TR/CSS21/box.html#propdef-padding-left)
+      - [CSS 2.1 - padding-left](https://www.w3.org/TR/CSS21/box.html#propdef-padding-left)
   - Drafts
       - [CSS 2.1 - padding-left](https://drafts.csswg.org/css2/box.html#propdef-padding-left)
   - Values: `PPLENGTH;`
-- [padding-right](http://www.w3.org/TR/CSS21/box.html#propdef-padding-right)
+- [padding-right](https://www.w3.org/TR/CSS21/box.html#propdef-padding-right)
   - TR
-      - [CSS 2.1 - padding-right](http://www.w3.org/TR/CSS21/box.html#propdef-padding-right)
+      - [CSS 2.1 - padding-right](https://www.w3.org/TR/CSS21/box.html#propdef-padding-right)
   - Drafts
       - [CSS 2.1 - padding-right](https://drafts.csswg.org/css2/box.html#propdef-padding-right)
   - Values: `PPLENGTH;`
-- [padding-top](http://www.w3.org/TR/CSS21/box.html#propdef-padding-top)
+- [padding-top](https://www.w3.org/TR/CSS21/box.html#propdef-padding-top)
   - TR
-      - [CSS 2.1 - padding-top](http://www.w3.org/TR/CSS21/box.html#propdef-padding-top)
+      - [CSS 2.1 - padding-top](https://www.w3.org/TR/CSS21/box.html#propdef-padding-top)
   - Drafts
       - [CSS 2.1 - padding-top](https://drafts.csswg.org/css2/box.html#propdef-padding-top)
   - Values: `PPLENGTH;`
-- [page-break-after](http://www.w3.org/TR/CSS21/page.html#propdef-page-break-after)
+- [page-break-after](https://www.w3.org/TR/CSS21/page.html#propdef-page-break-after)
   - TR
-      - [CSS 2.1 - page-break-after](http://www.w3.org/TR/CSS21/page.html#propdef-page-break-after)
+      - [CSS 2.1 - page-break-after](https://www.w3.org/TR/CSS21/page.html#propdef-page-break-after)
   - Drafts
       - [CSS 2.1 - page-break-after](https://drafts.csswg.org/css2/page.html#propdef-page-break-after)
   - Values: `PAGE_BREAK;`
-- [page-break-before](http://www.w3.org/TR/CSS21/page.html#propdef-page-break-before)
+- [page-break-before](https://www.w3.org/TR/CSS21/page.html#propdef-page-break-before)
   - TR
-      - [CSS 2.1 - page-break-before](http://www.w3.org/TR/CSS21/page.html#propdef-page-break-before)
+      - [CSS 2.1 - page-break-before](https://www.w3.org/TR/CSS21/page.html#propdef-page-break-before)
   - Drafts
       - [CSS 2.1 - page-break-before](https://drafts.csswg.org/css2/page.html#propdef-page-break-before)
   - Values: `PAGE_BREAK;`
-- [page-break-inside](http://www.w3.org/TR/CSS21/page.html#propdef-page-break-inside)
+- [page-break-inside](https://www.w3.org/TR/CSS21/page.html#propdef-page-break-inside)
   - TR
-      - [CSS 2.1 - page-break-inside](http://www.w3.org/TR/CSS21/page.html#propdef-page-break-inside)
+      - [CSS 2.1 - page-break-inside](https://www.w3.org/TR/CSS21/page.html#propdef-page-break-inside)
   - Drafts
       - [CSS 2.1 - page-break-inside](https://drafts.csswg.org/css2/page.html#propdef-page-break-inside)
   - Values: `avoid | auto;`
-- [pause](http://www.w3.org/TR/CSS21/aural.html#propdef-pause)
+- [pause](https://www.w3.org/TR/CSS21/aural.html#propdef-pause)
   - TR
-      - [CSS 2.1 - pause](http://www.w3.org/TR/CSS21/aural.html#propdef-pause)
-      - [CSS Speech 1 - pause](http://www.w3.org/TR/css3-speech/#pause)
+      - [CSS 2.1 - pause](https://www.w3.org/TR/CSS21/aural.html#propdef-pause)
+      - [CSS Speech 1 - pause](https://www.w3.org/TR/css3-speech/#pause)
   - Drafts
       - [CSS 2.1 - pause](https://drafts.csswg.org/css2/aural.html#propdef-pause)
       - [CSS Speech 1 - pause](https://drafts.csswg.org/css-speech-1/#pause)
   - Values: `INSETS pause-before pause-after;`
-- [pause-after](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
+- [pause-after](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
   - TR
-      - [CSS 2.1 - pause-after](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
-      - [CSS Speech 1 - pause-after](http://www.w3.org/TR/css3-speech/#pause-after)
+      - [CSS 2.1 - pause-after](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
+      - [CSS Speech 1 - pause-after](https://www.w3.org/TR/css3-speech/#pause-after)
   - Drafts
       - [CSS 2.1 - pause-after](https://drafts.csswg.org/css2/aural.html#propdef-pause-after)
       - [CSS Speech 1 - pause-after](https://drafts.csswg.org/css-speech-1/#pause-after)
   - Values: `PAUSE;`
-- [pause-before](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
+- [pause-before](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
   - TR
-      - [CSS 2.1 - pause-before](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
-      - [CSS Speech 1 - pause-before](http://www.w3.org/TR/css3-speech/#pause-before)
+      - [CSS 2.1 - pause-before](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
+      - [CSS Speech 1 - pause-before](https://www.w3.org/TR/css3-speech/#pause-before)
   - Drafts
       - [CSS 2.1 - pause-before](https://drafts.csswg.org/css2/aural.html#propdef-pause-before)
       - [CSS Speech 1 - pause-before](https://drafts.csswg.org/css-speech-1/#pause-before)
   - Values: `PAUSE;`
-- [pitch](http://www.w3.org/TR/CSS21/aural.html#propdef-pitch)
+- [pitch](https://www.w3.org/TR/CSS21/aural.html#propdef-pitch)
   - TR
-      - [CSS 2.1 - pitch](http://www.w3.org/TR/CSS21/aural.html#propdef-pitch)
+      - [CSS 2.1 - pitch](https://www.w3.org/TR/CSS21/aural.html#propdef-pitch)
   - Drafts
       - [CSS 2.1 - pitch](https://drafts.csswg.org/css2/aural.html#propdef-pitch)
   - Values: `FREQUENCY | x-low | low | medium | high | x-high;`
-- [pitch-range](http://www.w3.org/TR/CSS21/aural.html#propdef-pitch-range)
+- [pitch-range](https://www.w3.org/TR/CSS21/aural.html#propdef-pitch-range)
   - TR
-      - [CSS 2.1 - pitch-range](http://www.w3.org/TR/CSS21/aural.html#propdef-pitch-range)
+      - [CSS 2.1 - pitch-range](https://www.w3.org/TR/CSS21/aural.html#propdef-pitch-range)
   - Drafts
       - [CSS 2.1 - pitch-range](https://drafts.csswg.org/css2/aural.html#propdef-pitch-range)
   - Values: `NUM;`
-- [play-during](http://www.w3.org/TR/CSS21/aural.html#propdef-play-during)
+- [play-during](https://www.w3.org/TR/CSS21/aural.html#propdef-play-during)
   - TR
-      - [CSS 2.1 - play-during](http://www.w3.org/TR/CSS21/aural.html#propdef-play-during)
+      - [CSS 2.1 - play-during](https://www.w3.org/TR/CSS21/aural.html#propdef-play-during)
   - Drafts
       - [CSS 2.1 - play-during](https://drafts.csswg.org/css2/aural.html#propdef-play-during)
   - Values: `[URI [ mix || repeat ]?] | auto | none;`
-- [position](http://www.w3.org/TR/CSS21/visuren.html#propdef-position)
+- [position](https://www.w3.org/TR/CSS21/visuren.html#propdef-position)
   - TR
-      - [CSS 2.1 - position](http://www.w3.org/TR/CSS21/visuren.html#propdef-position)
-      - [CSS Positioned Layout 3 - position](http://www.w3.org/TR/css3-positioning/#propdef-position)
+      - [CSS 2.1 - position](https://www.w3.org/TR/CSS21/visuren.html#propdef-position)
+      - [CSS Positioned Layout 3 - position](https://www.w3.org/TR/css3-positioning/#propdef-position)
   - Drafts
       - [CSS 2.1 - position](https://drafts.csswg.org/css2/visuren.html#propdef-position)
       - [CSS Positioned Layout 3 - position](https://drafts.csswg.org/css-position-3/#propdef-position)
   - Values: `static | relative | absolute | fixed;`
-- [quotes](http://www.w3.org/TR/CSS21/generate.html#propdef-quotes)
+- [quotes](https://www.w3.org/TR/CSS21/generate.html#propdef-quotes)
   - TR
-      - [CSS 2.1 - quotes](http://www.w3.org/TR/CSS21/generate.html#propdef-quotes)
+      - [CSS 2.1 - quotes](https://www.w3.org/TR/CSS21/generate.html#propdef-quotes)
   - Drafts
       - [CSS Generated Content 3 - quotes](https://drafts.csswg.org/css-content-3/#propdef-quotes)
       - [CSS 2.1 - quotes](https://drafts.csswg.org/css2/generate.html#propdef-quotes)
   - Values: `[STRING STRING]+ | none;`
-- [richness](http://www.w3.org/TR/CSS21/aural.html#propdef-richness)
+- [richness](https://www.w3.org/TR/CSS21/aural.html#propdef-richness)
   - TR
-      - [CSS 2.1 - richness](http://www.w3.org/TR/CSS21/aural.html#propdef-richness)
+      - [CSS 2.1 - richness](https://www.w3.org/TR/CSS21/aural.html#propdef-richness)
   - Drafts
       - [CSS 2.1 - richness](https://drafts.csswg.org/css2/aural.html#propdef-richness)
   - Values: `NUM;`
-- [right](http://www.w3.org/TR/CSS21/visuren.html#propdef-right)
+- [right](https://www.w3.org/TR/CSS21/visuren.html#propdef-right)
   - TR
-      - [CSS 2.1 - right](http://www.w3.org/TR/CSS21/visuren.html#propdef-right)
-      - [CSS Positioned Layout 3 - right](http://www.w3.org/TR/css3-positioning/#propdef-right)
+      - [CSS 2.1 - right](https://www.w3.org/TR/CSS21/visuren.html#propdef-right)
+      - [CSS Positioned Layout 3 - right](https://www.w3.org/TR/css3-positioning/#propdef-right)
   - Drafts
       - [CSS 2.1 - right](https://drafts.csswg.org/css2/visuren.html#propdef-right)
       - [CSS Positioned Layout 3 - right](https://drafts.csswg.org/css-position-3/#propdef-right)
   - Values: `APLENGTH;`
-- [speak-header](http://www.w3.org/TR/CSS21/aural.html#propdef-speak-header)
+- [speak-header](https://www.w3.org/TR/CSS21/aural.html#propdef-speak-header)
   - TR
-      - [CSS 2.1 - speak-header](http://www.w3.org/TR/CSS21/aural.html#propdef-speak-header)
+      - [CSS 2.1 - speak-header](https://www.w3.org/TR/CSS21/aural.html#propdef-speak-header)
   - Drafts
-      - [CSS Tables 3 - speak-header](https://drafts.csswg.org/css3-tables/#speak-header)
-      - [CSS Tables 3 - speak-header](https://drafts.csswg.org/css3-tables/??#speak-header)
       - [CSS 2.1 - speak-header](https://drafts.csswg.org/css2/aural.html#propdef-speak-header)
   - Values: `once | always;`
-- [speak-numeral](http://www.w3.org/TR/CSS21/aural.html#propdef-speak-numeral)
+- [speak-numeral](https://www.w3.org/TR/CSS21/aural.html#propdef-speak-numeral)
   - TR
-      - [CSS 2.1 - speak-numeral](http://www.w3.org/TR/CSS21/aural.html#propdef-speak-numeral)
+      - [CSS 2.1 - speak-numeral](https://www.w3.org/TR/CSS21/aural.html#propdef-speak-numeral)
   - Drafts
       - [CSS 2.1 - speak-numeral](https://drafts.csswg.org/css2/aural.html#propdef-speak-numeral)
   - Values: `digits | continuous;`
-- [speak-punctuation](http://www.w3.org/TR/CSS21/aural.html#propdef-speak-punctuation)
+- [speak-punctuation](https://www.w3.org/TR/CSS21/aural.html#propdef-speak-punctuation)
   - TR
-      - [CSS 2.1 - speak-punctuation](http://www.w3.org/TR/CSS21/aural.html#propdef-speak-punctuation)
+      - [CSS 2.1 - speak-punctuation](https://www.w3.org/TR/CSS21/aural.html#propdef-speak-punctuation)
   - Drafts
       - [CSS 2.1 - speak-punctuation](https://drafts.csswg.org/css2/aural.html#propdef-speak-punctuation)
   - Values: `code | none;`
-- [speech-rate](http://www.w3.org/TR/CSS21/aural.html#propdef-speech-rate)
+- [speech-rate](https://www.w3.org/TR/CSS21/aural.html#propdef-speech-rate)
   - TR
-      - [CSS 2.1 - speech-rate](http://www.w3.org/TR/CSS21/aural.html#propdef-speech-rate)
+      - [CSS 2.1 - speech-rate](https://www.w3.org/TR/CSS21/aural.html#propdef-speech-rate)
   - Drafts
       - [CSS 2.1 - speech-rate](https://drafts.csswg.org/css2/aural.html#propdef-speech-rate)
   - Values: `NUM | x-slow | slow | medium | fast | x-fast | faster | slower;`
-- [stress](http://www.w3.org/TR/CSS21/aural.html#propdef-stress)
+- [stress](https://www.w3.org/TR/CSS21/aural.html#propdef-stress)
   - TR
-      - [CSS 2.1 - stress](http://www.w3.org/TR/CSS21/aural.html#propdef-stress)
+      - [CSS 2.1 - stress](https://www.w3.org/TR/CSS21/aural.html#propdef-stress)
   - Drafts
       - [CSS 2.1 - stress](https://drafts.csswg.org/css2/aural.html#propdef-stress)
   - Values: `NUM;`
-- [table-layout](http://www.w3.org/TR/CSS21/tables.html#propdef-table-layout)
+- [table-layout](https://www.w3.org/TR/CSS21/tables.html#propdef-table-layout)
   - TR
-      - [CSS 2.1 - table-layout](http://www.w3.org/TR/CSS21/tables.html#propdef-table-layout)
+      - [CSS 2.1 - table-layout](https://www.w3.org/TR/CSS21/tables.html#propdef-table-layout)
   - Drafts
-      - [CSS Tables 3 - table-layout](https://drafts.csswg.org/css3-tables/#table-layout)
-      - [CSS Tables 3 - table-layout](https://drafts.csswg.org/css3-tables/??#table-layout)
+      - [CSS Tables 3 - table-layout](https://drafts.csswg.org/css-tables-3/#propdef-table-layout)
       - [CSS 2.1 - table-layout](https://drafts.csswg.org/css2/tables.html#propdef-table-layout)
   - Values: `auto | fixed;`
-- [text-align](http://www.w3.org/TR/CSS21/text.html#propdef-text-align)
+- [text-align](https://www.w3.org/TR/CSS21/text.html#propdef-text-align)
   - TR
-      - [CSS 2.1 - text-align](http://www.w3.org/TR/CSS21/text.html#propdef-text-align)
-      - [CSS Text 3 - text-align](http://www.w3.org/TR/css-text-3/#text-align)
+      - [CSS 2.1 - text-align](https://www.w3.org/TR/CSS21/text.html#propdef-text-align)
+      - [CSS Text 3 - text-align](https://www.w3.org/TR/css-text-3/#text-align)
   - Drafts
       - [CSS 2.1 - text-align](https://drafts.csswg.org/css2/text.html#propdef-text-align)
       - [CSS Text 3 - text-align](https://drafts.csswg.org/css-text-3/#propdef-text-align)
   - Values: `left | right | center | justify;`
-- [text-decoration](http://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
+- [text-decoration](https://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
   - TR
-      - [CSS 2.1 - text-decoration](http://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
-      - [CSS Text Decoration 3 - text-decoration](http://www.w3.org/TR/css-text-decor-3/#text-decoration)
+      - [CSS 2.1 - text-decoration](https://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
+      - [CSS Text Decoration 3 - text-decoration](https://www.w3.org/TR/css-text-decor-3/#text-decoration)
   - Drafts
       - [CSS 2.1 - text-decoration](https://drafts.csswg.org/css2/text.html#propdef-text-decoration)
       - [CSS Text Decoration 3 - text-decoration](https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration)
   - Values: `none | [ underline || overline || line-through || blink ];`
-- [text-indent](http://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
+- [text-indent](https://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
   - TR
-      - [CSS 2.1 - text-indent](http://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
-      - [CSS Text 3 - text-indent](http://www.w3.org/TR/css-text-3/#text-indent)
+      - [CSS 2.1 - text-indent](https://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
+      - [CSS Text 3 - text-indent](https://www.w3.org/TR/css-text-3/#text-indent)
   - Drafts
       - [CSS 2.1 - text-indent](https://drafts.csswg.org/css2/text.html#propdef-text-indent)
       - [CSS Text 3 - text-indent](https://drafts.csswg.org/css-text-3/#propdef-text-indent)
   - Values: `PLENGTH;`
-- [text-transform](http://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
+- [text-transform](https://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
   - TR
-      - [CSS 2.1 - text-transform](http://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
-      - [CSS Text 3 - text-transform](http://www.w3.org/TR/css-text-3/#text-transform)
+      - [CSS 2.1 - text-transform](https://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
+      - [CSS Text 3 - text-transform](https://www.w3.org/TR/css-text-3/#text-transform)
   - Drafts
       - [CSS 2.1 - text-transform](https://drafts.csswg.org/css2/text.html#propdef-text-transform)
       - [CSS Text 3 - text-transform](https://drafts.csswg.org/css-text-3/#propdef-text-transform)
   - Values: `capitalize | uppercase | lowercase | none;`
-- [top](http://www.w3.org/TR/CSS21/visuren.html#propdef-top)
+- [top](https://www.w3.org/TR/CSS21/visuren.html#propdef-top)
   - TR
-      - [CSS 2.1 - top](http://www.w3.org/TR/CSS21/visuren.html#propdef-top)
-      - [CSS Positioned Layout 3 - top](http://www.w3.org/TR/css3-positioning/#propdef-top)
+      - [CSS 2.1 - top](https://www.w3.org/TR/CSS21/visuren.html#propdef-top)
+      - [CSS Positioned Layout 3 - top](https://www.w3.org/TR/css3-positioning/#propdef-top)
   - Drafts
       - [CSS 2.1 - top](https://drafts.csswg.org/css2/visuren.html#propdef-top)
       - [CSS Positioned Layout 3 - top](https://drafts.csswg.org/css-position-3/#propdef-top)
   - Values: `APLENGTH;`
-- [unicode-bidi](http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
+- [unicode-bidi](https://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
   - TR
-      - [CSS 2.1 - unicode-bidi](http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
-      - [CSS Writing Modes 3 - unicode-bidi](http://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
+      - [CSS 2.1 - unicode-bidi](https://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
+      - [CSS Writing Modes 3 - unicode-bidi](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
   - Drafts
       - [CSS 2.1 - unicode-bidi](https://drafts.csswg.org/css2/visuren.html#propdef-unicode-bidi)
       - [CSS Writing Modes 3 - unicode-bidi](https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi)
   - Values: `normal | embed | isolate | bidi-override | isolate-override | plaintext;`
-- [vertical-align](http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
+- [vertical-align](https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
   - TR
-      - [CSS 2.1 - vertical-align](http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
-      - [CSS Inline Layout 3 - vertical-align](http://www.w3.org/TR/css-inline-3/#propdef-vertical-align)
+      - [CSS 2.1 - vertical-align](https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
+      - [CSS Inline Layout 3 - vertical-align](https://www.w3.org/TR/css-inline-3/#propdef-vertical-align)
   - Drafts
       - [CSS 2.1 - vertical-align](https://drafts.csswg.org/css2/visudet.html#propdef-vertical-align)
       - [CSS Inline Layout 3 - vertical-align](https://drafts.csswg.org/css-inline-3/#propdef-vertical-align)
   - Values: `baseline | sub | super | top | text-top | middle | bottom | text-bottom | PLENGTH;`
-- [visibility](http://www.w3.org/TR/CSS21/visufx.html#propdef-visibility)
+- [visibility](https://www.w3.org/TR/CSS21/visufx.html#propdef-visibility)
   - TR
-      - [CSS 2.1 - visibility](http://www.w3.org/TR/CSS21/visufx.html#propdef-visibility)
+      - [CSS 2.1 - visibility](https://www.w3.org/TR/CSS21/visufx.html#propdef-visibility)
   - Drafts
       - [CSS 2.1 - visibility](https://drafts.csswg.org/css2/visufx.html#propdef-visibility)
   - Values: `visible | hidden | collapse;`
-- [voice-family](http://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
+- [voice-family](https://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
   - TR
-      - [CSS 2.1 - voice-family](http://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
-      - [CSS Speech 1 - voice-family](http://www.w3.org/TR/css3-speech/#voice-family)
+      - [CSS 2.1 - voice-family](https://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
+      - [CSS Speech 1 - voice-family](https://www.w3.org/TR/css3-speech/#voice-family)
   - Drafts
       - [CSS 2.1 - voice-family](https://drafts.csswg.org/css2/aural.html#propdef-voice-family)
       - [CSS Speech 1 - voice-family](https://drafts.csswg.org/css-speech-1/#voice-family)
   - Values: `FAMILY_LIST;`
-- [volume](http://www.w3.org/TR/CSS21/aural.html#propdef-volume)
+- [volume](https://www.w3.org/TR/CSS21/aural.html#propdef-volume)
   - TR
-      - [CSS 2.1 - volume](http://www.w3.org/TR/CSS21/aural.html#propdef-volume)
+      - [CSS 2.1 - volume](https://www.w3.org/TR/CSS21/aural.html#propdef-volume)
   - Drafts
       - [CSS 2.1 - volume](https://drafts.csswg.org/css2/aural.html#propdef-volume)
   - Values: `NUM | PERCENTAGE | silent | x-soft | soft | medium | loud | x-loud;`
-- [white-space](http://www.w3.org/TR/CSS21/text.html#propdef-white-space)
+- [white-space](https://www.w3.org/TR/CSS21/text.html#propdef-white-space)
   - TR
-      - [CSS 2.1 - white-space](http://www.w3.org/TR/CSS21/text.html#propdef-white-space)
-      - [CSS Text 3 - white-space](http://www.w3.org/TR/css-text-3/#white-space)
+      - [CSS 2.1 - white-space](https://www.w3.org/TR/CSS21/text.html#propdef-white-space)
+      - [CSS Text 3 - white-space](https://www.w3.org/TR/css-text-3/#white-space)
   - Drafts
       - [CSS 2.1 - white-space](https://drafts.csswg.org/css2/text.html#propdef-white-space)
       - [CSS Text 3 - white-space](https://drafts.csswg.org/css-text-3/#propdef-white-space)
       - [CSS Text 4 - white-space](https://drafts.csswg.org/css-text-4/#propdef-white-space)
   - Values: `normal | pre | nowrap | pre-wrap | pre-line;`
-- [widows](http://www.w3.org/TR/CSS21/page.html#propdef-widows)
+- [widows](https://www.w3.org/TR/CSS21/page.html#propdef-widows)
   - TR
-      - [CSS 2.1 - widows](http://www.w3.org/TR/CSS21/page.html#propdef-widows)
-      - [CSS Fragmentation 3 - widows](http://www.w3.org/TR/css3-break/#widows)
+      - [CSS 2.1 - widows](https://www.w3.org/TR/CSS21/page.html#propdef-widows)
+      - [CSS Fragmentation 3 - widows](https://www.w3.org/TR/css3-break/#propdef-widows)
   - Drafts
       - [CSS 2.1 - widows](https://drafts.csswg.org/css2/page.html#propdef-widows)
       - [CSS Fragmentation 3 - widows](https://drafts.csswg.org/css-break-3/#propdef-widows)
   - Values: `POS_INT;`
-- [width](http://www.w3.org/TR/CSS21/visudet.html#propdef-width)
+- [width](https://www.w3.org/TR/CSS21/visudet.html#propdef-width)
   - TR
-      - [CSS 2.1 - width](http://www.w3.org/TR/CSS21/visudet.html#propdef-width)
+      - [CSS 2.1 - width](https://www.w3.org/TR/CSS21/visudet.html#propdef-width)
   - Drafts
       - [CSS 2.1 - width](https://drafts.csswg.org/css2/visudet.html#propdef-width)
   - Values: `PAPLENGTH;`
-- [word-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
+- [word-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
   - TR
-      - [CSS 2.1 - word-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
-      - [CSS Text 3 - word-spacing](http://www.w3.org/TR/css-text-3/#word-spacing)
+      - [CSS 2.1 - word-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
+      - [CSS Text 3 - word-spacing](https://www.w3.org/TR/css-text-3/#word-spacing)
   - Drafts
       - [CSS 2.1 - word-spacing](https://drafts.csswg.org/css2/text.html#propdef-word-spacing)
       - [CSS Text 3 - word-spacing](https://drafts.csswg.org/css-text-3/#propdef-word-spacing)
   - Values: `normal | LENGTH;`
-- [z-index](http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
+- [z-index](https://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
   - TR
-      - [CSS 2.1 - z-index](http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
-      - [CSS Positioned Layout 3 - z-index](http://www.w3.org/TR/css3-positioning/#propdef-z-index)
+      - [CSS 2.1 - z-index](https://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
+      - [CSS Positioned Layout 3 - z-index](https://www.w3.org/TR/css3-positioning/#propdef-z-index)
   - Drafts
       - [CSS 2.1 - z-index](https://drafts.csswg.org/css2/visuren.html#propdef-z-index)
       - [CSS Positioned Layout 3 - z-index](https://drafts.csswg.org/css-position-3/#propdef-z-index)
   - Values: `auto | INT;`
 
-## [CSS Paged Media 3](http://www.w3.org/TR/css3-page/)
-- [page](http://www.w3.org/TR/css3-page/#page)
+## [CSS Paged Media 3](https://www.w3.org/TR/css3-page/)
+- [page](https://www.w3.org/TR/css3-page/#page)
     - Allowed prefixes: epubx
   - TR
-      - [CSS Paged Media 3 - page](http://www.w3.org/TR/css3-page/#page)
+      - [CSS Paged Media 3 - page](https://www.w3.org/TR/css3-page/#page)
   - Drafts
       - [CSS Paged Media 3 - page](https://drafts.csswg.org/css-page-3/#propdef-page)
   - Values: `INT | auto;`
-- [size](http://www.w3.org/TR/css3-page/#size)
+- [size](https://www.w3.org/TR/css3-page/#size)
   - TR
-      - [CSS Paged Media 3 - size](http://www.w3.org/TR/css3-page/#size)
+      - [CSS Paged Media 3 - size](https://www.w3.org/TR/css3-page/#size)
 
   - Values: `POS_LENGTH{1,2} | auto | [ PAGE_SIZE || [ portrait | landscape ] ];`
 
-## [CSS Color 3](http://www.w3.org/TR/css3-color/)
-- [color](http://www.w3.org/TR/CSS21/colors.html#propdef-color)
+## [CSS Color 3](https://www.w3.org/TR/css3-color/)
+- [color](https://www.w3.org/TR/CSS21/colors.html#propdef-color)
   - TR
-      - [CSS 2.1 - color](http://www.w3.org/TR/CSS21/colors.html#propdef-color)
-      - [CSS Color 3 - color](http://www.w3.org/TR/css3-color/#color0)
+      - [CSS 2.1 - color](https://www.w3.org/TR/CSS21/colors.html#propdef-color)
+      - [CSS Color 3 - color](https://www.w3.org/TR/css3-color/#color0)
   - Drafts
       - [CSS 2.1 - color](https://drafts.csswg.org/css2/colors.html#propdef-color)
       - [CSS Color 3 - color](https://drafts.csswg.org/css-color-3/#color0)
       - [CSS Color 4 - color](https://drafts.csswg.org/css-color-4/#propdef-color)
   - Values: `COLOR;`
-- [opacity](http://www.w3.org/TR/css3-color/#opacity)
+- [opacity](https://www.w3.org/TR/css3-color/#opacity)
   - TR
-      - [CSS Color 3 - opacity](http://www.w3.org/TR/css3-color/#opacity)
+      - [CSS Color 3 - opacity](https://www.w3.org/TR/css3-color/#opacity)
   - Drafts
       - [CSS Color 3 - opacity](https://drafts.csswg.org/css-color-3/#opacity)
       - [CSS Color 4 - opacity](https://drafts.csswg.org/css-color-4/#propdef-opacity)
   - Values: `NUM;`
 
 ## [CSS Color 4](https://drafts.csswg.org/css-color-4/)
-- [color](http://www.w3.org/TR/CSS21/colors.html#propdef-color)
+- [color](https://www.w3.org/TR/CSS21/colors.html#propdef-color)
   - TR
-      - [CSS 2.1 - color](http://www.w3.org/TR/CSS21/colors.html#propdef-color)
-      - [CSS Color 3 - color](http://www.w3.org/TR/css3-color/#color0)
+      - [CSS 2.1 - color](https://www.w3.org/TR/CSS21/colors.html#propdef-color)
+      - [CSS Color 3 - color](https://www.w3.org/TR/css3-color/#color0)
   - Drafts
       - [CSS 2.1 - color](https://drafts.csswg.org/css2/colors.html#propdef-color)
       - [CSS Color 3 - color](https://drafts.csswg.org/css-color-3/#color0)
       - [CSS Color 4 - color](https://drafts.csswg.org/css-color-4/#propdef-color)
   - Values: `COLOR;`
-- [opacity](http://www.w3.org/TR/css3-color/#opacity)
+- [opacity](https://www.w3.org/TR/css3-color/#opacity)
   - TR
-      - [CSS Color 3 - opacity](http://www.w3.org/TR/css3-color/#opacity)
+      - [CSS Color 3 - opacity](https://www.w3.org/TR/css3-color/#opacity)
   - Drafts
       - [CSS Color 3 - opacity](https://drafts.csswg.org/css-color-3/#opacity)
       - [CSS Color 4 - opacity](https://drafts.csswg.org/css-color-4/#propdef-opacity)
   - Values: `NUM;`
 
-## [CSS Backgrounds 3](http://www.w3.org/TR/css3-background/)
-- [background](http://www.w3.org/TR/CSS21/colors.html#propdef-background)
+## [CSS Backgrounds 3](https://www.w3.org/TR/css3-background/)
+- [background](https://www.w3.org/TR/CSS21/colors.html#propdef-background)
   - TR
-      - [CSS 2.1 - background](http://www.w3.org/TR/CSS21/colors.html#propdef-background)
-      - [CSS Backgrounds 3 - background](http://www.w3.org/TR/css3-background/#background)
+      - [CSS 2.1 - background](https://www.w3.org/TR/CSS21/colors.html#propdef-background)
+      - [CSS Backgrounds 3 - background](https://www.w3.org/TR/css3-background/#background)
   - Drafts
       - [CSS 2.1 - background](https://drafts.csswg.org/css2/colors.html#propdef-background)
       - [CSS Backgrounds 3 - background](https://drafts.csswg.org/css-backgrounds-3/#background)
   - Values: `COMMA background-image [background-position [ / background-size ]] background-repeat background-attachment [background-origin background-clip] background-color; /* background-color is a special case, see the code */`
-- [background-attachment](http://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
+- [background-attachment](https://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
   - TR
-      - [CSS 2.1 - background-attachment](http://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
-      - [CSS Backgrounds 3 - background-attachment](http://www.w3.org/TR/css3-background/#background-attachment)
+      - [CSS 2.1 - background-attachment](https://www.w3.org/TR/CSS21/colors.html#propdef-background-attachment)
+      - [CSS Backgrounds 3 - background-attachment](https://www.w3.org/TR/css3-background/#background-attachment)
   - Drafts
       - [CSS 2.1 - background-attachment](https://drafts.csswg.org/css2/colors.html#propdef-background-attachment)
       - [CSS Backgrounds 3 - background-attachment](https://drafts.csswg.org/css-backgrounds-3/#background-attachment)
   - Values: `COMMA( [scroll | fixed | local]+ );`
-- [background-clip](http://www.w3.org/TR/css3-background/#background-clip)
+- [background-clip](https://www.w3.org/TR/css3-background/#background-clip)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Backgrounds 3 - background-clip](http://www.w3.org/TR/css3-background/#background-clip)
+      - [CSS Backgrounds 3 - background-clip](https://www.w3.org/TR/css3-background/#background-clip)
   - Drafts
       - [CSS Backgrounds 3 - background-clip](https://drafts.csswg.org/css-backgrounds-3/#background-clip)
   - Values: `COMMA( BOX+ );`
-- [background-color](http://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
+- [background-color](https://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
   - TR
-      - [CSS 2.1 - background-color](http://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
-      - [CSS Backgrounds 3 - background-color](http://www.w3.org/TR/css3-background/#background-color)
+      - [CSS 2.1 - background-color](https://www.w3.org/TR/CSS21/colors.html#propdef-background-color)
+      - [CSS Backgrounds 3 - background-color](https://www.w3.org/TR/css3-background/#background-color)
   - Drafts
       - [CSS 2.1 - background-color](https://drafts.csswg.org/css2/colors.html#propdef-background-color)
       - [CSS Backgrounds 3 - background-color](https://drafts.csswg.org/css-backgrounds-3/#background-color)
   - Values: `COLOR;`
-- [background-image](http://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
+- [background-image](https://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
   - TR
-      - [CSS 2.1 - background-image](http://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
-      - [CSS Backgrounds 3 - background-image](http://www.w3.org/TR/css3-background/#background-image)
+      - [CSS 2.1 - background-image](https://www.w3.org/TR/CSS21/colors.html#propdef-background-image)
+      - [CSS Backgrounds 3 - background-image](https://www.w3.org/TR/css3-background/#background-image)
   - Drafts
       - [CSS 2.1 - background-image](https://drafts.csswg.org/css2/colors.html#propdef-background-image)
       - [CSS Backgrounds 3 - background-image](https://drafts.csswg.org/css-backgrounds-3/#background-image)
   - Values: `COMMA( URI_OR_NONE+ );`
-- [background-origin](http://www.w3.org/TR/css3-background/#background-origin)
+- [background-origin](https://www.w3.org/TR/css3-background/#background-origin)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Backgrounds 3 - background-origin](http://www.w3.org/TR/css3-background/#background-origin)
+      - [CSS Backgrounds 3 - background-origin](https://www.w3.org/TR/css3-background/#background-origin)
   - Drafts
       - [CSS Backgrounds 3 - background-origin](https://drafts.csswg.org/css-backgrounds-3/#background-origin)
   - Values: `COMMA( BOX+ );`
-- [background-position](http://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
+- [background-position](https://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
   - TR
-      - [CSS 2.1 - background-position](http://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
-      - [CSS Backgrounds 3 - background-position](http://www.w3.org/TR/css3-background/#background-position)
+      - [CSS 2.1 - background-position](https://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
+      - [CSS Backgrounds 3 - background-position](https://www.w3.org/TR/css3-background/#background-position)
   - Drafts
       - [CSS 2.1 - background-position](https://drafts.csswg.org/css2/colors.html#propdef-background-position)
       - [CSS Backgrounds 3 - background-position](https://drafts.csswg.org/css-backgrounds-3/#background-position)
       - [CSS Backgrounds 4 - background-position](https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position)
   - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
-- [background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
+- [background-repeat](https://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
   - TR
-      - [CSS 2.1 - background-repeat](http://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
-      - [CSS Backgrounds 3 - background-repeat](http://www.w3.org/TR/css3-background/#background-repeat)
+      - [CSS 2.1 - background-repeat](https://www.w3.org/TR/CSS21/colors.html#propdef-background-repeat)
+      - [CSS Backgrounds 3 - background-repeat](https://www.w3.org/TR/css3-background/#background-repeat)
   - Drafts
       - [CSS 2.1 - background-repeat](https://drafts.csswg.org/css2/colors.html#propdef-background-repeat)
       - [CSS Backgrounds 3 - background-repeat](https://drafts.csswg.org/css-backgrounds-3/#background-repeat)
   - Values: `COMMA( [repeat | repeat-x | repeat-y | no-repeat]+ );`
-- [background-size](http://www.w3.org/TR/css3-background/#background-size)
+- [background-size](https://www.w3.org/TR/css3-background/#background-size)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Backgrounds 3 - background-size](http://www.w3.org/TR/css3-background/#background-size)
+      - [CSS Backgrounds 3 - background-size](https://www.w3.org/TR/css3-background/#background-size)
   - Drafts
       - [CSS Backgrounds 3 - background-size](https://drafts.csswg.org/css-backgrounds-3/#background-size)
   - Values: `COMMA( SPACE( [PLENGTH | auto ]{1,2} | cover | contain)+ );`
-- [border](http://www.w3.org/TR/CSS21/box.html#propdef-border)
+- [border](https://www.w3.org/TR/CSS21/box.html#propdef-border)
   - TR
-      - [CSS 2.1 - border](http://www.w3.org/TR/CSS21/box.html#propdef-border)
-      - [CSS Backgrounds 3 - border](http://www.w3.org/TR/css3-background/#border)
+      - [CSS 2.1 - border](https://www.w3.org/TR/CSS21/box.html#propdef-border)
+      - [CSS Backgrounds 3 - border](https://www.w3.org/TR/css3-background/#border)
   - Drafts
       - [CSS 2.1 - border](https://drafts.csswg.org/css2/box.html#propdef-border)
       - [CSS Backgrounds 3 - border](https://drafts.csswg.org/css-backgrounds-3/#border)
   - Values: `border-width border-style border-color;`
-- [border-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
+- [border-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
   - TR
-      - [CSS 2.1 - border-bottom](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
-      - [CSS Backgrounds 3 - border-bottom](http://www.w3.org/TR/css3-background/#border-bottom)
+      - [CSS 2.1 - border-bottom](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom)
+      - [CSS Backgrounds 3 - border-bottom](https://www.w3.org/TR/css3-background/#border-bottom)
   - Drafts
       - [CSS 2.1 - border-bottom](https://drafts.csswg.org/css2/box.html#propdef-border-bottom)
       - [CSS Backgrounds 3 - border-bottom](https://drafts.csswg.org/css-backgrounds-3/#border-bottom)
   - Values: `border-bottom-width border-bottom-style border-bottom-color;`
-- [border-bottom-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
+- [border-bottom-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
   - TR
-      - [CSS 2.1 - border-bottom-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
-      - [CSS Backgrounds 3 - border-bottom-color](http://www.w3.org/TR/css3-background/#border-bottom-color)
+      - [CSS 2.1 - border-bottom-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color)
+      - [CSS Backgrounds 3 - border-bottom-color](https://www.w3.org/TR/css3-background/#border-bottom-color)
   - Drafts
       - [CSS 2.1 - border-bottom-color](https://drafts.csswg.org/css2/box.html#propdef-border-bottom-color)
       - [CSS Backgrounds 3 - border-bottom-color](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-bottom-left-radius](http://www.w3.org/TR/css3-background/#border-bottom-left-radius)
+- [border-bottom-left-radius](https://www.w3.org/TR/css3-background/#border-bottom-left-radius)
   - TR
-      - [CSS Backgrounds 3 - border-bottom-left-radius](http://www.w3.org/TR/css3-background/#border-bottom-left-radius)
+      - [CSS Backgrounds 3 - border-bottom-left-radius](https://www.w3.org/TR/css3-background/#border-bottom-left-radius)
   - Drafts
       - [CSS Backgrounds 3 - border-bottom-left-radius](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-left-radius)
   - Values: `BORDER_RADIUS;`
-- [border-bottom-right-radius](http://www.w3.org/TR/css3-background/#border-bottom-right-radius)
+- [border-bottom-right-radius](https://www.w3.org/TR/css3-background/#border-bottom-right-radius)
   - TR
-      - [CSS Backgrounds 3 - border-bottom-right-radius](http://www.w3.org/TR/css3-background/#border-bottom-right-radius)
+      - [CSS Backgrounds 3 - border-bottom-right-radius](https://www.w3.org/TR/css3-background/#border-bottom-right-radius)
   - Drafts
       - [CSS Backgrounds 3 - border-bottom-right-radius](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-right-radius)
   - Values: `BORDER_RADIUS;`
-- [border-bottom-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
+- [border-bottom-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
   - TR
-      - [CSS 2.1 - border-bottom-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
-      - [CSS Backgrounds 3 - border-bottom-style](http://www.w3.org/TR/css3-background/#border-bottom-style)
+      - [CSS 2.1 - border-bottom-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-style)
+      - [CSS Backgrounds 3 - border-bottom-style](https://www.w3.org/TR/css3-background/#border-bottom-style)
   - Drafts
       - [CSS 2.1 - border-bottom-style](https://drafts.csswg.org/css2/box.html#propdef-border-bottom-style)
       - [CSS Backgrounds 3 - border-bottom-style](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-bottom-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
+- [border-bottom-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
   - TR
-      - [CSS 2.1 - border-bottom-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
-      - [CSS Backgrounds 3 - border-bottom-width](http://www.w3.org/TR/css3-background/#border-bottom-width)
+      - [CSS 2.1 - border-bottom-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width)
+      - [CSS Backgrounds 3 - border-bottom-width](https://www.w3.org/TR/css3-background/#border-bottom-width)
   - Drafts
       - [CSS 2.1 - border-bottom-width](https://drafts.csswg.org/css2/box.html#propdef-border-bottom-width)
       - [CSS Backgrounds 3 - border-bottom-width](https://drafts.csswg.org/css-backgrounds-3/#border-bottom-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-color)
+- [border-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-color)
   - TR
-      - [CSS 2.1 - border-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-color)
-      - [CSS Backgrounds 3 - border-color](http://www.w3.org/TR/css3-background/#border-color)
+      - [CSS 2.1 - border-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-color)
+      - [CSS Backgrounds 3 - border-color](https://www.w3.org/TR/css3-background/#border-color)
   - Drafts
       - [CSS 2.1 - border-color](https://drafts.csswg.org/css2/box.html#propdef-border-color)
       - [CSS Backgrounds 3 - border-color](https://drafts.csswg.org/css-backgrounds-3/#border-color)
   - Values: `INSETS border-top-color border-right-color border-bottom-color border-left-color;`
-- [border-image](http://www.w3.org/TR/css3-background/#border-image)
+- [border-image](https://www.w3.org/TR/css3-background/#border-image)
   - TR
-      - [CSS Backgrounds 3 - border-image](http://www.w3.org/TR/css3-background/#border-image)
+      - [CSS Backgrounds 3 - border-image](https://www.w3.org/TR/css3-background/#border-image)
   - Drafts
       - [CSS Backgrounds 3 - border-image](https://drafts.csswg.org/css-backgrounds-3/#border-image)
   - Values: `border-image-source border-image-slice [ / border-image-width [ / border-image-outset ] ] border-image-repeat;`
-- [border-image-outset](http://www.w3.org/TR/css3-background/#border-image-outset)
+- [border-image-outset](https://www.w3.org/TR/css3-background/#border-image-outset)
   - TR
-      - [CSS Backgrounds 3 - border-image-outset](http://www.w3.org/TR/css3-background/#border-image-outset)
+      - [CSS Backgrounds 3 - border-image-outset](https://www.w3.org/TR/css3-background/#border-image-outset)
   - Drafts
       - [CSS Backgrounds 3 - border-image-outset](https://drafts.csswg.org/css-backgrounds-3/#border-image-outset)
   - Values: `[NUM | LENGTH]{1,4};`
-- [border-image-repeat](http://www.w3.org/TR/css3-background/#border-image-repeat)
+- [border-image-repeat](https://www.w3.org/TR/css3-background/#border-image-repeat)
   - TR
-      - [CSS Backgrounds 3 - border-image-repeat](http://www.w3.org/TR/css3-background/#border-image-repeat)
+      - [CSS Backgrounds 3 - border-image-repeat](https://www.w3.org/TR/css3-background/#border-image-repeat)
   - Drafts
       - [CSS Backgrounds 3 - border-image-repeat](https://drafts.csswg.org/css-backgrounds-3/#border-image-repeat)
   - Values: `[ stretch | repeat | round | space ]{1,2};`
-- [border-image-slice](http://www.w3.org/TR/css3-background/#border-image-slice)
+- [border-image-slice](https://www.w3.org/TR/css3-background/#border-image-slice)
   - TR
-      - [CSS Backgrounds 3 - border-image-slice](http://www.w3.org/TR/css3-background/#border-image-slice)
+      - [CSS Backgrounds 3 - border-image-slice](https://www.w3.org/TR/css3-background/#border-image-slice)
   - Drafts
       - [CSS Backgrounds 3 - border-image-slice](https://drafts.csswg.org/css-backgrounds-3/#border-image-slice)
   - Values: `[NUM | PERCENTAGE]{1,4} || fill; /* relaxed */`
-- [border-image-source](http://www.w3.org/TR/css3-background/#border-image-source)
+- [border-image-source](https://www.w3.org/TR/css3-background/#border-image-source)
   - TR
-      - [CSS Backgrounds 3 - border-image-source](http://www.w3.org/TR/css3-background/#border-image-source)
+      - [CSS Backgrounds 3 - border-image-source](https://www.w3.org/TR/css3-background/#border-image-source)
   - Drafts
       - [CSS Backgrounds 3 - border-image-source](https://drafts.csswg.org/css-backgrounds-3/#border-image-source)
   - Values: `URI_OR_NONE;`
-- [border-image-width](http://www.w3.org/TR/css3-background/#border-image-width)
+- [border-image-width](https://www.w3.org/TR/css3-background/#border-image-width)
   - TR
-      - [CSS Backgrounds 3 - border-image-width](http://www.w3.org/TR/css3-background/#border-image-width)
+      - [CSS Backgrounds 3 - border-image-width](https://www.w3.org/TR/css3-background/#border-image-width)
   - Drafts
       - [CSS Backgrounds 3 - border-image-width](https://drafts.csswg.org/css-backgrounds-3/#border-image-width)
   - Values: `[NUM | PLENGTH | auto]{1,4};`
-- [border-left](http://www.w3.org/TR/CSS21/box.html#propdef-border-left)
+- [border-left](https://www.w3.org/TR/CSS21/box.html#propdef-border-left)
   - TR
-      - [CSS 2.1 - border-left](http://www.w3.org/TR/CSS21/box.html#propdef-border-left)
-      - [CSS Backgrounds 3 - border-left](http://www.w3.org/TR/css3-background/#border-left)
+      - [CSS 2.1 - border-left](https://www.w3.org/TR/CSS21/box.html#propdef-border-left)
+      - [CSS Backgrounds 3 - border-left](https://www.w3.org/TR/css3-background/#border-left)
   - Drafts
       - [CSS 2.1 - border-left](https://drafts.csswg.org/css2/box.html#propdef-border-left)
       - [CSS Backgrounds 3 - border-left](https://drafts.csswg.org/css-backgrounds-3/#border-left)
   - Values: `border-left-width border-left-style border-left-color;`
-- [border-left-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
+- [border-left-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
   - TR
-      - [CSS 2.1 - border-left-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
-      - [CSS Backgrounds 3 - border-left-color](http://www.w3.org/TR/css3-background/#border-left-color)
+      - [CSS 2.1 - border-left-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-color)
+      - [CSS Backgrounds 3 - border-left-color](https://www.w3.org/TR/css3-background/#border-left-color)
   - Drafts
       - [CSS 2.1 - border-left-color](https://drafts.csswg.org/css2/box.html#propdef-border-left-color)
       - [CSS Backgrounds 3 - border-left-color](https://drafts.csswg.org/css-backgrounds-3/#border-left-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-left-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
+- [border-left-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
   - TR
-      - [CSS 2.1 - border-left-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
-      - [CSS Backgrounds 3 - border-left-style](http://www.w3.org/TR/css3-background/#border-left-style)
+      - [CSS 2.1 - border-left-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-style)
+      - [CSS Backgrounds 3 - border-left-style](https://www.w3.org/TR/css3-background/#border-left-style)
   - Drafts
       - [CSS 2.1 - border-left-style](https://drafts.csswg.org/css2/box.html#propdef-border-left-style)
       - [CSS Backgrounds 3 - border-left-style](https://drafts.csswg.org/css-backgrounds-3/#border-left-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-left-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
+- [border-left-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
   - TR
-      - [CSS 2.1 - border-left-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
-      - [CSS Backgrounds 3 - border-left-width](http://www.w3.org/TR/css3-background/#border-left-width)
+      - [CSS 2.1 - border-left-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-left-width)
+      - [CSS Backgrounds 3 - border-left-width](https://www.w3.org/TR/css3-background/#border-left-width)
   - Drafts
       - [CSS 2.1 - border-left-width](https://drafts.csswg.org/css2/box.html#propdef-border-left-width)
       - [CSS Backgrounds 3 - border-left-width](https://drafts.csswg.org/css-backgrounds-3/#border-left-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-radius](http://www.w3.org/TR/css3-background/#border-radius)
+- [border-radius](https://www.w3.org/TR/css3-background/#border-radius)
   - TR
-      - [CSS Backgrounds 3 - border-radius](http://www.w3.org/TR/css3-background/#border-radius)
+      - [CSS Backgrounds 3 - border-radius](https://www.w3.org/TR/css3-background/#border-radius)
   - Drafts
       - [CSS Backgrounds 3 - border-radius](https://drafts.csswg.org/css-backgrounds-3/#border-radius)
       - [CSS Backgrounds 4 - border-radius](https://drafts.csswg.org/css-backgrounds-4/#propdef-border-radius)
   - Values: `INSETS_SLASH border-top-left-radius border-top-right-radius border-bottom-right-radius border-bottom-left-radius;`
-- [border-right](http://www.w3.org/TR/CSS21/box.html#propdef-border-right)
+- [border-right](https://www.w3.org/TR/CSS21/box.html#propdef-border-right)
   - TR
-      - [CSS 2.1 - border-right](http://www.w3.org/TR/CSS21/box.html#propdef-border-right)
-      - [CSS Backgrounds 3 - border-right](http://www.w3.org/TR/css3-background/#border-right)
+      - [CSS 2.1 - border-right](https://www.w3.org/TR/CSS21/box.html#propdef-border-right)
+      - [CSS Backgrounds 3 - border-right](https://www.w3.org/TR/css3-background/#border-right)
   - Drafts
       - [CSS 2.1 - border-right](https://drafts.csswg.org/css2/box.html#propdef-border-right)
       - [CSS Backgrounds 3 - border-right](https://drafts.csswg.org/css-backgrounds-3/#border-right)
   - Values: `border-right-width border-right-style border-right-color;`
-- [border-right-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
+- [border-right-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
   - TR
-      - [CSS 2.1 - border-right-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
-      - [CSS Backgrounds 3 - border-right-color](http://www.w3.org/TR/css3-background/#border-right-color)
+      - [CSS 2.1 - border-right-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-color)
+      - [CSS Backgrounds 3 - border-right-color](https://www.w3.org/TR/css3-background/#border-right-color)
   - Drafts
       - [CSS 2.1 - border-right-color](https://drafts.csswg.org/css2/box.html#propdef-border-right-color)
       - [CSS Backgrounds 3 - border-right-color](https://drafts.csswg.org/css-backgrounds-3/#border-right-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-right-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
+- [border-right-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
   - TR
-      - [CSS 2.1 - border-right-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
-      - [CSS Backgrounds 3 - border-right-style](http://www.w3.org/TR/css3-background/#border-right-style)
+      - [CSS 2.1 - border-right-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-style)
+      - [CSS Backgrounds 3 - border-right-style](https://www.w3.org/TR/css3-background/#border-right-style)
   - Drafts
       - [CSS 2.1 - border-right-style](https://drafts.csswg.org/css2/box.html#propdef-border-right-style)
       - [CSS Backgrounds 3 - border-right-style](https://drafts.csswg.org/css-backgrounds-3/#border-right-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-right-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
+- [border-right-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
   - TR
-      - [CSS 2.1 - border-right-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
-      - [CSS Backgrounds 3 - border-right-width](http://www.w3.org/TR/css3-background/#border-right-width)
+      - [CSS 2.1 - border-right-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-right-width)
+      - [CSS Backgrounds 3 - border-right-width](https://www.w3.org/TR/css3-background/#border-right-width)
   - Drafts
       - [CSS 2.1 - border-right-width](https://drafts.csswg.org/css2/box.html#propdef-border-right-width)
       - [CSS Backgrounds 3 - border-right-width](https://drafts.csswg.org/css-backgrounds-3/#border-right-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-style)
+- [border-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-style)
   - TR
-      - [CSS 2.1 - border-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-style)
-      - [CSS Backgrounds 3 - border-style](http://www.w3.org/TR/css3-background/#border-style)
+      - [CSS 2.1 - border-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-style)
+      - [CSS Backgrounds 3 - border-style](https://www.w3.org/TR/css3-background/#border-style)
   - Drafts
       - [CSS 2.1 - border-style](https://drafts.csswg.org/css2/box.html#propdef-border-style)
       - [CSS Backgrounds 3 - border-style](https://drafts.csswg.org/css-backgrounds-3/#border-style)
   - Values: `INSETS border-top-style border-right-style border-bottom-style border-left-style;`
-- [border-top](http://www.w3.org/TR/CSS21/box.html#propdef-border-top)
+- [border-top](https://www.w3.org/TR/CSS21/box.html#propdef-border-top)
   - TR
-      - [CSS 2.1 - border-top](http://www.w3.org/TR/CSS21/box.html#propdef-border-top)
-      - [CSS Backgrounds 3 - border-top](http://www.w3.org/TR/css3-background/#border-top)
+      - [CSS 2.1 - border-top](https://www.w3.org/TR/CSS21/box.html#propdef-border-top)
+      - [CSS Backgrounds 3 - border-top](https://www.w3.org/TR/css3-background/#border-top)
   - Drafts
       - [CSS 2.1 - border-top](https://drafts.csswg.org/css2/box.html#propdef-border-top)
       - [CSS Backgrounds 3 - border-top](https://drafts.csswg.org/css-backgrounds-3/#border-top)
   - Values: `border-top-width border-top-style border-top-color;`
-- [border-top-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
+- [border-top-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
   - TR
-      - [CSS 2.1 - border-top-color](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
-      - [CSS Backgrounds 3 - border-top-color](http://www.w3.org/TR/css3-background/#border-top-color)
+      - [CSS 2.1 - border-top-color](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-color)
+      - [CSS Backgrounds 3 - border-top-color](https://www.w3.org/TR/css3-background/#border-top-color)
   - Drafts
       - [CSS 2.1 - border-top-color](https://drafts.csswg.org/css2/box.html#propdef-border-top-color)
       - [CSS Backgrounds 3 - border-top-color](https://drafts.csswg.org/css-backgrounds-3/#border-top-color)
   - Values: `BORDER_SIDE_COLOR;`
-- [border-top-left-radius](http://www.w3.org/TR/css3-background/#border-top-left-radius)
+- [border-top-left-radius](https://www.w3.org/TR/css3-background/#border-top-left-radius)
   - TR
-      - [CSS Backgrounds 3 - border-top-left-radius](http://www.w3.org/TR/css3-background/#border-top-left-radius)
+      - [CSS Backgrounds 3 - border-top-left-radius](https://www.w3.org/TR/css3-background/#border-top-left-radius)
   - Drafts
       - [CSS Backgrounds 3 - border-top-left-radius](https://drafts.csswg.org/css-backgrounds-3/#border-top-left-radius)
   - Values: `BORDER_RADIUS;`
-- [border-top-right-radius](http://www.w3.org/TR/css3-background/#border-top-right-radius)
+- [border-top-right-radius](https://www.w3.org/TR/css3-background/#border-top-right-radius)
   - TR
-      - [CSS Backgrounds 3 - border-top-right-radius](http://www.w3.org/TR/css3-background/#border-top-right-radius)
+      - [CSS Backgrounds 3 - border-top-right-radius](https://www.w3.org/TR/css3-background/#border-top-right-radius)
   - Drafts
       - [CSS Backgrounds 3 - border-top-right-radius](https://drafts.csswg.org/css-backgrounds-3/#border-top-right-radius)
   - Values: `BORDER_RADIUS;`
-- [border-top-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
+- [border-top-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
   - TR
-      - [CSS 2.1 - border-top-style](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
-      - [CSS Backgrounds 3 - border-top-style](http://www.w3.org/TR/css3-background/#border-top-style)
+      - [CSS 2.1 - border-top-style](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-style)
+      - [CSS Backgrounds 3 - border-top-style](https://www.w3.org/TR/css3-background/#border-top-style)
   - Drafts
       - [CSS 2.1 - border-top-style](https://drafts.csswg.org/css2/box.html#propdef-border-top-style)
       - [CSS Backgrounds 3 - border-top-style](https://drafts.csswg.org/css-backgrounds-3/#border-top-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [border-top-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
+- [border-top-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
   - TR
-      - [CSS 2.1 - border-top-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
-      - [CSS Backgrounds 3 - border-top-width](http://www.w3.org/TR/css3-background/#border-top-width)
+      - [CSS 2.1 - border-top-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-top-width)
+      - [CSS Backgrounds 3 - border-top-width](https://www.w3.org/TR/css3-background/#border-top-width)
   - Drafts
       - [CSS 2.1 - border-top-width](https://drafts.csswg.org/css2/box.html#propdef-border-top-width)
       - [CSS Backgrounds 3 - border-top-width](https://drafts.csswg.org/css-backgrounds-3/#border-top-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [border-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-width)
+- [border-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-width)
   - TR
-      - [CSS 2.1 - border-width](http://www.w3.org/TR/CSS21/box.html#propdef-border-width)
-      - [CSS Backgrounds 3 - border-width](http://www.w3.org/TR/css3-background/#border-width)
+      - [CSS 2.1 - border-width](https://www.w3.org/TR/CSS21/box.html#propdef-border-width)
+      - [CSS Backgrounds 3 - border-width](https://www.w3.org/TR/css3-background/#border-width)
   - Drafts
       - [CSS 2.1 - border-width](https://drafts.csswg.org/css2/box.html#propdef-border-width)
       - [CSS Backgrounds 3 - border-width](https://drafts.csswg.org/css-backgrounds-3/#border-width)
   - Values: `INSETS border-top-width border-right-width border-bottom-width border-left-width;`
-- [box-shadow](http://www.w3.org/TR/css3-background/#box-shadow)
+- [box-shadow](https://www.w3.org/TR/css3-background/#box-shadow)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Backgrounds 3 - box-shadow](http://www.w3.org/TR/css3-background/#box-shadow)
+      - [CSS Backgrounds 3 - box-shadow](https://www.w3.org/TR/css3-background/#box-shadow)
   - Drafts
       - [CSS Backgrounds 3 - box-shadow](https://drafts.csswg.org/css-backgrounds-3/#box-shadow)
   - Values: `none | COMMA( SHADOW+ );`
 
 ## [CSS Backgrounds 4](https://drafts.csswg.org/css-backgrounds-4/)
-- [background-position](http://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
+- [background-position](https://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
   - TR
-      - [CSS 2.1 - background-position](http://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
-      - [CSS Backgrounds 3 - background-position](http://www.w3.org/TR/css3-background/#background-position)
+      - [CSS 2.1 - background-position](https://www.w3.org/TR/CSS21/colors.html#propdef-background-position)
+      - [CSS Backgrounds 3 - background-position](https://www.w3.org/TR/css3-background/#background-position)
   - Drafts
       - [CSS 2.1 - background-position](https://drafts.csswg.org/css2/colors.html#propdef-background-position)
       - [CSS Backgrounds 3 - background-position](https://drafts.csswg.org/css-backgrounds-3/#background-position)
       - [CSS Backgrounds 4 - background-position](https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position)
   - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
-- [border-radius](http://www.w3.org/TR/css3-background/#border-radius)
+- [border-radius](https://www.w3.org/TR/css3-background/#border-radius)
   - TR
-      - [CSS Backgrounds 3 - border-radius](http://www.w3.org/TR/css3-background/#border-radius)
+      - [CSS Backgrounds 3 - border-radius](https://www.w3.org/TR/css3-background/#border-radius)
   - Drafts
       - [CSS Backgrounds 3 - border-radius](https://drafts.csswg.org/css-backgrounds-3/#border-radius)
       - [CSS Backgrounds 4 - border-radius](https://drafts.csswg.org/css-backgrounds-4/#propdef-border-radius)
   - Values: `INSETS_SLASH border-top-left-radius border-top-right-radius border-bottom-right-radius border-bottom-left-radius;`
 
-## [CSS Images 3](http://www.w3.org/TR/css3-images/)
-- [object-fit](http://www.w3.org/TR/css3-images/#object-fit)
+## [CSS Images 3](https://www.w3.org/TR/css3-images/)
+- [object-fit](https://www.w3.org/TR/css3-images/#object-fit)
   - TR
-      - [CSS Images 3 - object-fit](http://www.w3.org/TR/css3-images/#object-fit)
-      - [CSS Images 4 - object-fit](http://www.w3.org/TR/css4-images/#object-fit)
+      - [CSS Images 3 - object-fit](https://www.w3.org/TR/css3-images/#object-fit)
+      - [CSS Images 4 - object-fit](https://www.w3.org/TR/css4-images/#object-fit)
   - Drafts
       - [CSS Images 3 - object-fit](https://drafts.csswg.org/css-images-3/#propdef-object-fit)
   - Values: `fill | contain | cover | none | scale-down;`
-- [object-position](http://www.w3.org/TR/css3-images/#object-position)
+- [object-position](https://www.w3.org/TR/css3-images/#object-position)
   - TR
-      - [CSS Images 3 - object-position](http://www.w3.org/TR/css3-images/#object-position)
-      - [CSS Images 4 - object-position](http://www.w3.org/TR/css4-images/#object-position)
+      - [CSS Images 3 - object-position](https://www.w3.org/TR/css3-images/#object-position)
+      - [CSS Images 4 - object-position](https://www.w3.org/TR/css4-images/#object-position)
   - Drafts
       - [CSS Images 3 - object-position](https://drafts.csswg.org/css-images-3/#propdef-object-position)
   - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
 
-## [CSS Images 4](http://www.w3.org/TR/css4-images/)
-- [object-fit](http://www.w3.org/TR/css3-images/#object-fit)
+## [CSS Images 4](https://www.w3.org/TR/css4-images/)
+- [object-fit](https://www.w3.org/TR/css3-images/#object-fit)
   - TR
-      - [CSS Images 3 - object-fit](http://www.w3.org/TR/css3-images/#object-fit)
-      - [CSS Images 4 - object-fit](http://www.w3.org/TR/css4-images/#object-fit)
+      - [CSS Images 3 - object-fit](https://www.w3.org/TR/css3-images/#object-fit)
+      - [CSS Images 4 - object-fit](https://www.w3.org/TR/css4-images/#object-fit)
   - Drafts
       - [CSS Images 3 - object-fit](https://drafts.csswg.org/css-images-3/#propdef-object-fit)
   - Values: `fill | contain | cover | none | scale-down;`
-- [object-position](http://www.w3.org/TR/css3-images/#object-position)
+- [object-position](https://www.w3.org/TR/css3-images/#object-position)
   - TR
-      - [CSS Images 3 - object-position](http://www.w3.org/TR/css3-images/#object-position)
-      - [CSS Images 4 - object-position](http://www.w3.org/TR/css4-images/#object-position)
+      - [CSS Images 3 - object-position](https://www.w3.org/TR/css3-images/#object-position)
+      - [CSS Images 4 - object-position](https://www.w3.org/TR/css4-images/#object-position)
   - Drafts
       - [CSS Images 3 - object-position](https://drafts.csswg.org/css-images-3/#propdef-object-position)
   - Values: `COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */`
 
-## [CSS Fonts 3](http://www.w3.org/TR/css-fonts-3/)
-- [font](http://www.w3.org/TR/CSS21/fonts.html#propdef-font)
+## [CSS Fonts 3](https://www.w3.org/TR/css-fonts-3/)
+- [font](https://www.w3.org/TR/CSS21/fonts.html#propdef-font)
   - TR
-      - [CSS 2.1 - font](http://www.w3.org/TR/CSS21/fonts.html#propdef-font)
-      - [CSS Fonts 3 - font](http://www.w3.org/TR/css-fonts-3/#propdef-font)
+      - [CSS 2.1 - font](https://www.w3.org/TR/CSS21/fonts.html#propdef-font)
+      - [CSS Fonts 3 - font](https://www.w3.org/TR/css-fonts-3/#propdef-font)
   - Drafts
       - [CSS 2.1 - font](https://drafts.csswg.org/css2/fonts.html#propdef-font)
       - [CSS Fonts 3 - font](https://drafts.csswg.org/css-fonts-3/#propdef-font)
   - Values: `FONT font-style font-variant font-weight /* font-size line-height font-family are special-cased */;`
-- [font-family](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
+- [font-family](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
   - TR
-      - [CSS 2.1 - font-family](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
-      - [CSS Fonts 3 - font-family](http://www.w3.org/TR/css-fonts-3/#propdef-font-family)
+      - [CSS 2.1 - font-family](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-family)
+      - [CSS Fonts 3 - font-family](https://www.w3.org/TR/css-fonts-3/#propdef-font-family)
   - Drafts
       - [CSS 2.1 - font-family](https://drafts.csswg.org/css2/fonts.html#propdef-font-family)
       - [CSS Fonts 3 - font-family](https://drafts.csswg.org/css-fonts-3/#propdef-font-family)
   - Values: `FAMILY_LIST;`
-- [font-kerning](http://www.w3.org/TR/css-fonts-3/#propdef-font-kerning)
+- [font-kerning](https://www.w3.org/TR/css-fonts-3/#propdef-font-kerning)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Fonts 3 - font-kerning](http://www.w3.org/TR/css-fonts-3/#propdef-font-kerning)
+      - [CSS Fonts 3 - font-kerning](https://www.w3.org/TR/css-fonts-3/#propdef-font-kerning)
   - Drafts
       - [CSS Fonts 3 - font-kerning](https://drafts.csswg.org/css-fonts-3/#propdef-font-kerning)
   - Values: `auto | normal | none;`
-- [font-size](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
+- [font-size](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
   - TR
-      - [CSS 2.1 - font-size](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
-      - [CSS Fonts 3 - font-size](http://www.w3.org/TR/css-fonts-3/#propdef-font-size)
+      - [CSS 2.1 - font-size](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
+      - [CSS Fonts 3 - font-size](https://www.w3.org/TR/css-fonts-3/#propdef-font-size)
   - Drafts
       - [CSS 2.1 - font-size](https://drafts.csswg.org/css2/fonts.html#propdef-font-size)
       - [CSS Fonts 3 - font-size](https://drafts.csswg.org/css-fonts-3/#propdef-font-size)
   - Values: `xx-small | x-small | small | medium | large | x-large | xx-large | larger | smaller | PPLENGTH;`
-- [font-style](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
+- [font-style](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
   - TR
-      - [CSS 2.1 - font-style](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
-      - [CSS Fonts 3 - font-style](http://www.w3.org/TR/css-fonts-3/#propdef-font-style)
+      - [CSS 2.1 - font-style](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-style)
+      - [CSS Fonts 3 - font-style](https://www.w3.org/TR/css-fonts-3/#propdef-font-style)
   - Drafts
       - [CSS 2.1 - font-style](https://drafts.csswg.org/css2/fonts.html#propdef-font-style)
       - [CSS Fonts 3 - font-style](https://drafts.csswg.org/css-fonts-3/#propdef-font-style)
   - Values: `normal | italic | oblique;`
-- [font-variant](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
+- [font-variant](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
   - TR
-      - [CSS 2.1 - font-variant](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
-      - [CSS Fonts 3 - font-variant](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant)
+      - [CSS 2.1 - font-variant](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-variant)
+      - [CSS Fonts 3 - font-variant](https://www.w3.org/TR/css-fonts-3/#propdef-font-variant)
   - Drafts
       - [CSS 2.1 - font-variant](https://drafts.csswg.org/css2/fonts.html#propdef-font-variant)
       - [CSS Fonts 3 - font-variant](https://drafts.csswg.org/css-fonts-3/#propdef-font-variant)
   - Values: `normal | small-caps;`
-- [font-variant-east-asian](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
+- [font-variant-east-asian](https://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
   - TR
-      - [CSS Fonts 3 - font-variant-east-asian](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
+      - [CSS Fonts 3 - font-variant-east-asian](https://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
   - Drafts
       - [CSS Fonts 3 - font-variant-east-asian](https://drafts.csswg.org/css-fonts-3/#propdef-font-variant-east-asian)
   - Values: `normal | [[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ] || [ full-width | proportional-width ] || ruby];`
-- [font-weight](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
+- [font-weight](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
   - TR
-      - [CSS 2.1 - font-weight](http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
-      - [CSS Fonts 3 - font-weight](http://www.w3.org/TR/css-fonts-3/#propdef-font-weight)
+      - [CSS 2.1 - font-weight](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight)
+      - [CSS Fonts 3 - font-weight](https://www.w3.org/TR/css-fonts-3/#propdef-font-weight)
   - Drafts
       - [CSS 2.1 - font-weight](https://drafts.csswg.org/css2/fonts.html#propdef-font-weight)
       - [CSS Fonts 3 - font-weight](https://drafts.csswg.org/css-fonts-3/#propdef-font-weight)
   - Values: `normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;`
 
-## [CSS Text 3](http://www.w3.org/TR/css-text-3/)
-- [hyphens](http://www.w3.org/TR/css-text-3/#hyphens)
+## [CSS Text 3](https://www.w3.org/TR/css-text-3/)
+- [hyphens](https://www.w3.org/TR/css-text-3/#hyphens)
     - Allowed prefixes: epub, moz, ms, webkit
   - TR
-      - [CSS Text 3 - hyphens](http://www.w3.org/TR/css-text-3/#hyphens)
+      - [CSS Text 3 - hyphens](https://www.w3.org/TR/css-text-3/#hyphens)
   - Drafts
       - [CSS Text 3 - hyphens](https://drafts.csswg.org/css-text-3/#propdef-hyphens)
   - Values: `auto | manual | none;`
-- [letter-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
+- [letter-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
   - TR
-      - [CSS 2.1 - letter-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
-      - [CSS Text 3 - letter-spacing](http://www.w3.org/TR/css-text-3/#letter-spacing)
+      - [CSS 2.1 - letter-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-letter-spacing)
+      - [CSS Text 3 - letter-spacing](https://www.w3.org/TR/css-text-3/#letter-spacing)
   - Drafts
       - [CSS 2.1 - letter-spacing](https://drafts.csswg.org/css2/text.html#propdef-letter-spacing)
       - [CSS Text 3 - letter-spacing](https://drafts.csswg.org/css-text-3/#propdef-letter-spacing)
   - Values: `normal | LENGTH;`
-- [line-break](http://www.w3.org/TR/css-text-3/#line-break0)
+- [line-break](https://www.w3.org/TR/css-text-3/#line-break0)
     - Allowed prefixes: ms, webkit
   - TR
-      - [CSS Text 3 - line-break](http://www.w3.org/TR/css-text-3/#line-break0)
+      - [CSS Text 3 - line-break](https://www.w3.org/TR/css-text-3/#line-break0)
   - Drafts
       - [CSS Text 3 - line-break](https://drafts.csswg.org/css-text-3/#propdef-line-break)
   - Values: `auto | loose | normal | strict;`
-- [overflow-wrap](http://www.w3.org/TR/css-text-3/#overflow-wrap)
+- [overflow-wrap](https://www.w3.org/TR/css-text-3/#overflow-wrap)
   - TR
-      - [CSS Text 3 - overflow-wrap](http://www.w3.org/TR/css-text-3/#overflow-wrap)
+      - [CSS Text 3 - overflow-wrap](https://www.w3.org/TR/css-text-3/#overflow-wrap)
   - Drafts
       - [CSS Text 3 - overflow-wrap](https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap)
   - Values: `normal | break-word;`
-- [tab-size](http://www.w3.org/TR/css-text-3/#tab-size)
+- [tab-size](https://www.w3.org/TR/css-text-3/#tab-size)
     - Allowed prefixes: moz
   - TR
-      - [CSS Text 3 - tab-size](http://www.w3.org/TR/css-text-3/#tab-size)
+      - [CSS Text 3 - tab-size](https://www.w3.org/TR/css-text-3/#tab-size)
   - Drafts
       - [CSS Text 3 - tab-size](https://drafts.csswg.org/css-text-3/#propdef-tab-size)
   - Values: `NNEG_INT | NNEG_LENGTH;`
-- [text-align](http://www.w3.org/TR/CSS21/text.html#propdef-text-align)
+- [text-align](https://www.w3.org/TR/CSS21/text.html#propdef-text-align)
   - TR
-      - [CSS 2.1 - text-align](http://www.w3.org/TR/CSS21/text.html#propdef-text-align)
-      - [CSS Text 3 - text-align](http://www.w3.org/TR/css-text-3/#text-align)
+      - [CSS 2.1 - text-align](https://www.w3.org/TR/CSS21/text.html#propdef-text-align)
+      - [CSS Text 3 - text-align](https://www.w3.org/TR/css-text-3/#text-align)
   - Drafts
       - [CSS 2.1 - text-align](https://drafts.csswg.org/css2/text.html#propdef-text-align)
       - [CSS Text 3 - text-align](https://drafts.csswg.org/css-text-3/#propdef-text-align)
   - Values: `left | right | center | justify;`
-- [text-align-last](http://www.w3.org/TR/css-text-3/#text-align-last)
+- [text-align-last](https://www.w3.org/TR/css-text-3/#text-align-last)
     - Allowed prefixes: moz, ms
   - TR
-      - [CSS Text 3 - text-align-last](http://www.w3.org/TR/css-text-3/#text-align-last)
+      - [CSS Text 3 - text-align-last](https://www.w3.org/TR/css-text-3/#text-align-last)
   - Drafts
       - [CSS Text 3 - text-align-last](https://drafts.csswg.org/css-text-3/#propdef-text-align-last)
   - Values: `auto | start | end | left | right | center | justify;`
-- [text-indent](http://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
+- [text-indent](https://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
   - TR
-      - [CSS 2.1 - text-indent](http://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
-      - [CSS Text 3 - text-indent](http://www.w3.org/TR/css-text-3/#text-indent)
+      - [CSS 2.1 - text-indent](https://www.w3.org/TR/CSS21/text.html#propdef-text-indent)
+      - [CSS Text 3 - text-indent](https://www.w3.org/TR/css-text-3/#text-indent)
   - Drafts
       - [CSS 2.1 - text-indent](https://drafts.csswg.org/css2/text.html#propdef-text-indent)
       - [CSS Text 3 - text-indent](https://drafts.csswg.org/css-text-3/#propdef-text-indent)
   - Values: `PLENGTH;`
-- [text-justify](http://www.w3.org/TR/css-text-3/#text-justify)
+- [text-justify](https://www.w3.org/TR/css-text-3/#text-justify)
     - Allowed prefixes: ms
   - TR
-      - [CSS Text 3 - text-justify](http://www.w3.org/TR/css-text-3/#text-justify)
+      - [CSS Text 3 - text-justify](https://www.w3.org/TR/css-text-3/#text-justify)
   - Drafts
       - [CSS Text 3 - text-justify](https://drafts.csswg.org/css-text-3/#propdef-text-justify)
   - Values: `auto | none | inter-word | inter-character | inter-ideograph /* specified in UA stylesheet for IE */;`
-- [text-transform](http://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
+- [text-transform](https://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
   - TR
-      - [CSS 2.1 - text-transform](http://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
-      - [CSS Text 3 - text-transform](http://www.w3.org/TR/css-text-3/#text-transform)
+      - [CSS 2.1 - text-transform](https://www.w3.org/TR/CSS21/text.html#propdef-text-transform)
+      - [CSS Text 3 - text-transform](https://www.w3.org/TR/css-text-3/#text-transform)
   - Drafts
       - [CSS 2.1 - text-transform](https://drafts.csswg.org/css2/text.html#propdef-text-transform)
       - [CSS Text 3 - text-transform](https://drafts.csswg.org/css-text-3/#propdef-text-transform)
   - Values: `capitalize | uppercase | lowercase | none;`
-- [white-space](http://www.w3.org/TR/CSS21/text.html#propdef-white-space)
+- [white-space](https://www.w3.org/TR/CSS21/text.html#propdef-white-space)
   - TR
-      - [CSS 2.1 - white-space](http://www.w3.org/TR/CSS21/text.html#propdef-white-space)
-      - [CSS Text 3 - white-space](http://www.w3.org/TR/css-text-3/#white-space)
+      - [CSS 2.1 - white-space](https://www.w3.org/TR/CSS21/text.html#propdef-white-space)
+      - [CSS Text 3 - white-space](https://www.w3.org/TR/css-text-3/#white-space)
   - Drafts
       - [CSS 2.1 - white-space](https://drafts.csswg.org/css2/text.html#propdef-white-space)
       - [CSS Text 3 - white-space](https://drafts.csswg.org/css-text-3/#propdef-white-space)
       - [CSS Text 4 - white-space](https://drafts.csswg.org/css-text-4/#propdef-white-space)
   - Values: `normal | pre | nowrap | pre-wrap | pre-line;`
-- [word-break](http://www.w3.org/TR/css-text-3/#word-break)
+- [word-break](https://www.w3.org/TR/css-text-3/#word-break)
     - Allowed prefixes: ms
   - TR
-      - [CSS Text 3 - word-break](http://www.w3.org/TR/css-text-3/#word-break)
+      - [CSS Text 3 - word-break](https://www.w3.org/TR/css-text-3/#word-break)
   - Drafts
       - [CSS Text 3 - word-break](https://drafts.csswg.org/css-text-3/#propdef-word-break)
   - Values: `normal | keep-all | break-all;`
-- [word-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
+- [word-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
   - TR
-      - [CSS 2.1 - word-spacing](http://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
-      - [CSS Text 3 - word-spacing](http://www.w3.org/TR/css-text-3/#word-spacing)
+      - [CSS 2.1 - word-spacing](https://www.w3.org/TR/CSS21/text.html#propdef-word-spacing)
+      - [CSS Text 3 - word-spacing](https://www.w3.org/TR/css-text-3/#word-spacing)
   - Drafts
       - [CSS 2.1 - word-spacing](https://drafts.csswg.org/css2/text.html#propdef-word-spacing)
       - [CSS Text 3 - word-spacing](https://drafts.csswg.org/css-text-3/#propdef-word-spacing)
   - Values: `normal | LENGTH;`
-- [word-wrap](http://www.w3.org/TR/css-text-3/#word-wrap)
+- [word-wrap](https://www.w3.org/TR/css-text-3/#word-wrap)
     - Allowed prefixes: ms
   - TR
-      - [CSS Text 3 - word-wrap](http://www.w3.org/TR/css-text-3/#word-wrap)
+      - [CSS Text 3 - word-wrap](https://www.w3.org/TR/css-text-3/#word-wrap)
   - Drafts
       - [CSS Text 3 - word-wrap](https://drafts.csswg.org/css-text-3/#propdef-word-wrap)
   - Values: `normal | break-word;`
 
 ## [CSS Text 4](https://drafts.csswg.org/css-text-4/)
-- [white-space](http://www.w3.org/TR/CSS21/text.html#propdef-white-space)
+- [white-space](https://www.w3.org/TR/CSS21/text.html#propdef-white-space)
   - TR
-      - [CSS 2.1 - white-space](http://www.w3.org/TR/CSS21/text.html#propdef-white-space)
-      - [CSS Text 3 - white-space](http://www.w3.org/TR/css-text-3/#white-space)
+      - [CSS 2.1 - white-space](https://www.w3.org/TR/CSS21/text.html#propdef-white-space)
+      - [CSS Text 3 - white-space](https://www.w3.org/TR/css-text-3/#white-space)
   - Drafts
       - [CSS 2.1 - white-space](https://drafts.csswg.org/css2/text.html#propdef-white-space)
       - [CSS Text 3 - white-space](https://drafts.csswg.org/css-text-3/#propdef-white-space)
       - [CSS Text 4 - white-space](https://drafts.csswg.org/css-text-4/#propdef-white-space)
   - Values: `normal | pre | nowrap | pre-wrap | pre-line;`
 
-## [CSS Text Decoration 3](http://www.w3.org/TR/css-text-decor-3/)
-- [text-decoration](http://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
+## [CSS Text Decoration 3](https://www.w3.org/TR/css-text-decor-3/)
+- [text-decoration](https://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
   - TR
-      - [CSS 2.1 - text-decoration](http://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
-      - [CSS Text Decoration 3 - text-decoration](http://www.w3.org/TR/css-text-decor-3/#text-decoration)
+      - [CSS 2.1 - text-decoration](https://www.w3.org/TR/CSS21/text.html#propdef-text-decoration)
+      - [CSS Text Decoration 3 - text-decoration](https://www.w3.org/TR/css-text-decor-3/#text-decoration)
   - Drafts
       - [CSS 2.1 - text-decoration](https://drafts.csswg.org/css2/text.html#propdef-text-decoration)
       - [CSS Text Decoration 3 - text-decoration](https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration)
   - Values: `none | [ underline || overline || line-through || blink ];`
-- [text-decoration-color](http://www.w3.org/TR/css-text-decor-3/#text-decoration-color)
+- [text-decoration-color](https://www.w3.org/TR/css-text-decor-3/#text-decoration-color)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Text Decoration 3 - text-decoration-color](http://www.w3.org/TR/css-text-decor-3/#text-decoration-color)
+      - [CSS Text Decoration 3 - text-decoration-color](https://www.w3.org/TR/css-text-decor-3/#text-decoration-color)
   - Drafts
       - [CSS Text Decoration 3 - text-decoration-color](https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration-color)
   - Values: `COLOR;`
-- [text-decoration-line](http://www.w3.org/TR/css-text-decor-3/#text-decoration-line)
+- [text-decoration-line](https://www.w3.org/TR/css-text-decor-3/#text-decoration-line)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Text Decoration 3 - text-decoration-line](http://www.w3.org/TR/css-text-decor-3/#text-decoration-line)
+      - [CSS Text Decoration 3 - text-decoration-line](https://www.w3.org/TR/css-text-decor-3/#text-decoration-line)
   - Drafts
       - [CSS Text Decoration 3 - text-decoration-line](https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration-line)
   - Values: `none | [ underline || overline || line-through || blink ];`
-- [text-decoration-skip](http://www.w3.org/TR/css-text-decor-3/#text-decoration-skip)
+- [text-decoration-skip](https://www.w3.org/TR/css-text-decor-3/#text-decoration-skip)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Text Decoration 3 - text-decoration-skip](http://www.w3.org/TR/css-text-decor-3/#text-decoration-skip)
+      - [CSS Text Decoration 3 - text-decoration-skip](https://www.w3.org/TR/css-text-decor-3/#text-decoration-skip)
   - Drafts
       - [CSS Text Decoration 4 - text-decoration-skip](https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip)
       - [CSS Text Decoration 3 - text-decoration-skip](https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration-skip)
   - Values: `none | [ objects || spaces || ink || edges || box-decoration ];`
-- [text-decoration-style](http://www.w3.org/TR/css-text-decor-3/#text-decoration-style)
+- [text-decoration-style](https://www.w3.org/TR/css-text-decor-3/#text-decoration-style)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Text Decoration 3 - text-decoration-style](http://www.w3.org/TR/css-text-decor-3/#text-decoration-style)
+      - [CSS Text Decoration 3 - text-decoration-style](https://www.w3.org/TR/css-text-decor-3/#text-decoration-style)
   - Drafts
       - [CSS Text Decoration 3 - text-decoration-style](https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration-style)
   - Values: `solid | double | dotted | dashed | wavy;`
-- [text-emphasis](http://www.w3.org/TR/css-text-decor-3/#text-emphasis)
+- [text-emphasis](https://www.w3.org/TR/css-text-decor-3/#text-emphasis)
     - Allowed prefixes: epub, webkit
   - TR
-      - [CSS Text Decoration 3 - text-emphasis](http://www.w3.org/TR/css-text-decor-3/#text-emphasis)
+      - [CSS Text Decoration 3 - text-emphasis](https://www.w3.org/TR/css-text-decor-3/#text-emphasis)
   - Drafts
       - [CSS Text Decoration 3 - text-emphasis](https://drafts.csswg.org/css-text-decor-3/#propdef-text-emphasis)
   - Values: `text-emphasis-style text-emphasis-color;`
-- [text-emphasis-color](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-color)
+- [text-emphasis-color](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-color)
     - Allowed prefixes: epub, webkit
   - TR
-      - [CSS Text Decoration 3 - text-emphasis-color](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-color)
+      - [CSS Text Decoration 3 - text-emphasis-color](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-color)
   - Drafts
       - [CSS Text Decoration 3 - text-emphasis-color](https://drafts.csswg.org/css-text-decor-3/#propdef-text-emphasis-color)
   - Values: `COLOR;`
-- [text-emphasis-position](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-position)
+- [text-emphasis-position](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-position)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Text Decoration 3 - text-emphasis-position](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-position)
+      - [CSS Text Decoration 3 - text-emphasis-position](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-position)
   - Drafts
       - [CSS Text Decoration 3 - text-emphasis-position](https://drafts.csswg.org/css-text-decor-3/#propdef-text-emphasis-position)
   - Values: `[ over | under ] [ right | left ];`
-- [text-emphasis-style](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-style)
+- [text-emphasis-style](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-style)
     - Allowed prefixes: epub, webkit
   - TR
-      - [CSS Text Decoration 3 - text-emphasis-style](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-style)
+      - [CSS Text Decoration 3 - text-emphasis-style](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-style)
   - Drafts
       - [CSS Text Decoration 3 - text-emphasis-style](https://drafts.csswg.org/css-text-decor-3/#propdef-text-emphasis-style)
   - Values: `none | [[ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]] | STRING;`
-- [text-shadow](http://www.w3.org/TR/css-text-decor-3/#text-shadow)
+- [text-shadow](https://www.w3.org/TR/css-text-decor-3/#text-shadow)
   - TR
-      - [CSS Text Decoration 3 - text-shadow](http://www.w3.org/TR/css-text-decor-3/#text-shadow)
+      - [CSS Text Decoration 3 - text-shadow](https://www.w3.org/TR/css-text-decor-3/#text-shadow)
   - Drafts
       - [CSS Text Decoration 3 - text-shadow](https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow)
   - Values: `none |  COMMA( SHADOW+ );`
-- [text-underline-position](http://www.w3.org/TR/css-text-decor-3/#text-underline-position)
+- [text-underline-position](https://www.w3.org/TR/css-text-decor-3/#text-underline-position)
     - Allowed prefixes: ms, webkit
   - TR
-      - [CSS Text Decoration 3 - text-underline-position](http://www.w3.org/TR/css-text-decor-3/#text-underline-position)
+      - [CSS Text Decoration 3 - text-underline-position](https://www.w3.org/TR/css-text-decor-3/#text-underline-position)
   - Drafts
       - [CSS Text Decoration 3 - text-underline-position](https://drafts.csswg.org/css-text-decor-3/#propdef-text-underline-position)
   - Values: `auto | [ under || [ left | right ]];`
 
-## [CSS Multicol 1](http://www.w3.org/TR/css3-multicol/)
-- [break-after](http://www.w3.org/TR/css3-multicol/#break-after)
+## [CSS Multicol 1](https://www.w3.org/TR/css3-multicol/)
+- [break-after](https://www.w3.org/TR/css3-multicol/#break-after)
   - TR
-      - [CSS Multicol 1 - break-after](http://www.w3.org/TR/css3-multicol/#break-after)
-      - [CSS Fragmentation 3 - break-after](http://www.w3.org/TR/css3-break/#break-after)
-      - [CSS Regions 1 - break-after](http://www.w3.org/TR/css3-regions/#propdef-break-after)
+      - [CSS Multicol 1 - break-after](https://www.w3.org/TR/css3-multicol/#break-after)
+      - [CSS Fragmentation 3 - break-after](https://www.w3.org/TR/css3-break/#propdef-break-after)
+      - [CSS Regions 1 - break-after](https://www.w3.org/TR/css3-regions/#propdef-break-after)
   - Drafts
       - [CSS Fragmentation 3 - break-after](https://drafts.csswg.org/css-break-3/#propdef-break-after)
       - [CSS Regions 1 - break-after](https://drafts.csswg.org/css-regions-1/#propdef-break-after)
   - Values: `BREAK;`
-- [break-before](http://www.w3.org/TR/css3-multicol/#break-before)
+- [break-before](https://www.w3.org/TR/css3-multicol/#break-before)
   - TR
-      - [CSS Multicol 1 - break-before](http://www.w3.org/TR/css3-multicol/#break-before)
-      - [CSS Fragmentation 3 - break-before](http://www.w3.org/TR/css3-break/#break-before)
-      - [CSS Regions 1 - break-before](http://www.w3.org/TR/css3-regions/#propdef-break-before)
+      - [CSS Multicol 1 - break-before](https://www.w3.org/TR/css3-multicol/#break-before)
+      - [CSS Fragmentation 3 - break-before](https://www.w3.org/TR/css3-break/#propdef-break-before)
+      - [CSS Regions 1 - break-before](https://www.w3.org/TR/css3-regions/#propdef-break-before)
   - Drafts
       - [CSS Fragmentation 3 - break-before](https://drafts.csswg.org/css-break-3/#propdef-break-before)
       - [CSS Regions 1 - break-before](https://drafts.csswg.org/css-regions-1/#propdef-break-before)
   - Values: `BREAK;`
-- [break-inside](http://www.w3.org/TR/css3-multicol/#break-inside)
+- [break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
   - TR
-      - [CSS Multicol 1 - break-inside](http://www.w3.org/TR/css3-multicol/#break-inside)
-      - [CSS Fragmentation 3 - break-inside](http://www.w3.org/TR/css3-break/#break-inside)
-      - [CSS Regions 1 - break-inside](http://www.w3.org/TR/css3-regions/#propdef-break-inside)
+      - [CSS Multicol 1 - break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
+      - [CSS Fragmentation 3 - break-inside](https://www.w3.org/TR/css3-break/#propdef-break-inside)
+      - [CSS Regions 1 - break-inside](https://www.w3.org/TR/css3-regions/#propdef-break-inside)
   - Drafts
       - [CSS Fragmentation 3 - break-inside](https://drafts.csswg.org/css-break-3/#propdef-break-inside)
       - [CSS Regions 1 - break-inside](https://drafts.csswg.org/css-regions-1/#propdef-break-inside)
   - Values: `auto | avoid | avoid-page | avoid-column | avoid-region;`
-- [column-count](http://www.w3.org/TR/css3-multicol/#column-count)
+- [column-count](https://www.w3.org/TR/css3-multicol/#column-count)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - column-count](http://www.w3.org/TR/css3-multicol/#column-count)
+      - [CSS Multicol 1 - column-count](https://www.w3.org/TR/css3-multicol/#column-count)
   - Drafts
       - [CSS Multicol 1 - column-count](https://drafts.csswg.org/css-multicol-1/#propdef-column-count)
   - Values: `INT | auto;`
-- [column-fill](http://www.w3.org/TR/css3-multicol/#column-fill)
+- [column-fill](https://www.w3.org/TR/css3-multicol/#column-fill)
     - Allowed prefixes: moz
   - TR
-      - [CSS Multicol 1 - column-fill](http://www.w3.org/TR/css3-multicol/#column-fill)
+      - [CSS Multicol 1 - column-fill](https://www.w3.org/TR/css3-multicol/#column-fill)
   - Drafts
       - [CSS Multicol 1 - column-fill](https://drafts.csswg.org/css-multicol-1/#propdef-column-fill)
   - Values: `auto | balance;`
-- [column-gap](http://www.w3.org/TR/css3-multicol/#column-gap0)
+- [column-gap](https://www.w3.org/TR/css3-multicol/#column-gap0)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - column-gap](http://www.w3.org/TR/css3-multicol/#column-gap0)
+      - [CSS Multicol 1 - column-gap](https://www.w3.org/TR/css3-multicol/#column-gap0)
   - Drafts
       - [CSS Multicol 1 - column-gap](https://drafts.csswg.org/css-multicol-1/#propdef-column-gap)
   - Values: `LENGTH | normal;`
-- [column-rule](http://www.w3.org/TR/css3-multicol/#column-rule0)
+- [column-rule](https://www.w3.org/TR/css3-multicol/#column-rule0)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - column-rule](http://www.w3.org/TR/css3-multicol/#column-rule0)
+      - [CSS Multicol 1 - column-rule](https://www.w3.org/TR/css3-multicol/#column-rule0)
   - Drafts
       - [CSS Multicol 1 - column-rule](https://drafts.csswg.org/css-multicol-1/#propdef-column-rule)
   - Values: `column-rule-width column-rule-style column-rule-color;`
-- [column-rule-color](http://www.w3.org/TR/css3-multicol/#column-rule-color)
+- [column-rule-color](https://www.w3.org/TR/css3-multicol/#column-rule-color)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - column-rule-color](http://www.w3.org/TR/css3-multicol/#column-rule-color)
+      - [CSS Multicol 1 - column-rule-color](https://www.w3.org/TR/css3-multicol/#column-rule-color)
   - Drafts
       - [CSS Multicol 1 - column-rule-color](https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color)
   - Values: `COLOR;`
-- [column-rule-style](http://www.w3.org/TR/css3-multicol/#column-rule-style)
+- [column-rule-style](https://www.w3.org/TR/css3-multicol/#column-rule-style)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - column-rule-style](http://www.w3.org/TR/css3-multicol/#column-rule-style)
+      - [CSS Multicol 1 - column-rule-style](https://www.w3.org/TR/css3-multicol/#column-rule-style)
   - Drafts
       - [CSS Multicol 1 - column-rule-style](https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [column-rule-width](http://www.w3.org/TR/css3-multicol/#column-rule-width)
+- [column-rule-width](https://www.w3.org/TR/css3-multicol/#column-rule-width)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - column-rule-width](http://www.w3.org/TR/css3-multicol/#column-rule-width)
+      - [CSS Multicol 1 - column-rule-width](https://www.w3.org/TR/css3-multicol/#column-rule-width)
   - Drafts
       - [CSS Multicol 1 - column-rule-width](https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [column-span](http://www.w3.org/TR/css3-multicol/#column-span0)
+- [column-span](https://www.w3.org/TR/css3-multicol/#column-span0)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Multicol 1 - column-span](http://www.w3.org/TR/css3-multicol/#column-span0)
+      - [CSS Multicol 1 - column-span](https://www.w3.org/TR/css3-multicol/#column-span0)
   - Drafts
       - [CSS Multicol 1 - column-span](https://drafts.csswg.org/css-multicol-1/#propdef-column-span)
       - [CSS Multicol 2 - column-span](https://drafts.csswg.org/css-multicol-2/#propdef-column-span)
   - Values: `none | all;`
-- [column-width](http://www.w3.org/TR/css3-multicol/#column-width)
+- [column-width](https://www.w3.org/TR/css3-multicol/#column-width)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - column-width](http://www.w3.org/TR/css3-multicol/#column-width)
+      - [CSS Multicol 1 - column-width](https://www.w3.org/TR/css3-multicol/#column-width)
   - Drafts
       - [CSS Multicol 1 - column-width](https://drafts.csswg.org/css-multicol-1/#propdef-column-width)
   - Values: `LENGTH | auto;`
-- [columns](http://www.w3.org/TR/css3-multicol/#columns0)
+- [columns](https://www.w3.org/TR/css3-multicol/#columns0)
     - Allowed prefixes: moz, webkit
   - TR
-      - [CSS Multicol 1 - columns](http://www.w3.org/TR/css3-multicol/#columns0)
+      - [CSS Multicol 1 - columns](https://www.w3.org/TR/css3-multicol/#columns0)
   - Drafts
       - [CSS Multicol 1 - columns](https://drafts.csswg.org/css-multicol-1/#propdef-columns)
   - Values: `column-width column-count;`
 
 ## [CSS Multicol 2](https://drafts.csswg.org/css-multicol-2/)
-- [column-span](http://www.w3.org/TR/css3-multicol/#column-span0)
+- [column-span](https://www.w3.org/TR/css3-multicol/#column-span0)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Multicol 1 - column-span](http://www.w3.org/TR/css3-multicol/#column-span0)
+      - [CSS Multicol 1 - column-span](https://www.w3.org/TR/css3-multicol/#column-span0)
   - Drafts
       - [CSS Multicol 1 - column-span](https://drafts.csswg.org/css-multicol-1/#propdef-column-span)
       - [CSS Multicol 2 - column-span](https://drafts.csswg.org/css-multicol-2/#propdef-column-span)
   - Values: `none | all;`
 
-## [CSS User Interface 3](http://www.w3.org/TR/css3-ui/)
-- [box-sizing](http://www.w3.org/TR/css3-ui/#propdef-box-sizing)
+## [CSS User Interface 3](https://www.w3.org/TR/css3-ui/)
+- [box-sizing](https://www.w3.org/TR/css3-ui/#propdef-box-sizing)
   - TR
-      - [CSS User Interface 3 - box-sizing](http://www.w3.org/TR/css3-ui/#propdef-box-sizing)
+      - [CSS User Interface 3 - box-sizing](https://www.w3.org/TR/css3-ui/#propdef-box-sizing)
   - Drafts
       - [CSS User Interface 3 - box-sizing](https://drafts.csswg.org/css-ui-3/#propdef-box-sizing)
   - Values: `content-box | padding-box | border-box;`
-- [cursor](http://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
+- [cursor](https://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
   - TR
-      - [CSS 2.1 - cursor](http://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
-      - [CSS User Interface 3 - cursor](http://www.w3.org/TR/css3-ui/#propdef-cursor)
+      - [CSS 2.1 - cursor](https://www.w3.org/TR/CSS21/ui.html#propdef-cursor)
+      - [CSS User Interface 3 - cursor](https://www.w3.org/TR/css3-ui/#propdef-cursor)
   - Drafts
       - [CSS 2.1 - cursor](https://drafts.csswg.org/css2/ui.html#propdef-cursor)
       - [CSS User Interface 3 - cursor](https://drafts.csswg.org/css-ui-3/#propdef-cursor)
   - Values: `COMMA(URI* [ auto | crosshair | default | pointer | move | e-resize | ne-resize | nw-resize | n-resize | se-resize | sw-resize | s-resize | w-resize | text | wait | help | progress ]);`
-- [outline](http://www.w3.org/TR/CSS21/ui.html#propdef-outline)
+- [outline](https://www.w3.org/TR/CSS21/ui.html#propdef-outline)
   - TR
-      - [CSS 2.1 - outline](http://www.w3.org/TR/CSS21/ui.html#propdef-outline)
-      - [CSS User Interface 3 - outline](http://www.w3.org/TR/css3-ui/#propdef-outline)
+      - [CSS 2.1 - outline](https://www.w3.org/TR/CSS21/ui.html#propdef-outline)
+      - [CSS User Interface 3 - outline](https://www.w3.org/TR/css3-ui/#propdef-outline)
   - Drafts
       - [CSS 2.1 - outline](https://drafts.csswg.org/css2/ui.html#propdef-outline)
       - [CSS User Interface 3 - outline](https://drafts.csswg.org/css-ui-3/#propdef-outline)
   - Values: `outline-width outline-style outline-color;`
-- [outline-color](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
+- [outline-color](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
   - TR
-      - [CSS 2.1 - outline-color](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
-      - [CSS User Interface 3 - outline-color](http://www.w3.org/TR/css3-ui/#propdef-outline-color)
+      - [CSS 2.1 - outline-color](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-color)
+      - [CSS User Interface 3 - outline-color](https://www.w3.org/TR/css3-ui/#propdef-outline-color)
   - Drafts
       - [CSS 2.1 - outline-color](https://drafts.csswg.org/css2/ui.html#propdef-outline-color)
       - [CSS User Interface 3 - outline-color](https://drafts.csswg.org/css-ui-3/#propdef-outline-color)
   - Values: `COLOR | invert;`
-- [outline-style](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
+- [outline-style](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
   - TR
-      - [CSS 2.1 - outline-style](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
-      - [CSS User Interface 3 - outline-style](http://www.w3.org/TR/css3-ui/#propdef-outline-style)
+      - [CSS 2.1 - outline-style](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-style)
+      - [CSS User Interface 3 - outline-style](https://www.w3.org/TR/css3-ui/#propdef-outline-style)
   - Drafts
       - [CSS 2.1 - outline-style](https://drafts.csswg.org/css2/ui.html#propdef-outline-style)
       - [CSS User Interface 3 - outline-style](https://drafts.csswg.org/css-ui-3/#propdef-outline-style)
   - Values: `BORDER_SIDE_STYLE;`
-- [outline-width](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
+- [outline-width](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
   - TR
-      - [CSS 2.1 - outline-width](http://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
-      - [CSS User Interface 3 - outline-width](http://www.w3.org/TR/css3-ui/#propdef-outline-width)
+      - [CSS 2.1 - outline-width](https://www.w3.org/TR/CSS21/ui.html#propdef-outline-width)
+      - [CSS User Interface 3 - outline-width](https://www.w3.org/TR/css3-ui/#propdef-outline-width)
   - Drafts
       - [CSS 2.1 - outline-width](https://drafts.csswg.org/css2/ui.html#propdef-outline-width)
       - [CSS User Interface 3 - outline-width](https://drafts.csswg.org/css-ui-3/#propdef-outline-width)
   - Values: `BORDER_SIDE_WIDTH;`
-- [text-overflow](http://www.w3.org/TR/css3-ui/#propdef-text-overflow)
+- [text-overflow](https://www.w3.org/TR/css3-ui/#propdef-text-overflow)
     - Allowed prefixes: ms
   - TR
-      - [CSS User Interface 3 - text-overflow](http://www.w3.org/TR/css3-ui/#propdef-text-overflow)
+      - [CSS User Interface 3 - text-overflow](https://www.w3.org/TR/css3-ui/#propdef-text-overflow)
   - Drafts
       - [CSS User Interface 3 - text-overflow](https://drafts.csswg.org/css-ui-3/#propdef-text-overflow)
   - Values: `[clip | ellipsis | STRING]{1,2};`
 
-## [CSS Writing Modes 3](http://www.w3.org/TR/css-writing-modes-3/)
-- [direction](http://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
+## [CSS Writing Modes 3](https://www.w3.org/TR/css-writing-modes-3/)
+- [direction](https://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
   - TR
-      - [CSS 2.1 - direction](http://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
-      - [CSS Writing Modes 3 - direction](http://www.w3.org/TR/css-writing-modes-3/#propdef-direction)
+      - [CSS 2.1 - direction](https://www.w3.org/TR/CSS21/visuren.html#propdef-direction)
+      - [CSS Writing Modes 3 - direction](https://www.w3.org/TR/css-writing-modes-3/#propdef-direction)
   - Drafts
       - [CSS 2.1 - direction](https://drafts.csswg.org/css2/visuren.html#propdef-direction)
       - [CSS Writing Modes 3 - direction](https://drafts.csswg.org/css-writing-modes-3/#propdef-direction)
   - Values: `ltr | rtl;`
-- [text-combine-upright](http://www.w3.org/TR/css-writing-modes-3/#propdef-text-combine-upright)
+- [text-combine-upright](https://www.w3.org/TR/css-writing-modes-3/#propdef-text-combine-upright)
   - TR
-      - [CSS Writing Modes 3 - text-combine-upright](http://www.w3.org/TR/css-writing-modes-3/#propdef-text-combine-upright)
+      - [CSS Writing Modes 3 - text-combine-upright](https://www.w3.org/TR/css-writing-modes-3/#propdef-text-combine-upright)
   - Drafts
       - [CSS Writing Modes 3 - text-combine-upright](https://drafts.csswg.org/css-writing-modes-3/#propdef-text-combine-upright)
   - Values: `none | all | [ digits POS_INT? ]; /* relaxed */`
-- [text-orientation](http://www.w3.org/TR/css-writing-modes-3/#propdef-text-orientation)
+- [text-orientation](https://www.w3.org/TR/css-writing-modes-3/#propdef-text-orientation)
     - Allowed prefixes: epub, webkit
   - TR
-      - [CSS Writing Modes 3 - text-orientation](http://www.w3.org/TR/css-writing-modes-3/#propdef-text-orientation)
+      - [CSS Writing Modes 3 - text-orientation](https://www.w3.org/TR/css-writing-modes-3/#propdef-text-orientation)
   - Drafts
       - [CSS Writing Modes 3 - text-orientation](https://drafts.csswg.org/css-writing-modes-3/#propdef-text-orientation)
   - Values: `mixed | upright | sideways-right | sideways-left | sideways | use-glyph-orientation /* the following values are kept for backward-compatibility */ | vertical-right | rotate-right | rotate-left | rotate-normal | auto;`
-- [unicode-bidi](http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
+- [unicode-bidi](https://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
   - TR
-      - [CSS 2.1 - unicode-bidi](http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
-      - [CSS Writing Modes 3 - unicode-bidi](http://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
+      - [CSS 2.1 - unicode-bidi](https://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi)
+      - [CSS Writing Modes 3 - unicode-bidi](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
   - Drafts
       - [CSS 2.1 - unicode-bidi](https://drafts.csswg.org/css2/visuren.html#propdef-unicode-bidi)
       - [CSS Writing Modes 3 - unicode-bidi](https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi)
   - Values: `normal | embed | isolate | bidi-override | isolate-override | plaintext;`
-- [writing-mode](http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
+- [writing-mode](https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
     - Allowed prefixes: epub, webkit
   - TR
-      - [CSS Writing Modes 3 - writing-mode](http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
+      - [CSS Writing Modes 3 - writing-mode](https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
   - Drafts
       - [CSS Writing Modes 3 - writing-mode](https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode)
   - Values: `horizontal-tb | vertical-rl;`
 
-## [CSS Speech 1](http://www.w3.org/TR/css3-speech/)
-- [cue-after](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
+## [CSS Speech 1](https://www.w3.org/TR/css3-speech/)
+- [cue-after](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
   - TR
-      - [CSS 2.1 - cue-after](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
-      - [CSS Speech 1 - cue-after](http://www.w3.org/TR/css3-speech/#cue-after)
+      - [CSS 2.1 - cue-after](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-after)
+      - [CSS Speech 1 - cue-after](https://www.w3.org/TR/css3-speech/#cue-after)
   - Drafts
       - [CSS 2.1 - cue-after](https://drafts.csswg.org/css2/aural.html#propdef-cue-after)
       - [CSS Speech 1 - cue-after](https://drafts.csswg.org/css-speech-1/#cue-after)
   - Values: `URI_OR_NONE;`
-- [cue-before](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
+- [cue-before](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
   - TR
-      - [CSS 2.1 - cue-before](http://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
-      - [CSS Speech 1 - cue-before](http://www.w3.org/TR/css3-speech/#cue-before)
+      - [CSS 2.1 - cue-before](https://www.w3.org/TR/CSS21/aural.html#propdef-cue-before)
+      - [CSS Speech 1 - cue-before](https://www.w3.org/TR/css3-speech/#cue-before)
   - Drafts
       - [CSS 2.1 - cue-before](https://drafts.csswg.org/css2/aural.html#propdef-cue-before)
       - [CSS Speech 1 - cue-before](https://drafts.csswg.org/css-speech-1/#cue-before)
   - Values: `URI_OR_NONE;`
-- [pause](http://www.w3.org/TR/CSS21/aural.html#propdef-pause)
+- [pause](https://www.w3.org/TR/CSS21/aural.html#propdef-pause)
   - TR
-      - [CSS 2.1 - pause](http://www.w3.org/TR/CSS21/aural.html#propdef-pause)
-      - [CSS Speech 1 - pause](http://www.w3.org/TR/css3-speech/#pause)
+      - [CSS 2.1 - pause](https://www.w3.org/TR/CSS21/aural.html#propdef-pause)
+      - [CSS Speech 1 - pause](https://www.w3.org/TR/css3-speech/#pause)
   - Drafts
       - [CSS 2.1 - pause](https://drafts.csswg.org/css2/aural.html#propdef-pause)
       - [CSS Speech 1 - pause](https://drafts.csswg.org/css-speech-1/#pause)
   - Values: `INSETS pause-before pause-after;`
-- [pause-after](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
+- [pause-after](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
   - TR
-      - [CSS 2.1 - pause-after](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
-      - [CSS Speech 1 - pause-after](http://www.w3.org/TR/css3-speech/#pause-after)
+      - [CSS 2.1 - pause-after](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-after)
+      - [CSS Speech 1 - pause-after](https://www.w3.org/TR/css3-speech/#pause-after)
   - Drafts
       - [CSS 2.1 - pause-after](https://drafts.csswg.org/css2/aural.html#propdef-pause-after)
       - [CSS Speech 1 - pause-after](https://drafts.csswg.org/css-speech-1/#pause-after)
   - Values: `PAUSE;`
-- [pause-before](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
+- [pause-before](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
   - TR
-      - [CSS 2.1 - pause-before](http://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
-      - [CSS Speech 1 - pause-before](http://www.w3.org/TR/css3-speech/#pause-before)
+      - [CSS 2.1 - pause-before](https://www.w3.org/TR/CSS21/aural.html#propdef-pause-before)
+      - [CSS Speech 1 - pause-before](https://www.w3.org/TR/css3-speech/#pause-before)
   - Drafts
       - [CSS 2.1 - pause-before](https://drafts.csswg.org/css2/aural.html#propdef-pause-before)
       - [CSS Speech 1 - pause-before](https://drafts.csswg.org/css-speech-1/#pause-before)
   - Values: `PAUSE;`
-- [voice-family](http://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
+- [voice-family](https://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
   - TR
-      - [CSS 2.1 - voice-family](http://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
-      - [CSS Speech 1 - voice-family](http://www.w3.org/TR/css3-speech/#voice-family)
+      - [CSS 2.1 - voice-family](https://www.w3.org/TR/CSS21/aural.html#propdef-voice-family)
+      - [CSS Speech 1 - voice-family](https://www.w3.org/TR/css3-speech/#voice-family)
   - Drafts
       - [CSS 2.1 - voice-family](https://drafts.csswg.org/css2/aural.html#propdef-voice-family)
       - [CSS Speech 1 - voice-family](https://drafts.csswg.org/css-speech-1/#voice-family)
   - Values: `FAMILY_LIST;`
 
-## [CSS Flexbox 1](http://www.w3.org/TR/css-flexbox-1/)
-- [align-content](http://www.w3.org/TR/css-flexbox-1/#propdef-align-content)
+## [CSS Flexbox 1](https://www.w3.org/TR/css-flexbox-1/)
+- [align-content](https://www.w3.org/TR/css-flexbox-1/#propdef-align-content)
   - TR
-      - [CSS Flexbox 1 - align-content](http://www.w3.org/TR/css-flexbox-1/#propdef-align-content)
+      - [CSS Flexbox 1 - align-content](https://www.w3.org/TR/css-flexbox-1/#propdef-align-content)
   - Drafts
       - [CSS Flexbox 1 - align-content](https://drafts.csswg.org/css-flexbox-1/#propdef-align-content)
   - Values: `flex-start | flex-end | center | space-between | space-around | stretch;`
-- [align-items](http://www.w3.org/TR/css-flexbox-1/#propdef-align-items)
+- [align-items](https://www.w3.org/TR/css-flexbox-1/#propdef-align-items)
   - TR
-      - [CSS Flexbox 1 - align-items](http://www.w3.org/TR/css-flexbox-1/#propdef-align-items)
+      - [CSS Flexbox 1 - align-items](https://www.w3.org/TR/css-flexbox-1/#propdef-align-items)
   - Drafts
       - [CSS Flexbox 1 - align-items](https://drafts.csswg.org/css-flexbox-1/#propdef-align-items)
   - Values: `flex-start | flex-end | center | baseline | stretch;`
-- [align-self](http://www.w3.org/TR/css-flexbox-1/#propdef-align-self)
+- [align-self](https://www.w3.org/TR/css-flexbox-1/#propdef-align-self)
   - TR
-      - [CSS Flexbox 1 - align-self](http://www.w3.org/TR/css-flexbox-1/#propdef-align-self)
+      - [CSS Flexbox 1 - align-self](https://www.w3.org/TR/css-flexbox-1/#propdef-align-self)
   - Drafts
       - [CSS Flexbox 1 - align-self](https://drafts.csswg.org/css-flexbox-1/#propdef-align-self)
   - Values: `auto | flex-start | flex-end | center | baseline | stretch;`
-- [flex](http://www.w3.org/TR/css-flexbox-1/#propdef-flex)
+- [flex](https://www.w3.org/TR/css-flexbox-1/#propdef-flex)
   - TR
-      - [CSS Flexbox 1 - flex](http://www.w3.org/TR/css-flexbox-1/#propdef-flex)
+      - [CSS Flexbox 1 - flex](https://www.w3.org/TR/css-flexbox-1/#propdef-flex)
   - Drafts
       - [CSS Flexbox 1 - flex](https://drafts.csswg.org/css-flexbox-1/#propdef-flex)
   - Values: `none | [ [ NNEG_NUM NNEG_NUM? ] || FLEX_BASIS ];`
-- [flex-basis](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis)
+- [flex-basis](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis)
   - TR
-      - [CSS Flexbox 1 - flex-basis](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis)
+      - [CSS Flexbox 1 - flex-basis](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis)
   - Drafts
       - [CSS Flexbox 1 - flex-basis](https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis)
   - Values: `FLEX_BASIS;`
-- [flex-direction](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction)
+- [flex-direction](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction)
   - TR
-      - [CSS Flexbox 1 - flex-direction](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction)
+      - [CSS Flexbox 1 - flex-direction](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction)
   - Drafts
       - [CSS Flexbox 1 - flex-direction](https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction)
   - Values: `row | row-reverse | column | column-reverse;`
-- [flex-flow](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow)
+- [flex-flow](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow)
   - TR
-      - [CSS Flexbox 1 - flex-flow](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow)
+      - [CSS Flexbox 1 - flex-flow](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow)
   - Drafts
       - [CSS Flexbox 1 - flex-flow](https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow)
   - Values: `flex-direction flex-wrap;`
-- [flex-grow](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow)
+- [flex-grow](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow)
   - TR
-      - [CSS Flexbox 1 - flex-grow](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow)
+      - [CSS Flexbox 1 - flex-grow](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow)
   - Drafts
       - [CSS Flexbox 1 - flex-grow](https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow)
   - Values: `NNEG_NUM;`
-- [flex-shrink](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink)
+- [flex-shrink](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink)
   - TR
-      - [CSS Flexbox 1 - flex-shrink](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink)
+      - [CSS Flexbox 1 - flex-shrink](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink)
   - Drafts
       - [CSS Flexbox 1 - flex-shrink](https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink)
   - Values: `NNEG_NUM;`
-- [flex-wrap](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap)
+- [flex-wrap](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap)
   - TR
-      - [CSS Flexbox 1 - flex-wrap](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap)
+      - [CSS Flexbox 1 - flex-wrap](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap)
   - Drafts
       - [CSS Flexbox 1 - flex-wrap](https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap)
   - Values: `nowrap | wrap | wrap-reverse;`
-- [justify-content](http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content)
+- [justify-content](https://www.w3.org/TR/css-flexbox-1/#propdef-justify-content)
   - TR
-      - [CSS Flexbox 1 - justify-content](http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content)
+      - [CSS Flexbox 1 - justify-content](https://www.w3.org/TR/css-flexbox-1/#propdef-justify-content)
   - Drafts
       - [CSS Flexbox 1 - justify-content](https://drafts.csswg.org/css-flexbox-1/#propdef-justify-content)
   - Values: `flex-start | flex-end | center | space-between | space-around;`
-- [order](http://www.w3.org/TR/css-flexbox-1/#propdef-order)
+- [order](https://www.w3.org/TR/css-flexbox-1/#propdef-order)
   - TR
-      - [CSS Flexbox 1 - order](http://www.w3.org/TR/css-flexbox-1/#propdef-order)
+      - [CSS Flexbox 1 - order](https://www.w3.org/TR/css-flexbox-1/#propdef-order)
   - Drafts
       - [CSS Flexbox 1 - order](https://drafts.csswg.org/css-flexbox-1/#propdef-order)
   - Values: `INT;`
 
-## [CSS Lists 3](http://www.w3.org/TR/css3-lists/)
-- [counter-increment](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
+## [CSS Lists 3](https://www.w3.org/TR/css3-lists/)
+- [counter-increment](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
   - TR
-      - [CSS 2.1 - counter-increment](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
-      - [CSS Lists 3 - counter-increment](http://www.w3.org/TR/css3-lists/#propdef-counter-increment)
+      - [CSS 2.1 - counter-increment](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment)
+      - [CSS Lists 3 - counter-increment](https://www.w3.org/TR/css3-lists/#propdef-counter-increment)
   - Drafts
       - [CSS 2.1 - counter-increment](https://drafts.csswg.org/css2/generate.html#propdef-counter-increment)
       - [CSS Lists 3 - counter-increment](https://drafts.csswg.org/css-lists-3/#propdef-counter-increment)
   - Values: `COUNTER;`
-- [counter-reset](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
+- [counter-reset](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
   - TR
-      - [CSS 2.1 - counter-reset](http://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
-      - [CSS Lists 3 - counter-reset](http://www.w3.org/TR/css3-lists/#propdef-counter-reset)
+      - [CSS 2.1 - counter-reset](https://www.w3.org/TR/CSS21/generate.html#propdef-counter-reset)
+      - [CSS Lists 3 - counter-reset](https://www.w3.org/TR/css3-lists/#propdef-counter-reset)
   - Drafts
       - [CSS 2.1 - counter-reset](https://drafts.csswg.org/css2/generate.html#propdef-counter-reset)
       - [CSS Lists 3 - counter-reset](https://drafts.csswg.org/css-lists-3/#propdef-counter-reset)
   - Values: `COUNTER;`
-- [list-style](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
+- [list-style](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
   - TR
-      - [CSS 2.1 - list-style](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
-      - [CSS Lists 3 - list-style](http://www.w3.org/TR/css3-lists/#propdef-list-style)
+      - [CSS 2.1 - list-style](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style)
+      - [CSS Lists 3 - list-style](https://www.w3.org/TR/css3-lists/#propdef-list-style)
   - Drafts
       - [CSS 2.1 - list-style](https://drafts.csswg.org/css2/generate.html#propdef-list-style)
       - [CSS Lists 3 - list-style](https://drafts.csswg.org/css-lists-3/#propdef-list-style)
   - Values: `list-style-type list-style-position list-style-image;`
-- [list-style-image](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
+- [list-style-image](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
   - TR
-      - [CSS 2.1 - list-style-image](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
-      - [CSS Lists 3 - list-style-image](http://www.w3.org/TR/css3-lists/#propdef-list-style-image)
+      - [CSS 2.1 - list-style-image](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image)
+      - [CSS Lists 3 - list-style-image](https://www.w3.org/TR/css3-lists/#propdef-list-style-image)
   - Drafts
       - [CSS 2.1 - list-style-image](https://drafts.csswg.org/css2/generate.html#propdef-list-style-image)
       - [CSS Lists 3 - list-style-image](https://drafts.csswg.org/css-lists-3/#propdef-list-style-image)
   - Values: `URI_OR_NONE;`
-- [list-style-position](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
+- [list-style-position](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
   - TR
-      - [CSS 2.1 - list-style-position](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
-      - [CSS Lists 3 - list-style-position](http://www.w3.org/TR/css3-lists/#propdef-list-style-position)
+      - [CSS 2.1 - list-style-position](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position)
+      - [CSS Lists 3 - list-style-position](https://www.w3.org/TR/css3-lists/#propdef-list-style-position)
   - Drafts
       - [CSS 2.1 - list-style-position](https://drafts.csswg.org/css2/generate.html#propdef-list-style-position)
       - [CSS Lists 3 - list-style-position](https://drafts.csswg.org/css-lists-3/#propdef-list-style-position)
   - Values: `inside | outside;`
-- [list-style-type](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
+- [list-style-type](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
   - TR
-      - [CSS 2.1 - list-style-type](http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
-      - [CSS Lists 3 - list-style-type](http://www.w3.org/TR/css3-lists/#propdef-list-style-type)
+      - [CSS 2.1 - list-style-type](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type)
+      - [CSS Lists 3 - list-style-type](https://www.w3.org/TR/css3-lists/#propdef-list-style-type)
   - Drafts
       - [CSS 2.1 - list-style-type](https://drafts.csswg.org/css2/generate.html#propdef-list-style-type)
       - [CSS Lists 3 - list-style-type](https://drafts.csswg.org/css-lists-3/#propdef-list-style-type)
   - Values: `LIST_STYLE_TYPE;`
 
-## [CSS Masking 1](http://www.w3.org/TR/css-masking-1/)
-- [clip](http://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
+## [CSS Masking 1](https://www.w3.org/TR/css-masking-1/)
+- [clip](https://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
   - TR
-      - [CSS 2.1 - clip](http://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
-      - [CSS Masking 1 - clip](http://www.w3.org/TR/css-masking-1/#propdef-clip)
+      - [CSS 2.1 - clip](https://www.w3.org/TR/CSS21/visufx.html#propdef-clip)
+      - [CSS Masking 1 - clip](https://www.w3.org/TR/css-masking-1/#propdef-clip)
   - Drafts
       - [CSS 2.1 - clip](https://drafts.csswg.org/css2/visufx.html#propdef-clip)
       - [CSS Masking 1 - clip](https://drafts.fxtf.org/css-masking-1/#propdef-clip)
   - Values: `rect(ALENGTH{4}) | rect(SPACE(ALENGTH{4})) | auto;`
 
-## [CSS Positioned Layout 3](http://www.w3.org/TR/css3-positioning/)
-- [bottom](http://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
+## [CSS Positioned Layout 3](https://www.w3.org/TR/css3-positioning/)
+- [bottom](https://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
   - TR
-      - [CSS 2.1 - bottom](http://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
-      - [CSS Positioned Layout 3 - bottom](http://www.w3.org/TR/css3-positioning/#propdef-bottom)
+      - [CSS 2.1 - bottom](https://www.w3.org/TR/CSS21/visuren.html#propdef-bottom)
+      - [CSS Positioned Layout 3 - bottom](https://www.w3.org/TR/css3-positioning/#propdef-bottom)
   - Drafts
       - [CSS 2.1 - bottom](https://drafts.csswg.org/css2/visuren.html#propdef-bottom)
       - [CSS Positioned Layout 3 - bottom](https://drafts.csswg.org/css-position-3/#propdef-bottom)
   - Values: `APLENGTH;`
-- [left](http://www.w3.org/TR/CSS21/visuren.html#propdef-left)
+- [left](https://www.w3.org/TR/CSS21/visuren.html#propdef-left)
   - TR
-      - [CSS 2.1 - left](http://www.w3.org/TR/CSS21/visuren.html#propdef-left)
-      - [CSS Positioned Layout 3 - left](http://www.w3.org/TR/css3-positioning/#propdef-left)
+      - [CSS 2.1 - left](https://www.w3.org/TR/CSS21/visuren.html#propdef-left)
+      - [CSS Positioned Layout 3 - left](https://www.w3.org/TR/css3-positioning/#propdef-left)
   - Drafts
       - [CSS 2.1 - left](https://drafts.csswg.org/css2/visuren.html#propdef-left)
       - [CSS Positioned Layout 3 - left](https://drafts.csswg.org/css-position-3/#propdef-left)
   - Values: `APLENGTH;`
-- [position](http://www.w3.org/TR/CSS21/visuren.html#propdef-position)
+- [position](https://www.w3.org/TR/CSS21/visuren.html#propdef-position)
   - TR
-      - [CSS 2.1 - position](http://www.w3.org/TR/CSS21/visuren.html#propdef-position)
-      - [CSS Positioned Layout 3 - position](http://www.w3.org/TR/css3-positioning/#propdef-position)
+      - [CSS 2.1 - position](https://www.w3.org/TR/CSS21/visuren.html#propdef-position)
+      - [CSS Positioned Layout 3 - position](https://www.w3.org/TR/css3-positioning/#propdef-position)
   - Drafts
       - [CSS 2.1 - position](https://drafts.csswg.org/css2/visuren.html#propdef-position)
       - [CSS Positioned Layout 3 - position](https://drafts.csswg.org/css-position-3/#propdef-position)
   - Values: `static | relative | absolute | fixed;`
-- [right](http://www.w3.org/TR/CSS21/visuren.html#propdef-right)
+- [right](https://www.w3.org/TR/CSS21/visuren.html#propdef-right)
   - TR
-      - [CSS 2.1 - right](http://www.w3.org/TR/CSS21/visuren.html#propdef-right)
-      - [CSS Positioned Layout 3 - right](http://www.w3.org/TR/css3-positioning/#propdef-right)
+      - [CSS 2.1 - right](https://www.w3.org/TR/CSS21/visuren.html#propdef-right)
+      - [CSS Positioned Layout 3 - right](https://www.w3.org/TR/css3-positioning/#propdef-right)
   - Drafts
       - [CSS 2.1 - right](https://drafts.csswg.org/css2/visuren.html#propdef-right)
       - [CSS Positioned Layout 3 - right](https://drafts.csswg.org/css-position-3/#propdef-right)
   - Values: `APLENGTH;`
-- [top](http://www.w3.org/TR/CSS21/visuren.html#propdef-top)
+- [top](https://www.w3.org/TR/CSS21/visuren.html#propdef-top)
   - TR
-      - [CSS 2.1 - top](http://www.w3.org/TR/CSS21/visuren.html#propdef-top)
-      - [CSS Positioned Layout 3 - top](http://www.w3.org/TR/css3-positioning/#propdef-top)
+      - [CSS 2.1 - top](https://www.w3.org/TR/CSS21/visuren.html#propdef-top)
+      - [CSS Positioned Layout 3 - top](https://www.w3.org/TR/css3-positioning/#propdef-top)
   - Drafts
       - [CSS 2.1 - top](https://drafts.csswg.org/css2/visuren.html#propdef-top)
       - [CSS Positioned Layout 3 - top](https://drafts.csswg.org/css-position-3/#propdef-top)
   - Values: `APLENGTH;`
-- [z-index](http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
+- [z-index](https://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
   - TR
-      - [CSS 2.1 - z-index](http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
-      - [CSS Positioned Layout 3 - z-index](http://www.w3.org/TR/css3-positioning/#propdef-z-index)
+      - [CSS 2.1 - z-index](https://www.w3.org/TR/CSS21/visuren.html#propdef-z-index)
+      - [CSS Positioned Layout 3 - z-index](https://www.w3.org/TR/css3-positioning/#propdef-z-index)
   - Drafts
       - [CSS 2.1 - z-index](https://drafts.csswg.org/css2/visuren.html#propdef-z-index)
       - [CSS Positioned Layout 3 - z-index](https://drafts.csswg.org/css-position-3/#propdef-z-index)
   - Values: `auto | INT;`
 
-## [CSS Fragmentation 3](http://www.w3.org/TR/css3-break/)
-- [box-decoration-break](http://www.w3.org/TR/css3-break/#box-decoration-break)
+## [CSS Fragmentation 3](https://www.w3.org/TR/css3-break/)
+- [box-decoration-break](https://www.w3.org/TR/css3-break/#propdef-box-decoration-break)
     - Allowed prefixes: webkit
   - TR
-      - [CSS Fragmentation 3 - box-decoration-break](http://www.w3.org/TR/css3-break/#box-decoration-break)
+      - [CSS Fragmentation 3 - box-decoration-break](https://www.w3.org/TR/css3-break/#propdef-box-decoration-break)
   - Drafts
       - [CSS Fragmentation 3 - box-decoration-break](https://drafts.csswg.org/css-break-3/#propdef-box-decoration-break)
   - Values: `slice | clone;`
-- [break-after](http://www.w3.org/TR/css3-multicol/#break-after)
+- [break-after](https://www.w3.org/TR/css3-multicol/#break-after)
   - TR
-      - [CSS Multicol 1 - break-after](http://www.w3.org/TR/css3-multicol/#break-after)
-      - [CSS Fragmentation 3 - break-after](http://www.w3.org/TR/css3-break/#break-after)
-      - [CSS Regions 1 - break-after](http://www.w3.org/TR/css3-regions/#propdef-break-after)
+      - [CSS Multicol 1 - break-after](https://www.w3.org/TR/css3-multicol/#break-after)
+      - [CSS Fragmentation 3 - break-after](https://www.w3.org/TR/css3-break/#propdef-break-after)
+      - [CSS Regions 1 - break-after](https://www.w3.org/TR/css3-regions/#propdef-break-after)
   - Drafts
       - [CSS Fragmentation 3 - break-after](https://drafts.csswg.org/css-break-3/#propdef-break-after)
       - [CSS Regions 1 - break-after](https://drafts.csswg.org/css-regions-1/#propdef-break-after)
   - Values: `BREAK;`
-- [break-before](http://www.w3.org/TR/css3-multicol/#break-before)
+- [break-before](https://www.w3.org/TR/css3-multicol/#break-before)
   - TR
-      - [CSS Multicol 1 - break-before](http://www.w3.org/TR/css3-multicol/#break-before)
-      - [CSS Fragmentation 3 - break-before](http://www.w3.org/TR/css3-break/#break-before)
-      - [CSS Regions 1 - break-before](http://www.w3.org/TR/css3-regions/#propdef-break-before)
+      - [CSS Multicol 1 - break-before](https://www.w3.org/TR/css3-multicol/#break-before)
+      - [CSS Fragmentation 3 - break-before](https://www.w3.org/TR/css3-break/#propdef-break-before)
+      - [CSS Regions 1 - break-before](https://www.w3.org/TR/css3-regions/#propdef-break-before)
   - Drafts
       - [CSS Fragmentation 3 - break-before](https://drafts.csswg.org/css-break-3/#propdef-break-before)
       - [CSS Regions 1 - break-before](https://drafts.csswg.org/css-regions-1/#propdef-break-before)
   - Values: `BREAK;`
-- [break-inside](http://www.w3.org/TR/css3-multicol/#break-inside)
+- [break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
   - TR
-      - [CSS Multicol 1 - break-inside](http://www.w3.org/TR/css3-multicol/#break-inside)
-      - [CSS Fragmentation 3 - break-inside](http://www.w3.org/TR/css3-break/#break-inside)
-      - [CSS Regions 1 - break-inside](http://www.w3.org/TR/css3-regions/#propdef-break-inside)
+      - [CSS Multicol 1 - break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
+      - [CSS Fragmentation 3 - break-inside](https://www.w3.org/TR/css3-break/#propdef-break-inside)
+      - [CSS Regions 1 - break-inside](https://www.w3.org/TR/css3-regions/#propdef-break-inside)
   - Drafts
       - [CSS Fragmentation 3 - break-inside](https://drafts.csswg.org/css-break-3/#propdef-break-inside)
       - [CSS Regions 1 - break-inside](https://drafts.csswg.org/css-regions-1/#propdef-break-inside)
   - Values: `auto | avoid | avoid-page | avoid-column | avoid-region;`
-- [orphans](http://www.w3.org/TR/CSS21/page.html#propdef-orphans)
+- [orphans](https://www.w3.org/TR/CSS21/page.html#propdef-orphans)
   - TR
-      - [CSS 2.1 - orphans](http://www.w3.org/TR/CSS21/page.html#propdef-orphans)
-      - [CSS Fragmentation 3 - orphans](http://www.w3.org/TR/css3-break/#orphans)
+      - [CSS 2.1 - orphans](https://www.w3.org/TR/CSS21/page.html#propdef-orphans)
+      - [CSS Fragmentation 3 - orphans](https://www.w3.org/TR/css3-break/#propdef-orphans)
   - Drafts
       - [CSS 2.1 - orphans](https://drafts.csswg.org/css2/page.html#propdef-orphans)
       - [CSS Fragmentation 3 - orphans](https://drafts.csswg.org/css-break-3/#propdef-orphans)
   - Values: `POS_INT;`
-- [widows](http://www.w3.org/TR/CSS21/page.html#propdef-widows)
+- [widows](https://www.w3.org/TR/CSS21/page.html#propdef-widows)
   - TR
-      - [CSS 2.1 - widows](http://www.w3.org/TR/CSS21/page.html#propdef-widows)
-      - [CSS Fragmentation 3 - widows](http://www.w3.org/TR/css3-break/#widows)
+      - [CSS 2.1 - widows](https://www.w3.org/TR/CSS21/page.html#propdef-widows)
+      - [CSS Fragmentation 3 - widows](https://www.w3.org/TR/css3-break/#propdef-widows)
   - Drafts
       - [CSS 2.1 - widows](https://drafts.csswg.org/css2/page.html#propdef-widows)
       - [CSS Fragmentation 3 - widows](https://drafts.csswg.org/css-break-3/#propdef-widows)
   - Values: `POS_INT;`
 
-## [CSS Transforms 1](http://www.w3.org/TR/css-transforms-1/)
-- [backface-visibility](http://www.w3.org/TR/css-transforms-1/#propdef-backface-visibility)
+## [CSS Transforms 1](https://www.w3.org/TR/css-transforms-1/)
+- [backface-visibility](https://www.w3.org/TR/css-transforms-1/#propdef-backface-visibility)
     - Allowed prefixes: ms, webkit
   - TR
-      - [CSS Transforms 1 - backface-visibility](http://www.w3.org/TR/css-transforms-1/#propdef-backface-visibility)
+      - [CSS Transforms 1 - backface-visibility](https://www.w3.org/TR/css-transforms-1/#propdef-backface-visibility)
   - Drafts
       - [CSS Transforms 1 - backface-visibility](https://drafts.csswg.org/css-transforms-1/#propdef-backface-visibility)
   - Values: `visible | hidden;`
-- [transform](http://www.w3.org/TR/css-transforms-1/#propdef-transform)
+- [transform](https://www.w3.org/TR/css-transforms-1/#propdef-transform)
     - Allowed prefixes: epub, ms
   - TR
-      - [CSS Transforms 1 - transform](http://www.w3.org/TR/css-transforms-1/#propdef-transform)
+      - [CSS Transforms 1 - transform](https://www.w3.org/TR/css-transforms-1/#propdef-transform)
   - Drafts
       - [CSS Transforms 1 - transform](https://drafts.csswg.org/css-transforms-1/#propdef-transform)
   - Values: `none | TRANSFORM_FUNCTION+;`
-- [transform-origin](http://www.w3.org/TR/css-transforms-1/#propdef-transform-origin)
+- [transform-origin](https://www.w3.org/TR/css-transforms-1/#propdef-transform-origin)
     - Allowed prefixes: epub, ms
   - TR
-      - [CSS Transforms 1 - transform-origin](http://www.w3.org/TR/css-transforms-1/#propdef-transform-origin)
+      - [CSS Transforms 1 - transform-origin](https://www.w3.org/TR/css-transforms-1/#propdef-transform-origin)
   - Drafts
       - [CSS Transforms 1 - transform-origin](https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin)
   - Values: `[[[ top | bottom | left | right] PLENGTH?] | center | PLENGTH]{1,2}; /* relaxed */`
 
-## [CSS Ruby 1](http://www.w3.org/TR/css-ruby-1/)
-- [display](http://www.w3.org/TR/CSS21/visuren.html#propdef-display)
+## [CSS Ruby 1](https://www.w3.org/TR/css-ruby-1/)
+- [display](https://www.w3.org/TR/CSS21/visuren.html#propdef-display)
   - TR
-      - [CSS 2.1 - display](http://www.w3.org/TR/CSS21/visuren.html#propdef-display)
-      - [CSS Ruby 1 - display](http://www.w3.org/TR/css-ruby-1/#propdef-display)
+      - [CSS 2.1 - display](https://www.w3.org/TR/CSS21/visuren.html#propdef-display)
+      - [CSS Ruby 1 - display](https://www.w3.org/TR/css-ruby-1/#propdef-display)
   - Drafts
       - [CSS Display 3 - display](https://drafts.csswg.org/css-display-3/#propdef-display)
       - [CSS 2.1 - display](https://drafts.csswg.org/css2/visuren.html#propdef-display)
       - [CSS Ruby 1 - display](https://drafts.csswg.org/css-ruby-1/#propdef-display)
   - Values: `inline | block | list-item | inline-block | table | inline-table | table-row-group | table-header-group | table-footer-group | table-row | table-column-group | table-column | table-cell | table-caption | none | oeb-page-head | oeb-page-foot | flex | inline-flex | ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container;`
-- [ruby-align](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
+- [ruby-align](https://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
   - TR
-      - [CSS Ruby 1 - ruby-align](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
+      - [CSS Ruby 1 - ruby-align](https://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
   - Drafts
       - [CSS Ruby 1 - ruby-align](https://drafts.csswg.org/css-ruby-1/#propdef-ruby-align)
   - Values: `start | center | space-between | space-around;`
-- [ruby-position](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-position)
+- [ruby-position](https://www.w3.org/TR/css-ruby-1/#propdef-ruby-position)
   - TR
-      - [CSS Ruby 1 - ruby-position](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-position)
+      - [CSS Ruby 1 - ruby-position](https://www.w3.org/TR/css-ruby-1/#propdef-ruby-position)
   - Drafts
       - [CSS Ruby 1 - ruby-position](https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position)
   - Values: `over | under | inter-character;`
 
-## [CSS Overflow 3](http://www.w3.org/TR/css-overflow-3/)
-- [overflow](http://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
+## [CSS Overflow 3](https://www.w3.org/TR/css-overflow-3/)
+- [overflow](https://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
   - TR
-      - [CSS 2.1 - overflow](http://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
-      - [CSS Overflow 3 - overflow](http://www.w3.org/TR/css-overflow-3/#overflow)
+      - [CSS 2.1 - overflow](https://www.w3.org/TR/CSS21/visufx.html#propdef-overflow)
+      - [CSS Overflow 3 - overflow](https://www.w3.org/TR/css-overflow-3/#overflow)
   - Drafts
+      - [CSS Overflow 4 - overflow](https://drafts.csswg.org/css-overflow-4/#propdef-overflow)
       - [CSS 2.1 - overflow](https://drafts.csswg.org/css2/visufx.html#propdef-overflow)
       - [CSS Overflow 3 - overflow](https://drafts.csswg.org/css-overflow-3/#propdef-overflow)
   - Values: `visible | hidden | scroll | auto;`
 
-## [CSS Shapes 1](http://www.w3.org/TR/css-shapes-1/)
-- [shape-outside](http://www.w3.org/TR/css-shapes-1/#propdef-shape-outside)
+## [CSS Shapes 1](https://www.w3.org/TR/css-shapes-1/)
+- [shape-outside](https://www.w3.org/TR/css-shapes-1/#propdef-shape-outside)
     - Allowed prefixes: epubx, webkit
   - TR
-      - [CSS Shapes 1 - shape-outside](http://www.w3.org/TR/css-shapes-1/#propdef-shape-outside)
+      - [CSS Shapes 1 - shape-outside](https://www.w3.org/TR/css-shapes-1/#propdef-shape-outside)
   - Drafts
       - [CSS Shapes 1 - shape-outside](https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside)
   - Values: `SHAPE;`
@@ -2068,54 +2063,54 @@
       - [CSS Shapes 2 - shape-inside](https://drafts.csswg.org/css-shapes-2/#propdef-shape-inside)
   - Values: `SHAPE;`
 
-## [CSS Regions 1](http://www.w3.org/TR/css3-regions/)
-- [break-after](http://www.w3.org/TR/css3-multicol/#break-after)
+## [CSS Regions 1](https://www.w3.org/TR/css3-regions/)
+- [break-after](https://www.w3.org/TR/css3-multicol/#break-after)
   - TR
-      - [CSS Multicol 1 - break-after](http://www.w3.org/TR/css3-multicol/#break-after)
-      - [CSS Fragmentation 3 - break-after](http://www.w3.org/TR/css3-break/#break-after)
-      - [CSS Regions 1 - break-after](http://www.w3.org/TR/css3-regions/#propdef-break-after)
+      - [CSS Multicol 1 - break-after](https://www.w3.org/TR/css3-multicol/#break-after)
+      - [CSS Fragmentation 3 - break-after](https://www.w3.org/TR/css3-break/#propdef-break-after)
+      - [CSS Regions 1 - break-after](https://www.w3.org/TR/css3-regions/#propdef-break-after)
   - Drafts
       - [CSS Fragmentation 3 - break-after](https://drafts.csswg.org/css-break-3/#propdef-break-after)
       - [CSS Regions 1 - break-after](https://drafts.csswg.org/css-regions-1/#propdef-break-after)
   - Values: `BREAK;`
-- [break-before](http://www.w3.org/TR/css3-multicol/#break-before)
+- [break-before](https://www.w3.org/TR/css3-multicol/#break-before)
   - TR
-      - [CSS Multicol 1 - break-before](http://www.w3.org/TR/css3-multicol/#break-before)
-      - [CSS Fragmentation 3 - break-before](http://www.w3.org/TR/css3-break/#break-before)
-      - [CSS Regions 1 - break-before](http://www.w3.org/TR/css3-regions/#propdef-break-before)
+      - [CSS Multicol 1 - break-before](https://www.w3.org/TR/css3-multicol/#break-before)
+      - [CSS Fragmentation 3 - break-before](https://www.w3.org/TR/css3-break/#propdef-break-before)
+      - [CSS Regions 1 - break-before](https://www.w3.org/TR/css3-regions/#propdef-break-before)
   - Drafts
       - [CSS Fragmentation 3 - break-before](https://drafts.csswg.org/css-break-3/#propdef-break-before)
       - [CSS Regions 1 - break-before](https://drafts.csswg.org/css-regions-1/#propdef-break-before)
   - Values: `BREAK;`
-- [break-inside](http://www.w3.org/TR/css3-multicol/#break-inside)
+- [break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
   - TR
-      - [CSS Multicol 1 - break-inside](http://www.w3.org/TR/css3-multicol/#break-inside)
-      - [CSS Fragmentation 3 - break-inside](http://www.w3.org/TR/css3-break/#break-inside)
-      - [CSS Regions 1 - break-inside](http://www.w3.org/TR/css3-regions/#propdef-break-inside)
+      - [CSS Multicol 1 - break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
+      - [CSS Fragmentation 3 - break-inside](https://www.w3.org/TR/css3-break/#propdef-break-inside)
+      - [CSS Regions 1 - break-inside](https://www.w3.org/TR/css3-regions/#propdef-break-inside)
   - Drafts
       - [CSS Fragmentation 3 - break-inside](https://drafts.csswg.org/css-break-3/#propdef-break-inside)
       - [CSS Regions 1 - break-inside](https://drafts.csswg.org/css-regions-1/#propdef-break-inside)
   - Values: `auto | avoid | avoid-page | avoid-column | avoid-region;`
-- [flow-from](http://www.w3.org/TR/css3-regions/#propdef-flow-from)
+- [flow-from](https://www.w3.org/TR/css3-regions/#propdef-flow-from)
     - Allowed prefixes: epubx, webkit
   - TR
-      - [CSS Regions 1 - flow-from](http://www.w3.org/TR/css3-regions/#propdef-flow-from)
+      - [CSS Regions 1 - flow-from](https://www.w3.org/TR/css3-regions/#propdef-flow-from)
   - Drafts
       - [CSS Regions 1 - flow-from](https://drafts.csswg.org/css-regions-1/#propdef-flow-from)
   - Values: `IDENT;`
-- [flow-into](http://www.w3.org/TR/css3-regions/#propdef-flow-into)
+- [flow-into](https://www.w3.org/TR/css3-regions/#propdef-flow-into)
     - Allowed prefixes: epubx, webkit
   - TR
-      - [CSS Regions 1 - flow-into](http://www.w3.org/TR/css3-regions/#propdef-flow-into)
+      - [CSS Regions 1 - flow-into](https://www.w3.org/TR/css3-regions/#propdef-flow-into)
   - Drafts
       - [CSS Regions 1 - flow-into](https://drafts.csswg.org/css-regions-1/#propdef-flow-into)
   - Values: `IDENT;`
 
-## [CSS Exclusions 1](http://www.w3.org/TR/css3-exclusions/)
-- [wrap-flow](http://www.w3.org/TR/css3-exclusions/#propdef-wrap-flow)
+## [CSS Exclusions 1](https://www.w3.org/TR/css3-exclusions/)
+- [wrap-flow](https://www.w3.org/TR/css3-exclusions/#propdef-wrap-flow)
     - Allowed prefixes: epubx, ms
   - TR
-      - [CSS Exclusions 1 - wrap-flow](http://www.w3.org/TR/css3-exclusions/#propdef-wrap-flow)
+      - [CSS Exclusions 1 - wrap-flow](https://www.w3.org/TR/css3-exclusions/#propdef-wrap-flow)
   - Drafts
       - [CSS Exclusions 1 - wrap-flow](https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow)
   - Values: `auto | both | start | end | maximum | clear | around /* epub al */;`
@@ -2128,27 +2123,27 @@
       - [CSS Size Adjustment 1 - text-size-adjust](https://drafts.csswg.org/css-size-adjust-1/#text-size-adjust)
   - Values: `auto | none | POS_PERCENTAGE;`
 
-## [CSS Inline Layout 3](http://www.w3.org/TR/css-inline-3/)
-- [vertical-align](http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
+## [CSS Inline Layout 3](https://www.w3.org/TR/css-inline-3/)
+- [vertical-align](https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
   - TR
-      - [CSS 2.1 - vertical-align](http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
-      - [CSS Inline Layout 3 - vertical-align](http://www.w3.org/TR/css-inline-3/#propdef-vertical-align)
+      - [CSS 2.1 - vertical-align](https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)
+      - [CSS Inline Layout 3 - vertical-align](https://www.w3.org/TR/css-inline-3/#propdef-vertical-align)
   - Drafts
       - [CSS 2.1 - vertical-align](https://drafts.csswg.org/css2/visudet.html#propdef-vertical-align)
       - [CSS Inline Layout 3 - vertical-align](https://drafts.csswg.org/css-inline-3/#propdef-vertical-align)
   - Values: `baseline | sub | super | top | text-top | middle | bottom | text-bottom | PLENGTH;`
 
 ## [CSS Page Floats 3](https://drafts.csswg.org/css-page-floats-3/)
-- [clear](http://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
+- [clear](https://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
   - TR
-      - [CSS 2.1 - clear](http://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
+      - [CSS 2.1 - clear](https://www.w3.org/TR/CSS21/visuren.html#propdef-clear)
   - Drafts
       - [CSS 2.1 - clear](https://drafts.csswg.org/css2/visuren.html#propdef-clear)
       - [CSS Page Floats 3 - clear](https://drafts.csswg.org/css-page-floats-3/#propdef-clear)
   - Values: `none | left | right | both;`
-- [float](http://www.w3.org/TR/CSS21/visuren.html#propdef-float)
+- [float](https://www.w3.org/TR/CSS21/visuren.html#propdef-float)
   - TR
-      - [CSS 2.1 - float](http://www.w3.org/TR/CSS21/visuren.html#propdef-float)
+      - [CSS 2.1 - float](https://www.w3.org/TR/CSS21/visuren.html#propdef-float)
   - Drafts
       - [CSS 2.1 - float](https://drafts.csswg.org/css2/visuren.html#propdef-float)
       - [CSS Page Floats 3 - float](https://drafts.csswg.org/css-page-floats-3/#propdef-float)
@@ -2175,6 +2170,10 @@
 
 
   - Values: `IDENT;`
+- [bleed]()
+
+
+  - Values: `auto | LENGTH;`
 - [border-after-color]()
     - Allowed prefixes: adapt
 
@@ -2290,6 +2289,10 @@
 
 
   - Values: `APLENGTH;`
+- [marks]()
+
+
+  - Values: `none | [ crop || cross ];`
 - [min-page-height]()
     - Allowed prefixes: epubx
 
@@ -2314,16 +2317,6 @@
 
 
   - Values: `COMMA(IDENT+);`
-- [snap-height]()
-    - Allowed prefixes: epubx
-
-
-  - Values: `LENGTH | none;`
-- [snap-width]()
-    - Allowed prefixes: epubx
-
-
-  - Values: `LENGTH | none;`
 - [src]()
 
 

--- a/doc/supported-features.md
+++ b/doc/supported-features.md
@@ -6,23 +6,23 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 
 ## Values
 
-- [Supported CSS-wide keywords](http://www.w3.org/TR/css-values/#common-keywords): `inherit`
+- [Supported CSS-wide keywords](https://www.w3.org/TR/css-values/#common-keywords): `inherit`
   - Supported in all browsers
   - `initial` and `unset` are *not* supported.
-- [Supported length units](http://www.w3.org/TR/css-values/#lengths): `em`, `ex`, `ch`, `rem`, `cm`, `mm`, `q`, `in`, `pc`, `pt`, `px`.
+- [Supported length units](https://www.w3.org/TR/css-values/#lengths): `em`, `ex`, `ch`, `rem`, `cm`, `mm`, `q`, `in`, `pc`, `pt`, `px`.
   - Supported in all browsers
 - Supported color values
   - Support depends on browser capabilities
-  - [Basic color keywords](http://www.w3.org/TR/css3-color/#html4)
-  - [RGB color values](http://www.w3.org/TR/css3-color/#rgb-color), [RGBA color values](http://www.w3.org/TR/css3-color/#rgba-color)
-  - [‘transparent’ color keyword](http://www.w3.org/TR/css3-color/#transparent)
-  - [HSL color values](http://www.w3.org/TR/css3-color/#hsl-color), [HSLA color values](http://www.w3.org/TR/css3-color/#hsla-color)
-  - [Extended color keywords](http://www.w3.org/TR/css3-color/#svg-color)
-  - [‘currentColor’ color keyword](http://www.w3.org/TR/css3-color/#currentcolor)
+  - [Basic color keywords](https://www.w3.org/TR/css3-color/#html4)
+  - [RGB color values](https://www.w3.org/TR/css3-color/#rgb-color), [RGBA color values](https://www.w3.org/TR/css3-color/#rgba-color)
+  - [‘transparent’ color keyword](https://www.w3.org/TR/css3-color/#transparent)
+  - [HSL color values](https://www.w3.org/TR/css3-color/#hsl-color), [HSLA color values](https://www.w3.org/TR/css3-color/#hsla-color)
+  - [Extended color keywords](https://www.w3.org/TR/css3-color/#svg-color)
+  - [‘currentColor’ color keyword](https://www.w3.org/TR/css3-color/#currentcolor)
 
 ## Selectors
 
-### [CSS 2](http://www.w3.org/TR/CSS2/)
+### [CSS 2](https://www.w3.org/TR/CSS2/)
 
 - [Universal selector `*`](https://www.w3.org/TR/CSS2/selector.html#universal-selector)
   - Supported in all browsers
@@ -106,22 +106,22 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 
 ## At-rules
 
-### [CSS 2](http://www.w3.org/TR/CSS2/)
+### [CSS 2](https://www.w3.org/TR/CSS2/)
 
-- [@charset](http://www.w3.org/TR/CSS2/syndata.html#charset)
+- [@charset](https://www.w3.org/TR/CSS2/syndata.html#charset)
   - Supported in all browsers
-- [@import](http://www.w3.org/TR/CSS2/cascade.html#at-import)
-  - [Also in CSS Cascading and Inheritance 3](http://www.w3.org/TR/css-cascade-3/#at-import)
-  - Supported in all browsers
-
-### [CSS Namespaces 3](http://www.w3.org/TR/css3-namespace/)
-
-- [@namespace](http://www.w3.org/TR/css3-namespace/#declaration)
+- [@import](https://www.w3.org/TR/CSS2/cascade.html#at-import)
+  - [Also in CSS Cascading and Inheritance 3](https://www.w3.org/TR/css-cascade-3/#at-import)
   - Supported in all browsers
 
-### [CSS Conditional Rules 3](http://www.w3.org/TR/css3-conditional/)
+### [CSS Namespaces 3](https://www.w3.org/TR/css3-namespace/)
 
-- [@media](http://www.w3.org/TR/css3-conditional/#atmedia-rule)
+- [@namespace](https://www.w3.org/TR/css3-namespace/#declaration)
+  - Supported in all browsers
+
+### [CSS Conditional Rules 3](https://www.w3.org/TR/css3-conditional/)
+
+- [@media](https://www.w3.org/TR/css3-conditional/#atmedia-rule)
   - Supported in all browsers
 
 ### [CSS Paged Media 3](https://drafts.csswg.org/css-page-3/)
@@ -131,386 +131,392 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 - [Page-margin boxes (@top-left-corner, @top-left, @top-center, @top-right, @top-right-corner, @left-top, @left-middle, @left-bottom, @right-top, @right-middle, @right-bottom, @bottom-left-corner, @bottom-left, @bottom-center, @bottom-right, @bottom-right-coner)](https://drafts.csswg.org/css-page/#margin-at-rules)
   - Supported in all browsers
 
-### [CSS Fonts 3](http://www.w3.org/TR/css-fonts-3/)
+### [CSS Fonts 3](https://www.w3.org/TR/css-fonts-3/)
 
-- [@font-face](http://www.w3.org/TR/css-fonts-3/#font-face-rule)
+- [@font-face](https://www.w3.org/TR/css-fonts-3/#font-face-rule)
   - Support depends on browser capabilities
   - Note: `font-stretch`, `unicode-range` and `font-feature-settings` descriptors are currently ignored.
 
 ## Media queries
 
-- Vivliostyle uses styles specified for [`print` media](http://www.w3.org/TR/CSS2/media.html#media-types) (as well as `all`).
+- Vivliostyle uses styles specified for [`print` media](https://www.w3.org/TR/CSS2/media.html#media-types) (as well as `all`).
   - Supported in all browsers
 - Supported media features
-  - [`(min-|max-)width`](http://www.w3.org/TR/css3-mediaqueries/#width)
+  - [`(min-|max-)width`](https://www.w3.org/TR/css3-mediaqueries/#width)
       - Supported in all browsers
-  - [`(min-|max-)height`](http://www.w3.org/TR/css3-mediaqueries/#height)
+  - [`(min-|max-)height`](https://www.w3.org/TR/css3-mediaqueries/#height)
       - Supported in all browsers
-  - [`(min-|max-)device-width`](http://www.w3.org/TR/css3-mediaqueries/#device-width)
+  - [`(min-|max-)device-width`](https://www.w3.org/TR/css3-mediaqueries/#device-width)
       - Supported in all browsers
-  - [`(min-|max-)device-height`](http://www.w3.org/TR/css3-mediaqueries/#device-height)
+  - [`(min-|max-)device-height`](https://www.w3.org/TR/css3-mediaqueries/#device-height)
       - Supported in all browsers
-  - [`(min-|max-)color`](http://www.w3.org/TR/css3-mediaqueries/#color)
+  - [`(min-|max-)color`](https://www.w3.org/TR/css3-mediaqueries/#color)
       - Supported in all browsers
 
 ## Properties
 
-### [CSS 2](http://www.w3.org/TR/CSS2/)
+### [CSS 2](https://www.w3.org/TR/CSS2/)
 
-- [background](http://www.w3.org/TR/CSS2/colors.html#propdef-background)
-  - Supports [CSS Backgrounds 3 syntax](http://www.w3.org/TR/css3-background/#background)
+- [background](https://www.w3.org/TR/CSS2/colors.html#propdef-background)
+  - Supports [CSS Backgrounds 3 syntax](https://www.w3.org/TR/css3-background/#background)
   - Support depends on browser capabilities
-- [background-attachment](http://www.w3.org/TR/CSS2/colors.html#propdef-background-attachment)
-  - Supports [CSS Backgrounds 3 syntax](http://www.w3.org/TR/css3-background/#background-attachment)
-  - Support depends on browser capabilities
-  - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-color](http://www.w3.org/TR/CSS2/colors.html#propdef-background-color)
-  - Supports [CSS Backgrounds 3 syntax](http://www.w3.org/TR/css3-background/#background-color)
-  - Support depends on browser capabilities
-- [background-image](http://www.w3.org/TR/CSS2/colors.html#propdef-background-image)
-  - Supports [CSS Backgrounds 3 syntax](http://www.w3.org/TR/css3-background/#background-image)
+- [background-attachment](https://www.w3.org/TR/CSS2/colors.html#propdef-background-attachment)
+  - Supports [CSS Backgrounds 3 syntax](https://www.w3.org/TR/css3-background/#background-attachment)
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-position](http://www.w3.org/TR/CSS2/colors.html#propdef-background-position)
-  - Supports [CSS Backgrounds 3 syntax](http://www.w3.org/TR/css3-background/#background-position)
+- [background-color](https://www.w3.org/TR/CSS2/colors.html#propdef-background-color)
+  - Supports [CSS Backgrounds 3 syntax](https://www.w3.org/TR/css3-background/#background-color)
+  - Support depends on browser capabilities
+- [background-image](https://www.w3.org/TR/CSS2/colors.html#propdef-background-image)
+  - Supports [CSS Backgrounds 3 syntax](https://www.w3.org/TR/css3-background/#background-image)
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-repeat](http://www.w3.org/TR/CSS2/colors.html#propdef-background-repeat)
-  - Supports [CSS Backgrounds 3 syntax](http://www.w3.org/TR/css3-background/#background-repeat)
+- [background-position](https://www.w3.org/TR/CSS2/colors.html#propdef-background-position)
+  - Supports [CSS Backgrounds 3 syntax](https://www.w3.org/TR/css3-background/#background-position)
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [border](http://www.w3.org/TR/CSS2/box.html#propdef-border)
+- [background-repeat](https://www.w3.org/TR/CSS2/colors.html#propdef-background-repeat)
+  - Supports [CSS Backgrounds 3 syntax](https://www.w3.org/TR/css3-background/#background-repeat)
   - Support depends on browser capabilities
-- [border-bottom](http://www.w3.org/TR/CSS2/box.html#propdef-border-bottom)
+  - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
+- [border](https://www.w3.org/TR/CSS2/box.html#propdef-border)
   - Support depends on browser capabilities
-- [border-bottom-color](http://www.w3.org/TR/CSS2/box.html#propdef-border-bottom-color)
+- [border-bottom](https://www.w3.org/TR/CSS2/box.html#propdef-border-bottom)
   - Support depends on browser capabilities
-- [border-bottom-style](http://www.w3.org/TR/CSS2/box.html#propdef-border-bottom-style)
+- [border-bottom-color](https://www.w3.org/TR/CSS2/box.html#propdef-border-bottom-color)
   - Support depends on browser capabilities
-- [border-bottom-width](http://www.w3.org/TR/CSS2/box.html#propdef-border-bottom-width)
+- [border-bottom-style](https://www.w3.org/TR/CSS2/box.html#propdef-border-bottom-style)
   - Support depends on browser capabilities
-- [border-collapse](http://www.w3.org/TR/CSS2/tables.html#propdef-border-collapse)
+- [border-bottom-width](https://www.w3.org/TR/CSS2/box.html#propdef-border-bottom-width)
   - Support depends on browser capabilities
-- [border-color](http://www.w3.org/TR/CSS2/box.html#propdef-border-color)
+- [border-collapse](https://www.w3.org/TR/CSS2/tables.html#propdef-border-collapse)
   - Support depends on browser capabilities
-- [border-left](http://www.w3.org/TR/CSS2/box.html#propdef-border-left)
+- [border-color](https://www.w3.org/TR/CSS2/box.html#propdef-border-color)
   - Support depends on browser capabilities
-- [border-left-color](http://www.w3.org/TR/CSS2/box.html#propdef-border-left-color)
+- [border-left](https://www.w3.org/TR/CSS2/box.html#propdef-border-left)
   - Support depends on browser capabilities
-- [border-left-style](http://www.w3.org/TR/CSS2/box.html#propdef-border-left-style)
+- [border-left-color](https://www.w3.org/TR/CSS2/box.html#propdef-border-left-color)
   - Support depends on browser capabilities
-- [border-left-width](http://www.w3.org/TR/CSS2/box.html#propdef-border-left-width)
+- [border-left-style](https://www.w3.org/TR/CSS2/box.html#propdef-border-left-style)
   - Support depends on browser capabilities
-- [border-right](http://www.w3.org/TR/CSS2/box.html#propdef-border-right)
+- [border-left-width](https://www.w3.org/TR/CSS2/box.html#propdef-border-left-width)
   - Support depends on browser capabilities
-- [border-right-color](http://www.w3.org/TR/CSS2/box.html#propdef-border-right-color)
+- [border-right](https://www.w3.org/TR/CSS2/box.html#propdef-border-right)
   - Support depends on browser capabilities
-- [border-right-style](http://www.w3.org/TR/CSS2/box.html#propdef-border-right-style)
+- [border-right-color](https://www.w3.org/TR/CSS2/box.html#propdef-border-right-color)
   - Support depends on browser capabilities
-- [border-right-width](http://www.w3.org/TR/CSS2/box.html#propdef-border-right-width)
+- [border-right-style](https://www.w3.org/TR/CSS2/box.html#propdef-border-right-style)
   - Support depends on browser capabilities
-- [border-spacing](http://www.w3.org/TR/CSS2/tables.html#propdef-border-spacing)
+- [border-right-width](https://www.w3.org/TR/CSS2/box.html#propdef-border-right-width)
   - Support depends on browser capabilities
-- [border-style](http://www.w3.org/TR/CSS2/box.html#propdef-border-style)
+- [border-spacing](https://www.w3.org/TR/CSS2/tables.html#propdef-border-spacing)
   - Support depends on browser capabilities
-- [border-top](http://www.w3.org/TR/CSS2/box.html#propdef-border-top)
+- [border-style](https://www.w3.org/TR/CSS2/box.html#propdef-border-style)
   - Support depends on browser capabilities
-- [border-top-color](http://www.w3.org/TR/CSS2/box.html#propdef-border-top-color)
+- [border-top](https://www.w3.org/TR/CSS2/box.html#propdef-border-top)
   - Support depends on browser capabilities
-- [border-top-style](http://www.w3.org/TR/CSS2/box.html#propdef-border-top-style)
+- [border-top-color](https://www.w3.org/TR/CSS2/box.html#propdef-border-top-color)
   - Support depends on browser capabilities
-- [border-top-width](http://www.w3.org/TR/CSS2/box.html#propdef-border-top-width)
+- [border-top-style](https://www.w3.org/TR/CSS2/box.html#propdef-border-top-style)
   - Support depends on browser capabilities
-- [border-width](http://www.w3.org/TR/CSS2/box.html#propdef-border-width)
+- [border-top-width](https://www.w3.org/TR/CSS2/box.html#propdef-border-top-width)
   - Support depends on browser capabilities
-- [bottom](http://www.w3.org/TR/CSS2/visuren.html#propdef-bottom)
+- [border-width](https://www.w3.org/TR/CSS2/box.html#propdef-border-width)
   - Support depends on browser capabilities
-- [caption-side](http://www.w3.org/TR/CSS2/tables.html#propdef-caption-side)
+- [bottom](https://www.w3.org/TR/CSS2/visuren.html#propdef-bottom)
   - Support depends on browser capabilities
-- [clear](http://www.w3.org/TR/CSS2/visuren.html#propdef-clear)
+- [caption-side](https://www.w3.org/TR/CSS2/tables.html#propdef-caption-side)
+  - Support depends on browser capabilities
+- [clear](https://www.w3.org/TR/CSS2/visuren.html#propdef-clear)
   - Supported in all browsers
-- [clip](http://www.w3.org/TR/CSS2/visufx.html#propdef-clip)
+- [clip](https://www.w3.org/TR/CSS2/visufx.html#propdef-clip)
   - Support depends on browser capabilities
-- [color](http://www.w3.org/TR/CSS2/colors.html#propdef-color)
+- [color](https://www.w3.org/TR/CSS2/colors.html#propdef-color)
   - Support depends on browser capabilities
-- [content](http://www.w3.org/TR/CSS2/generate.html#propdef-content)
+- [content](https://www.w3.org/TR/CSS2/generate.html#propdef-content)
   - Supported in all browsers
-- [counter-increment](http://www.w3.org/TR/CSS2/generate.html#propdef-counter-increment)
+- [counter-increment](https://www.w3.org/TR/CSS2/generate.html#propdef-counter-increment)
   - Supported in all browsers
-- [counter-reset](http://www.w3.org/TR/CSS2/generate.html#propdef-counter-reset)
+- [counter-reset](https://www.w3.org/TR/CSS2/generate.html#propdef-counter-reset)
   - Supported in all browsers
-- [cursor](http://www.w3.org/TR/CSS2/ui.html#propdef-cursor)
+- [cursor](https://www.w3.org/TR/CSS2/ui.html#propdef-cursor)
   - Support depends on browser capabilities
-- [direction](http://www.w3.org/TR/CSS2/visuren.html#propdef-direction)
+- [direction](https://www.w3.org/TR/CSS2/visuren.html#propdef-direction)
   - Support depends on browser capabilities
-- [display](http://www.w3.org/TR/CSS2/visuren.html#propdef-display)
+- [display](https://www.w3.org/TR/CSS2/visuren.html#propdef-display)
   - Support depends on browser capabilities
   - Supports [`flex`, `inline-flex`](https://www.w3.org/TR/css-flexbox-1/#flex-containers), [`ruby`, `ruby-base`, `ruby-text`, `ruby-base-container` and `ruby-text-container`](https://www.w3.org/TR/css-ruby-1/#propdef-display) values.
-- [empty-cells](http://www.w3.org/TR/CSS2/tables.html#propdef-empty-cells)
+- [empty-cells](https://www.w3.org/TR/CSS2/tables.html#propdef-empty-cells)
   - Support depends on browser capabilities
-- [float](http://www.w3.org/TR/CSS2/visuren.html#propdef-float)
+- [float](https://www.w3.org/TR/CSS2/visuren.html#propdef-float)
   - Supported in all browsers
-- [font](http://www.w3.org/TR/CSS2/fonts.html#propdef-font)
+- [font](https://www.w3.org/TR/CSS2/fonts.html#propdef-font)
   - Support depends on browser capabilities
-- [font-family](http://www.w3.org/TR/CSS2/fonts.html#propdef-font-family)
+- [font-family](https://www.w3.org/TR/CSS2/fonts.html#propdef-font-family)
   - Support depends on browser capabilities
-- [font-size](http://www.w3.org/TR/CSS2/fonts.html#propdef-font-size)
+- [font-size](https://www.w3.org/TR/CSS2/fonts.html#propdef-font-size)
   - Support depends on browser capabilities
-- [font-style](http://www.w3.org/TR/CSS2/fonts.html#propdef-font-style)
+- [font-style](https://www.w3.org/TR/CSS2/fonts.html#propdef-font-style)
   - Support depends on browser capabilities
-- [font-variant](http://www.w3.org/TR/CSS2/fonts.html#propdef-font-variant)
+- [font-variant](https://www.w3.org/TR/CSS2/fonts.html#propdef-font-variant)
   - Support depends on browser capabilities
-- [font-weight](http://www.w3.org/TR/CSS2/fonts.html#propdef-font-weight)
+- [font-weight](https://www.w3.org/TR/CSS2/fonts.html#propdef-font-weight)
   - Support depends on browser capabilities
-- [height](http://www.w3.org/TR/CSS2/visudet.html#propdef-height)
+- [height](https://www.w3.org/TR/CSS2/visudet.html#propdef-height)
   - Support depends on browser capabilities
-- [left](http://www.w3.org/TR/CSS2/visuren.html#propdef-left)
+- [left](https://www.w3.org/TR/CSS2/visuren.html#propdef-left)
   - Support depends on browser capabilities
-- [letter-spacing](http://www.w3.org/TR/CSS2/text.html#propdef-letter-spacing)
+- [letter-spacing](https://www.w3.org/TR/CSS2/text.html#propdef-letter-spacing)
   - Support depends on browser capabilities
-- [line-height](http://www.w3.org/TR/CSS2/visudet.html#propdef-line-height)
+- [line-height](https://www.w3.org/TR/CSS2/visudet.html#propdef-line-height)
   - Support depends on browser capabilities
-- [list-style](http://www.w3.org/TR/CSS2/generate.html#propdef-list-style)
+- [list-style](https://www.w3.org/TR/CSS2/generate.html#propdef-list-style)
   - Support depends on browser capabilities
-- [list-style-image](http://www.w3.org/TR/CSS2/generate.html#propdef-list-style-image)
+- [list-style-image](https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-image)
   - Support depends on browser capabilities
-- [list-style-position](http://www.w3.org/TR/CSS2/generate.html#propdef-list-style-position)
+- [list-style-position](https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-position)
   - Support depends on browser capabilities
-- [list-style-type](http://www.w3.org/TR/CSS2/generate.html#propdef-list-style-type)
+- [list-style-type](https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-type)
   - Support depends on browser capabilities
-- [margin](http://www.w3.org/TR/CSS2/box.html#propdef-margin)
+- [margin](https://www.w3.org/TR/CSS2/box.html#propdef-margin)
   - Support depends on browser capabilities
-- [margin-bottom](http://www.w3.org/TR/CSS2/box.html#propdef-margin-bottom)
+- [margin-bottom](https://www.w3.org/TR/CSS2/box.html#propdef-margin-bottom)
   - Support depends on browser capabilities
-- [margin-left](http://www.w3.org/TR/CSS2/box.html#propdef-margin-left)
+- [margin-left](https://www.w3.org/TR/CSS2/box.html#propdef-margin-left)
   - Support depends on browser capabilities
-- [margin-right](http://www.w3.org/TR/CSS2/box.html#propdef-margin-right)
+- [margin-right](https://www.w3.org/TR/CSS2/box.html#propdef-margin-right)
   - Support depends on browser capabilities
-- [margin-top](http://www.w3.org/TR/CSS2/box.html#propdef-margin-top)
+- [margin-top](https://www.w3.org/TR/CSS2/box.html#propdef-margin-top)
   - Support depends on browser capabilities
-- [max-height](http://www.w3.org/TR/CSS2/visudet.html#propdef-max-height)
+- [max-height](https://www.w3.org/TR/CSS2/visudet.html#propdef-max-height)
   - Support depends on browser capabilities
-- [max-width](http://www.w3.org/TR/CSS2/visudet.html#propdef-max-width)
+- [max-width](https://www.w3.org/TR/CSS2/visudet.html#propdef-max-width)
   - Support depends on browser capabilities
-- [min-height](http://www.w3.org/TR/CSS2/visudet.html#propdef-min-height)
+- [min-height](https://www.w3.org/TR/CSS2/visudet.html#propdef-min-height)
   - Support depends on browser capabilities
-- [min-width](http://www.w3.org/TR/CSS2/visudet.html#propdef-min-width)
+- [min-width](https://www.w3.org/TR/CSS2/visudet.html#propdef-min-width)
   - Support depends on browser capabilities
-- [orphans](http://www.w3.org/TR/CSS2/page.html#propdef-orphans)
+- [orphans](https://www.w3.org/TR/CSS2/page.html#propdef-orphans)
   - Supported in all browsers
-- [outline](http://www.w3.org/TR/CSS2/ui.html#propdef-outline)
+- [outline](https://www.w3.org/TR/CSS2/ui.html#propdef-outline)
   - Support depends on browser capabilities
-- [outline-color](http://www.w3.org/TR/CSS2/ui.html#propdef-outline-color)
+- [outline-color](https://www.w3.org/TR/CSS2/ui.html#propdef-outline-color)
   - Support depends on browser capabilities
-- [outline-style](http://www.w3.org/TR/CSS2/ui.html#propdef-outline-style)
+- [outline-style](https://www.w3.org/TR/CSS2/ui.html#propdef-outline-style)
   - Support depends on browser capabilities
-- [outline-width](http://www.w3.org/TR/CSS2/ui.html#propdef-outline-width)
+- [outline-width](https://www.w3.org/TR/CSS2/ui.html#propdef-outline-width)
   - Support depends on browser capabilities
-- [overflow](http://www.w3.org/TR/CSS2/visufx.html#propdef-overflow)
+- [overflow](https://www.w3.org/TR/CSS2/visufx.html#propdef-overflow)
   - Support depends on browser capabilities
-- [padding](http://www.w3.org/TR/CSS2/box.html#propdef-padding)
+- [padding](https://www.w3.org/TR/CSS2/box.html#propdef-padding)
   - Support depends on browser capabilities
-- [padding-bottom](http://www.w3.org/TR/CSS2/box.html#propdef-padding-bottom)
+- [padding-bottom](https://www.w3.org/TR/CSS2/box.html#propdef-padding-bottom)
   - Support depends on browser capabilities
-- [padding-left](http://www.w3.org/TR/CSS2/box.html#propdef-padding-left)
+- [padding-left](https://www.w3.org/TR/CSS2/box.html#propdef-padding-left)
   - Support depends on browser capabilities
-- [padding-right](http://www.w3.org/TR/CSS2/box.html#propdef-padding-right)
+- [padding-right](https://www.w3.org/TR/CSS2/box.html#propdef-padding-right)
   - Support depends on browser capabilities
-- [padding-top](http://www.w3.org/TR/CSS2/box.html#propdef-padding-top)
+- [padding-top](https://www.w3.org/TR/CSS2/box.html#propdef-padding-top)
   - Support depends on browser capabilities
-- [page-break-after](http://www.w3.org/TR/CSS2/page.html#propdef-page-break-after)
+- [page-break-after](https://www.w3.org/TR/CSS2/page.html#propdef-page-break-after)
   - Supported in all browsers
-- [page-break-before](http://www.w3.org/TR/CSS2/page.html#propdef-page-break-before)
+- [page-break-before](https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before)
   - Supported in all browsers
-- [page-break-inside](http://www.w3.org/TR/CSS2/page.html#propdef-page-break-inside)
+- [page-break-inside](https://www.w3.org/TR/CSS2/page.html#propdef-page-break-inside)
   - Supported in all browsers
-- [position](http://www.w3.org/TR/CSS2/visuren.html#propdef-position)
+- [position](https://www.w3.org/TR/CSS2/visuren.html#propdef-position)
   - Support depends on browser capabilities
-- [quotes](http://www.w3.org/TR/CSS2/generate.html#propdef-quotes)
+- [quotes](https://www.w3.org/TR/CSS2/generate.html#propdef-quotes)
   - Supported in all browsers
   - Note: not supported within `@page` rules. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/43)
-- [right](http://www.w3.org/TR/CSS2/visuren.html#propdef-right)
+- [right](https://www.w3.org/TR/CSS2/visuren.html#propdef-right)
   - Support depends on browser capabilities
-- [table-layout](http://www.w3.org/TR/CSS2/tables.html#propdef-table-layout)
+- [table-layout](https://www.w3.org/TR/CSS2/tables.html#propdef-table-layout)
   - Support depends on browser capabilities
-- [text-align](http://www.w3.org/TR/CSS2/text.html#propdef-text-align)
+- [text-align](https://www.w3.org/TR/CSS2/text.html#propdef-text-align)
   - Support depends on browser capabilities
-- [text-decoration](http://www.w3.org/TR/CSS2/text.html#propdef-text-decoration)
+- [text-decoration](https://www.w3.org/TR/CSS2/text.html#propdef-text-decoration)
   - Support depends on browser capabilities
-- [text-indent](http://www.w3.org/TR/CSS2/text.html#propdef-text-indent)
+- [text-indent](https://www.w3.org/TR/CSS2/text.html#propdef-text-indent)
   - Support depends on browser capabilities
-- [text-transform](http://www.w3.org/TR/CSS2/text.html#propdef-text-transform)
+- [text-transform](https://www.w3.org/TR/CSS2/text.html#propdef-text-transform)
   - Support depends on browser capabilities
-- [top](http://www.w3.org/TR/CSS2/visuren.html#propdef-top)
+- [top](https://www.w3.org/TR/CSS2/visuren.html#propdef-top)
   - Support depends on browser capabilities
-- [unicode-bidi](http://www.w3.org/TR/CSS2/visuren.html#propdef-unicode-bidi)
+- [unicode-bidi](https://www.w3.org/TR/CSS2/visuren.html#propdef-unicode-bidi)
   - Support depends on browser capabilities
   - Supports [new values (`isolate`, `isolate-override`, `plaintext`) in CSS Writing Modes 3](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
-- [vertical-align](http://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align)
+- [vertical-align](https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align)
   - Support depends on browser capabilities
-- [visibility](http://www.w3.org/TR/CSS2/visufx.html#propdef-visibility)
+- [visibility](https://www.w3.org/TR/CSS2/visufx.html#propdef-visibility)
   - Support depends on browser capabilities
-- [white-space](http://www.w3.org/TR/CSS2/text.html#propdef-white-space)
+- [white-space](https://www.w3.org/TR/CSS2/text.html#propdef-white-space)
   - Support depends on browser capabilities
-- [widows](http://www.w3.org/TR/CSS2/page.html#propdef-widows)
+- [widows](https://www.w3.org/TR/CSS2/page.html#propdef-widows)
   - Supported in all browsers
-- [width](http://www.w3.org/TR/CSS2/visudet.html#propdef-width)
+- [width](https://www.w3.org/TR/CSS2/visudet.html#propdef-width)
   - Support depends on browser capabilities
-- [word-spacing](http://www.w3.org/TR/CSS2/text.html#propdef-word-spacing)
+- [word-spacing](https://www.w3.org/TR/CSS2/text.html#propdef-word-spacing)
   - Support depends on browser capabilities
-- [z-index](http://www.w3.org/TR/CSS2/visuren.html#propdef-z-index)
+- [z-index](https://www.w3.org/TR/CSS2/visuren.html#propdef-z-index)
   - Support depends on browser capabilities
 
 ### [CSS Paged Media 3](https://drafts.csswg.org/css-page-3/)
 
+- [bleed](https://drafts.csswg.org/css-page/#bleed)
+  - Supported in all browsers
+  - Only effective when specified within an `@page` rule without page selectors
+- [marks](https://drafts.csswg.org/css-page/#marks)
+  - Supported in all browsers
+  - Only effective when specified within an `@page` rule without page selectors
 - [size](https://drafts.csswg.org/css-page-3/#descdef-page-size)
   - Supported in all browsers
   - Supports `JIS-B5` and `JIS-B4` values in the current editor's draft.
 
-### [CSS Color 3](http://www.w3.org/TR/css3-color/)
+### [CSS Color 3](https://www.w3.org/TR/css3-color/)
 
-- [color](http://www.w3.org/TR/css3-color/#color0)
+- [color](https://www.w3.org/TR/css3-color/#color0)
   - Support depends on browser capabilities
-- [opacity](http://www.w3.org/TR/css3-color/#opacity)
+- [opacity](https://www.w3.org/TR/css3-color/#opacity)
   - Support depends on browser capabilities
 
-### [CSS Backgrounds and Borders 3](http://www.w3.org/TR/css3-background/)
+### [CSS Backgrounds and Borders 3](https://www.w3.org/TR/css3-background/)
 
-- [background](http://www.w3.org/TR/css3-background/#background)
+- [background](https://www.w3.org/TR/css3-background/#background)
   - Support depends on browser capabilities
-- [background-attachment](http://www.w3.org/TR/css3-background/#background-attachment)
+- [background-attachment](https://www.w3.org/TR/css3-background/#background-attachment)
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-clip](http://www.w3.org/TR/css3-background/#background-clip)
+- [background-clip](https://www.w3.org/TR/css3-background/#background-clip)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-color](http://www.w3.org/TR/css3-background/#background-color)
+- [background-color](https://www.w3.org/TR/css3-background/#background-color)
   - Support depends on browser capabilities
-- [background-image](http://www.w3.org/TR/css3-background/#background-image)
+- [background-image](https://www.w3.org/TR/css3-background/#background-image)
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-origin](http://www.w3.org/TR/css3-background/#background-origin)
+- [background-origin](https://www.w3.org/TR/css3-background/#background-origin)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-position](http://www.w3.org/TR/css3-background/#background-position)
+- [background-position](https://www.w3.org/TR/css3-background/#background-position)
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-repeat](http://www.w3.org/TR/css3-background/#background-repeat)
+- [background-repeat](https://www.w3.org/TR/css3-background/#background-repeat)
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [background-size](http://www.w3.org/TR/css3-background/#background-size)
+- [background-size](https://www.w3.org/TR/css3-background/#background-size)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
   - Note: behavior when used within `@page` rules is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/22)
-- [border](http://www.w3.org/TR/css3-background/#border)
+- [border](https://www.w3.org/TR/css3-background/#border)
   - Support depends on browser capabilities
-- [border-bottom](http://www.w3.org/TR/css3-background/#border-bottom)
+- [border-bottom](https://www.w3.org/TR/css3-background/#border-bottom)
   - Support depends on browser capabilities
-- [border-bottom-color](http://www.w3.org/TR/css3-background/#border-bottom-color)
+- [border-bottom-color](https://www.w3.org/TR/css3-background/#border-bottom-color)
   - Support depends on browser capabilities
-- [border-bottom-left-radius](http://www.w3.org/TR/css3-background/#border-bottom-left-radius)
+- [border-bottom-left-radius](https://www.w3.org/TR/css3-background/#border-bottom-left-radius)
   - Support depends on browser capabilities
-- [border-bottom-right-radius](http://www.w3.org/TR/css3-background/#border-bottom-right-radius)
+- [border-bottom-right-radius](https://www.w3.org/TR/css3-background/#border-bottom-right-radius)
   - Support depends on browser capabilities
-- [border-bottom-style](http://www.w3.org/TR/css3-background/#border-bottom-style)
+- [border-bottom-style](https://www.w3.org/TR/css3-background/#border-bottom-style)
   - Support depends on browser capabilities
-- [border-bottom-width](http://www.w3.org/TR/css3-background/#border-bottom-width)
+- [border-bottom-width](https://www.w3.org/TR/css3-background/#border-bottom-width)
   - Support depends on browser capabilities
-- [border-color](http://www.w3.org/TR/css3-background/#border-color)
+- [border-color](https://www.w3.org/TR/css3-background/#border-color)
   - Support depends on browser capabilities
-- [border-image](http://www.w3.org/TR/css3-background/#border-image)
+- [border-image](https://www.w3.org/TR/css3-background/#border-image)
   - Support depends on browser capabilities
-- [border-image-outset](http://www.w3.org/TR/css3-background/#border-image-outset)
+- [border-image-outset](https://www.w3.org/TR/css3-background/#border-image-outset)
   - Support depends on browser capabilities
-- [border-image-repeat](http://www.w3.org/TR/css3-background/#border-image-repeat)
+- [border-image-repeat](https://www.w3.org/TR/css3-background/#border-image-repeat)
   - Support depends on browser capabilities
-- [border-image-slice](http://www.w3.org/TR/css3-background/#border-image-slice)
+- [border-image-slice](https://www.w3.org/TR/css3-background/#border-image-slice)
   - Support depends on browser capabilities
-- [border-image-source](http://www.w3.org/TR/css3-background/#border-image-source)
+- [border-image-source](https://www.w3.org/TR/css3-background/#border-image-source)
   - Support depends on browser capabilities
-- [border-image-width](http://www.w3.org/TR/css3-background/#border-image-width)
+- [border-image-width](https://www.w3.org/TR/css3-background/#border-image-width)
   - Support depends on browser capabilities
-- [border-left](http://www.w3.org/TR/css3-background/#border-left)
+- [border-left](https://www.w3.org/TR/css3-background/#border-left)
   - Support depends on browser capabilities
-- [border-left-color](http://www.w3.org/TR/css3-background/#border-left-color)
+- [border-left-color](https://www.w3.org/TR/css3-background/#border-left-color)
   - Support depends on browser capabilities
-- [border-left-style](http://www.w3.org/TR/css3-background/#border-left-style)
+- [border-left-style](https://www.w3.org/TR/css3-background/#border-left-style)
   - Support depends on browser capabilities
-- [border-left-width](http://www.w3.org/TR/css3-background/#border-left-width)
+- [border-left-width](https://www.w3.org/TR/css3-background/#border-left-width)
   - Support depends on browser capabilities
-- [border-radius](http://www.w3.org/TR/css3-background/#border-radius)
+- [border-radius](https://www.w3.org/TR/css3-background/#border-radius)
   - Support depends on browser capabilities
-- [border-right](http://www.w3.org/TR/css3-background/#border-right)
+- [border-right](https://www.w3.org/TR/css3-background/#border-right)
   - Support depends on browser capabilities
-- [border-right-color](http://www.w3.org/TR/css3-background/#border-right-color)
+- [border-right-color](https://www.w3.org/TR/css3-background/#border-right-color)
   - Support depends on browser capabilities
-- [border-right-style](http://www.w3.org/TR/css3-background/#border-right-style)
+- [border-right-style](https://www.w3.org/TR/css3-background/#border-right-style)
   - Support depends on browser capabilities
-- [border-right-width](http://www.w3.org/TR/css3-background/#border-right-width)
+- [border-right-width](https://www.w3.org/TR/css3-background/#border-right-width)
   - Support depends on browser capabilities
-- [border-style](http://www.w3.org/TR/css3-background/#border-style)
+- [border-style](https://www.w3.org/TR/css3-background/#border-style)
   - Support depends on browser capabilities
-- [border-top](http://www.w3.org/TR/css3-background/#border-top)
+- [border-top](https://www.w3.org/TR/css3-background/#border-top)
   - Support depends on browser capabilities
-- [border-top-color](http://www.w3.org/TR/css3-background/#border-top-color)
+- [border-top-color](https://www.w3.org/TR/css3-background/#border-top-color)
   - Support depends on browser capabilities
-- [border-top-left-radius](http://www.w3.org/TR/css3-background/#border-top-left-radius)
+- [border-top-left-radius](https://www.w3.org/TR/css3-background/#border-top-left-radius)
   - Support depends on browser capabilities
-- [border-top-right-radius](http://www.w3.org/TR/css3-background/#border-top-right-radius)
+- [border-top-right-radius](https://www.w3.org/TR/css3-background/#border-top-right-radius)
   - Support depends on browser capabilities
-- [border-top-style](http://www.w3.org/TR/css3-background/#border-top-style)
+- [border-top-style](https://www.w3.org/TR/css3-background/#border-top-style)
   - Support depends on browser capabilities
-- [border-top-width](http://www.w3.org/TR/css3-background/#border-top-width)
+- [border-top-width](https://www.w3.org/TR/css3-background/#border-top-width)
   - Support depends on browser capabilities
-- [border-width](http://www.w3.org/TR/css3-background/#border-width)
+- [border-width](https://www.w3.org/TR/css3-background/#border-width)
   - Support depends on browser capabilities
-- [box-shadow](http://www.w3.org/TR/css3-background/#box-shadow)
+- [box-shadow](https://www.w3.org/TR/css3-background/#box-shadow)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
 
-### [CSS Image Values and Replaced Content 3](http://www.w3.org/TR/css3-images/)
+### [CSS Image Values and Replaced Content 3](https://www.w3.org/TR/css3-images/)
 
-- [object-fit](http://www.w3.org/TR/css3-images/#object-fit)
+- [object-fit](https://www.w3.org/TR/css3-images/#object-fit)
   - Support depends on browser capabilities
-- [object-position](http://www.w3.org/TR/css3-images/#object-position)
+- [object-position](https://www.w3.org/TR/css3-images/#object-position)
   - Support depends on browser capabilities
 
-### [CSS Fonts 3](http://www.w3.org/TR/css-fonts-3/)
+### [CSS Fonts 3](https://www.w3.org/TR/css-fonts-3/)
 
-- [font-family](http://www.w3.org/TR/css-fonts-3/#propdef-font-family)
+- [font-family](https://www.w3.org/TR/css-fonts-3/#propdef-font-family)
   - Support depends on browser capabilities
-- [font-kerning](http://www.w3.org/TR/css-fonts-3/#propdef-font-kerning)
+- [font-kerning](https://www.w3.org/TR/css-fonts-3/#propdef-font-kerning)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
-- [font-size](http://www.w3.org/TR/css-fonts-3/#propdef-font-size)
+- [font-size](https://www.w3.org/TR/css-fonts-3/#propdef-font-size)
   - Support depends on browser capabilities
-- [font-style](http://www.w3.org/TR/css-fonts-3/#propdef-font-style)
+- [font-style](https://www.w3.org/TR/css-fonts-3/#propdef-font-style)
   - Support depends on browser capabilities
-- [font-variant-east-asian](http://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
+- [font-variant-east-asian](https://www.w3.org/TR/css-fonts-3/#propdef-font-variant-east-asian)
   - Support depends on browser capabilities
-- [font-weight](http://www.w3.org/TR/css-fonts-3/#propdef-font-weight)
+- [font-weight](https://www.w3.org/TR/css-fonts-3/#propdef-font-weight)
   - Support depends on browser capabilities
 
-### [CSS Text 3](http://www.w3.org/TR/css-text-3/)
+### [CSS Text 3](https://www.w3.org/TR/css-text-3/)
 
-- [hyphens](http://www.w3.org/TR/css-text-3/#hyphens)
+- [hyphens](https://www.w3.org/TR/css-text-3/#hyphens)
   - Allowed prefixes: epub, moz, ms, webkit
   - Support depends on browser capabilities
-- [letter-spacing](http://www.w3.org/TR/css-text-3/#letter-spacing)
+- [letter-spacing](https://www.w3.org/TR/css-text-3/#letter-spacing)
   - Support depends on browser capabilities
-- [line-break](http://www.w3.org/TR/css-text-3/#line-break0)
+- [line-break](https://www.w3.org/TR/css-text-3/#line-break0)
   - Support depends on browser capabilities
   - Allowed prefixes: ms, webkit
   - Values: `auto | loose | normal | strict;`
-- [overflow-wrap](http://www.w3.org/TR/css-text-3/#overflow-wrap)
+- [overflow-wrap](https://www.w3.org/TR/css-text-3/#overflow-wrap)
   - Support depends on browser capabilities
   - Note: While the spec states that `word-wrap` must be treated as if it were a shorthand of `overflow-wrap`, Vivliostyle treat them for now as different properties and might result in an incorrect cascading behavior when inconsistent values are specified for both of the properties.
-- [tab-size](http://www.w3.org/TR/css-text-3/#tab-size)
+- [tab-size](https://www.w3.org/TR/css-text-3/#tab-size)
   - Allowed prefixes: moz
   - Support depends on browser capabilities
-- [text-align-last](http://www.w3.org/TR/css-text-3/#text-align-last)
+- [text-align-last](https://www.w3.org/TR/css-text-3/#text-align-last)
   - Allowed prefixes: moz, ms
   - Support depends on browser capabilities
   - Note: While `text-align` property is a shorthand in CSS Text 3, Vivliostyle treats `text-align` for now as an independent property (defined in CSS 2.1) rather than a shorthand.
@@ -518,191 +524,191 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Allowed prefixes: ms
   - Support depends on browser capabilities
   - Note: `inter-ideograph` value as well as values defined in the current editor's draft is supported since we use it in UA stylesheet to emulate text-justify: auto behavior defined in the spec on IE.
-- [white-space](http://www.w3.org/TR/css-text-3/#white-space)
+- [white-space](https://www.w3.org/TR/css-text-3/#white-space)
   - Support depends on browser capabilities
-- [word-break](http://www.w3.org/TR/css-text-3/#word-break)
+- [word-break](https://www.w3.org/TR/css-text-3/#word-break)
   - Allowed prefixes: ms
   - Support depends on browser capabilities
-- [word-wrap](http://www.w3.org/TR/css-text-3/#word-wrap)
+- [word-wrap](https://www.w3.org/TR/css-text-3/#word-wrap)
   - Allowed prefixes: ms
   - Support depends on browser capabilities
   - Note: While the spec states that `word-wrap` must be treated as if it were a shorthand of `overflow-wrap`, Vivliostyle treat them for now as different properties and might result in an incorrect cascading behavior when inconsistent values are specified for both of the properties.
 
-### [CSS Text Decoration 3](http://www.w3.org/TR/css-text-decor-3/)
+### [CSS Text Decoration 3](https://www.w3.org/TR/css-text-decor-3/)
 
 - Note: While `text-decoration` property is a shorthand in CSS Text Decoration 3, Vivliostyle treats `text-decoration` for now as an independent property defined in CSS Level 2.1.
-- [text-decoration-color](http://www.w3.org/TR/css-text-decor-3/#text-decoration-color)
+- [text-decoration-color](https://www.w3.org/TR/css-text-decor-3/#text-decoration-color)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
-- [text-decoration-line](http://www.w3.org/TR/css-text-decor-3/#text-decoration-line)
+- [text-decoration-line](https://www.w3.org/TR/css-text-decor-3/#text-decoration-line)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
-- [text-decoration-skip](http://www.w3.org/TR/css-text-decor-3/#text-decoration-skip)
+- [text-decoration-skip](https://www.w3.org/TR/css-text-decor-3/#text-decoration-skip)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
-- [text-decoration-style](http://www.w3.org/TR/css-text-decor-3/#text-decoration-style)
+- [text-decoration-style](https://www.w3.org/TR/css-text-decor-3/#text-decoration-style)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
-- [text-emphasis](http://www.w3.org/TR/css-text-decor-3/#text-emphasis)
+- [text-emphasis](https://www.w3.org/TR/css-text-decor-3/#text-emphasis)
   - Allowed prefixes: epub, webkit
   - Support depends on browser capabilities
-- [text-emphasis-color](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-color)
+- [text-emphasis-color](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-color)
   - Allowed prefixes: epub, webkit
   - Support depends on browser capabilities
-- [text-emphasis-position](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-position)
+- [text-emphasis-position](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-position)
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
-- [text-emphasis-style](http://www.w3.org/TR/css-text-decor-3/#text-emphasis-style)
+- [text-emphasis-style](https://www.w3.org/TR/css-text-decor-3/#text-emphasis-style)
   - Allowed prefixes: epub, webkit
   - Support depends on browser capabilities
-- [text-shadow](http://www.w3.org/TR/css-text-decor-3/#text-shadow)
+- [text-shadow](https://www.w3.org/TR/css-text-decor-3/#text-shadow)
   - Support depends on browser capabilities
-- [text-underline-position](http://www.w3.org/TR/css-text-decor-3/#text-underline-position)
+- [text-underline-position](https://www.w3.org/TR/css-text-decor-3/#text-underline-position)
   - Support depends on browser capabilities
   - Allowed prefixes: ms, webkit
 
-### [CSS Multi-column Layout 1](http://www.w3.org/TR/css3-multicol/)
+### [CSS Multi-column Layout 1](https://www.w3.org/TR/css3-multicol/)
 
-- [break-after](http://www.w3.org/TR/css3-multicol/#break-after)
+- [break-after](https://www.w3.org/TR/css3-multicol/#break-after)
   - Supported in all browsers
   - Note: behavior when multiple forced break values coincide at a single break point is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/129)
-- [break-before](http://www.w3.org/TR/css3-multicol/#break-before)
+- [break-before](https://www.w3.org/TR/css3-multicol/#break-before)
   - Supported in all browsers
   - Note: behavior when multiple forced break values coincide at a single break point is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/129)
-- [break-inside](http://www.w3.org/TR/css3-multicol/#break-inside)
+- [break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
   - Supported in all browsers
   - Note: All of `avoid-page`, `avoid-column` and `avoid-region` values are treated as if they were `avoid`. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/128)
-- [column-count](http://www.w3.org/TR/css3-multicol/#column-count)
+- [column-count](https://www.w3.org/TR/css3-multicol/#column-count)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
-- [column-gap](http://www.w3.org/TR/css3-multicol/#column-gap0)
+- [column-gap](https://www.w3.org/TR/css3-multicol/#column-gap0)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
-- [column-rule](http://www.w3.org/TR/css3-multicol/#column-rule0)
+- [column-rule](https://www.w3.org/TR/css3-multicol/#column-rule0)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
-- [column-rule-color](http://www.w3.org/TR/css3-multicol/#column-rule-color)
+- [column-rule-color](https://www.w3.org/TR/css3-multicol/#column-rule-color)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
-- [column-rule-style](http://www.w3.org/TR/css3-multicol/#column-rule-style)
+- [column-rule-style](https://www.w3.org/TR/css3-multicol/#column-rule-style)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
-- [column-rule-width](http://www.w3.org/TR/css3-multicol/#column-rule-width)
+- [column-rule-width](https://www.w3.org/TR/css3-multicol/#column-rule-width)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
-- [column-width](http://www.w3.org/TR/css3-multicol/#column-width)
+- [column-width](https://www.w3.org/TR/css3-multicol/#column-width)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
-- [columns](http://www.w3.org/TR/css3-multicol/#columns0)
+- [columns](https://www.w3.org/TR/css3-multicol/#columns0)
   - Allowed prefixes: moz, webkit
   - Supported in all browsers
 
-### [CSS Basic User Interface 3](http://www.w3.org/TR/css3-ui/)
+### [CSS Basic User Interface 3](https://www.w3.org/TR/css3-ui/)
 
-- [box-sizing](http://www.w3.org/TR/css3-ui/#propdef-box-sizing)
+- [box-sizing](https://www.w3.org/TR/css3-ui/#propdef-box-sizing)
   - Support depends on browser capabilities
-- [outline](http://www.w3.org/TR/css3-ui/#propdef-outline)
+- [outline](https://www.w3.org/TR/css3-ui/#propdef-outline)
   - Support depends on browser capabilities
-- [outline-color](http://www.w3.org/TR/css3-ui/#propdef-outline-color)
+- [outline-color](https://www.w3.org/TR/css3-ui/#propdef-outline-color)
   - Support depends on browser capabilities
-- [outline-style](http://www.w3.org/TR/css3-ui/#propdef-outline-style)
+- [outline-style](https://www.w3.org/TR/css3-ui/#propdef-outline-style)
   - Support depends on browser capabilities
-- [outline-width](http://www.w3.org/TR/css3-ui/#propdef-outline-width)
+- [outline-width](https://www.w3.org/TR/css3-ui/#propdef-outline-width)
   - Support depends on browser capabilities
-- [text-overflow](http://www.w3.org/TR/css3-ui/#propdef-text-overflow)
+- [text-overflow](https://www.w3.org/TR/css3-ui/#propdef-text-overflow)
   - Allowed prefixes: ms
   - Support depends on browser capabilities
 
-### [CSS Writing Modes 3](http://www.w3.org/TR/css-writing-modes-3/)
+### [CSS Writing Modes 3](https://www.w3.org/TR/css-writing-modes-3/)
 
-- [direction](http://www.w3.org/TR/css-writing-modes-3/#propdef-direction)
+- [direction](https://www.w3.org/TR/css-writing-modes-3/#propdef-direction)
   - Support depends on browser capabilities
-- [text-combine-upright](http://www.w3.org/TR/css-writing-modes-3/#propdef-text-combine-upright)
+- [text-combine-upright](https://www.w3.org/TR/css-writing-modes-3/#propdef-text-combine-upright)
   - Support depends on browser capabilities
-- [text-combine-horizontal](http://www.w3.org/TR/2012/WD-css3-writing-modes-20121115/#text-combine-horizontal0)
+- [text-combine-horizontal](https://www.w3.org/TR/2012/WD-css3-writing-modes-20121115/#text-combine-horizontal0)
   - This deprecated property is kept for compatibility.
   - Allowed prefixes: epub, ms
   - Support depends on browser capabilities
-- [text-combine](http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine0)
+- [text-combine](https://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine0)
   - This deprecated property is kept for compatibility.
   - Allowed prefixes: webkit
   - Support depends on browser capabilities
-- [text-orientation](http://www.w3.org/TR/css-writing-modes-3/#propdef-text-orientation)
+- [text-orientation](https://www.w3.org/TR/css-writing-modes-3/#propdef-text-orientation)
   - Allowed prefixes: epub, webkit
   - Support depends on browser capabilities
   - Note: supported values are [those defined in 20 March 2014 Candidate Recommendation](https://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#propdef-text-orientation), not those in the latest spec.
 - [unicode-bidi](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
   - Support depends on browser capabilities
   - Supports [new values (`isolate`, `isolate-override`, `plaintext`) in CSS Writing Modes 3](https://www.w3.org/TR/css-writing-modes-3/#propdef-unicode-bidi)
-- [writing-mode](http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
+- [writing-mode](https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode)
   - Allowed prefixes: epub, webkit
   - Support depends on browser capabilities
   - Note: supported values are [those defined in 20 March 2014 Candidate Recommendation](https://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/#propdef-writing-mode), not those in the latest spec.
 
-### [CSS Flexible Box Layout 1](http://www.w3.org/TR/css-flexbox-1/)
+### [CSS Flexible Box Layout 1](https://www.w3.org/TR/css-flexbox-1/)
 
-- [align-content](http://www.w3.org/TR/css-flexbox-1/#propdef-align-content)
+- [align-content](https://www.w3.org/TR/css-flexbox-1/#propdef-align-content)
   - Support depends on browser capabilities
-- [align-items](http://www.w3.org/TR/css-flexbox-1/#propdef-align-items)
+- [align-items](https://www.w3.org/TR/css-flexbox-1/#propdef-align-items)
   - Support depends on browser capabilities
-- [align-self](http://www.w3.org/TR/css-flexbox-1/#propdef-align-self)
+- [align-self](https://www.w3.org/TR/css-flexbox-1/#propdef-align-self)
   - Support depends on browser capabilities
 - [display](https://www.w3.org/TR/css-flexbox-1/#flex-containers)
   - Support depends on browser capabilities
   - Supports [`flex`, `inline-flex`](https://www.w3.org/TR/css-flexbox-1/#flex-containers), [`ruby`, `ruby-base`, `ruby-text`, `ruby-base-container` and `ruby-text-container`](https://www.w3.org/TR/css-ruby-1/#propdef-display) values.
-- [flex](http://www.w3.org/TR/css-flexbox-1/#propdef-flex)
+- [flex](https://www.w3.org/TR/css-flexbox-1/#propdef-flex)
   - Support depends on browser capabilities
-- [flex-basis](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis)
+- [flex-basis](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis)
   - Support depends on browser capabilities
-- [flex-direction](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction)
+- [flex-direction](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction)
   - Support depends on browser capabilities
-- [flex-flow](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow)
+- [flex-flow](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow)
   - Support depends on browser capabilities
-- [flex-grow](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow)
+- [flex-grow](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow)
   - Support depends on browser capabilities
-- [flex-shrink](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink)
+- [flex-shrink](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink)
   - Support depends on browser capabilities
-- [flex-wrap](http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap)
+- [flex-wrap](https://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap)
   - Support depends on browser capabilities
-- [justify-content](http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content)
+- [justify-content](https://www.w3.org/TR/css-flexbox-1/#propdef-justify-content)
   - Support depends on browser capabilities
-- [order](http://www.w3.org/TR/css-flexbox-1/#propdef-order)
+- [order](https://www.w3.org/TR/css-flexbox-1/#propdef-order)
   - Support depends on browser capabilities
 
-### [CSS Fragmentation 3](http://www.w3.org/TR/css3-break/)
+### [CSS Fragmentation 3](https://www.w3.org/TR/css3-break/)
 
-- [break-after](http://www.w3.org/TR/css3-break/#break-after)
+- [break-after](https://www.w3.org/TR/css3-break/#propdef-break-after)
   - Supported in all browsers
   - Note: behavior when multiple forced break values coincide at a single break point is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/129)
-- [break-before](http://www.w3.org/TR/css3-break/#break-before)
+- [break-before](https://www.w3.org/TR/css3-break/#propdef-break-before)
   - Supported in all browsers
   - Note: behavior when multiple forced break values coincide at a single break point is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/129)
-- [break-inside](http://www.w3.org/TR/css3-break/#break-inside)
+- [break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
   - Supported in all browsers
   - Note: All of `avoid-page`, `avoid-column` and `avoid-region` values are treated as if they were `avoid`. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/128)
-- [orphans](http://www.w3.org/TR/css3-break/#orphans)
+- [orphans](https://www.w3.org/TR/css3-break/#propdef-orphans)
   - Supported in all browsers
-- [widows](http://www.w3.org/TR/css3-break/#widows)
+- [widows](https://www.w3.org/TR/css3-break/#propdef-widows)
   - Supported in all browsers
 
-### [CSS Transforms 1](http://www.w3.org/TR/css-transforms-1/)
+### [CSS Transforms 1](https://www.w3.org/TR/css-transforms-1/)
 
-- [backface-visibility](http://www.w3.org/TR/css-transforms-1/#propdef-backface-visibility)
+- [backface-visibility](https://www.w3.org/TR/css-transforms-1/#propdef-backface-visibility)
   - Allowed prefixes: ms, webkit
   - Support depends on browser capabilities
-- [transform](http://www.w3.org/TR/css-transforms-1/#propdef-transform)
+- [transform](https://www.w3.org/TR/css-transforms-1/#propdef-transform)
   - Allowed prefixes: epub, ms
   - Support depends on browser capabilities
-- [transform-origin](http://www.w3.org/TR/css-transforms-1/#propdef-transform-origin)
+- [transform-origin](https://www.w3.org/TR/css-transforms-1/#propdef-transform-origin)
   - Allowed prefixes: epub, ms
   - Support depends on browser capabilities
 
-### [CSS Ruby Layout 1](http://www.w3.org/TR/css-ruby-1/)
+### [CSS Ruby Layout 1](https://www.w3.org/TR/css-ruby-1/)
 
 - [display](https://www.w3.org/TR/css-ruby-1/#propdef-display)
   - Support depends on browser capabilities
   - Supports [`flex`, `inline-flex`](https://www.w3.org/TR/css-flexbox-1/#flex-containers), [`ruby`, `ruby-base`, `ruby-text`, `ruby-base-container` and `ruby-text-container`](https://www.w3.org/TR/css-ruby-1/#propdef-display) values.
-- [ruby-align](http://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
+- [ruby-align](https://www.w3.org/TR/css-ruby-1/#propdef-ruby-align)
   - Support depends on browser capabilities
 - [ruby-position](https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position)
   - Support depends on browser capabilities
@@ -714,9 +720,9 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Allowed prefixes: moz, ms
   - Support depends on browser capabilities
 
-### [Pointer Events](http://www.w3.org/TR/pointerevents/)
+### [Pointer Events](https://www.w3.org/TR/pointerevents/)
 
-- [touch-action](http://www.w3.org/TR/pointerevents/#the-touch-action-css-property)
+- [touch-action](https://www.w3.org/TR/pointerevents/#the-touch-action-css-property)
   - Allowed prefixes: ms
   - Support depends on browser capabilities
 
@@ -775,11 +781,11 @@ Note: This spec is not on a W3C standards track. Future version of Vivliostyle m
 - [-epubx-shape-outside](http://www.idpf.org/epub/pgt/#prop-shape-outside)
   - Supported in all browsers
   - Only effective when specified to EPUB Adaptive Layout partitions.
-  - Note: only [old syntaxes from 3 May 2012 Working Draft](http://www.w3.org/TR/2012/WD-css3-exclusions-20120503/#supported-svg-shapes) are supported.
+  - Note: only [old syntaxes from 3 May 2012 Working Draft](https://www.w3.org/TR/2012/WD-css3-exclusions-20120503/#supported-svg-shapes) are supported.
 - [-epubx-shape-inside](http://www.idpf.org/epub/pgt/#prop-shape-inside)
   - Supported in all browsers
   - Only effective when specified to EPUB Adaptive Layout partitions.
-  - Note: only [old syntaxes from 3 May 2012 Working Draft](http://www.w3.org/TR/2012/WD-css3-exclusions-20120503/#supported-svg-shapes) are supported.
+  - Note: only [old syntaxes from 3 May 2012 Working Draft](https://www.w3.org/TR/2012/WD-css3-exclusions-20120503/#supported-svg-shapes) are supported.
 - [-epubx-snap-height](http://www.idpf.org/epub/pgt/#prop-snap-height)
   - Supported in all browsers
 - [-epubx-snap-width](http://www.idpf.org/epub/pgt/#prop-snap-width)

--- a/resources/validation.txt
+++ b/resources/validation.txt
@@ -269,6 +269,8 @@ object-position = COMMA( SPACE(BG_POSITION_TERM{1,4})+ ); /* relaxed */
 
 /* CSS Paged Media */
 PAGE_SIZE = a5 | a4 | a3 | b5 | b4 | jis-b5 | jis-b4 | letter | legal | ledger;
+bleed = auto | LENGTH;
+marks = none | [ crop || cross ];
 size = POS_LENGTH{1,2} | auto | [ PAGE_SIZE || [ portrait | landscape ] ];
 
 /* CSS Page Floats */

--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -2,8 +2,21 @@
  * Copyright 2015 Vivliostyle Inc.
  */
 
+[data-vivliostyle-page-container] {
+    position: relative;
+    overflow: hidden;
+    max-height: 100%;
+}
+
+[data-vivliostyle-bleed-box] {
+    position: absolute;
+    overflow: hidden;
+    max-width: 100%;
+    max-height: 100%;
+}
+
 @media print {
-    [data-vivliostyle-outer-zoom-box], [data-vivliostyle-spread-container], [data-vivliostyle-page-container] {
+    [data-vivliostyle-outer-zoom-box], [data-vivliostyle-spread-container] {
         width: 100% !important;
         height: 100% !important;
     }
@@ -15,15 +28,9 @@
         transform: none !important;
     }
 
-    /* Workaround for Chrome printing problem */
     [data-vivliostyle-page-container] {
         display: block !important;
         page-break-after: always;
-    }
-    /* Workaround for Chrome printing problem */
-    [data-vivliostyle-page-box] {
-        padding-bottom: 0 !important;
-        overflow: visible !important;
     }
 }
 

--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -3,12 +3,12 @@
  */
 
 @media print {
-    [data-vivliostyle-viewer-viewport] > div, [data-vivliostyle-viewer-viewport] > div > div, [data-vivliostyle-viewer-viewport] > div > div > div {
+    [data-vivliostyle-outer-zoom-box], [data-vivliostyle-spread-container], [data-vivliostyle-page-container] {
         width: 100% !important;
         height: 100% !important;
     }
 
-    [data-vivliostyle-viewer-viewport] > div > div {
+    [data-vivliostyle-spread-container] {
         -moz-transform: none !important;
         -ms-transform: none !important;
         -webkit-transform: none !important;
@@ -16,7 +16,7 @@
     }
 
     /* Workaround for Chrome printing problem */
-    [data-vivliostyle-viewer-viewport] > div > div > div {
+    [data-vivliostyle-page-container] {
         display: block !important;
         page-break-after: always;
     }
@@ -32,7 +32,7 @@
         background: #AAAAAA;
     }
 
-    [data-vivliostyle-viewer-viewport] > div > div > div {
+    [data-vivliostyle-page-container] {
         background: white;
     }
 
@@ -41,14 +41,14 @@
         display: flex;
     }
 
-    [data-vivliostyle-viewer-viewport] > div {
+    [data-vivliostyle-outer-zoom-box] {
         margin: auto;
         overflow: visible;
         -webkit-flex: none;
         flex: none;
     }
 
-    [data-vivliostyle-viewer-viewport][data-vivliostyle-viewer-status=complete] > div > div {
+    [data-vivliostyle-viewer-viewport][data-vivliostyle-viewer-status=complete] [data-vivliostyle-spread-container] {
         display: -webkit-flex;
         display: flex;
         -webkit-flex: none;
@@ -61,29 +61,29 @@
         transform-origin: left top;
     }
 
-    [data-vivliostyle-viewer-viewport][data-vivliostyle-page-progression=ltr] > div > div {
+    [data-vivliostyle-viewer-viewport][data-vivliostyle-page-progression=ltr] [data-vivliostyle-spread-container] {
         -webkit-flex-direction: row;
         flex-direction: row;
     }
-    [data-vivliostyle-viewer-viewport][data-vivliostyle-page-progression=rtl] > div > div {
+    [data-vivliostyle-viewer-viewport][data-vivliostyle-page-progression=rtl] [data-vivliostyle-spread-container] {
         -webkit-flex-direction: row-reverse;
         flex-direction: row-reverse;
     }
 
-    [data-vivliostyle-viewer-viewport] > div > div > div {
+    [data-vivliostyle-viewer-viewport] [data-vivliostyle-page-container] {
         margin: 0 auto;
         -webkit-flex: none;
         flex: none;
     }
-    [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view=true] > div > div > div[data-vivliostyle-page-side=left] {
+    [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view=true] [data-vivliostyle-page-container][data-vivliostyle-page-side=left] {
         margin-right: 1px;
         transform-origin: right center;
     }
-    [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view=true] >div > div > div[data-vivliostyle-page-side=right] {
+    [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view=true] [data-vivliostyle-page-container][data-vivliostyle-page-side=right] {
         margin-left: 1px;
         transform-origin: left center;
     }
-    [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view=true] > div > div > div[data-vivliostyle-unpaired-page=true] {
+    [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view=true] [data-vivliostyle-page-container][data-vivliostyle-unpaired-page=true] {
         margin-left: auto;
         margin-right: auto;
         transform-origin: center center;

--- a/src/adapt/css.js
+++ b/src/adapt/css.js
@@ -889,6 +889,8 @@ adapt.css.ident = {
     block_start: adapt.css.getName("block-start"),
     both: adapt.css.getName("both"),
     bottom: adapt.css.getName("bottom"),
+    crop: adapt.css.getName("crop"),
+    cross: adapt.css.getName("cross"),
     exclusive: adapt.css.getName("exclusive"),
     _false: adapt.css.getName("false"),
     footnote: adapt.css.getName("footnote"),

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -893,12 +893,14 @@ adapt.epub.OPFViewItem;
  * @param {adapt.vgen.Viewport} viewport
  * @param {adapt.font.Mapper} fontMapper
  * @param {adapt.expr.Preferences} pref
+ * @param {!function(!Object<string, !{width: number, height: number}>, number, number)} pageSheetSizeReporter
  * @implements {adapt.vgen.CustomRendererFactory}
  */
-adapt.epub.OPFView = function(opf, viewport, fontMapper, pref) {
+adapt.epub.OPFView = function(opf, viewport, fontMapper, pref, pageSheetSizeReporter) {
 	/** @const */ this.opf = opf;
 	/** @const */ this.viewport = viewport;
 	/** @const */ this.fontMapper = fontMapper;
+	/** @const */ this.pageSheetSizeReporter = pageSheetSizeReporter;
 	/** @type {Array.<adapt.epub.OPFViewItem>} */ this.spineItems = [];
 	/** @type {number} */ this.spineIndex = 0;
 	/** @type {number} */ this.pageIndex = 0;
@@ -999,8 +1001,10 @@ adapt.epub.OPFView.prototype.renderPage = function() {
                 page.container.style.visibility = "visible";
                 page.container.setAttribute("data-vivliostyle-page-side", /** @type {string} */ (page.side));
 		    	pos = /** @type {adapt.vtree.LayoutPosition} */ (posParam);
+				var pageIndex = pos ? pos.page - 1 : viewItem.layoutPositions.length - 1;
+				self.pageSheetSizeReporter(viewItem.instance.pageSheetSize, viewItem.item.spineIndex, pageIndex);
 			    if (pos) {
-                    viewItem.pages[pos.page - 1] = page;
+                    viewItem.pages[pageIndex] = page;
 			    	viewItem.layoutPositions.push(pos);
 			    	if (seekOffset >= 0) {
 			    		// Searching for offset, don't know the page number.
@@ -1012,17 +1016,17 @@ adapt.epub.OPFView.prototype.renderPage = function() {
 			    			return;
 			    		}
 			    	}
-                    page.isFirstPage = viewItem.item.spineIndex == 0 && pos.page - 1 == 0;
+                    page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
 			    	loopFrame.continueLoop();
 			    } else {
                     viewItem.pages.push(page);
 			    	resultPage = page;
-			    	self.pageIndex = viewItem.layoutPositions.length - 1;
+			    	self.pageIndex = pageIndex;
 			    	if (seekOffset < 0) {
 			    		self.offsetInItem = page.offset;
 			    	}
 			    	viewItem.complete = true;
-					page.isFirstPage = viewItem.item.spineIndex == 0 && self.pageIndex == 0;
+					page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
 					page.isLastPage = viewItem.item.spineIndex == self.opf.spine.length - 1;
 					loopFrame.breakLoop();
 			    }
@@ -1043,15 +1047,17 @@ adapt.epub.OPFView.prototype.renderPage = function() {
                 page.container.style.visibility = "visible";
                 page.container.setAttribute("data-vivliostyle-page-side", /** @type {string} */ (page.side));
 		    	pos = /** @type {adapt.vtree.LayoutPosition} */ (posParam);
+				var pageIndex = pos ? pos.page - 1 : viewItem.layoutPositions.length - 1;
+				self.pageSheetSizeReporter(viewItem.instance.pageSheetSize, viewItem.item.spineIndex, pageIndex);
 			    if (pos) {
-                    viewItem.pages[pos.page - 1] = page;
+                    viewItem.pages[pageIndex] = page;
 			    	viewItem.layoutPositions[self.pageIndex + 1] = pos;
 			    } else {
                     viewItem.pages.push(page);
 			    	viewItem.complete = true;
 			    	page.isLastPage = viewItem.item.spineIndex == self.opf.spine.length - 1;
 			    }
-				page.isFirstPage = viewItem.item.spineIndex == 0 && self.pageIndex == 0;
+				page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
 			    frame.finish(page);
 		    });
 		});		    

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1356,7 +1356,7 @@ adapt.epub.OPFView.prototype.navigateTo = function(href) {
 /**
  * @param {adapt.epub.OPFViewItem} viewItem
  * @param {adapt.vtree.LayoutPosition} pos
- * @return {adapt.vtree.Page}
+ * @return {!adapt.vtree.Page}
  */
 adapt.epub.OPFView.prototype.makePage = function(viewItem, pos) {
 	var viewport = viewItem.instance.viewport;

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1360,16 +1360,19 @@ adapt.epub.OPFView.prototype.navigateTo = function(href) {
  */
 adapt.epub.OPFView.prototype.makePage = function(viewItem, pos) {
 	var viewport = viewItem.instance.viewport;
+
     var pageCont = /** @type {HTMLElement} */ (viewport.document.createElement("div"));
 	pageCont.setAttribute("data-vivliostyle-page-container", true);
-    viewport.contentContainer.appendChild(pageCont);
-    pageCont.style.position = "relative";
 	if (!vivliostyle.constants.isDebug) {
 		pageCont.style.visibility = "hidden";
 	}
-    pageCont.style.left = "0px";
-    pageCont.style.top = "0px";
-    var page = new adapt.vtree.Page(pageCont);
+	viewport.contentContainer.appendChild(pageCont);
+
+	var bleedBox = /** @type {HTMLElement} */ (viewport.document.createElement("div"));
+	bleedBox.setAttribute("data-vivliostyle-bleed-box", true);
+	pageCont.appendChild(bleedBox);
+
+    var page = new adapt.vtree.Page(pageCont, bleedBox);
     page.spineIndex = viewItem.item.spineIndex;
     page.position = pos;
     page.offset = viewItem.instance.getPosition(pos);

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1355,6 +1355,7 @@ adapt.epub.OPFView.prototype.navigateTo = function(href) {
 adapt.epub.OPFView.prototype.makePage = function(viewItem, pos) {
 	var viewport = viewItem.instance.viewport;
     var pageCont = /** @type {HTMLElement} */ (viewport.document.createElement("div"));
+	pageCont.setAttribute("data-vivliostyle-page-container", true);
     viewport.contentContainer.appendChild(pageCont);
     pageCont.style.position = "relative";
 	if (!vivliostyle.constants.isDebug) {

--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -258,6 +258,8 @@ adapt.expr.ScopeContext;
  */
 adapt.expr.Context = function(rootScope, viewportWidth, viewportHeight, fontSize) {
 	/** @const */ this.rootScope = rootScope;
+    /** @const */ this.viewportWidth = viewportWidth;
+    /** @const */ this.viewportHeight = viewportHeight;
     /** @protected @type {?number} */ this.actualPageWidth = null;
     /** @const @type {function(this:adapt.expr.Context): number} */
     this.pageWidth = function() {

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -711,7 +711,7 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
         self.styler.replayFlowElementsFromOffset(-1);
     }
     if (this.lang) {
-    	page.container.setAttribute("lang", this.lang);
+    	page.bleedBox.setAttribute("lang", this.lang);
     }
     cp = self.currentLayoutPosition;
     cp.page++;
@@ -743,14 +743,14 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
     /** @type {!adapt.task.Frame.<adapt.vtree.LayoutPosition>} */ var frame
     	= adapt.task.newFrame("layoutNextPage");
 	frame.loopWithFrame(function(loopFrame) {
-		self.layoutContainer(page, pageMaster, page.container, 0, 0, exclusions.concat(), pageFloatHolder).then(function() {
+		self.layoutContainer(page, pageMaster, page.bleedBox, 0, 0, exclusions.concat(), pageFloatHolder).then(function() {
 			if (pageFloatHolder.hasNewlyAddedFloats()) {
 				exclusions = exclusions.concat(pageFloatHolder.getShapesOfNewlyAddedFloats());
 				pageFloatHolder.clearNewlyAddedFloats();
 				cp = self.currentLayoutPosition = currentLayoutPosition.clone();
 				var c;
-				while (c = page.container.lastChild) {
-					page.container.removeChild(c);
+				while (c = page.bleedBox.lastChild) {
+					page.bleedBox.removeChild(c);
 				}
 				loopFrame.continueLoop();
 			} else {
@@ -777,7 +777,7 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
 /**
  * Resolve actual page width, height and bleed from style specified in page context.
  * @param cascadedPageStyle
- * @returns {!{pageWidth: number, pageHeight: number, cropOffset: number}}
+ * @returns {!{pageWidth: number, pageHeight: number, bleed: number, bleedOffset: number, cropOffset: number}}
  */
 adapt.ops.StyleInstance.prototype.resolvePageSizeAndBleed = function(cascadedPageStyle) {
 	var resolved = {};
@@ -797,6 +797,8 @@ adapt.ops.StyleInstance.prototype.resolvePageSizeAndBleed = function(cascadedPag
 	} else {
 		resolved.pageHeight = height.num * this.queryUnitSize(height.unit, false);
 	}
+	resolved.bleed = bleed;
+	resolved.bleedOffset = bleedOffset;
 	resolved.cropOffset = cropOffset;
 	return resolved;
 };
@@ -811,9 +813,13 @@ adapt.ops.StyleInstance.prototype.setPageSizeAndBleed = function(cascadedPageSty
 	var resolved = this.resolvePageSizeAndBleed(cascadedPageStyle);
 	this.actualPageWidth = resolved.pageWidth;
 	this.actualPageHeight = resolved.pageHeight;
-	page.container.style.padding = resolved.cropOffset + "px";
-	page.container.style.width = resolved.pageWidth + "px";
-	page.container.style.height = resolved.pageHeight + "px";
+	page.container.style.width = (resolved.pageWidth + resolved.cropOffset * 2) + "px";
+	page.container.style.height = (resolved.pageHeight + resolved.cropOffset * 2) + "px";
+	page.bleedBox.style.left = resolved.bleedOffset + "px";
+	page.bleedBox.style.right = resolved.bleedOffset + "px";
+	page.bleedBox.style.top = resolved.bleedOffset + "px";
+	page.bleedBox.style.bottom = resolved.bleedOffset + "px";
+	page.bleedBox.style.padding = resolved.bleed + "px";
 };
 
 /**

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -697,7 +697,7 @@ adapt.ops.StyleInstance.prototype.noMorePrimaryFlows = function(cp) {
 };
 
 /**
- * @param {adapt.vtree.Page} page
+ * @param {!adapt.vtree.Page} page
  * @param {adapt.vtree.LayoutPosition|undefined} cp
  * @return {adapt.task.Result.<adapt.vtree.LayoutPosition>}
  */
@@ -720,9 +720,6 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
 
     // Resolve page size before page master selection.
     var cascadedPageStyle = self.pageManager.getCascadedPageStyle();
-	var evaluatedPageSizeAndBleed = vivliostyle.page.evaluatePageSizeAndBleed(
-		vivliostyle.page.resolvePageSizeAndBleed(cascadedPageStyle), this);
-    self.setPageSizeAndBleed(evaluatedPageSizeAndBleed, page);
     var pageMaster = self.selectPageMaster(cascadedPageStyle);
     if (!pageMaster) {
     	// end of primary content
@@ -736,6 +733,12 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
 		page.setAutoPageHeight(true);
     }
 	self.pageCounterStore.updatePageCounters(cascadedPageStyle, self);
+
+	// setup bleed area and crop marks
+	var evaluatedPageSizeAndBleed = vivliostyle.page.evaluatePageSizeAndBleed(
+		vivliostyle.page.resolvePageSizeAndBleed(cascadedPageStyle), this);
+	self.setPageSizeAndBleed(evaluatedPageSizeAndBleed, page);
+	vivliostyle.page.addPrinterMarks(cascadedPageStyle, evaluatedPageSizeAndBleed, page, this);
 
 	var writingMode = pageMaster.getProp(self, "writing-mode") || adapt.css.ident.horizontal_tb;
 	var direction = pageMaster.getProp(self, "direction") || adapt.css.ident.ltr;

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -704,7 +704,7 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
 
     // Resolve page size before page master selection.
     var cascadedPageStyle = self.pageManager.getCascadedPageStyle();
-    self.setPageSize(cascadedPageStyle);
+    self.setPageSizeAndBleed(cascadedPageStyle, page);
     var pageMaster = self.selectPageMaster(cascadedPageStyle);
     if (!pageMaster) {
     	// end of primary content
@@ -760,24 +760,29 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
 };
 
 /**
- * Set actual page width & height from style specified in page context.
+ * Set actual page width, height and bleed from style specified in page context.
  * @private
  * @param {!adapt.csscasc.ElementStyle} cascadedPageStyle
+ * @param {adapt.vtree.Page} page
  */
-adapt.ops.StyleInstance.prototype.setPageSize = function(cascadedPageStyle) {
+adapt.ops.StyleInstance.prototype.setPageSizeAndBleed = function(cascadedPageStyle, page) {
     var pageSize = vivliostyle.page.resolvePageSize(cascadedPageStyle);
+	var bleed = pageSize.bleed.num * this.queryUnitSize(pageSize.bleed.unit, false);
+	var bleedOffset = pageSize.bleedOffset.num * this.queryUnitSize(pageSize.bleedOffset.unit, false);
+	var cropOffset = bleed + bleedOffset;
     var width = pageSize.width;
     if (width === adapt.css.fullWidth) {
-        this.actualPageWidth = null;
+        this.actualPageWidth = (this.pref.spreadView ? Math.floor(this.viewportWidth / 2) - this.pref.pageBorder : this.viewportWidth) - cropOffset * 2;
     } else {
         this.actualPageWidth = width.num * this.queryUnitSize(width.unit, false);
     }
     var height = pageSize.height;
     if (height === adapt.css.fullHeight) {
-        this.actualPageHeight = null;
+        this.actualPageHeight = this.viewportHeight - cropOffset * 2;
     } else {
         this.actualPageHeight = height.num * this.queryUnitSize(height.unit, false);
     }
+	page.container.style.padding = cropOffset + "px";
 };
 
 /**

--- a/src/adapt/pm.js
+++ b/src/adapt/pm.js
@@ -160,7 +160,7 @@ adapt.pm.PageMaster = function(scope, name, pseudoName, classes, parent, conditi
     this.specified["height"] = new adapt.csscasc.CascadeValue(adapt.css.fullHeight, 0);
     this.specified["wrap-flow"] =  new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0);
     this.specified["position"] = new adapt.csscasc.CascadeValue(adapt.css.ident.relative, 0);
-    this.specified["overflow"] = new adapt.csscasc.CascadeValue(adapt.css.ident.hidden, 0);
+    this.specified["overflow"] = new adapt.csscasc.CascadeValue(adapt.css.ident.visible, 0);
     /** @type {Object.<string,string>} */ this.keyMap = {};
 };
 goog.inherits(adapt.pm.PageMaster, adapt.pm.PageBox);

--- a/src/adapt/toc.js
+++ b/src/adapt/toc.js
@@ -165,7 +165,7 @@ adapt.toc.TOCView.prototype.showTOC = function(elem, viewport, width, height, fo
 	}
 	var self = this;
 	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame = adapt.task.newFrame("showTOC");
-	var page = new adapt.vtree.Page(elem);
+	var page = new adapt.vtree.Page(elem, elem);
 	this.page = page;
     this.store.load(this.url).then(function (xmldoc) {
     	var style = self.store.getStyleForDoc(xmldoc);

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -1313,11 +1313,13 @@ adapt.vgen.Viewport = function(window, fontSize, opt_root, opt_width, opt_height
 	var outerZoomBox = this.root.firstElementChild;
 	if (!outerZoomBox) {
 		outerZoomBox = this.document.createElement("div");
+		outerZoomBox.setAttribute("data-vivliostyle-outer-zoom-box", true);
 		this.root.appendChild(outerZoomBox);
 	}
 	var contentContainer = outerZoomBox.firstElementChild;
 	if (!contentContainer) {
 		contentContainer = this.document.createElement("div");
+		contentContainer.setAttribute("data-vivliostyle-spread-container", true);
 		outerZoomBox.appendChild(contentContainer);
 	}
 	/** @private @type {!HTMLElement} */ this.outerZoomBox = /** @type {!HTMLElement} */ (outerZoomBox);

--- a/src/adapt/vtree.js
+++ b/src/adapt/vtree.js
@@ -81,12 +81,14 @@ adapt.vtree.makeListener = function(refs, action) {
 
 /**
  * @param {!HTMLElement} container
+ * @param {!HTMLElement} bleedBox
  * @constructor
  * @extends {adapt.base.SimpleEventTarget}
  */
-adapt.vtree.Page = function(container) {
+adapt.vtree.Page = function(container, bleedBox) {
 	adapt.base.SimpleEventTarget.call(this);
 	/** @const */ this.container = container;
+	/** @const */ this.bleedBox = bleedBox;
 	/** @type {HTMLElement} */ this.pageAreaElement = null;
 	/** @type {Array.<adapt.vtree.DelayedItem>} */ this.delayedItems = [];
 	var self = this;

--- a/src/adapt/vtree.js
+++ b/src/adapt/vtree.js
@@ -186,7 +186,7 @@ adapt.vtree.Page.prototype.registerElementWithId = function(element, id) {
  */
 adapt.vtree.Page.prototype.finish = function(triggers, clientLayout) {
 	// use size of the container of the PageMasterInstance
-	var rect = clientLayout.getElementClientRect(this.container.firstElementChild);
+	var rect = clientLayout.getElementClientRect(this.container);
 	this.dimensions.width = rect.width;
 	this.dimensions.height = rect.height;
 

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -1315,9 +1315,7 @@ vivliostyle.page.PageMarginBoxPartitionInstance.prototype.positionAndSizeAlongFi
         var insideName = names.inside;
         var outsideName = names.outside;
         var extentName = names.extent;
-        // Reduce page margin by 2px: workaround for Chrome printing problem.
-        // https://github.com/vivliostyle/vivliostyle.js/issues/97
-        var pageMargin = adapt.expr.sub(scope, dim["margin" + outsideName.charAt(0).toUpperCase() + outsideName.substring(1)], new adapt.expr.Const(scope, 2));
+        var pageMargin = dim["margin" + outsideName.charAt(0).toUpperCase() + outsideName.substring(1)];
         var marginInside = adapt.pm.toExprZeroAuto(scope, style["margin-" + insideName], pageMargin);
         var marginOutside = adapt.pm.toExprZeroAuto(scope, style["margin-" + outsideName], pageMargin);
         var paddingInside = adapt.pm.toExprZero(scope, style["padding-" + insideName], pageMargin);

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -67,11 +67,11 @@ vivliostyle.page.fitToViewportSize = {
 };
 
 /**
- * @param {!Object.<string, adapt.css.Val>} style
+ * @param {!Object.<string, adapt.csscasc.CascadeValue>} style
  * @return {!vivliostyle.page.PageSize}
  */
 vivliostyle.page.resolvePageSize = function(style) {
-    /** @type {adapt.css.Val} */ var size = style["size"];
+    /** @type {adapt.csscasc.CascadeValue} */ var size = style["size"];
     if (!size || size.value === adapt.css.ident.auto) {
         // if size is auto, fit to the viewport
         return vivliostyle.page.fitToViewportSize;

--- a/test/conf/karma-common.conf.js
+++ b/test/conf/karma-common.conf.js
@@ -6,6 +6,7 @@ module.exports = function(config) {
         "test/util/dom.js",
         "test/util/matchers.js",
         "test/util/mock/vivliostyle/logging-mock.js",
+        "test/util/mock/vivliostyle/plugin-mock.js",
         "test/spec/**/*.js"
     ];
     return {

--- a/test/files/crop-marks.html
+++ b/test/files/crop-marks.html
@@ -8,7 +8,7 @@
             size: A4;
         }
         @page {
-            bleed: 5mm;
+            bleed: 2mm;
             marks: crop cross;
             margin: 0;
         }
@@ -18,11 +18,26 @@
         div {
             width: 210mm;
             height: 297mm;
+            margin-left: -10mm;
+            margin-right: -10mm;
+            margin-top: -10mm;
+            margin-bottom: -10mm;
+            padding-left: 10mm;
+            padding-top: 10mm;
+            padding-right: 10mm;
+            padding-bottom: 10mm;
+            page-break-after: always;
+        }
+        #page1 {
             background: #CFC;
+        }
+        #page2 {
+            background: #CCF;
         }
     </style>
 </head>
 <body>
-<div>This green div has 210mm width and 297mm height.</div>
+<div id="page1">This green div covers entire bleed area of page 1.</div>
+<div id="page2">This blue div covers entire bleed area of page 2.</div>
 </body>
 </html>

--- a/test/files/crop-marks.html
+++ b/test/files/crop-marks.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Crop marks and bleed</title>
+    <style>
+        @page {
+/*            size: A4;*/
+            bleed: 5mm;
+            marks: crop cross;
+            margin: 0;
+        }
+        body {
+            margin: 0;
+            font-size: 200%;
+        }
+        div {
+/*            width: 210mm;
+            height: 297mm;*/
+            background: #CFC;
+        }
+    </style>
+</head>
+<body>
+<div>This green div has 210mm width and 297mm height.</div>
+</body>
+</html>

--- a/test/files/crop-marks.html
+++ b/test/files/crop-marks.html
@@ -5,18 +5,19 @@
     <title>Crop marks and bleed</title>
     <style>
         @page {
-/*            size: A4;*/
+            size: A4;
+        }
+        @page {
             bleed: 5mm;
             marks: crop cross;
             margin: 0;
         }
         body {
             margin: 0;
-            font-size: 200%;
         }
         div {
-/*            width: 210mm;
-            height: 297mm;*/
+            width: 210mm;
+            height: 297mm;
             background: #CFC;
         }
     </style>

--- a/test/files/empty_page.html
+++ b/test/files/empty_page.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>empty page</title>
+    <style>
+        @page {
+            size: A4;
+            margin: 0;
+        }
+    </style>
+</head>
+<body>
+Output PDF should have only one page.
+</body>
+</html>

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -1,6 +1,8 @@
 describe("csscasc", function() {
     describe("CascadeParserHandler", function() {
         describe("simpleProperty", function() {
+            vivliostyle.test.util.mock.plugin.setup();
+
             it("convert property declaration by calling functions registered to 'SIMPLE_PROPERTY' hook", function() {
                 function hook1(original) {
                     return {

--- a/test/spec/vivliostyle/page-spec.js
+++ b/test/spec/vivliostyle/page-spec.js
@@ -1,0 +1,81 @@
+describe("page", function() {
+    var module = vivliostyle.page;
+    var expected;
+
+    beforeEach(function() {
+        expected = {
+            width: adapt.css.fullWidth,
+            height: adapt.css.fullHeight
+        };
+    });
+
+    describe("resolvePageSize", function() {
+        it("has fullWidth and fullHeight when nothing specified", function() {
+            var resolved = module.resolvePageSize({});
+            expect(resolved).toEqual(expected);
+        });
+
+        it("has fullWidth and fullHeight when size=auto", function() {
+            var resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0)
+            });
+            expect(resolved).toEqual(expected);
+        });
+
+        it("has the same width and height when only one length is specified in size property", function() {
+            var resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(new adapt.css.Numeric(10, "cm"), 0)
+            });
+            expected.width = new adapt.css.Numeric(10, "cm");
+            expected.height = new adapt.css.Numeric(10, "cm");
+            expect(resolved).toEqual(expected);
+        });
+
+        it("has the width and height specified in size property", function() {
+            var resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(
+                    new adapt.css.SpaceList([new adapt.css.Numeric(10, "cm"), new adapt.css.Numeric(12, "cm")]), 0)
+            });
+            expected.width = new adapt.css.Numeric(10, "cm");
+            expected.height = new adapt.css.Numeric(12, "cm");
+            expect(resolved).toEqual(expected);
+        });
+
+        it("has fullWidth and fullHeight when portrait of landscape is specified alone in size property", function() {
+            var resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(adapt.css.getName("portrait"), 0)
+            });
+            expect(resolved).toEqual(expected);
+
+            resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(adapt.css.ident.landscape, 0)
+            });
+            expect(resolved).toEqual(expected);
+        });
+
+        it("has the width and height of the paper size specified in size property", function() {
+            var resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(new adapt.css.getName("A5"), 0)
+            });
+            expected.width = new adapt.css.Numeric(148, "mm");
+            expected.height = new adapt.css.Numeric(210, "mm");
+            expect(resolved).toEqual(expected);
+
+            resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(
+                    new adapt.css.SpaceList([new adapt.css.getName("A5"), new adapt.css.getName("portrait")]), 0)
+            });
+            expected.width = new adapt.css.Numeric(148, "mm");
+            expected.height = new adapt.css.Numeric(210, "mm");
+            expect(resolved).toEqual(expected);
+
+            resolved = module.resolvePageSize({
+                size: new adapt.csscasc.CascadeValue(
+                    new adapt.css.SpaceList([new adapt.css.getName("A5"), adapt.css.ident.landscape]), 0)
+            });
+            expected.width = new adapt.css.Numeric(210, "mm");
+            expected.height = new adapt.css.Numeric(148, "mm");
+            expect(resolved).toEqual(expected);
+        });
+    });
+});

--- a/test/spec/vivliostyle/page-spec.js
+++ b/test/spec/vivliostyle/page-spec.js
@@ -5,7 +5,9 @@ describe("page", function() {
     beforeEach(function() {
         expected = {
             width: adapt.css.fullWidth,
-            height: adapt.css.fullHeight
+            height: adapt.css.fullHeight,
+            bleed: adapt.css.numericZero,
+            bleedOffset: adapt.css.numericZero
         };
     });
 
@@ -75,6 +77,67 @@ describe("page", function() {
             });
             expected.width = new adapt.css.Numeric(210, "mm");
             expected.height = new adapt.css.Numeric(148, "mm");
+            expect(resolved).toEqual(expected);
+        });
+
+        it("has the default bleed offset value when 'crop' and/or 'cross' value is specified in 'marks' property", function() {
+           var resolved = module.resolvePageSize({
+               marks: new adapt.csscasc.CascadeValue(adapt.css.ident.none, 0)
+           });
+            expect(resolved).toEqual(expected);
+
+            expected.bleedOffset = module.defaultBleedOffset;
+
+            resolved = module.resolvePageSize({
+                bleed: new adapt.csscasc.CascadeValue(adapt.css.numericZero, 0), // if bleed=auto, it computes to 6pt (see below)
+                marks: new adapt.csscasc.CascadeValue(adapt.css.ident.crop, 0)
+            });
+            expect(resolved).toEqual(expected);
+
+            resolved = module.resolvePageSize({
+                marks: new adapt.csscasc.CascadeValue(adapt.css.ident.cross, 0)
+            });
+            expect(resolved).toEqual(expected);
+
+            resolved = module.resolvePageSize({
+                bleed: new adapt.csscasc.CascadeValue(adapt.css.numericZero, 0), // if bleed=auto, it computes to 6pt (see below)
+                marks: new adapt.csscasc.CascadeValue(
+                    new adapt.css.SpaceList([adapt.css.ident.crop, adapt.css.ident.cross]), 0)
+            });
+            expect(resolved).toEqual(expected);
+        });
+
+        it("has the bleed value specified in 'bleed' property when it is specified with a concrete length", function() {
+            var resolved = module.resolvePageSize({
+                bleed: new adapt.csscasc.CascadeValue(new adapt.css.Numeric(5, "mm"), 0)
+            });
+            expected.bleed = new adapt.css.Numeric(5, "mm");
+            expect(resolved).toEqual(expected);
+        });
+
+        it("'auto' bleed value computes to 6pt if 'marks' has 'crop'", function() {
+            expected.bleedOffset = module.defaultBleedOffset;
+            expected.bleed = new adapt.css.Numeric(6, "pt");
+
+            var resolved = module.resolvePageSize({
+                marks: new adapt.csscasc.CascadeValue(adapt.css.ident.crop, 0)
+            });
+            expect(resolved).toEqual(expected);
+
+            resolved = module.resolvePageSize({
+                bleed: new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0),
+                marks: new adapt.csscasc.CascadeValue(adapt.css.ident.crop, 0)
+            });
+            expect(resolved).toEqual(expected);
+        });
+
+        it("'auto' bleed value computes to zero if 'marks' does not has 'crop'", function() {
+            var resolved = module.resolvePageSize({
+                bleed: new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0),
+                marks: new adapt.csscasc.CascadeValue(adapt.css.ident.cross, 0)
+            });
+            expected.bleedOffset = module.defaultBleedOffset;
+            expected.bleed = adapt.css.numericZero;
             expect(resolved).toEqual(expected);
         });
     });

--- a/test/spec/vivliostyle/page-spec.js
+++ b/test/spec/vivliostyle/page-spec.js
@@ -2,7 +2,7 @@ describe("page", function() {
     var module = vivliostyle.page;
     var expected;
 
-    describe("resolvePageSize", function() {
+    describe("resolvePageSizeAndBleed", function() {
         beforeEach(function() {
             expected = {
                 width: adapt.css.fullWidth,
@@ -13,19 +13,19 @@ describe("page", function() {
         });
 
         it("has fullWidth and fullHeight when nothing specified", function() {
-            var resolved = module.resolvePageSize({});
+            var resolved = module.resolvePageSizeAndBleed({});
             expect(resolved).toEqual(expected);
         });
 
         it("has fullWidth and fullHeight when size=auto", function() {
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0)
             });
             expect(resolved).toEqual(expected);
         });
 
         it("has the same width and height when only one length is specified in size property", function() {
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(new adapt.css.Numeric(10, "cm"), 0)
             });
             expected.width = new adapt.css.Numeric(10, "cm");
@@ -34,7 +34,7 @@ describe("page", function() {
         });
 
         it("has the width and height specified in size property", function() {
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(
                     new adapt.css.SpaceList([new adapt.css.Numeric(10, "cm"), new adapt.css.Numeric(12, "cm")]), 0)
             });
@@ -44,26 +44,26 @@ describe("page", function() {
         });
 
         it("has fullWidth and fullHeight when portrait of landscape is specified alone in size property", function() {
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(adapt.css.getName("portrait"), 0)
             });
             expect(resolved).toEqual(expected);
 
-            resolved = module.resolvePageSize({
+            resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(adapt.css.ident.landscape, 0)
             });
             expect(resolved).toEqual(expected);
         });
 
         it("has the width and height of the paper size specified in size property", function() {
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(new adapt.css.getName("A5"), 0)
             });
             expected.width = new adapt.css.Numeric(148, "mm");
             expected.height = new adapt.css.Numeric(210, "mm");
             expect(resolved).toEqual(expected);
 
-            resolved = module.resolvePageSize({
+            resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(
                     new adapt.css.SpaceList([new adapt.css.getName("A5"), new adapt.css.getName("portrait")]), 0)
             });
@@ -71,7 +71,7 @@ describe("page", function() {
             expected.height = new adapt.css.Numeric(210, "mm");
             expect(resolved).toEqual(expected);
 
-            resolved = module.resolvePageSize({
+            resolved = module.resolvePageSizeAndBleed({
                 size: new adapt.csscasc.CascadeValue(
                     new adapt.css.SpaceList([new adapt.css.getName("A5"), adapt.css.ident.landscape]), 0)
             });
@@ -81,25 +81,25 @@ describe("page", function() {
         });
 
         it("has the default bleed offset value when 'crop' and/or 'cross' value is specified in 'marks' property", function() {
-           var resolved = module.resolvePageSize({
+           var resolved = module.resolvePageSizeAndBleed({
                marks: new adapt.csscasc.CascadeValue(adapt.css.ident.none, 0)
            });
             expect(resolved).toEqual(expected);
 
             expected.bleedOffset = module.defaultBleedOffset;
 
-            resolved = module.resolvePageSize({
+            resolved = module.resolvePageSizeAndBleed({
                 bleed: new adapt.csscasc.CascadeValue(adapt.css.numericZero, 0), // if bleed=auto, it computes to 6pt (see below)
                 marks: new adapt.csscasc.CascadeValue(adapt.css.ident.crop, 0)
             });
             expect(resolved).toEqual(expected);
 
-            resolved = module.resolvePageSize({
+            resolved = module.resolvePageSizeAndBleed({
                 marks: new adapt.csscasc.CascadeValue(adapt.css.ident.cross, 0)
             });
             expect(resolved).toEqual(expected);
 
-            resolved = module.resolvePageSize({
+            resolved = module.resolvePageSizeAndBleed({
                 bleed: new adapt.csscasc.CascadeValue(adapt.css.numericZero, 0), // if bleed=auto, it computes to 6pt (see below)
                 marks: new adapt.csscasc.CascadeValue(
                     new adapt.css.SpaceList([adapt.css.ident.crop, adapt.css.ident.cross]), 0)
@@ -108,7 +108,7 @@ describe("page", function() {
         });
 
         it("has the bleed value specified in 'bleed' property when it is specified with a concrete length", function() {
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 bleed: new adapt.csscasc.CascadeValue(new adapt.css.Numeric(5, "mm"), 0)
             });
             expected.bleed = new adapt.css.Numeric(5, "mm");
@@ -119,12 +119,12 @@ describe("page", function() {
             expected.bleedOffset = module.defaultBleedOffset;
             expected.bleed = new adapt.css.Numeric(6, "pt");
 
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 marks: new adapt.csscasc.CascadeValue(adapt.css.ident.crop, 0)
             });
             expect(resolved).toEqual(expected);
 
-            resolved = module.resolvePageSize({
+            resolved = module.resolvePageSizeAndBleed({
                 bleed: new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0),
                 marks: new adapt.csscasc.CascadeValue(adapt.css.ident.crop, 0)
             });
@@ -132,7 +132,7 @@ describe("page", function() {
         });
 
         it("'auto' bleed value computes to zero if 'marks' does not has 'crop'", function() {
-            var resolved = module.resolvePageSize({
+            var resolved = module.resolvePageSizeAndBleed({
                 bleed: new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0),
                 marks: new adapt.csscasc.CascadeValue(adapt.css.ident.cross, 0)
             });

--- a/test/spec/vivliostyle/plugin-spec.js
+++ b/test/spec/vivliostyle/plugin-spec.js
@@ -4,15 +4,9 @@ describe("plugin", function() {
     var fn1 = function() {}, fn2 = function() {};
     var hookName = vivliostyle.plugin.HOOKS["SIMPLE_PROPERTY"];
 
-    var originalHooks;
-    beforeAll(function() {
-        originalHooks = vivliostyle.plugin.hooks;
-    });
+    vivliostyle.test.util.mock.plugin.setup();
     beforeEach(function() {
         vivliostyle.plugin.hooks = {};
-    });
-    afterAll(function() {
-        vivliostyle.plugin.hooks = originalHooks;
     });
 
     describe("registerHook", function() {

--- a/test/util/mock/vivliostyle/plugin-mock.js
+++ b/test/util/mock/vivliostyle/plugin-mock.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2016 Vivliostyle Inc.
+ */
+goog.provide("vivliostyle.test.util.mock.plugin");
+
+(function() {
+    var pluginMock = vivliostyle.test.util.mock.plugin;
+
+    pluginMock.setup = function() {
+        var originalHooks;
+        beforeAll(function() {
+            originalHooks = vivliostyle.plugin.hooks;
+        });
+        beforeEach(function() {
+            var hooks = vivliostyle.plugin.hooks = {};
+            Object.keys(originalHooks).forEach(function(name) {
+                hooks[name] = Array.from(originalHooks[name]);
+            });
+        });
+        afterAll(function() {
+            vivliostyle.plugin.hooks = originalHooks;
+        });
+    };
+})();


### PR DESCRIPTION
Issue: #98

A bleed area is added around the page box. Page contents outside the bleed area are clipped. The size of the bleed area is determined by [`bleed` property](https://drafts.csswg.org/css-page/#bleed).

Printer marks are placed outside the bleed area when [`marks` property](https://drafts.csswg.org/css-page/#marks) is specified.
The default values for printer marks parameters are as follows. They
are hardcoded in the source code for now.
- Line width: 0.24pt (same as AHF)
- Line length of marks: 10mm (the line of corner marks (shorter one),
  the shorter line of cross marks)
- Distance from paper edge: 3mm

To avoid making the implementation complicated, `bleed` and `marks` properties are only effective when specified within `@page` rule without page selectors. Furthermore, only those properties from the first spine item are used for the case of EPUB documents. See a commit message of edd480b6d116d318d9c7147b23fb1f40695ed10e for detail.

Being added the bleed area, a hierarchy of boxes created around a page is as follows:
- `div[data-vivliostyle-viewer-viewport]`
  - `div[data-vivliostyle-outer-zoom-box]`: Outer box used for handling zoom
    - `div[data-vivliostyle-spread-container]`: Containing a spread when the spread view is enabled, a page otherwise
      - `div[data-vivliostyle-page-container]`: Outer box of a single page
        - `div[data-vivliostyle-page-box]`: Present only when `@page` rules are used (i.e. Adaptive Layout page masters are not used). Represent a page box.

This change to the box structure (and change to how sizes of the boxes are specified) lead to the following consequences:
- Issues #97 and #112 are resolved.
- When printing a document with `auto` page size, the output PDF has the same page size as shown on the browser window.
