### PR TITLE
Defer overflown footnote

### DIFF
--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -812,6 +812,15 @@ adapt.layout.Column.prototype.layoutFootnoteInner = function(boxOffset, footnote
     initResult.then(function() {
 		footnoteArea.layout(footnotePosition).then(function(footnoteOverflowParam) {
 			var footnoteOverflow = /** @type {adapt.vtree.ChunkPosition} */ (footnoteOverflowParam);
+			// If the footnote overflows, defer it to the next column entirely.
+			// TODO: Possibility of infinite loops?
+			if (footnoteOverflow) {
+				self.element.removeChild(footnoteArea.element);
+				self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
+				self.footnoteArea = null;
+				frame.finish(true);
+				return;
+			}
 			if (self.vertical) {
 				self.footnoteEdge = self.afterEdge + (footnoteArea.computedBlockSize
 						+ footnoteArea.getInsetLeft() + footnoteArea.getInsetRight());

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -814,7 +814,7 @@ adapt.layout.Column.prototype.layoutFootnoteInner = function(boxOffset, footnote
 			var footnoteOverflow = /** @type {adapt.vtree.ChunkPosition} */ (footnoteOverflowParam);
 			// If the footnote overflows, defer it to the next column entirely.
 			// TODO: Possibility of infinite loops?
-			if (footnoteOverflow) {
+			if (firstFootnoteInColumn && footnoteOverflow) {
 				self.element.removeChild(footnoteArea.element);
 				self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
 				self.footnoteArea = null;


### PR DESCRIPTION
Defer a footnote to the next column entirely when it is the first footnote of the column and does not fit in the current column.
**TODO**: This may lead to infinite loops in some (probably rare) cases.
