### PR TITLE
Implement UI states selectors (`:checked`, `:enabled` and `:disabled`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@
 - Support `:empty` pseudo-class selector
   - <https://github.com/vivliostyle/vivliostyle.js/pull/205>
   - Spec: [Selectors Level 3 - :empty pseudo-class](https://www.w3.org/TR/css3-selectors/#empty-pseudo)
+- Support UI states selectors (`:checked`, `:enabled` and `:disabled`)
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/206>
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/197>
+  - Spec: [Selectors Level 3 - The UI element states pseudo-classes](https://www.w3.org/TR/css3-selectors/#UIstates)
+  - Note that the current implementation can use only initial states of those UI elements. Even if the actual state of the element is toggled by user interaction, the style does not change.
 
 ### Fixed
 - Lengths in 'rem' specified within page context are now interpreted correctly.

--- a/doc/supported-features.md
+++ b/doc/supported-features.md
@@ -70,6 +70,9 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Supported in all browsers
 - [Attribute selectors with namespaces `[ns|att]`, `[|att]`, `[ns|att=val]`, `[|att=val]`, `[ns|att~=val]`, `[|att~=val]`, `[ns|att|=val]`, `[|att|=val]`, `[ns|att^=val]`, `[|att^=val]`, `[ns|att$=val]`, `[|att$=val]`, `[ns|att*=val]`, `[|att*=val]`](https://www.w3.org/TR/css3-selectors/#attrnmsp)
   - Supported in all browsers
+- [The UI element states pseudo-classes `:enabled`, `:disabled`, `:checked`, `:indeterminate`](https://www.w3.org/TR/css3-selectors/#UIstates)
+  - Supported in all browsers
+  - Note that the current implementation can use only initial states of those UI elements. Even if the actual state of the element is toggled by user interaction, the style does not change.
 - [`:root` pseudo-class](https://www.w3.org/TR/css3-selectors/#root-pseudo)
   - Supported in all browsers
 - [`:nth-child()` pseudo-class](https://www.w3.org/TR/css3-selectors/#nth-child-pseudo)
@@ -111,7 +114,6 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 - [Universal selector without namespaces `|*`](https://www.w3.org/TR/css3-selectors/#univnmsp)
 - [Attribute selectors with universal namespace `[*|att]`, `[*|att=val]`, `[*|att~=val]`, `[*|att|=val]`](https://www.w3.org/TR/css3-selectors/#attrnmsp)
 - [Target pseudo-class `:target`](https://www.w3.org/TR/css3-selectors/#target-pseudo)
-- [The UI element states pseudo-classes `:enabled`, `:disabled`, `:checked`, `:indeterminate`](https://www.w3.org/TR/css3-selectors/#UIstates)
 - [The negation pseudo-class `:not()`](https://www.w3.org/TR/css3-selectors/#negation)
 
 ## At-rules

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -1234,6 +1234,84 @@ adapt.csscasc.IsEmptyAction.prototype.getPriority = function() {
 };
 
 /**
+ * @constructor
+ * @extends {adapt.csscasc.ChainedAction}
+ */
+adapt.csscasc.IsEnabledAction = function() {
+	adapt.csscasc.ChainedAction.call(this);
+};
+goog.inherits(adapt.csscasc.IsEnabledAction, adapt.csscasc.ChainedAction);
+
+/**
+ * @override
+ */
+adapt.csscasc.IsEnabledAction.prototype.apply = function(cascadeInstance) {
+	var elem = cascadeInstance.currentElement;
+	if (elem.disabled === false) {
+		this.chained.apply(cascadeInstance);
+	}
+};
+
+/**
+ * @override
+ */
+adapt.csscasc.IsEnabledAction.prototype.getPriority = function() {
+	return 5;
+};
+
+/**
+ * @constructor
+ * @extends {adapt.csscasc.ChainedAction}
+ */
+adapt.csscasc.IsDisabledAction = function() {
+	adapt.csscasc.ChainedAction.call(this);
+};
+goog.inherits(adapt.csscasc.IsDisabledAction, adapt.csscasc.ChainedAction);
+
+/**
+ * @override
+ */
+adapt.csscasc.IsDisabledAction.prototype.apply = function(cascadeInstance) {
+	var elem = cascadeInstance.currentElement;
+	if (elem.disabled === true) {
+		this.chained.apply(cascadeInstance);
+	}
+};
+
+/**
+ * @override
+ */
+adapt.csscasc.IsDisabledAction.prototype.getPriority = function() {
+	return 5;
+};
+
+/**
+ * @constructor
+ * @extends {adapt.csscasc.ChainedAction}
+ */
+adapt.csscasc.IsCheckedAction = function() {
+	adapt.csscasc.ChainedAction.call(this);
+};
+goog.inherits(adapt.csscasc.IsCheckedAction, adapt.csscasc.ChainedAction);
+
+/**
+ * @override
+ */
+adapt.csscasc.IsCheckedAction.prototype.apply = function(cascadeInstance) {
+	var elem = cascadeInstance.currentElement;
+	if (elem.selected === true || elem.checked === true) {
+		this.chained.apply(cascadeInstance);
+	}
+};
+
+/**
+ * @override
+ */
+adapt.csscasc.IsCheckedAction.prototype.getPriority = function() {
+	return 5;
+};
+
+/**
  * @param {string} condition
  * @constructor
  * @extends {adapt.csscasc.ChainedAction}
@@ -2625,6 +2703,15 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
     	return;
     }
     switch (name.toLowerCase()) {
+		case "enabled":
+			this.chain.push(new adapt.csscasc.IsEnabledAction());
+			break;
+		case "disabled":
+			this.chain.push(new adapt.csscasc.IsDisabledAction());
+			break;
+		case "checked":
+			this.chain.push(new adapt.csscasc.IsCheckedAction());
+			break;
         case "root":
             this.chain.push(new adapt.csscasc.IsRootAction());
             break;

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -33,6 +33,7 @@
     <li><a href="incorrect_layout_with_empty_partition.html">Incorrect layout with empty partition</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/incorrect_layout_with_empty_partition.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/incorrect_layout_with_empty_partition.html">prod</a>]</li>
     <li><a href="nth_selectors.html">nth selectors</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/nth_selectors.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/nth_selectors.html">prod</a>]</li>
     <li><a href="empty_selector.html">empty selector</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/empty_selector.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/empty_selector.html">prod</a>]</li>
+    <li><a href="ui_state_selectors.html">UI state selectors</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/ui_state_selectors.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/ui_state_selectors.html">prod</a>]</li>
 </ul>
 </body>
 </html>

--- a/test/files/ui_state_selectors.html
+++ b/test/files/ui_state_selectors.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>UI state selectors</title>
+    <style>
+        input[type="text"] {
+            border: solid red;
+            width: 200px;
+        }
+        input[type="text"]:enabled {
+            border: solid green;
+        }
+        input[type="text"]:disabled {
+            border: solid green;
+        }
+
+        button {
+            color: red;
+        }
+        button:enabled {
+            color: green;
+        }
+        button:disabled {
+            color: green;
+        }
+
+        select {
+            border: solid red;
+        }
+        select:enabled {
+            border: solid green;
+        }
+        select:disabled {
+            border: solid green;
+        }
+
+        datalist {
+            display: block;
+        }
+        datalist option {
+            color: red;
+        }
+        datalist.enabled-option option:enabled {
+            color: green;
+        }
+        datalist.disabled-option option:disabled {
+            color: green;
+        }
+
+        textarea {
+            color: red;
+        }
+        textarea:enabled {
+            color: green;
+        }
+        textarea:disabled {
+            color: green;
+        }
+
+        keygen {
+            border: solid red;
+        }
+        keygen:enabled {
+            border: solid green;
+        }
+        keygen:disabled {
+            border: solid green;
+        }
+
+        fieldset {
+            border: solid red;
+            color: red;
+        }
+        fieldset:enabled {
+            border: solid green;
+            color: green;
+        }
+        fieldset:disabled {
+            border: solid green;
+            color: green;
+        }
+
+
+        input[type="checkbox"] {
+            color: red;
+        }
+        input[type="checkbox"]::after {
+            content: "input[type=checkbox]";
+            padding-left: 0.5em;
+        }
+        input[type="checkbox"]:checked {
+            color: green;
+        }
+        input[type="checkbox"]:checked::before {
+            content: "checked";
+            padding-left: 2em;
+        }
+
+        datalist.selected-option option:checked {
+            color: green;
+        }
+
+
+        div {
+            color: green;
+        }
+        div:disabled {
+            color: red;
+        }
+        div:checked {
+            color: red;
+        }
+    </style>
+</head>
+<body>
+<p><input type="text" placeholder="enabled input[type=text]"></p>
+<p><button>enabled button</button></p>
+<p><select><option>enabled select</option></select></p>
+<p><datalist class="enabled-option"><option>enabled option</option></datalist></p>
+<p><textarea>enabled textarea</textarea></p>
+<p><keygen></keygen></p>
+<fieldset><legend>enabled fieldset</legend></fieldset>
+
+<p><input type="text" placeholder="disabled input[type=text]" disabled></p>
+<p><button disabled>disabled button</button></p>
+<p><select disabled><option>disabled select</option></select></p>
+<p><datalist class="disabled-option"><option disabled>disabled option</option></datalist></p>
+<p><textarea disabled>disabled textarea</textarea></p>
+<p><keygen disabled></keygen></p>
+<fieldset disabled><legend>disabled fieldset</legend></fieldset>
+
+<p><input type="checkbox" checked></p>
+<p><datalist class="selected-option"><option selected>selected option</option></datalist></p>
+
+<div checked disabled>div element with 'checked' and 'disabled' attributes</div>
+</body>
+</html>

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -619,6 +619,88 @@ describe("csscasc", function() {
         });
     });
 
+    describe("IsEnabledAction", function() {
+        var action = new adapt.csscasc.IsEnabledAction();
+        var chained;
+
+        beforeEach(function() {
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+        });
+
+        it("applies if the element's 'disabled' property is false (not undefined)", function() {
+            action.apply({currentElement: {disabled: false}});
+            expect(chained.apply).toHaveBeenCalled();
+        });
+
+        it("not applies if the element's 'disabled' property is true", function() {
+            action.apply({currentElement: {disabled: true}});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+
+        it("applies if the element does not have 'disabled' property", function() {
+            action.apply({currentElement: {}});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("IsDisabledAction", function() {
+        var action = new adapt.csscasc.IsDisabledAction();
+        var chained;
+
+        beforeEach(function() {
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+        });
+
+        it("applies if the element's 'disabled' property is true", function() {
+            action.apply({currentElement: {disabled: true}});
+            expect(chained.apply).toHaveBeenCalled();
+        });
+
+        it("not applies if the element's 'disabled' property is false (not undefined)", function() {
+            action.apply({currentElement: {disabled: false}});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+
+        it("applies if the element does not have 'disabled' property", function() {
+            action.apply({currentElement: {}});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("IsCheckedAction", function() {
+        var action = new adapt.csscasc.IsCheckedAction();
+        var chained;
+
+        beforeEach(function() {
+            chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+        });
+
+        it("applies if the element's 'selected' property is true", function() {
+            action.apply({currentElement: {selected: true}});
+            expect(chained.apply).toHaveBeenCalled();
+        });
+
+        it("applies if the element's 'checked' property is true", function() {
+            action.apply({currentElement: {checked: true}});
+            expect(chained.apply).toHaveBeenCalled();
+        });
+
+        it("not applies if the element's 'selected' property is false (not undefined)", function() {
+            action.apply({currentElement: {selected: false}});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+
+        it("not applies if the element's 'checked' property is false (not undefined)", function() {
+            action.apply({currentElement: {checked: false}});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+
+        it("applies if the element does not have 'selected' nor 'checked' property", function() {
+            action.apply({currentElement: {}});
+            expect(chained.apply).not.toHaveBeenCalled();
+        });
+    });
+
     describe("CascadeParserHandler", function() {
         describe("simpleProperty", function() {
             vivliostyle.test.util.mock.plugin.setup();


### PR DESCRIPTION
Issue: #197

This implementation simply uses attributes on the source DOM node to judge the UI state. Specifically, `:checked` matches if the element has `checked` or `selected` attribute and its value is true, and `:enabled`/`:disabled` matches if the element has `disabled` attribute and its value is false/true. The selectors do not match an element without UI states (such as a `p` element), even if it has `disabled` or `selected` content attribute, for such an element does not have `disabled` or `selected` DOM property.
