### PR TITLE
Fix parse error when '+' follows a type selector and a pseudo-class selector

### DIFF
--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -2013,8 +2013,15 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                         continue;
                 	}
                 }
-                this.exprError("E_CSS_UNEXPECTED_PLUS", token);
-            	continue;
+                if (this.actions === adapt.cssparse.actionsPropVal && tokenizer.hasMark()) {
+                    tokenizer.reset();
+                    this.actions = adapt.cssparse.actionsSelectorStart;
+                    handler.startSelectorRule();
+                    continue;
+                } else {
+                    this.exprError("E_CSS_UNEXPECTED_PLUS", token);
+                    continue;
+                }
             case adapt.cssparse.Action.VAL_END:
                 tokenizer.consume();
                 // fall through

--- a/test/spec/adapt/cssparse-spec.js
+++ b/test/spec/adapt/cssparse-spec.js
@@ -439,6 +439,14 @@ describe("cssparse", function() {
                 });
             });
 
+            describe("pseudo-class followed by +", function() {
+                it("should be parsed successfully", function(done) {
+                    parse(done, "div:empty + div {}", function() {
+                        expect(handler.error).not.toHaveBeenCalled();
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("empty", null);
+                    });
+                })
+            });
         });
     });
 });


### PR DESCRIPTION
When a type selector is followed by a pseudo-class selector (for example `div:empty`), the parser cannot distinguish it from a property declaration and tries to judge by looking at the next token. If the next token is, for example, `~` (`div:empty ~ div`), the parser knows it is not a property declaration since a tilde cannot be in a property declaration. However, if the next token is `+` (`div:empty + div`), it is allowed in a property declaration _only if_ it is followed by a number. The old implementation checked this, and raised an error if the `+` was followed by something other than a number.
In this commit, the code is changed so that if the `+` is followed by something other than a number and if the parser is trying to distinguish a property declaration and a selector, the parser goes back to the start of the selector and parses the input again as a selector.
