### PR TITLE
Bug fix: avoid error when `elementStyle` contains `_regions` key

### DIFF
--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2609,11 +2609,10 @@ adapt.csscasc.CascadeInstance.prototype.pushElement = function(element, baseStyl
 */
 adapt.csscasc.CascadeInstance.prototype.applyAttrFilterInner = function(visitor, elementStyle) {
     for (var propName in elementStyle) {
-        if (propName === "_pseudos")
-            continue;
-        elementStyle[propName] = elementStyle[propName].filterValue(visitor);
+        if (adapt.csscasc.isPropName(propName))
+            elementStyle[propName] = elementStyle[propName].filterValue(visitor);
     }
-}
+};
 /**
 * @private
 * @return {void}


### PR DESCRIPTION
Fix a bug in code introduced in #234.
`elementStyle` can have a key not corresponding to a property, other than `_pseudos`, e.g. `_regions`.
`adapt.csscasc.isPropName` is the proper method to see whether the key corresponds to a property or not.
