### PR TITLE
Don't pass some properties (handled by Vivliostyle) to browsers

### DIFF
--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -1125,6 +1125,18 @@ adapt.vgen.ViewFactory.prototype.addImageFetchers = function(bg) {
 	}
 };
 
+/**
+ * @const
+ */
+adapt.vgen.propertiesNotPassedToDOM = {
+	"box-decoration-break": true,
+	"flow-into": true,
+	"flow-linger": true,
+	"flow-priority": true,
+	"flow-options": true,
+	"page": true,
+	"float-reference": true
+};
 
 /**
  * @param {Element} target
@@ -1137,6 +1149,9 @@ adapt.vgen.ViewFactory.prototype.applyComputedStyles = function(target, computed
 	}
 	var isRelativePositioned = computedStyle["position"] === adapt.css.ident.relative;
 	for (var propName in computedStyle) {
+		if (adapt.vgen.propertiesNotPassedToDOM[propName]) {
+			continue;
+		}
 		var value = computedStyle[propName];
 		if (adapt.vtree.delayedProps[propName] ||
 			(isRelativePositioned && adapt.vtree.delayedPropsIfRelativePositioned[propName])) {


### PR DESCRIPTION
This is to address a side effect of #215.
Some properties related to CSS Regions, CSS Paged Media etc. are handled by Vivliostyle and should not be passed directly to elements in the view DOM, since layout may be broken if the browser supports these features.
