### PR TITLE
`:nth-*` pseudo-classes with `an+b` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
 - Support substring matching attribute selectors `^=`, `$=` and `*=`
   - <https://github.com/vivliostyle/vivliostyle.js/issues/196>
   - Spec: [Selectors Level 3 - Substring matching attribute selectors](https://www.w3.org/TR/css3-selectors/#attribute-substrings)
+- Support `an+b` arguments for `:nth-child()` pseudo-class selector
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/163>
+  - Spec: [Selectors Level 3 - :nth-child() pseudo-class](http://www.w3.org/TR/css3-selectors/#nth-child-pseudo)
+- Support `:nth-last-child()`, `:nth-of-type()`, `:nth-last-of-type()`, `:last-child`, `:first-of-type`, `:last-of-type`, `:only-child` and `:only-of-type` pseudo-class selectors
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/86>
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/193>
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/194>
+  - Spec: [Selectors Level 3 - Structural pseudo-classes](https://www.w3.org/TR/css3-selectors/#structural-pseudos)
 
 ### Fixed
 - Lengths in 'rem' specified within page context are now interpreted correctly.

--- a/doc/supported-features.md
+++ b/doc/supported-features.md
@@ -74,8 +74,24 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Supported in all browsers
 - [`:nth-child()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-child-pseudo)
   - Supported in all browsers
-  - Note: only a single integer or "even"/"odd" arguments are accepted for now. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/163)
+- [`:nth-last-child()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-last-child-pseudo)
+  - Supported in all browsers
+- [`:nth-of-type()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-of-type-pseudo)
+  - Supported in all browsers
+- [`:nth-last-of-type()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-last-of-type-pseudo)
+  - Supported in all browsers
 - [`:first-child` pseudo-class](https://www.w3.org/TR/css3-selectors/#first-child-pseudo)
+  - Supported in all browsers
+- [`:last-child` pseudo-class](https://www.w3.org/TR/css3-selectors/#last-child-pseudo)
+  - Supported in all browsers
+- [`:first-of-type` pseudo-class](https://www.w3.org/TR/css3-selectors/#first-of-type-pseudo)
+  - Supported in all browsers
+- [`:last-of-type` pseudo-class](https://www.w3.org/TR/css3-selectors/#last-of-type-pseudo)
+  - Supported in all browsers
+- [`:only-child` pseudo-class](https://www.w3.org/TR/css3-selectors/#only-child-pseudo)
+  - Supported in all browsers
+- [`:only-of-type` pseudo-class](https://www.w3.org/TR/css3-selectors/#only-of-type-pseudo)
+  - Supported in all browsers
 - [`::first-line` pseudo-element](https://www.w3.org/TR/css3-selectors/#first-line)
   - Supported in all browsers
   - Note: there is a bug when used alone or with the universal selector(`*`). [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/133)
@@ -94,14 +110,6 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 - [Attribute selectors with universal namespace `[*|att]`, `[*|att=val]`, `[*|att~=val]`, `[*|att|=val]`](https://www.w3.org/TR/css3-selectors/#attrnmsp)
 - [Target pseudo-class `:target`](https://www.w3.org/TR/css3-selectors/#target-pseudo)
 - [The UI element states pseudo-classes `:enabled`, `:disabled`, `:checked`, `:indeterminate`](https://www.w3.org/TR/css3-selectors/#UIstates)
-- [`:nth-last-child()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-last-child-pseudo)
-- [`:nth-of-type()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-of-type-pseudo)
-- [`:nth-last-of-type()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-last-of-type-pseudo)
-- [`:last-child` pseudo-class](https://www.w3.org/TR/css3-selectors/#last-child-pseudo)
-- [`:first-of-type` pseudo-class](https://www.w3.org/TR/css3-selectors/#first-of-type-pseudo)
-- [`:last-of-type` pseudo-class](https://www.w3.org/TR/css3-selectors/#last-of-type-pseudo)
-- [`:only-child` pseudo-class](https://www.w3.org/TR/css3-selectors/#only-child-pseudo)
-- [`:only-of-type` pseudo-class](https://www.w3.org/TR/css3-selectors/#only-of-type-pseudo)
 - [`:empty` pseudo-class](https://www.w3.org/TR/css3-selectors/#empty-pseudo)
 - [The negation pseudo-class `:not()`](https://www.w3.org/TR/css3-selectors/#negation)
 

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2590,12 +2590,6 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
     	return;
     }
     switch (name.toLowerCase()) {
-        case "first-child":
-            this.chain.push(new adapt.csscasc.IsFirstAction());
-            break;
-		case "last-child":
-			this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
-			break;
         case "root":
             this.chain.push(new adapt.csscasc.IsRootAction());
             break;
@@ -2634,8 +2628,8 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
 	    	}
 	    	break;
 		case "nth-child":
-		case "nth-of-type":
 		case "nth-last-child":
+		case "nth-of-type":
 		case "nth-last-of-type":
 			var ActionClass = adapt.csscasc.nthSelectorActionClasses[name.toLowerCase()];
 			if (params && params.length == 2) {
@@ -2643,6 +2637,18 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
 			} else {
 				this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
 			}
+			break;
+		case "first-child":
+			this.chain.push(new adapt.csscasc.IsFirstAction());
+			break;
+		case "last-child":
+			this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
+			break;
+		case "first-of-type":
+			this.chain.push(new adapt.csscasc.IsNthSiblingOfTypeAction(0, 1));
+			break;
+		case "last-of-type":
+			this.chain.push(new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 1));
 			break;
         case "before":
         case "after":

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2593,6 +2593,9 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
         case "first-child":
             this.chain.push(new adapt.csscasc.IsFirstAction());
             break;
+		case "last-child":
+			this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
+			break;
         case "root":
             this.chain.push(new adapt.csscasc.IsRootAction());
             break;

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2638,16 +2638,8 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
 		case "nth-last-child":
 		case "nth-last-of-type":
 			var ActionClass = adapt.csscasc.nthSelectorActionClasses[name.toLowerCase()];
-			if (params && params.length == 1) {
-				if (typeof params[0] == "number") {
-					this.chain.push(new ActionClass(0, /** @type {number} */ (params[0])));
-				} else if (params[0] === "even") {
-					this.chain.push(new ActionClass(2, 0));
-				} else if (params[0] === "odd") {
-					this.chain.push(new ActionClass(2, 1));
-				} else {
-					this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
-				}
+			if (params && params.length == 2) {
+				this.chain.push(new ActionClass(/** @type {number} */ (params[0]), /** @type {number} */ (params[1])));
 			} else {
 				this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
 			}

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2650,6 +2650,14 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
 		case "last-of-type":
 			this.chain.push(new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 1));
 			break;
+		case "only-child":
+			this.chain.push(new adapt.csscasc.IsFirstAction());
+			this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
+			break;
+		case "only-of-type":
+			this.chain.push(new adapt.csscasc.IsNthSiblingOfTypeAction(0, 1));
+			this.chain.push(new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 1));
+			break;
         case "before":
         case "after":
         case "first-line":

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -31,6 +31,7 @@
     <li><a href="combine_breaks.html">Combine forced break values</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/combine_breaks.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/combine_breaks.html">prod</a>]</li>
     <li><a href="background-gradient.html">Background gradient</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/background-gradient.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/background-gradient.html">prod</a>]</li>
     <li><a href="incorrect_layout_with_empty_partition.html">Incorrect layout with empty partition</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/incorrect_layout_with_empty_partition.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/incorrect_layout_with_empty_partition.html">prod</a>]</li>
+    <li><a href="nth_selectors.html">nth selectors</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/nth_selectors.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/nth_selectors.html">prod</a>]</li>
 </ul>
 </body>
 </html>

--- a/test/files/nth_selectors.html
+++ b/test/files/nth_selectors.html
@@ -24,7 +24,7 @@
         .b :nth-child(-2) {
             color: red;
         }
-/*
+
         .a_1 :nth-child(n) {
             font-weight: bold;
         }
@@ -64,7 +64,7 @@
         .a_-3 :nth-child(-3n-1) {
             color: red;
         }
-*/
+
 
         .even_odd_type span:nth-of-type(odd) {
             font-weight: bold;
@@ -82,7 +82,7 @@
         .b_type span:nth-of-type(-2) {
             color: red;
         }
-/*
+
         .a_1_type span:nth-of-type(n) {
             font-weight: bold;
         }
@@ -122,7 +122,7 @@
         .a_-3_type span:nth-of-type(-3n-1) {
             color: red;
         }
-*/
+
 
         .even_odd_last :nth-last-child(odd) {
             font-weight: bold;
@@ -140,7 +140,7 @@
         .b_last :nth-last-child(-2) {
             color: red;
         }
-/*
+
         .a_1_last :nth-last-child(n) {
             font-weight: bold;
         }
@@ -180,7 +180,7 @@
         .a_-3_last :nth-last-child(-3n-1) {
             color: red;
         }
-*/
+
 
         .even_odd_last_type span:nth-last-of-type(odd) {
             font-weight: bold;
@@ -198,7 +198,7 @@
         .b_last_type span:nth-last-of-type(-2) {
             color: red;
         }
-/*
+
         .a_1_last_type span:nth-last-of-type(n) {
             font-weight: bold;
         }
@@ -238,7 +238,6 @@
         .a_-3_last_type span:nth-last-of-type(-3n-1) {
             color: red;
         }
-*/
     </style>
 </head>
 <body>

--- a/test/files/nth_selectors.html
+++ b/test/files/nth_selectors.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <title>nth-* pseudo-class selectors</title>
     <style>
+        .last-child :last-child {
+            font-weight: bold;
+        }
+
         .even_odd :nth-child(odd) {
             font-weight: bold;
         }
@@ -119,9 +123,130 @@
             color: red;
         }
 */
+
+        .even_odd_last :nth-last-child(odd) {
+            font-weight: bold;
+        }
+        .even_odd_last :nth-last-child(even) {
+            font-style: italic;
+        }
+
+        .b_last :nth-last-child(0) {
+            color: red;
+        }
+        .b_last :nth-last-child(3) {
+            font-weight: bold;
+        }
+        .b_last :nth-last-child(-2) {
+            color: red;
+        }
+/*
+        .a_1_last :nth-last-child(n) {
+            font-weight: bold;
+        }
+        .a_1_last :nth-last-child(n+3) {
+            font-style: italic;
+        }
+        .a_1_last :nth-last-child(n-3) {
+            color: green;
+        }
+
+        .a_3_last :nth-last-child(3n) {
+            font-weight: bold;
+        }
+        .a_3_last :nth-last-child(3n+1) {
+            font-style: italic;
+        }
+        .a_3_last :nth-last-child(3n-1) {
+            color: green;
+        }
+
+        .a_-1_last :nth-last-child(-n) {
+            color: red;
+        }
+        .a_-1_last :nth-last-child(-n+1) {
+            font-weight: bold;
+        }
+        .a_-1_last :nth-last-child(-n-1) {
+            color: red;
+        }
+
+        .a_-3_last :nth-last-child(-3n) {
+            color: red;
+        }
+        .a_-3_last :nth-last-child(-3n+5) {
+            font-weight: bold;
+        }
+        .a_-3_last :nth-last-child(-3n-1) {
+            color: red;
+        }
+*/
+
+        .even_odd_last_type span:nth-last-of-type(odd) {
+            font-weight: bold;
+        }
+        .even_odd_last_type span:nth-last-of-type(even) {
+            font-style: italic;
+        }
+
+        .b_last_type span:nth-last-of-type(0) {
+            color: red;
+        }
+        .b_last_type span:nth-last-of-type(3) {
+            font-weight: bold;
+        }
+        .b_last_type span:nth-last-of-type(-2) {
+            color: red;
+        }
+/*
+        .a_1_last_type span:nth-last-of-type(n) {
+            font-weight: bold;
+        }
+        .a_1_last_type span:nth-last-of-type(n+3) {
+            font-style: italic;
+        }
+        .a_1_last_type span:nth-last-of-type(n-3) {
+            color: green;
+        }
+
+        .a_3_last_type span:nth-last-of-type(3n) {
+            font-weight: bold;
+        }
+        .a_3_last_type span:nth-last-of-type(3n+1) {
+            font-style: italic;
+        }
+        .a_3_last_type span:nth-last-of-type(3n-1) {
+            color: green;
+        }
+
+        .a_-1_last_type span:nth-last-of-type(-n) {
+            color: red;
+        }
+        .a_-1_last_type span:nth-last-of-type(-n+1) {
+            font-weight: bold;
+        }
+        .a_-1_last_type span:nth-last-of-type(-n-1) {
+            color: red;
+        }
+
+        .a_-3_last_type span:nth-last-of-type(-3n) {
+            color: red;
+        }
+        .a_-3_last_type span:nth-last-of-type(-3n+5) {
+            font-weight: bold;
+        }
+        .a_-3_last_type span:nth-last-of-type(-3n-1) {
+            color: red;
+        }
+*/
     </style>
 </head>
 <body>
+<div class="last-child">
+    (:last-child) Only 5 should be bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span>
+</div>
+
 <div class="even_odd">
     (:nth-child(odd|even)) Bold and italic are applied alternatively:
     <span>bold</span>
@@ -176,6 +301,63 @@
 </div>
 <div class="a_-3_type">
     (:nth-of-type(-3n+b)) 2 and 5 bold:
+    <span>1</span> <div style="display: inline">other</div> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+
+<div class="even_odd_last">
+    (:nth-last-child(odd|even)) Bold and italic are applied alternatively:
+    <span>italic</span>
+    <span>bold</span>
+    <span>italic</span>
+    <span>bold</span>
+</div>
+<div class="b_last">
+    (:nth-last-child(b)) Only 4 should be bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_1_last">
+    (:nth-last-child(n+b)) All bold, 1 and 2 are italic, All green:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span>
+</div>
+<div class="a_3_last">
+    (:nth-last-child(3n+b)) 1 and 4 bold, 3 and 6 italic, 2 and 5 green:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_-1_last">
+    (:nth-last-child(-n+b)) Only 6 should be bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_-3_last">
+    (:nth-last-child(-3n+b)) 2 and 5 bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+
+<div class="even_odd_last_type">
+    (:nth-last-of-type(odd|even))
+    <span>italic</span>
+    <span>bold</span>
+    <span>italic</span>
+    <div style="display: inline">(regular)</div>
+    <span>bold</span>
+</div>
+<div class="b_last_type">
+    (:nth-last-of-type(b)) Only 3 should be bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <div style="display: inline">other</div> <span>5</span>
+</div>
+<div class="a_1_last_type">
+    (:nth-last-of-type(n+b)) All bold, 1 and 2 are italic, All green:
+    <span>1</span> <span>2</span> <div style="display: inline">other (not green)</div> <span>3</span> <span>4</span>
+</div>
+<div class="a_3_last_type">
+    (:nth-last-of-type(3n+b)) 1 and 4 bold, 3 and 6 italic, 2 and 5 green:
+    <span>1</span> <div style="display: inline">other</div> <span>2</span> <span>3</span> <span>4</span> <div style="display: inline">other</div> <span>5</span> <span>6</span>
+</div>
+<div class="a_-1_last_type">
+    (:nth-last-of-type(-n+b)) Only 6 should be bold:
+    <div style="display: inline">other</div> <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_-3_last_type">
+    (:nth-last-of-type(-3n+b)) 2 and 5 bold:
     <span>1</span> <div style="display: inline">other</div> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
 </div>
 </body>

--- a/test/files/nth_selectors.html
+++ b/test/files/nth_selectors.html
@@ -248,6 +248,16 @@
         .last-of-type span:last-of-type {
             font-weight: bold;
         }
+
+
+        .only-child span:only-child {
+            font-weight: bold;
+        }
+
+
+        .only-of-type span:only-of-type {
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -378,6 +388,24 @@
 <div class="last-of-type">
     (:last-of-type) Only 2 should be bold:
     <span>1</span> <span>2</span> <div style="display: inline">other</div>
+</div>
+
+<div class="only-child">
+    (:only-child) "bold" should be bold:
+    <span>bold</span>
+</div>
+<div class="only-child">
+    (:only-child) there should not be any bold element:
+    <div style="display: inline">other</div> <span>regular</span> <div style="display: inline">other</div>
+</div>
+
+<div class="only-of-type">
+    (:only-of-type) "bold" should be bold:
+    <div style="display: inline">other</div> <span>bold</span> <div style="display: inline">other</div>
+</div>
+<div class="only-of-type">
+    (:only-of-type) there should not be any bold element:
+    <div style="display: inline">other</div> <span>regular</span> <div style="display: inline">other</div> <span>regular</span>
 </div>
 </body>
 </html>

--- a/test/files/nth_selectors.html
+++ b/test/files/nth_selectors.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>nth-* pseudo-class selectors</title>
+    <style>
+        .even_odd :nth-child(odd) {
+            font-weight: bold;
+        }
+        .even_odd :nth-child(even) {
+            font-style: italic;
+        }
+
+        .b :nth-child(0) {
+            color: red;
+        }
+        .b :nth-child(3) {
+            font-weight: bold;
+        }
+        .b :nth-child(-2) {
+            color: red;
+        }
+/*
+        .a_1 :nth-child(n) {
+            font-weight: bold;
+        }
+        .a_1 :nth-child(n+3) {
+            font-style: italic;
+        }
+        .a_1 :nth-child(n-3) {
+            color: green;
+        }
+
+        .a_3 :nth-child(3n) {
+            font-weight: bold;
+        }
+        .a_3 :nth-child(3n+1) {
+            font-style: italic;
+        }
+        .a_3 :nth-child(3n-1) {
+            color: green;
+        }
+
+        .a_-1 :nth-child(-n) {
+            color: red;
+        }
+        .a_-1 :nth-child(-n+1) {
+            font-weight: bold;
+        }
+        .a_-1 :nth-child(-n-1) {
+            color: red;
+        }
+
+        .a_-3 :nth-child(-3n) {
+            color: red;
+        }
+        .a_-3 :nth-child(-3n+5) {
+            font-weight: bold;
+        }
+        .a_-3 :nth-child(-3n-1) {
+            color: red;
+        }
+*/
+
+        .even_odd_type span:nth-of-type(odd) {
+            font-weight: bold;
+        }
+        .even_odd_type span:nth-of-type(even) {
+            font-style: italic;
+        }
+
+        .b_type span:nth-of-type(0) {
+            color: red;
+        }
+        .b_type span:nth-of-type(3) {
+            font-weight: bold;
+        }
+        .b_type span:nth-of-type(-2) {
+            color: red;
+        }
+/*
+        .a_1_type span:nth-of-type(n) {
+            font-weight: bold;
+        }
+        .a_1_type span:nth-of-type(n+3) {
+            font-style: italic;
+        }
+        .a_1_type span:nth-of-type(n-3) {
+            color: green;
+        }
+
+        .a_3_type span:nth-of-type(3n) {
+            font-weight: bold;
+        }
+        .a_3_type span:nth-of-type(3n+1) {
+            font-style: italic;
+        }
+        .a_3_type span:nth-of-type(3n-1) {
+            color: green;
+        }
+
+        .a_-1_type span:nth-of-type(-n) {
+            color: red;
+        }
+        .a_-1_type span:nth-of-type(-n+1) {
+            font-weight: bold;
+        }
+        .a_-1_type span:nth-of-type(-n-1) {
+            color: red;
+        }
+
+        .a_-3_type span:nth-of-type(-3n) {
+            color: red;
+        }
+        .a_-3_type span:nth-of-type(-3n+5) {
+            font-weight: bold;
+        }
+        .a_-3_type span:nth-of-type(-3n-1) {
+            color: red;
+        }
+*/
+    </style>
+</head>
+<body>
+<div class="even_odd">
+    (:nth-child(odd|even)) Bold and italic are applied alternatively:
+    <span>bold</span>
+    <span>italic</span>
+    <span>bold</span>
+    <span>italic</span>
+</div>
+<div class="b">
+    (:nth-child(b)) Only 3 should be bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_1">
+    (:nth-child(n+b)) All bold, 3 and 4 are italic, All green:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span>
+</div>
+<div class="a_3">
+    (:nth-child(3n+b)) 3 and 6 bold, 1 and 4 italic, 2 and 5 green:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_-1">
+    (:nth-child(-n+b)) Only 1 should be bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_-3">
+    (:nth-child(-3n+b)) 2 and 5 bold:
+    <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+
+<div class="even_odd_type">
+    (:nth-of-type(odd|even))
+    <span>bold</span>
+    <span>italic</span>
+    <div style="display: inline">(regular)</div>
+    <span>bold</span>
+    <span>italic</span>
+</div>
+<div class="b_type">
+    (:nth-of-type(b)) Only 3 should be bold:
+    <span>1</span> <span>2</span> <div style="display: inline">other</div> <span>3</span> <span>4</span> <span>5</span>
+</div>
+<div class="a_1_type">
+    (:nth-of-type(n+b)) All bold, 3 and 4 are italic, All green:
+    <span>1</span> <span>2</span> <div style="display: inline">other (not green)</div> <span>3</span> <span>4</span>
+</div>
+<div class="a_3_type">
+    (:nth-of-type(3n+b)) 3 and 6 bold, 1 and 4 italic, 2 and 5 green:
+    <span>1</span> <div style="display: inline">other</div> <span>2</span> <span>3</span> <span>4</span> <div style="display: inline">other</div> <span>5</span> <span>6</span>
+</div>
+<div class="a_-1_type">
+    (:nth-of-type(-n+b)) Only 1 should be bold:
+    <div style="display: inline">other</div> <span>1</span> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+<div class="a_-3_type">
+    (:nth-of-type(-3n+b)) 2 and 5 bold:
+    <span>1</span> <div style="display: inline">other</div> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+</body>
+</html>

--- a/test/files/nth_selectors.html
+++ b/test/files/nth_selectors.html
@@ -238,6 +238,16 @@
         .a_-3_last_type span:nth-last-of-type(-3n-1) {
             color: red;
         }
+
+
+        .first-of-type span:first-of-type {
+            font-weight: bold;
+        }
+
+
+        .last-of-type span:last-of-type {
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -358,6 +368,16 @@
 <div class="a_-3_last_type">
     (:nth-last-of-type(-3n+b)) 2 and 5 bold:
     <span>1</span> <div style="display: inline">other</div> <span>2</span> <span>3</span> <span>4</span> <span>5</span> <span>6</span>
+</div>
+
+<div class="first-of-type">
+    (:first-of-type) Only 1 should be bold:
+    <div style="display: inline">other</div> <span>1</span> <span>2</span>
+</div>
+
+<div class="last-of-type">
+    (:last-of-type) Only 2 should be bold:
+    <span>1</span> <span>2</span> <div style="display: inline">other</div>
 </div>
 </body>
 </html>

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -1,4 +1,113 @@
 describe("csscasc", function() {
+    describe("IsNthSiblingAction", function() {
+        it("when a=0, matches if currentSiblingOrder=b", function() {
+            var action = new adapt.csscasc.IsNthSiblingAction(0, 3);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 1});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 3});
+            expect(chained.apply).toHaveBeenCalled();
+        });
+
+        it("when a is non-zero, matches if non-negative n which satisfies currentSiblingOrder=an+b exists", function() {
+
+            var action = new adapt.csscasc.IsNthSiblingAction(3, 0);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 1});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 2});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 3});
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 4});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 5});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 6});
+            expect(chained.apply).toHaveBeenCalled();
+
+            action = new adapt.csscasc.IsNthSiblingAction(2, 3);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 1});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 2});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 3});
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 4});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 5});
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 6});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 7});
+            expect(chained.apply).toHaveBeenCalled();
+
+            action = new adapt.csscasc.IsNthSiblingAction(-3, 0);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 1});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 2});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 3});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action = new adapt.csscasc.IsNthSiblingAction(-2, 5);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 1});
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 2});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 3});
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 4});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 5});
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply({currentSiblingOrder: 6});
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply({currentSiblingOrder: 7});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+    });
+
     describe("CascadeParserHandler", function() {
         describe("simpleProperty", function() {
             vivliostyle.test.util.mock.plugin.setup();

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -108,6 +108,126 @@ describe("csscasc", function() {
         });
     });
 
+    describe("IsNthSiblingOfTypeAction", function() {
+        var element = {namespaceURI: "foo", localName: "bar"};
+        function dummyCascadeInstance(counts) {
+            var currentSiblingTypeCounts = {};
+            currentSiblingTypeCounts[element.namespaceURI] = counts;
+            return {
+                currentSiblingTypeCounts: currentSiblingTypeCounts,
+                currentNamespace: element.namespaceURI,
+                currentLocalName: element.localName
+            };
+        }
+
+        it("when a=0, matches if currentSiblingTypeCounts[namespace][locaName]=b", function() {
+            var action = new adapt.csscasc.IsNthSiblingOfTypeAction(0, 3);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 1, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 3, "baz": 3}));
+            expect(chained.apply).toHaveBeenCalled();
+        });
+
+        it("when a is non-zero, matches if non-negative n which satisfies currentSiblingOrder=an+b exists", function() {
+
+            var action = new adapt.csscasc.IsNthSiblingOfTypeAction(3, 0);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 1, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 2, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 3, "baz": 1}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 4, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 5, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 6, "baz": 1}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            action = new adapt.csscasc.IsNthSiblingOfTypeAction(2, 3);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 1, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 2, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 3, "baz": 1}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 4, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 5, "baz": 1}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 6, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 7, "baz": 3}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            action = new adapt.csscasc.IsNthSiblingOfTypeAction(-3, 0);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 1, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 2, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 3, "baz": 3}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action = new adapt.csscasc.IsNthSiblingOfTypeAction(-2, 5);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 1, "baz": 2}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 2, "baz": 1}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 3, "baz": 2}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 4, "baz": 1}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 5, "baz": 2}));
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            action.apply(dummyCascadeInstance({"bar": 6, "baz": 1}));
+            expect(chained.apply).not.toHaveBeenCalled();
+
+            action.apply(dummyCascadeInstance({"bar": 7, "baz": 1}));
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+    });
+
     describe("CascadeParserHandler", function() {
         describe("simpleProperty", function() {
             vivliostyle.test.util.mock.plugin.setup();

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -109,8 +109,8 @@ describe("csscasc", function() {
     });
 
     describe("IsNthSiblingOfTypeAction", function() {
-        var element = {namespaceURI: "foo", localName: "bar"};
         function dummyCascadeInstance(counts) {
+            var element = {namespaceURI: "foo", localName: "bar"};
             var currentSiblingTypeCounts = {};
             currentSiblingTypeCounts[element.namespaceURI] = counts;
             return {
@@ -131,7 +131,7 @@ describe("csscasc", function() {
             expect(chained.apply).toHaveBeenCalled();
         });
 
-        it("when a is non-zero, matches if non-negative n which satisfies currentSiblingOrder=an+b exists", function() {
+        it("when a is non-zero, matches if non-negative n which satisfies currentSiblingTypeCounts[namespace][locaName]=an+b exists", function() {
 
             var action = new adapt.csscasc.IsNthSiblingOfTypeAction(3, 0);
             var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
@@ -225,6 +225,351 @@ describe("csscasc", function() {
 
             action.apply(dummyCascadeInstance({"bar": 7, "baz": 1}));
             expect(chained.apply).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("IsNthLastSiblingAction", function() {
+        function dummyCascadeInstance(count) {
+            return {
+                currentFollowingSiblingOrder: null,
+                currentSiblingOrder: 3,
+                currentElement: { parentNode: { childElementCount: count } }
+            };
+        }
+
+        it("when a=0, matches if currentFollowingSiblingOrder=b", function() {
+            var action = new adapt.csscasc.IsNthLastSiblingAction(0, 3);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            var cascadeInstance = dummyCascadeInstance(4);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+
+            cascadeInstance = dummyCascadeInstance(5);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+        });
+
+        it("when a is non-zero, matches if non-negative n which satisfies currentFollowingSiblingOrder=an+b exists", function() {
+
+            var action = new adapt.csscasc.IsNthLastSiblingAction(3, 0);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            var cascadeInstance = dummyCascadeInstance(3);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+
+            cascadeInstance = dummyCascadeInstance(4);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+
+            cascadeInstance = dummyCascadeInstance(5);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(6);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
+
+            cascadeInstance = dummyCascadeInstance(7);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
+
+            cascadeInstance = dummyCascadeInstance(8);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
+
+            action = new adapt.csscasc.IsNthLastSiblingAction(2, 3);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(3);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+
+            cascadeInstance = dummyCascadeInstance(4);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+
+            cascadeInstance = dummyCascadeInstance(5);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(6);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
+
+            cascadeInstance = dummyCascadeInstance(7);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(8);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
+
+            cascadeInstance = dummyCascadeInstance(9);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(7);
+
+            action = new adapt.csscasc.IsNthLastSiblingAction(-3, 0);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(3);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+
+            cascadeInstance = dummyCascadeInstance(4);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+
+            cascadeInstance = dummyCascadeInstance(5);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+
+            action = new adapt.csscasc.IsNthLastSiblingAction(-2, 5);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(3);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(4);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+
+            cascadeInstance = dummyCascadeInstance(5);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+
+            cascadeInstance = dummyCascadeInstance(6);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
+
+            cascadeInstance = dummyCascadeInstance(7);
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance(8);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
+
+            cascadeInstance = dummyCascadeInstance(9);
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingOrder).toBe(7);
+        });
+    });
+
+    describe("IsNthLastSiblingOfTypeAction", function() {
+        function dummyCascadeInstance(counts) {
+            var currentElement = {namespaceURI: "foo", localName: "bar"};
+            var element = currentElement;
+            Object.keys(counts).forEach(function(name) {
+                for (var i = counts[name]; i > 0; i--) {
+                    element = element.nextElementSibling = {
+                        namespaceURI: currentElement.namespaceURI,
+                        localName: name
+                    };
+                }
+            });
+            return {
+                currentFollowingSiblingTypeCounts: {},
+                currentNamespace: currentElement.namespaceURI,
+                currentLocalName: currentElement.localName,
+                currentElement: currentElement
+            };
+        }
+
+        it("when a=0, matches if currentFollowingSiblingTypeCounts[namespace][locaName]=b", function() {
+            var action = new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 3);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            var cascadeInstance = dummyCascadeInstance({"bar": 1, "baz": 2});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 2, "baz": 2} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 2, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 3, "baz": 1} });
+        });
+
+        it("when a is non-zero, matches if non-negative n which satisfies currentFollowingSiblingTypeCounts[namespace][locaName]=an+b exists", function() {
+
+            var action = new adapt.csscasc.IsNthLastSiblingOfTypeAction(3, 0);
+            var chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            var cascadeInstance = dummyCascadeInstance({"bar": 0, "baz": 2});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 1, "baz": 2} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 1, "baz": 2});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 2, "baz": 2} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 2, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 3, "baz": 1} });
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 3, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 4, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 4, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 5, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 5, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 6, "baz": 1} });
+
+            action = new adapt.csscasc.IsNthLastSiblingOfTypeAction(2, 3);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 0, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 1, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 1, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 2, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 2, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 3, "baz": 1} });
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 3, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 4, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 4, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 5, "baz": 1} });
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 5, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 6, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 6, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 7, "baz": 3} });
+
+            action = new adapt.csscasc.IsNthLastSiblingOfTypeAction(-3, 0);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 0, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 1, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 1, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 2, "baz": 3} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 2, "baz": 3});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 3, "baz": 3} });
+
+            action = new adapt.csscasc.IsNthLastSiblingOfTypeAction(-2, 5);
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 0, "baz": 2});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 1, "baz": 2} });
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 1, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 2, "baz": 1} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 2, "baz": 2});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 3, "baz": 2} });
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 3, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 4, "baz": 1} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 4, "baz": 2});
+            action.apply(cascadeInstance);
+            expect(chained.apply).toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 5, "baz": 2} });
+
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+
+            cascadeInstance = dummyCascadeInstance({"bar": 5, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 6, "baz": 1} });
+
+            cascadeInstance = dummyCascadeInstance({"bar": 6, "baz": 1});
+            action.apply(cascadeInstance);
+            expect(chained.apply).not.toHaveBeenCalled();
+            expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({ "foo": {"bar": 7, "baz": 1} });
         });
     });
 

--- a/test/spec/adapt/cssparse-spec.js
+++ b/test/spec/adapt/cssparse-spec.js
@@ -95,185 +95,234 @@ describe("cssparse", function() {
                     });
                 });
 
-                it("can take an 'n' argument", function(done) {
-                    parse(done, ":nth-child(n) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
-                    });
-                });
-
-                it("error if there is whitespaces between an 'n' and a plus/minus sign", function(done) {
-                    parse(done, ":nth-child(+ n) {}", function() {
-                        expect(handler.error).toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
-                    });
-                });
-
-                it("can take an 'n' argument with a plus sign", function(done) {
-                    parse(done, ":nth-child(+n) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
-                    });
-                });
-
-                it("can take an 'an' argument", function(done) {
-                    parse(done, ":nth-child(2n) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 0]);
-                    });
-                });
-
-                it("can take an 'an' argument with a plus sign", function(done) {
-                    parse(done, ":nth-child(+2n) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 0]);
-                    });
-                });
-
-                it("error if there is whitespaces between an 'a' and a plus/minus sign", function(done) {
+                it("reject '+ an' argument", function(done) {
                     parse(done, ":nth-child(+ 2n) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("error if there is whitespaces between an 'a' and an 'n'", function(done) {
-                    parse(done, ":nth-child(+2 n) {}", function() {
+                it("can take 'n -0' argument", function(done) {
+                    parse(done, ":nth-child(n -0) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
+                    });
+                });
+
+                it("reject 'n + -0' argument", function(done) {
+                    parse(done, ":nth-child(n + -0) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("can take an 'an+b' argument", function(done) {
-                    parse(done, ":nth-child(2n+3) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 3]);
-                    });
-                });
-
-                it("can take an 'an +b' argument", function(done) {
-                    parse(done, ":nth-child(2n +1) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
-                    });
-                });
-
-                it("can take an 'an+ b' argument", function(done) {
-                    parse(done, ":nth-child(2n+ 1) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
-                    });
-                });
-
-                it("can take an 'an + b' argument", function(done) {
-                    parse(done, ":nth-child(2n + 1) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
-                    });
-                });
-
-                it("error an 'an+' argument", function(done) {
-                    parse(done, ":nth-child(2n+) {}", function() {
+                it("reject 'n - -0' argument", function(done) {
+                    parse(done, ":nth-child(n - -0) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("error an 'an +' argument", function(done) {
-                    parse(done, ":nth-child(2n +) {}", function() {
+                it("can take 'n -a' argument", function(done) {
+                    parse(done, ":nth-child(n -3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
+                    });
+                });
+
+                it("reject 'n + -a' argument", function(done) {
+                    parse(done, ":nth-child(n + -3) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("can take an 'an' argument with a minus sign", function(done) {
+                it("reject 'n - -a' argument", function(done) {
+                    parse(done, ":nth-child(n - -3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take 'n+a' argument", function(done) {
+                    parse(done, ":nth-child(n+3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 3]);
+                    });
+                });
+
+                it("can take 'n +a' argument", function(done) {
+                    parse(done, ":nth-child(n +3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 3]);
+                    });
+                });
+
+                it("can take 'n + a' argument", function(done) {
+                    parse(done, ":nth-child(n + 3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 3]);
+                    });
+                });
+
+                it("can take 'n - a' argument", function(done) {
+                    parse(done, ":nth-child(n - 3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
+                    });
+                });
+
+                it("can take 'n - 0' argument", function(done) {
+                    parse(done, ":nth-child(n - 0) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
+                    });
+                });
+
+                it("reject 'n b' argument", function(done) {
+                    parse(done, ":nth-child(n 2) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject 'n + +0' argument", function(done) {
+                    parse(done, ":nth-child(n + +0) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject 'n + +b' argument", function(done) {
+                    parse(done, ":nth-child(n + +3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take 'n' argument", function(done) {
+                    parse(done, ":nth-child(n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
+                    });
+                });
+
+                it("can take 'n' argument with a plus sign", function(done) {
+                    parse(done, ":nth-child(+n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
+                    });
+                });
+
+                it("can take 'an' argument", function(done) {
+                    parse(done, ":nth-child(2n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 0]);
+                    });
+                });
+
+                it("can take '-an' argument", function(done) {
                     parse(done, ":nth-child(-2n) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-2, 0]);
                     });
                 });
 
-                it("can take an 'n' argument with a minus sign", function(done) {
+                it("can take 'an' argument with a plus sign", function(done) {
+                    parse(done, ":nth-child(+2n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 0]);
+                    });
+                });
+
+                it("reject '+a n' argument", function(done) {
+                    parse(done, ":nth-child(+2 n) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject 'an+' argument", function(done) {
+                    parse(done, ":nth-child(2n+) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject 'an +' argument", function(done) {
+                    parse(done, ":nth-child(2n +) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take 'n' argument with a minus sign", function(done) {
                     parse(done, ":nth-child(-n) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-1, 0]);
                     });
                 });
 
-                it("can take an '-n+b' argument", function(done) {
+                it("reject '- n' argument", function(done) {
+                    parse(done, ":nth-child(- n) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take '-n+b' argument", function(done) {
                     parse(done, ":nth-child(-n+3) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-1, 3]);
                     });
                 });
 
-                it("can take an 'an -b' argument", function(done) {
+                it("can take 'an -b' argument", function(done) {
                     parse(done, ":nth-child(2n -1) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, -1]);
                     });
                 });
 
-                it("can take an 'an + b' argument", function(done) {
+                it("can take 'an + b' argument", function(done) {
                     parse(done, ":nth-child(2n + 3) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 3]);
                     });
                 });
 
-                it("can take an 'an- b' argument", function(done) {
+                it("can take 'an- b' argument", function(done) {
                     parse(done, ":nth-child(2n- 1) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
                     });
                 });
 
-                it("reject an '+ an- b' argument", function(done) {
+                it("reject '+ an- b' argument", function(done) {
                     parse(done, ":nth-child(+ 2n- 1) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("reject an 'an- -b' argument", function(done) {
+                it("reject 'an- -b' argument", function(done) {
                     parse(done, ":nth-child(2n- -1) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("can take an 'an - b' argument", function(done) {
-                    parse(done, ":nth-child(2n - 3) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 3]);
-                    });
-                });
-
-                it("error an 'an-' argument", function(done) {
+                it("reject 'an-' argument", function(done) {
                     parse(done, ":nth-child(2n-) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("error an 'an -' argument", function(done) {
+                it("reject 'an -' argument", function(done) {
                     parse(done, ":nth-child(2n -) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
-                    });
-                });
-
-                it("can take an 'n-b' argument", function(done) {
-                    parse(done, ":nth-child(n-3) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
-                    });
-                });
-
-                it("can take an '+n-b' argument", function(done) {
-                    parse(done, ":nth-child(+n-3) {}", function() {
-                        expect(handler.error).not.toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
                     });
                 });
 
@@ -284,59 +333,101 @@ describe("cssparse", function() {
                     });
                 });
 
-                it("can take an 'an-b' argument", function(done) {
+                it("reject 'n- +b' argument ", function(done) {
+                    parse(done, ":nth-child(n- +3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject 'n- -b' argument ", function(done) {
+                    parse(done, ":nth-child(n- -3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject 'n- -0' argument ", function(done) {
+                    parse(done, ":nth-child(n- -0) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject '+ an-b' argument ", function(done) {
+                    parse(done, ":nth-child(+ 2n-3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take 'n-b' argument", function(done) {
+                    parse(done, ":nth-child(n-3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
+                    });
+                });
+
+                it("can take '+n-b' argument", function(done) {
+                    parse(done, ":nth-child(+n-3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
+                    });
+                });
+
+                it("can take 'an-b' argument", function(done) {
                     parse(done, ":nth-child(2n-3) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, -3]);
                     });
                 });
 
-                it("can take an '-n-b argument", function(done) {
+                it("can take '-n-b argument", function(done) {
                     parse(done, ":nth-child(-n-10) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-1, -10]);
                     })
                 });
 
-                it("reject '+-n-b' argument ", function(done) {
-                    parse(done, ":nth-child(+-n-3) {}", function() {
-                        expect(handler.error).toHaveBeenCalled();
-                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
-                    });
-                });
-
-                it("error if an invalid identifier is passed", function(done) {
+                it("reject invalid identifier", function(done) {
                     parse(done, ":nth-child(foo) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("can take a single integer argument", function(done) {
+                it("can take 'b' argument", function(done) {
                     parse(done, ":nth-child(3) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [0, 3]);
                     });
                 });
 
-                it("can take a single integer argument with a plus sign", function(done) {
+                it("can take '+b' argument", function(done) {
                     parse(done, ":nth-child(+3) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [0, 3]);
                     });
                 });
 
-                it("error if there is whitespaces between a single integer and a plus/minus sign", function(done) {
+                it("reject '+ b' argument", function(done) {
                     parse(done, ":nth-child(+ 3) {}", function() {
                         expect(handler.error).toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 
-                it("can take a single integer argument with a minus sign", function(done) {
+                it("can take '-b' argument", function(done) {
                     parse(done, ":nth-child(-3) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [0, -3]);
+                    });
+                });
+
+                it("reject '- b' argument", function(done) {
+                    parse(done, ":nth-child(- 3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
                     });
                 });
 

--- a/test/spec/adapt/cssparse-spec.js
+++ b/test/spec/adapt/cssparse-spec.js
@@ -1,0 +1,353 @@
+describe("cssparse", function() {
+    describe("Parser", function() {
+        describe("pseudoclass", function() {
+            var handler = new adapt.cssparse.ParserHandler(null);
+
+            beforeEach(function() {
+                spyOn(handler, "error");
+                spyOn(handler, "pseudoclassSelector");
+            });
+
+            function parse(done, text, fn) {
+                var tokenizer = new adapt.csstok.Tokenizer(text, handler);
+
+                adapt.task.start(function() {
+                    adapt.cssparse.parseStylesheet(tokenizer, handler, null, null, null).then(function(result) {
+                        expect(result).toBe(true);
+                        fn();
+                        done();
+                    });
+                });
+            }
+
+            describe(":lang", function() {
+                it("takes one identifier as an argument", function(done) {
+                    parse(done, ":lang(ja) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("lang", ["ja"]);
+                    });
+                });
+
+                it("error if no arguments are passed", function(done) {
+                    parse(done, ":lang() {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("error if invalid arguments are passed", function(done) {
+                    parse(done, ":lang(2) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe(":href-epub-type", function() {
+                it("takes one identifier as an argument", function(done) {
+                    parse(done, ":href-epub-type(foo) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("href-epub-type", ["foo"]);
+                    });
+                });
+
+                it("error if no arguments are passed", function(done) {
+                    parse(done, ":href-epub-type() {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("error if invalid arguments are passed", function(done) {
+                    parse(done, ":href-epub-type(2) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe(":nth-child", function() {
+                it("can take 'odd' argument", function(done) {
+                    parse(done, ":nth-child(odd) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
+                    });
+                });
+
+                it("can take 'even' argument", function(done) {
+                    parse(done, ":nth-child(even) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 0]);
+                    });
+                });
+
+                it("reject '+-an' argument", function(done) {
+                    parse(done, ":nth-child(+-2n) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject '+-n' argument", function(done) {
+                    parse(done, ":nth-child(+-n) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take an 'n' argument", function(done) {
+                    parse(done, ":nth-child(n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
+                    });
+                });
+
+                it("error if there is whitespaces between an 'n' and a plus/minus sign", function(done) {
+                    parse(done, ":nth-child(+ n) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take an 'n' argument with a plus sign", function(done) {
+                    parse(done, ":nth-child(+n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, 0]);
+                    });
+                });
+
+                it("can take an 'an' argument", function(done) {
+                    parse(done, ":nth-child(2n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 0]);
+                    });
+                });
+
+                it("can take an 'an' argument with a plus sign", function(done) {
+                    parse(done, ":nth-child(+2n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 0]);
+                    });
+                });
+
+                it("error if there is whitespaces between an 'a' and a plus/minus sign", function(done) {
+                    parse(done, ":nth-child(+ 2n) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("error if there is whitespaces between an 'a' and an 'n'", function(done) {
+                    parse(done, ":nth-child(+2 n) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take an 'an+b' argument", function(done) {
+                    parse(done, ":nth-child(2n+3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 3]);
+                    });
+                });
+
+                it("can take an 'an +b' argument", function(done) {
+                    parse(done, ":nth-child(2n +1) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
+                    });
+                });
+
+                it("can take an 'an+ b' argument", function(done) {
+                    parse(done, ":nth-child(2n+ 1) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
+                    });
+                });
+
+                it("can take an 'an + b' argument", function(done) {
+                    parse(done, ":nth-child(2n + 1) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
+                    });
+                });
+
+                it("error an 'an+' argument", function(done) {
+                    parse(done, ":nth-child(2n+) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("error an 'an +' argument", function(done) {
+                    parse(done, ":nth-child(2n +) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take an 'an' argument with a minus sign", function(done) {
+                    parse(done, ":nth-child(-2n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-2, 0]);
+                    });
+                });
+
+                it("can take an 'n' argument with a minus sign", function(done) {
+                    parse(done, ":nth-child(-n) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-1, 0]);
+                    });
+                });
+
+                it("can take an '-n+b' argument", function(done) {
+                    parse(done, ":nth-child(-n+3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-1, 3]);
+                    });
+                });
+
+                it("can take an 'an -b' argument", function(done) {
+                    parse(done, ":nth-child(2n -1) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, -1]);
+                    });
+                });
+
+                it("can take an 'an + b' argument", function(done) {
+                    parse(done, ":nth-child(2n + 3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 3]);
+                    });
+                });
+
+                it("can take an 'an- b' argument", function(done) {
+                    parse(done, ":nth-child(2n- 1) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 1]);
+                    });
+                });
+
+                it("reject an '+ an- b' argument", function(done) {
+                    parse(done, ":nth-child(+ 2n- 1) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("reject an 'an- -b' argument", function(done) {
+                    parse(done, ":nth-child(2n- -1) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take an 'an - b' argument", function(done) {
+                    parse(done, ":nth-child(2n - 3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, 3]);
+                    });
+                });
+
+                it("error an 'an-' argument", function(done) {
+                    parse(done, ":nth-child(2n-) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("error an 'an -' argument", function(done) {
+                    parse(done, ":nth-child(2n -) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take an 'n-b' argument", function(done) {
+                    parse(done, ":nth-child(n-3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
+                    });
+                });
+
+                it("can take an '+n-b' argument", function(done) {
+                    parse(done, ":nth-child(+n-3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [1, -3]);
+                    });
+                });
+
+                it("reject '+ n-b' argument ", function(done) {
+                    parse(done, ":nth-child(+ n-3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take an 'an-b' argument", function(done) {
+                    parse(done, ":nth-child(2n-3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [2, -3]);
+                    });
+                });
+
+                it("can take an '-n-b argument", function(done) {
+                    parse(done, ":nth-child(-n-10) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-1, -10]);
+                    })
+                });
+
+                it("reject '+-n-b' argument ", function(done) {
+                    parse(done, ":nth-child(+-n-3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("error if an invalid identifier is passed", function(done) {
+                    parse(done, ":nth-child(foo) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take a single integer argument", function(done) {
+                    parse(done, ":nth-child(3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [0, 3]);
+                    });
+                });
+
+                it("can take a single integer argument with a plus sign", function(done) {
+                    parse(done, ":nth-child(+3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [0, 3]);
+                    });
+                });
+
+                it("error if there is whitespaces between a single integer and a plus/minus sign", function(done) {
+                    parse(done, ":nth-child(+ 3) {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+
+                it("can take a single integer argument with a minus sign", function(done) {
+                    parse(done, ":nth-child(-3) {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [0, -3]);
+                    });
+                });
+
+                it("error if no arguments are passed", function(done) {
+                    parse(done, ":nth-child() {}", function() {
+                        expect(handler.error).toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).not.toHaveBeenCalled();
+                    });
+                });
+            });
+
+        });
+    });
+});


### PR DESCRIPTION
- Resolves #163, #86, #193 and #194.
- Support `an+b` arguments for `:nth-child()` pseudo-class selector (#163)
- Support `:nth-last-child()` (#193), `:nth-of-type()` and `:nth-last-of-type()` (#194) pseudo-class selectors with `an+b` arguments
- Also support the following related pseudo-class selectors: `:last-child` (#86), `:first-of-type`, `:last-of-type`, `:only-child` and `:only-of-type`
