### PR TITLE
Propagate and combine all break values at a single break point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@
   - <https://github.com/vivliostyle/vivliostyle.js/issues/83>
   - Spec: [CSS Fragmentation Module Level 3 - Adjoining Margins at Breaks](https://drafts.csswg.org/css-break/#break-margins)
 - box-shadow / text-shadow is now supported.
-  - <https://github.com/vivliostyle/vivliostyle.js/issues/156>  
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/156>
+- Propagate and combine multiple break values at a single break point
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/129>
+  - Spec: [CSS Fragmentation Module Level 3 - Forced Breaks](https://drafts.csswg.org/css-break/#forced-breaks)
 
 ## [2016.1](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.1) - 2016-01-20
 

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1791,7 +1791,6 @@ adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
 						}
 						// Margins don't collapse across non-zero borders and paddings.
 						trailingEdgeContexts = [lastAfterNodeContext];
-						breakAtTheEdge = null;
 						lastAfterNodeContext = null;
 					}
 				} else {

--- a/src/vivliostyle/break.js
+++ b/src/vivliostyle/break.js
@@ -94,16 +94,32 @@ goog.scope(function() {
             return second;
         } else if (!second) {
             return first;
-        } else if (vivliostyle.break.isForcedBreakValue(second)) {
-            return second;
-        } else if (vivliostyle.break.isForcedBreakValue(first)) {
-            return first;
-        } else if (vivliostyle.break.isAvoidBreakValue(second)) {
-            return second;
-        } else if (vivliostyle.break.isAvoidBreakValue(first)) {
-            return first;
         } else {
-            return second;
+            var firstIsForcedBreakValue = vivliostyle.break.isForcedBreakValue(first);
+            var secondIsForcedBreakValue = vivliostyle.break.isForcedBreakValue(second);
+            if (firstIsForcedBreakValue && secondIsForcedBreakValue) {
+                switch (second) {
+                    case "column":
+                        // "column" is the weakest value
+                        return first;
+                    case "region":
+                        // "region" is stronger than "column" but weaker than page values
+                        return first === "column" ? second : first;
+                    default:
+                        // page values are strongest
+                        return second;
+                }
+            } else if (secondIsForcedBreakValue) {
+                return second;
+            } else if (firstIsForcedBreakValue) {
+                return first;
+            } else if (vivliostyle.break.isAvoidBreakValue(second)) {
+                return second;
+            } else if (vivliostyle.break.isAvoidBreakValue(first)) {
+                return first;
+            } else {
+                return second;
+            }
         }
     };
 

--- a/test/files/combine_breaks.html
+++ b/test/files/combine_breaks.html
@@ -47,6 +47,9 @@
         .top-padding {
             padding-top: 10px;
         }
+        .bottom-padding {
+            padding-bottom: 10px;
+        }
     </style>
 </head>
 <body>
@@ -59,6 +62,7 @@
 <div class="column-break-before"><div class="page-break-before"><svg></svg> There should be a red square before this sentence. This should be on the 7th page.</div></div>
 <div class="page-break-before"><div class="top-padding">This should be on the 8th page.</div></div>
 <div class="page-break-after"><div class="column-break-after">This should be on the 8th page.</div></div>
-<div>This should be on the 9th page.</div>
+<div class="page-break-after bottom-padding">This should be on the 9th page.</div>
+<div>This should be on the 10th page.</div>
 </body>
 </html>

--- a/test/files/combine_breaks.html
+++ b/test/files/combine_breaks.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>combine breaks</title>
+    <style>
+        @page {
+            size: 500px 300px;
+            margin: 20px;
+            @bottom-center {
+                content: counter(page);
+            }
+        }
+        html {
+            column-count: 2;
+        }
+        body {
+            margin: 0;
+        }
+        .column-break-before {
+            break-before: column;
+        }
+        .column-break-after {
+            break-after: column;
+        }
+        .page-break-before {
+            break-before: page;
+        }
+        .page-break-after {
+            break-after: page;
+        }
+        .clear {
+            clear: both;
+        }
+        .float {
+            float: left;
+        }
+        .empty {
+            height: 100px;
+            background: #DFD;
+        }
+        svg {
+            width: 100px;
+            height: 100px;
+            background: #FDD;
+        }
+        .top-padding {
+            padding-top: 10px;
+        }
+    </style>
+</head>
+<body>
+<div>This should be on the 1st page.</div>
+<div class="column-break-before"><div class="page-break-before">This should be on the 2nd page.</div></div>
+<div class="column-break-before"><div class="page-break-before"><div class="clear">This should be on the 3rd page.</div></div></div>
+<div class="column-break-before"><div class="page-break-before"><div class="float">This should be on the 4th page.</div></div></div>
+<div class="column-break-before"><div class="page-break-before float">This should be on the 5th page. This should not be covered by a green rectangle. The green rectangle is on the next (6th) page.</div></div>
+<div class="column-break-before"><div class="page-break-before empty"></div></div>
+<div class="column-break-before"><div class="page-break-before"><svg></svg> There should be a red square before this sentence. This should be on the 7th page.</div></div>
+<div class="page-break-before"><div class="top-padding">This should be on the 8th page.</div></div>
+<div class="page-break-after"><div class="column-break-after">This should be on the 8th page.</div></div>
+<div>This should be on the 9th page.</div>
+</body>
+</html>

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -28,6 +28,7 @@
     <li><a href="outline.html">Outline</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/outline.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/outline.html">prod</a>]</li>        
     <li><a href="font-feature-settings.html">Font feature settings</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/font-feature-settings.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/font-feature-settings.html">prod</a>]</li>
     <li><a href="truncate_margin_at_breaks.html">Truncate margin at breaks</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/truncate_margin_at_breaks.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/truncate_margin_at_breaks.html">prod</a>]</li>
+    <li><a href="combine_breaks.html">Combine forced break values</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/combine_breaks.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/combine_breaks.html">prod</a>]</li>
 </ul>
 </body>
 </html>

--- a/test/spec/vivliostyle/break-spec.js
+++ b/test/spec/vivliostyle/break-spec.js
@@ -73,8 +73,14 @@ describe("break", function() {
             expect(resolveEffectiveBreakValue("region", "avoid-page")).toBe("region");
         });
 
-        it("returns the second one if both are forced break values", function() {
-            expect(resolveEffectiveBreakValue("page", "column")).toBe("column");
+        it("honor both values when they are forced break values", function() {
+            expect(resolveEffectiveBreakValue("region", "column")).toBe("region");
+            expect(resolveEffectiveBreakValue("page", "region")).toBe("page");
+            expect(resolveEffectiveBreakValue("page", "column")).toBe("page");
+        });
+
+        it("returns the second one if both forced break values are conflicting each other", function() {
+            expect(resolveEffectiveBreakValue("left", "right")).toBe("right");
         });
 
         it("returns an avoid break value if the other is auto", function() {


### PR DESCRIPTION
Break values of child boxes are now [propagated](https://drafts.csswg.org/css-break/#break-between) and [combined](https://drafts.csswg.org/css-break/#forced-breaks) as the CSS Fragmentation spec says.

Fix #129
