### PR TITLE
Fix internal hyperlinks in output PDF

### DIFF
--- a/src/adapt/base.js
+++ b/src/adapt/base.js
@@ -104,6 +104,30 @@ adapt.base.resolveURL = function(relURL, baseURL) {
     return url.replace(/\/(\.\/)+/g, '/');
 };
 
+/**
+ * @interface
+ */
+adapt.base.DocumentURLTransformer = function() {};
+
+/**
+ * @param {string} fragment
+ * @param {string} baseURL
+ * @returns {string}
+ */
+adapt.base.DocumentURLTransformer.prototype.transformFragment = function(fragment, baseURL) {};
+
+/**
+ * @param {string} url
+ * @param {string} baseURL
+ * @returns {string}
+ */
+adapt.base.DocumentURLTransformer.prototype.transformURL = function(url, baseURL) {};
+
+/**
+ * @param {string} encoded
+ * @returns {!Array<string>}
+ */
+adapt.base.DocumentURLTransformer.prototype.restoreURL = function(encoded) {};
 
 /**
  * Various namespaces.

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -148,6 +148,7 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @param {adapt.vgen.CustomRenderer} customRenderer
  * @param {Object.<string,string>} fallbackMap
  * @param {number} pageNumberOffset
+ * @param {!adapt.base.DocumentURLTransformer} documentURLTransformer
  * @constructor
  * @extends {adapt.expr.Context}
  * @implements {adapt.cssstyler.FlowListener}
@@ -155,7 +156,7 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @implements {adapt.vgen.StylerProducer}
  */
 adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientLayout, 
-		fontMapper, customRenderer, fallbackMap, pageNumberOffset) {
+		fontMapper, customRenderer, fallbackMap, pageNumberOffset, documentURLTransformer) {
 	adapt.expr.Context.call(this, style.rootScope, viewport.width, viewport.height, viewport.fontSize);
 	/** @const */ this.style = style;
 	/** @const */ this.xmldoc = xmldoc;
@@ -180,6 +181,7 @@ adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientL
     /** @const */ this.customRenderer = customRenderer;
     /** @const */ this.fallbackMap = fallbackMap;
 	/** @const @type {number} */ this.pageNumberOffset = pageNumberOffset;
+	/** @const */ this.documentURLTransformer = documentURLTransformer;
     for (var flowName in style.flowProps) {
     	var flowStyle = style.flowProps[flowName];
     	var consume = adapt.csscasc.getProp(flowStyle, "flow-consume");
@@ -657,7 +659,7 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
         var layoutContext = new adapt.vgen.ViewFactory(flowNameStr, self,
                 self.viewport, self.styler, regionIds, self.xmldoc, self.faces,
                 self.style.footnoteProps, self, page, self.customRenderer,
-                self.fallbackMap, pageFloatHolder);
+                self.fallbackMap, pageFloatHolder, this.documentURLTransformer);
         var columnIndex = 0;
         var region = null;
         frame.loopWithFrame(function(loopFrame) {

--- a/src/adapt/toc.js
+++ b/src/adapt/toc.js
@@ -30,11 +30,12 @@ adapt.toc.bulletEmpty = "\u25B9";
  * @param {adapt.expr.Preferences} pref
  * @param {adapt.vgen.CustomRendererFactory} rendererFactory
  * @param {Object.<string,string>} fallbackMap
+ * @param {!adapt.base.DocumentURLTransformer} documentURLTransformer
  * @constructor
  * @implements {adapt.vgen.CustomRendererFactory}
  */
 adapt.toc.TOCView = function(store, url, lang, clientLayout, fontMapper, pref,
-		rendererFactory, fallbackMap) {
+		rendererFactory, fallbackMap, documentURLTransformer) {
 	/** @const */ this.store = store;
 	/** @const */ this.url = url;
 	/** @const */ this.lang = lang;	
@@ -43,6 +44,7 @@ adapt.toc.TOCView = function(store, url, lang, clientLayout, fontMapper, pref,
 	/** @const */ this.pref = adapt.expr.clonePreferences(pref);
 	/** @const */ this.rendererFactory = rendererFactory;
 	/** @const */ this.fallbackMap = fallbackMap;
+	/** @const */ this.documentURLTransformer = documentURLTransformer;
 	/** @type {adapt.vtree.Page} */ this.page = null;
 	/** @type {adapt.ops.StyleInstance} */ this.instance = null;
 };
@@ -174,7 +176,8 @@ adapt.toc.TOCView.prototype.showTOC = function(elem, viewport, width, height, fo
     				viewportSize.width, viewportSize.height);
     	var customRenderer = self.makeCustomRenderer(xmldoc);
         var instance = new adapt.ops.StyleInstance(style, xmldoc, self.lang,
-        		viewport, self.clientLayout, self.fontMapper, customRenderer, self.fallbackMap, 0);
+        		viewport, self.clientLayout, self.fontMapper, customRenderer, self.fallbackMap, 0,
+        		self.documentURLTransformer);
         self.instance = instance;
         instance.pref = self.pref;
         instance.init().then(function() {

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -799,10 +799,10 @@ adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnfor
 			                continue; // don't propagate JavaScript code
 			            if (attributeName == "style")
 			                continue; // we do styling ourselves
-			            if (attributeName == "id") {
+			            if (attributeName == "id" || attributeName == "name") {
 			            	// Propagate transformed ids and collect them on the page.
 							attributeValue = self.documentURLTransformer.transformFragment(attributeValue, self.xmldoc.url);
-							result.setAttribute("id", attributeValue);
+							result.setAttribute(attributeName, attributeValue);
 			            	self.page.registerElementWithId(result, attributeValue);
 			            	continue;
 			            }

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -787,7 +787,7 @@ adapt.viewer.Viewer.prototype.initEmbed = function (cmd) {
         var scheduler = adapt.task.currentTask().getScheduler();
         viewer.hyperlinkListener = function(evt) {
     		var hrefEvent = /** @type {adapt.vtree.PageHyperlinkEvent} */ (evt);
-            var internal = viewer.packageURL.some(function(url) {
+            var internal = hrefEvent.href.charAt(0) === "#" || viewer.packageURL.some(function(url) {
                 return hrefEvent.href.substr(0, url.length) == url;
             });
     		var msg = {"t":"hyperlink", "href":hrefEvent.href, "internal": internal};


### PR DESCRIPTION
Internal hyperlinks did not work in output PDF since IDs on elements were dropped during layout.
To address this issue, such an element is attached a transformed ID, which is given by combining the URL of the document HTML and the original ID and then encoding it by `encodeURIComponent`. This transformation is introduced to keep uniqueness of IDs when there are multple input HTML files (e.g. EPUB).
`href` attribute of an `a` element is also transformed in the same way so that internal hyperlinks in output PDF work correctly.
Logic for page navigation of JS Viewer is also modified.

Resolves #178.
