### PR TITLE
Fix bug on forced page break

### DIFF
--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1702,8 +1702,8 @@ adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
 	}
 
 	function processForcedBreak() {
-		self.removeNodesAfterForcedBreak(leadingEdgeContexts);
-		nodeContext = leadingEdgeContexts[0];
+		nodeContext = leadingEdgeContexts[0] || nodeContext;
+		nodeContext.viewNode.parentNode.removeChild(nodeContext.viewNode);
 		self.pageBreakType = breakAtTheEdge;
 	}
 
@@ -1939,15 +1939,6 @@ adapt.layout.Column.prototype.skipTailEdges = function(nodeContext) {
 		frame.finish(resultNodeContext);
 	});
 	return frame.result();
-};
-
-/**
- * @private
- * @param {!Array<!adapt.vtree.NodeContext>} leadingEdgeContexts
- */
-adapt.layout.Column.prototype.removeNodesAfterForcedBreak = function(leadingEdgeContexts) {
-	var nodePosition = leadingEdgeContexts[0];
-	nodePosition.viewNode.parentNode.removeChild(nodePosition.viewNode);
 };
 
 /**

--- a/test/files/combine_breaks.html
+++ b/test/files/combine_breaks.html
@@ -63,6 +63,6 @@
 <div class="page-break-before"><div class="top-padding">This should be on the 8th page.</div></div>
 <div class="page-break-after"><div class="column-break-after">This should be on the 8th page.</div></div>
 <div class="page-break-after bottom-padding">This should be on the 9th page.</div>
-<div>This should be on the 10th page.</div>
+This should be on the 10th page.
 </body>
 </html>


### PR DESCRIPTION
Avoid error when an element with a forced break value of `break-after` is followed by a (non-empty) text node.
This bug was introduced by #188.
