### PR TITLE
Support substring matching attribute selectors `^=`, `$=` and `*=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@
   - Spec: [CSS Basic User Interface Module Level 3 (CSS3 UI) - outline-offset property](https://drafts.csswg.org/css-ui-3/#outline-offset)
 - Support font-feature-settings
   - <https://github.com/vivliostyle/vivliostyle.js/issues/151>
-  - Spec [CSS Fonts Module Level 3 - font-feature-settings descriptors](https://drafts.csswg.org/css-fonts-3/#propdef-font-feature-settings)
+  - Spec: [CSS Fonts Module Level 3 - font-feature-settings descriptors](https://drafts.csswg.org/css-fonts-3/#propdef-font-feature-settings)
 - Support linear-gradient/radial-gradient
   - <https://github.com/vivliostyle/vivliostyle-formatter-issues/issues/35>
-  - Spec [CSS Image Values and Replaced Content Module - Gradients](https://drafts.csswg.org/css-images-3/#gradients)
+  - Spec: [CSS Image Values and Replaced Content Module - Gradients](https://drafts.csswg.org/css-images-3/#gradients)
+- Support substring matching attribute selectors `^=`, `$=` and `*=`
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/196>
+  - Spec: [Selectors Level 3 - Substring matching attribute selectors](https://www.w3.org/TR/css3-selectors/#attribute-substrings)
 
 ### Fixed
 - Lengths in 'rem' specified within page context are now interpreted correctly.

--- a/doc/supported-features.md
+++ b/doc/supported-features.md
@@ -66,7 +66,9 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Supported in all browsers
 - [Universal selector with namespaces `ns|*`, `*|*`](https://www.w3.org/TR/css3-selectors/#univnmsp)
   - Supported in all browsers
-- [Attribute selectors with namespaces `[ns|att]`, `[|att]`, `[ns|att=val]`, `[|att=val]`, `[ns|att~=val]`, `[|att~=val]`, `[ns|att|=val]`, `[|att|=val]`](https://www.w3.org/TR/css3-selectors/#attrnmsp)
+- [Substring matching attribute selectors `[att^=val]`, `[att$=val]`, `[att*=val]`](https://www.w3.org/TR/css3-selectors/#attribute-substrings)
+  - Supported in all browsers
+- [Attribute selectors with namespaces `[ns|att]`, `[|att]`, `[ns|att=val]`, `[|att=val]`, `[ns|att~=val]`, `[|att~=val]`, `[ns|att|=val]`, `[|att|=val]`, `[ns|att^=val]`, `[|att^=val]`, `[ns|att$=val]`, `[|att$=val]`, `[ns|att*=val]`, `[|att*=val]`](https://www.w3.org/TR/css3-selectors/#attrnmsp)
   - Supported in all browsers
 - [`:root` pseudo-class](https://www.w3.org/TR/css3-selectors/#root-pseudo)
   - Supported in all browsers
@@ -89,7 +91,6 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 
 - [Type selectors without namespaces `|E`](https://www.w3.org/TR/css3-selectors/#typenmsp)
 - [Universal selector without namespaces `|*`](https://www.w3.org/TR/css3-selectors/#univnmsp)
-- [Substring matching attribute selectors `[att^=val]`, `[att$=val]`, `[att*=val]`](https://www.w3.org/TR/css3-selectors/#attribute-substrings)
 - [Attribute selectors with universal namespace `[*|att]`, `[*|att=val]`, `[*|att~=val]`, `[*|att|=val]`](https://www.w3.org/TR/css3-selectors/#attrnmsp)
 - [Target pseudo-class `:target`](https://www.w3.org/TR/css3-selectors/#target-pseudo)
 - [The UI element states pseudo-classes `:enabled`, `:disabled`, `:checked`, `:indeterminate`](https://www.w3.org/TR/css3-selectors/#UIstates)

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2591,12 +2591,8 @@ adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, na
 			}
             break;
         case adapt.csstok.TokenType.BAR_EQ:
-			if (!value) {
-				action = new adapt.csscasc.CheckConditionAction(""); // always fails
-			} else {
-				action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
-					new RegExp("^" + adapt.base.escapeRegExp(value) + "($|-)"));
-			}
+			action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+				new RegExp("^" + adapt.base.escapeRegExp(value) + "($|-)"));
             break;
 		case adapt.csstok.TokenType.HAT_EQ:
 			if (!value) {

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2589,6 +2589,10 @@ adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, na
             this.chain.push(new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
                 new RegExp("^" + adapt.base.escapeRegExp(value) + "($|-)")));
             break;
+		case adapt.csstok.TokenType.STAR_EQ:
+			this.chain.push(new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+				new RegExp(adapt.base.escapeRegExp(value))));
+			break;
         case adapt.csstok.TokenType.COL_COL:
         	if (value == "supported") {
                 this.chain.push(new adapt.csscasc.CheckNamespaceSupportedAction(ns, name));
@@ -2597,7 +2601,6 @@ adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, na
 				this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
         	}
         	break;
-        case adapt.csstok.TokenType.STAR_EQ:
         default:
 			vivliostyle.logging.logger.warn("Unsupported attr selector:", op);
 			this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2606,6 +2606,14 @@ adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, na
 					new RegExp("^" + adapt.base.escapeRegExp(value)));
 			}
 			break;
+		case adapt.csstok.TokenType.DOLLAR_EQ:
+			if (!value) {
+				action = new adapt.csscasc.CheckConditionAction(""); // always fails
+			} else {
+				action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+					new RegExp(adapt.base.escapeRegExp(value) + "$"));
+			}
+			break;
 		case adapt.csstok.TokenType.STAR_EQ:
 			if (!value) {
 				action = new adapt.csscasc.CheckConditionAction(""); // always fails

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2598,6 +2598,14 @@ adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, na
 					new RegExp("^" + adapt.base.escapeRegExp(value) + "($|-)"));
 			}
             break;
+		case adapt.csstok.TokenType.HAT_EQ:
+			if (!value) {
+				action = new adapt.csscasc.CheckConditionAction(""); // always fails
+			} else {
+				action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+					new RegExp("^" + adapt.base.escapeRegExp(value)));
+			}
+			break;
 		case adapt.csstok.TokenType.STAR_EQ:
 			if (!value) {
 				action = new adapt.csscasc.CheckConditionAction(""); // always fails

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2594,11 +2594,13 @@ adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, na
                 this.chain.push(new adapt.csscasc.CheckNamespaceSupportedAction(ns, name));
         	} else {
 				vivliostyle.logging.logger.warn("Unsupported :: attr selector op:", value);
+				this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
         	}
         	break;
         case adapt.csstok.TokenType.STAR_EQ:
         default:
 			vivliostyle.logging.logger.warn("Unsupported attr selector:", op);
+			this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
     }
 };
 

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -1707,6 +1707,7 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     case adapt.csstok.TokenType.TILDE_EQ:
                     case adapt.csstok.TokenType.BAR_EQ:
                     case adapt.csstok.TokenType.HAT_EQ:
+                    case adapt.csstok.TokenType.DOLLAR_EQ:
                     case adapt.csstok.TokenType.STAR_EQ:
                     case adapt.csstok.TokenType.COL_COL:
                         num = token.type;

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -1706,6 +1706,7 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     case adapt.csstok.TokenType.EQ:
                     case adapt.csstok.TokenType.TILDE_EQ:
                     case adapt.csstok.TokenType.BAR_EQ:
+                    case adapt.csstok.TokenType.HAT_EQ:
                     case adapt.csstok.TokenType.STAR_EQ:
                     case adapt.csstok.TokenType.COL_COL:
                         num = token.type;

--- a/test/files/attr_selectors.html
+++ b/test/files/attr_selectors.html
@@ -28,6 +28,12 @@
         [data-foo^=""] {
             color: red;
         }
+        [data-foo$="bazz"] {
+            color: green;
+        }
+        [data-foo$=""] {
+            color: red;
+        }
         [data-foo*="o b"] {
             color: green;
         }
@@ -41,6 +47,7 @@
 <p data-foo="bar-baz">This paragraph should be green. (using <code>|=</code> selector)</p>
 <div data-foo="-baz">This paragraph should not be red.</div>
 <p data-foo="bazbar">This paragraph should be green. (using <code>^=</code> selector)</p>
+<p data-foo="barbazz">This paragraph should be green. (using <code>$=</code> selector)</p>
 <p data-foo="foo bar">This paragraph should be green. (using <code>*=</code> selector)</p>
 This sentence should not be green.
 </body>

--- a/test/files/attr_selectors.html
+++ b/test/files/attr_selectors.html
@@ -10,9 +10,14 @@
         [data-foo~="baz"] {
             color: green;
         }
+        [data-foo*="o b"] {
+            color: green;
+        }
     </style>
 </head>
 <body>
 <p data-foo="bar baz">This paragraph should be green. (using <code>~=</code> selector)</p>
+<p data-foo="foo bar">This paragraph should be green. (using <code>*=</code> selector)</p>
+This sentence should not be green.
 </body>
 </html>

--- a/test/files/attr_selectors.html
+++ b/test/files/attr_selectors.html
@@ -22,6 +22,12 @@
         [data-foo|=""] {
             color: red;
         }
+        [data-foo^="baz"] {
+            color: green;
+        }
+        [data-foo^=""] {
+            color: red;
+        }
         [data-foo*="o b"] {
             color: green;
         }
@@ -34,6 +40,7 @@
 <p data-foo="bar baz">This paragraph should be green. (using <code>~=</code> selector)</p>
 <p data-foo="bar-baz">This paragraph should be green. (using <code>|=</code> selector)</p>
 <div data-foo="-baz">This paragraph should not be red.</div>
+<p data-foo="bazbar">This paragraph should be green. (using <code>^=</code> selector)</p>
 <p data-foo="foo bar">This paragraph should be green. (using <code>*=</code> selector)</p>
 This sentence should not be green.
 </body>

--- a/test/files/attr_selectors.html
+++ b/test/files/attr_selectors.html
@@ -10,13 +10,30 @@
         [data-foo~="baz"] {
             color: green;
         }
+        [data-foo~="bar baz"] {
+            color: red;
+        }
+        [data-foo~=""] {
+            color: red;
+        }
+        [data-foo|="bar"] {
+            color: green;
+        }
+        [data-foo|=""] {
+            color: red;
+        }
         [data-foo*="o b"] {
             color: green;
+        }
+        [data-foo*=""] {
+            color: red;
         }
     </style>
 </head>
 <body>
 <p data-foo="bar baz">This paragraph should be green. (using <code>~=</code> selector)</p>
+<p data-foo="bar-baz">This paragraph should be green. (using <code>|=</code> selector)</p>
+<div data-foo="-baz">This paragraph should not be red.</div>
 <p data-foo="foo bar">This paragraph should be green. (using <code>*=</code> selector)</p>
 This sentence should not be green.
 </body>

--- a/test/files/attr_selectors.html
+++ b/test/files/attr_selectors.html
@@ -20,7 +20,7 @@
             color: green;
         }
         [data-foo|=""] {
-            color: red;
+            color: green;
         }
         [data-foo^="baz"] {
             color: green;
@@ -45,7 +45,7 @@
 <body>
 <p data-foo="bar baz">This paragraph should be green. (using <code>~=</code> selector)</p>
 <p data-foo="bar-baz">This paragraph should be green. (using <code>|=</code> selector)</p>
-<div data-foo="-baz">This paragraph should not be red.</div>
+<div data-foo="-baz">This paragraph should be green. (using <code>|=</code> selector with an empty string)</div>
 <p data-foo="bazbar">This paragraph should be green. (using <code>^=</code> selector)</p>
 <p data-foo="barbazz">This paragraph should be green. (using <code>$=</code> selector)</p>
 <p data-foo="foo bar">This paragraph should be green. (using <code>*=</code> selector)</p>

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -125,13 +125,18 @@ describe("csscasc", function() {
                     expect("a-bar-b".match(regexp)).toBeFalsy();
                 });
 
-                it("represents nothing when the value is an empty string", function() {
+                it("also use CheckAttributeRegExpAction when the value is an empty string", function() {
                     handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.BAR_EQ, "");
 
                     expect(handler.chain.length).toBe(1);
                     var action = handler.chain[0];
-                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
-                    expect(action.condition).toBe("");
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                    var regexp = action.regexp;
+                    expect("-bar".match(regexp)).toBeTruthy();
+                    expect("-".match(regexp)).toBeTruthy();
+                    expect("bar-b".match(regexp)).toBeFalsy();
                 });
             });
 

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -41,5 +41,74 @@ describe("csscasc", function() {
                 expect(style["foo12"].priority).not.toBe(originalPriority);
             });
         });
+
+        describe("attributeSelector", function() {
+            var handler;
+
+            beforeEach(function() {
+                handler = new adapt.csscasc.CascadeParserHandler();
+                handler.startSelectorRule();
+            });
+
+            describe("Attribute presence selector", function() {
+                it("push CheckAttributePresentAction in the chain when the operator is EOF (no operator)", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.EOF, null);
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributePresentAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                });
+            });
+
+            it("push CheckAttributeEqAction in the chain when the operator is '='", function() {
+                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.EQ, "bar");
+
+                expect(handler.chain.length).toBe(1);
+                var action = handler.chain[0];
+                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeEqAction));
+                expect(action.ns).toBe("ns");
+                expect(action.name).toBe("foo");
+                expect(action.value).toBe("bar");
+            });
+
+            it("push CheckAttributeRegExpAction in the chain when the operator is '~='", function() {
+                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.TILDE_EQ, "bar");
+
+                expect(handler.chain.length).toBe(1);
+                var action = handler.chain[0];
+                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                expect(action.ns).toBe("ns");
+                expect(action.name).toBe("foo");
+                var regexp = action.regexp;
+                expect("bar".match(regexp)).toBeTruthy();
+                expect("a bar b".match(regexp)).toBeTruthy();
+                expect("abar b".match(regexp)).toBeFalsy();
+            });
+
+            it("push CheckAttributeRegExpAction in the chain when the operator is '|='", function() {
+                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.BAR_EQ, "bar");
+
+                expect(handler.chain.length).toBe(1);
+                var action = handler.chain[0];
+                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                expect(action.ns).toBe("ns");
+                expect(action.name).toBe("foo");
+                var regexp = action.regexp;
+                expect("bar".match(regexp)).toBeTruthy();
+                expect("bar-b".match(regexp)).toBeTruthy();
+                expect("barb".match(regexp)).toBeFalsy();
+            });
+
+            it("push always failing CheckConditionAction in the chain when an unsupported operator is passed", function() {
+                handler.attributeSelector("ns", "foo", null, "bar");
+
+                expect(handler.chain.length).toBe(1);
+                var action = handler.chain[0];
+                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
+                expect(action.condition).toBe("");
+            });
+        })
     });
 });

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -51,7 +51,7 @@ describe("csscasc", function() {
             });
 
             describe("Attribute presence selector", function() {
-                it("push CheckAttributePresentAction in the chain when the operator is EOF (no operator)", function() {
+                it("use CheckAttributePresentAction when the operator is EOF (no operator)", function() {
                     handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.EOF, null);
 
                     expect(handler.chain.length).toBe(1);
@@ -62,61 +62,105 @@ describe("csscasc", function() {
                 });
             });
 
-            it("push CheckAttributeEqAction in the chain when the operator is '='", function() {
-                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.EQ, "bar");
+            describe("Attribute equality selector", function() {
+                it("use CheckAttributeEqAction when the operator is '='", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.EQ, "bar");
 
-                expect(handler.chain.length).toBe(1);
-                var action = handler.chain[0];
-                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeEqAction));
-                expect(action.ns).toBe("ns");
-                expect(action.name).toBe("foo");
-                expect(action.value).toBe("bar");
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeEqAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                    expect(action.value).toBe("bar");
+                });
             });
 
-            it("push CheckAttributeRegExpAction in the chain when the operator is '~='", function() {
-                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.TILDE_EQ, "bar");
+            describe("~= attribute selector", function() {
+                it("use CheckAttributeRegExpAction when the value is not empty and contains no whitespaces", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.TILDE_EQ, "bar");
 
-                expect(handler.chain.length).toBe(1);
-                var action = handler.chain[0];
-                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
-                expect(action.ns).toBe("ns");
-                expect(action.name).toBe("foo");
-                var regexp = action.regexp;
-                expect("bar".match(regexp)).toBeTruthy();
-                expect("a bar b".match(regexp)).toBeTruthy();
-                expect("abar b".match(regexp)).toBeFalsy();
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                    var regexp = action.regexp;
+                    expect("bar".match(regexp)).toBeTruthy();
+                    expect("a bar b".match(regexp)).toBeTruthy();
+                    expect("abar b".match(regexp)).toBeFalsy();
+                });
+
+                it("represents nothing when the value contains whitespaces", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.TILDE_EQ, "b c");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
+                    expect(action.condition).toBe("");
+                });
+
+                it("represents nothing when the value is an empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.TILDE_EQ, "");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
+                    expect(action.condition).toBe("");
+                });
             });
 
-            it("push CheckAttributeRegExpAction in the chain when the operator is '|='", function() {
-                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.BAR_EQ, "bar");
+            describe("|= attribute selector", function() {
+                it("use CheckAttributeRegExpAction when the value is a non-empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.BAR_EQ, "bar");
 
-                expect(handler.chain.length).toBe(1);
-                var action = handler.chain[0];
-                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
-                expect(action.ns).toBe("ns");
-                expect(action.name).toBe("foo");
-                var regexp = action.regexp;
-                expect("bar".match(regexp)).toBeTruthy();
-                expect("bar-b".match(regexp)).toBeTruthy();
-                expect("barb".match(regexp)).toBeFalsy();
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                    var regexp = action.regexp;
+                    expect("bar".match(regexp)).toBeTruthy();
+                    expect("bar-b".match(regexp)).toBeTruthy();
+                    expect("barb".match(regexp)).toBeFalsy();
+                });
+
+                it("represents nothing when the value is an empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.BAR_EQ, "");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
+                    expect(action.condition).toBe("");
+                });
             });
 
-            it("push CheckAttributeRegExpAction in the chain when the operator is '*='", function() {
-                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.STAR_EQ, "bar");
+            describe("*= attribute selector", function() {
+                it("use CheckAttributeRegExpAction when the value is a non-empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.STAR_EQ, "bar");
 
-                expect(handler.chain.length).toBe(1);
-                var action = handler.chain[0];
-                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
-                expect(action.ns).toBe("ns");
-                expect(action.name).toBe("foo");
-                var regexp = action.regexp;
-                expect("bar".match(regexp)).toBeTruthy();
-                expect("a bar b".match(regexp)).toBeTruthy();
-                expect("abarb".match(regexp)).toBeTruthy();
-                expect("foo".match(regexp)).toBeFalsy();
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                    var regexp = action.regexp;
+                    expect("bar".match(regexp)).toBeTruthy();
+                    expect("a bar b".match(regexp)).toBeTruthy();
+                    expect("abarb".match(regexp)).toBeTruthy();
+                    expect("foo".match(regexp)).toBeFalsy();
+                });
+
+                it("represents nothing when the value is an empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.STAR_EQ, "");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
+                    expect(action.condition).toBe("");
+                });
             });
 
-            it("push always failing CheckConditionAction in the chain when an unsupported operator is passed", function() {
+            it("represents nothing when an unsupported operator is passed", function() {
                 handler.attributeSelector("ns", "foo", null, "bar");
 
                 expect(handler.chain.length).toBe(1);

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -161,6 +161,32 @@ describe("csscasc", function() {
                 });
             });
 
+            describe("$= attribute selector", function() {
+                it("use CheckAttributeRegExpAction when the value is a non-empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.DOLLAR_EQ, "bar");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                    var regexp = action.regexp;
+                    expect("bar".match(regexp)).toBeTruthy();
+                    expect("b-bar".match(regexp)).toBeTruthy();
+                    expect("bbar".match(regexp)).toBeTruthy();
+                    expect("bbarb".match(regexp)).toBeFalsy();
+                });
+
+                it("represents nothing when the value is an empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.DOLLAR_EQ, "");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
+                    expect(action.condition).toBe("");
+                });
+            });
+
             describe("*= attribute selector", function() {
                 it("use CheckAttributeRegExpAction when the value is a non-empty string", function() {
                     handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.STAR_EQ, "bar");

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -122,10 +122,37 @@ describe("csscasc", function() {
                     expect("bar".match(regexp)).toBeTruthy();
                     expect("bar-b".match(regexp)).toBeTruthy();
                     expect("barb".match(regexp)).toBeFalsy();
+                    expect("a-bar-b".match(regexp)).toBeFalsy();
                 });
 
                 it("represents nothing when the value is an empty string", function() {
                     handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.BAR_EQ, "");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
+                    expect(action.condition).toBe("");
+                });
+            });
+
+            describe("^= attribute selector", function() {
+                it("use CheckAttributeRegExpAction when the value is a non-empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.HAT_EQ, "bar");
+
+                    expect(handler.chain.length).toBe(1);
+                    var action = handler.chain[0];
+                    expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                    expect(action.ns).toBe("ns");
+                    expect(action.name).toBe("foo");
+                    var regexp = action.regexp;
+                    expect("bar".match(regexp)).toBeTruthy();
+                    expect("bar-b".match(regexp)).toBeTruthy();
+                    expect("barb".match(regexp)).toBeTruthy();
+                    expect("a-bar-b".match(regexp)).toBeFalsy();
+                });
+
+                it("represents nothing when the value is an empty string", function() {
+                    handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.HAT_EQ, "");
 
                     expect(handler.chain.length).toBe(1);
                     var action = handler.chain[0];

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -101,6 +101,21 @@ describe("csscasc", function() {
                 expect("barb".match(regexp)).toBeFalsy();
             });
 
+            it("push CheckAttributeRegExpAction in the chain when the operator is '*='", function() {
+                handler.attributeSelector("ns", "foo", adapt.csstok.TokenType.STAR_EQ, "bar");
+
+                expect(handler.chain.length).toBe(1);
+                var action = handler.chain[0];
+                expect(action).toEqual(jasmine.any(adapt.csscasc.CheckAttributeRegExpAction));
+                expect(action.ns).toBe("ns");
+                expect(action.name).toBe("foo");
+                var regexp = action.regexp;
+                expect("bar".match(regexp)).toBeTruthy();
+                expect("a bar b".match(regexp)).toBeTruthy();
+                expect("abarb".match(regexp)).toBeTruthy();
+                expect("foo".match(regexp)).toBeFalsy();
+            });
+
             it("push always failing CheckConditionAction in the chain when an unsupported operator is passed", function() {
                 handler.attributeSelector("ns", "foo", null, "bar");
 


### PR DESCRIPTION
Resolves #196.
Incorrect behavior of existing implementation is also fixed. See ea82fe6, 753e111 and 95a5bc0.
