### PR TITLE
Avoid error when an element with pseudoelements overflows its container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/issues/232>
 - Fix layout when a float is wider than its containing block
   - <https://github.com/vivliostyle/vivliostyle.js/issues/233>
+- Avoid error when an element with pseudoelements overflows its container
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/241>
 
 ## [2016.4](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.4) - 2016-04-08
 

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1925,7 +1925,7 @@ adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
  * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.skipTailEdges = function(nodeContext) {
-	var resultNodeContext = nodeContext;
+	var resultNodeContext = nodeContext.copy();
 	var self = this;
 	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
 		= adapt.task.newFrame("skipEdges");


### PR DESCRIPTION
Since `nodeContext` can be modified inside `skipTailEdges` method, it should be copied beforehand.
