### PR TITLE
Update OS versions used on CI; do not run 'floats-141' reftest on CI

### DIFF
--- a/build/wpt-sauce.sh
+++ b/build/wpt-sauce.sh
@@ -34,4 +34,4 @@ pip install -e wptrunner
 pip install -r wptrunner/requirements_sauce.txt
 
 # run tests
-wptrunner --metadata=csswg-test/vivliostyle.js/test/wpt/metadata --tests=csswg-test --product=sauceconnect --ssl-type=none --run-vivliostyle --log-mach - --sauce-config=csswg-test/vivliostyle.js/test/wpt/sauce.ini --processes=2 --no-pause-after-test
+wptrunner --metadata=csswg-test/vivliostyle.js/test/wpt/metadata --tests=csswg-test --product=sauceconnect --ssl-type=none --run-vivliostyle --log-mach - --sauce-config=csswg-test/vivliostyle.js/test/wpt/sauce.ini --processes=4 --no-pause-after-test

--- a/test/conf/karma-sauce.conf.js
+++ b/test/conf/karma-sauce.conf.js
@@ -35,7 +35,8 @@ module.exports = function(config) {
         captureTimeout: 120000,
         customLaunchers: customLaunchers,
         browsers: Object.keys(customLaunchers),
-        singleRun: true
+        singleRun: true,
+        concurrency: 4
     };
     for (var key in commonConfig) {
         if (commonConfig.hasOwnProperty(key)) {

--- a/test/conf/karma-sauce.conf.js
+++ b/test/conf/karma-sauce.conf.js
@@ -4,22 +4,22 @@ module.exports = function(config) {
         sl_chrome: {
             base: "SauceLabs",
             browserName: "chrome",
-            platform: "Windows 8.1"
+            platform: "Windows 10"
         },
-        //sl_firefox: {
-        //    base: "SauceLabs",
-        //    browserName: "firefox",
-        //    platform: "Windows 8.1"
-        //},
+        sl_firefox: {
+           base: "SauceLabs",
+           browserName: "firefox",
+           platform: "Windows 10"
+        },
         sl_safari: {
             base: "SauceLabs",
             browserName: "safari",
-            platform: "OS X 10.10"
+            platform: "OS X 10.11"
         },
         sl_ie_11: {
             base: "SauceLabs",
             browserName: "internet explorer",
-            platform: "Windows 8.1"
+            platform: "Windows 10"
         }
     };
 

--- a/test/wpt/metadata/MANIFEST.json
+++ b/test/wpt/metadata/MANIFEST.json
@@ -576,13 +576,6 @@
         "url": "/css21/floats-clear/floats-139.xht"
       },
       {
-        "path": "css21/floats-clear/floats-141.xht",
-        "references": [
-          ["/css21/floats-clear/floats-141-ref.xht", "=="]
-        ],
-        "url": "/css21/floats-clear/floats-141.xht"
-      },
-      {
         "path": "css21/floats-clear/floats-144.xht",
         "references": [
           ["/css21/floats-clear/floats-144-ref.xht", "=="]

--- a/test/wpt/metadata/MANIFEST_failing.json
+++ b/test/wpt/metadata/MANIFEST_failing.json
@@ -349,6 +349,13 @@
         "url": "/css21/floats-clear/floats-136.xht"
       },
       {
+        "path": "css21/floats-clear/floats-141.xht",
+        "references": [
+          ["/css21/floats-clear/floats-141-ref.xht", "=="]
+        ],
+        "url": "/css21/floats-clear/floats-141.xht"
+      },
+      {
         "path": "css21/floats-clear/floats-142.xht",
         "references": [
           ["/css21/floats-clear/floats-142-ref.xht", "=="]

--- a/test/wpt/sauce.ini
+++ b/test/wpt/sauce.ini
@@ -5,5 +5,5 @@ prerun_executable = https://raw.githubusercontent.com/vivliostyle/vivliostyle.js
 
 [browser]
 name = chrome
-platform = Windows 8.1
+platform = Windows 10
 version =


### PR DESCRIPTION
- OS versions used on Sauce Labs are updated to Windows 10 and OS X 10.11.
- Enable Firefox in unit tests once again, since vertical writing mode is already shipped in the latest stable version of Firefox (see ef9461cc07502acd3063446baa301c9e28d1a9a6)
- Move 'floats-141' reftest to the list of failing tests, for it fails on Chrome 51 on Windows 10 probably due to uncontrollable errors in layout calculation.
