### PR TITLE
Fix `rem` calculation when `font-size` is specified to the `body` element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
   - Spec: [CSS Fragmentation Module Level 3 - Forced Breaks](https://drafts.csswg.org/css-break/#forced-breaks)
 - Fix problematic handling of prefixed properties.
   - <https://github.com/vivliostyle/vivliostyle.js/issues/209>, <https://github.com/vivliostyle/vivliostyle.js/issues/210>
+- Fix `rem` calculation when `font-size` is specified to the `body` element.
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/217>
 
 ## [2016.1](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.1) - 2016-01-20
 

--- a/src/adapt/cssstyler.js
+++ b/src/adapt/cssstyler.js
@@ -256,29 +256,31 @@ adapt.cssstyler.Styler.prototype.postprocessTopStyle = function(elemStyle, isBod
 			}
 		}
 	}
-    var fontSize = elemStyle["font-size"];
-    if (fontSize) {
-        var val = fontSize.evaluate(this.context);
-        var px = val.num;
-        switch (val.unit) {
-            case "em":
-            case "rem":
-                px *= this.context.initialFontSize;
-                break;
-            case "ex":
-            case "rex":
-                px *= this.context.initialFontSize * adapt.expr.defaultUnitSizes["ex"] / adapt.expr.defaultUnitSizes["em"];
-                break;
-            case "%":
-                px *= this.context.initialFontSize / 100;
-                break;
-            default:
-                var unitSize = adapt.expr.defaultUnitSizes[val.unit];
-                if (unitSize) {
-                    px *= unitSize;
-                }
+    if (!isBody) {
+        var fontSize = elemStyle["font-size"];
+        if (fontSize) {
+            var val = fontSize.evaluate(this.context);
+            var px = val.num;
+            switch (val.unit) {
+                case "em":
+                case "rem":
+                    px *= this.context.initialFontSize;
+                    break;
+                case "ex":
+                case "rex":
+                    px *= this.context.initialFontSize * adapt.expr.defaultUnitSizes["ex"] / adapt.expr.defaultUnitSizes["em"];
+                    break;
+                case "%":
+                    px *= this.context.initialFontSize / 100;
+                    break;
+                default:
+                    var unitSize = adapt.expr.defaultUnitSizes[val.unit];
+                    if (unitSize) {
+                        px *= unitSize;
+                    }
+            }
+            this.context.rootFontSize = px;
         }
-        this.context.rootFontSize = px;
     }
 };
 


### PR DESCRIPTION
The reference value for `rem` calculation was incorrectly calculated when `font-size` was specified to the `body` element.
