### PR TITLE
Support box-decoration-break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Support cross references by `target-counter()`/`target-counters()`
   - <https://github.com/vivliostyle/vivliostyle.js/pull/248>
   - Spec: [CSS Generated Content Module Level 3 - Cross references and the target-* functions](https://drafts.csswg.org/css-content/#cross-references)
+- Support `box-decoration-break` property
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/250>
+  - Spec: [CSS Fragmentation Module Level 3 - Fragmented Borders and Backgrounds: the box-decoration-break property](https://drafts.csswg.org/css-break/#break-decoration)
 
 ### Fixed
 - Fix a bug that `clear` is ignored when `white-space` property is used before the element
@@ -39,6 +42,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/issues/233>
 - Avoid error when an element with pseudoelements overflows its container
   - <https://github.com/vivliostyle/vivliostyle.js/pull/241>
+- Fix handling of padding and border of a block fragmented by a page/column break
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/250>
 
 ## [2016.4](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.4) - 2016-04-08
 

--- a/doc/supported-features.md
+++ b/doc/supported-features.md
@@ -703,10 +703,8 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
 
 - [break-after](https://www.w3.org/TR/css3-break/#propdef-break-after)
   - Supported in all browsers
-  - Note: behavior when multiple forced break values coincide at a single break point is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/129)
 - [break-before](https://www.w3.org/TR/css3-break/#propdef-break-before)
   - Supported in all browsers
-  - Note: behavior when multiple forced break values coincide at a single break point is not compliant to the spec. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/129)
 - [break-inside](https://www.w3.org/TR/css3-multicol/#break-inside)
   - Supported in all browsers
   - Note: All of `avoid-page`, `avoid-column` and `avoid-region` values are treated as if they were `avoid`. [[Issue]](https://github.com/vivliostyle/vivliostyle.js/issues/128)
@@ -714,6 +712,10 @@ Properties where <quote>Allowed prefixes</quote> is indicated may be used with a
   - Supported in all browsers
 - [widows](https://www.w3.org/TR/css3-break/#propdef-widows)
   - Supported in all browsers
+- [box-decoration-break](https://www.w3.org/TR/css3-break/#propdef-box-decoration-break)
+  - Allowed prefixes: webkit
+  - Supported in all browsers
+  - Note: Background, box-shadow and border images on inline-start/end borders are always rendered as if `box-decoration-break: clone` is specified.
 
 ### [CSS Transforms 1](https://www.w3.org/TR/css-transforms-1/)
 

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1641,7 +1641,7 @@ adapt.layout.Column.prototype.finishBreak = function(nodeContext, forceRemoveSel
     this.clearOverflownViewNodes(nodeContext, removeSelf);
     if (endOfRegion) {
 		this.fixJustificationIfNeeded(nodeContext, true);
-		this.layoutContext.processFragmentedBlockEdge(nodeContext);
+		this.layoutContext.processFragmentedBlockEdge(removeSelf ? nodeContext : nodeContext.parent);
 	}
     return this.clearFootnotes(nodeContext.boxOffset);	
 };

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1639,8 +1639,10 @@ adapt.layout.Column.prototype.findEdgeBreakPosition = function(bp) {
 adapt.layout.Column.prototype.finishBreak = function(nodeContext, forceRemoveSelf, endOfRegion) {
 	var removeSelf = forceRemoveSelf || (nodeContext.viewNode != null && nodeContext.viewNode.nodeType == 1 && !nodeContext.after);
     this.clearOverflownViewNodes(nodeContext, removeSelf);
-    if (endOfRegion)
-    	this.fixJustificationIfNeeded(nodeContext, true);
+    if (endOfRegion) {
+		this.fixJustificationIfNeeded(nodeContext, true);
+		this.layoutContext.processFragmentedBlockEdge(nodeContext);
+	}
     return this.clearFootnotes(nodeContext.boxOffset);	
 };
 

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1592,16 +1592,14 @@ adapt.layout.Column.prototype.findBoxBreakPosition = function(bp, force) {
 
 	// In case of box-decoration-break: clone, width (or height in vertical writing mode) of cloned paddings and borders should be taken into account.
 	var clonedPaddingBorder = 0;
-	var isBlockVertical = block ? block.vertical : false;
-	while (block && block.vertical === isBlockVertical) {
+	while (block) {
 		if (!block.inline && block.inheritedProps["box-decoration-break"] === "clone") {
 			goog.asserts.assert(block.viewNode instanceof Element);
 			var paddingBorders = this.getComputedPaddingBorder(block.viewNode);
-			clonedPaddingBorder += isBlockVertical ? -paddingBorders.left : paddingBorders.bottom;
+			clonedPaddingBorder += block.vertical ? -paddingBorders.left : paddingBorders.bottom;
 		}
 		if (block.establishesBFC)
 			break;
-		isBlockVertical = block.vertical;
 		block = block.parent;
 	}
 

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1592,16 +1592,13 @@ adapt.layout.Column.prototype.findBoxBreakPosition = function(bp, force) {
 
 	// In case of box-decoration-break: clone, width (or height in vertical writing mode) of cloned paddings and borders should be taken into account.
 	var clonedPaddingBorder = 0;
-	while (block) {
-		if (!block.inline && block.inheritedProps["box-decoration-break"] === "clone") {
+	block.walkBlocksUpToBFC(function(block) {
+		if (block.inheritedProps["box-decoration-break"] === "clone") {
 			goog.asserts.assert(block.viewNode instanceof Element);
-			var paddingBorders = this.getComputedPaddingBorder(block.viewNode);
+			var paddingBorders = self.getComputedPaddingBorder(block.viewNode);
 			clonedPaddingBorder += block.vertical ? -paddingBorders.left : paddingBorders.bottom;
 		}
-		if (block.establishesBFC)
-			break;
-		block = block.parent;
-	}
+	});
 
 	// Select the first overflowing line break position
 	var linePositions = this.findLinePositions(checkPoints);

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -27,7 +27,9 @@ adapt.vgen.frontEdgeBlackListHor = {
     "padding-top": "0px",
     "border-top-width": "0px",
     "border-top-style": "none",
-    "border-top-color": "transparent"
+    "border-top-color": "transparent",
+	"border-top-left-radius": "0px",
+	"border-top-right-radius": "0px"
 };
 
 /**
@@ -41,7 +43,9 @@ adapt.vgen.frontEdgeBlackListVert = {
     "padding-right": "0px",
     "border-right-width": "0px",
     "border-right-style": "none",
-    "border-right-color": "transparent"
+    "border-right-color": "transparent",
+	"border-top-right-radius": "0px",
+	"border-bottom-right-radius": "0px"
 };
 
 /**
@@ -1314,9 +1318,13 @@ adapt.vgen.ViewFactory.prototype.processFragmentedBlockEdge = function(nodeConte
 			if (block.vertical) {
 				adapt.base.setCSSProperty(elem, "padding-left", "0");
 				adapt.base.setCSSProperty(elem, "border-left", "none");
+				adapt.base.setCSSProperty(elem, "border-top-left-radius", "0");
+				adapt.base.setCSSProperty(elem, "border-bottom-left-radius", "0");
 			} else {
 				adapt.base.setCSSProperty(elem, "padding-bottom", "0");
 				adapt.base.setCSSProperty(elem, "border-bottom", "none");
+				adapt.base.setCSSProperty(elem, "border-bottom-left-radius", "0");
+				adapt.base.setCSSProperty(elem, "border-bottom-right-radius", "0");
 			}
 		}
 	});

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -577,7 +577,12 @@ adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnfor
 		var floatReference = computedStyle["float-reference"];
 	    var floatSide = computedStyle["float"];
 	    var clearSide = computedStyle["clear"];
-		self.nodeContext.establishesBFC = vivliostyle.display.establishesBFC(display, position, floatSide, computedStyle["overflow"]);
+		var writingMode = self.nodeContext.vertical ? adapt.css.ident.vertical_rl : adapt.css.ident.horizontal_tb;
+		var parentWritingMode = self.nodeContext.parent ?
+			(self.nodeContext.parent.vertical ? adapt.css.ident.vertical_rl : adapt.css.ident.horizontal_tb) :
+			writingMode;
+		self.nodeContext.establishesBFC = vivliostyle.display.establishesBFC(display, position, floatSide,
+			computedStyle["overflow"], writingMode, parentWritingMode);
 		self.nodeContext.containingBlockForAbsolute = vivliostyle.display.establishesCBForAbsolute(position);
 	    if (self.nodeContext.isInsideBFC()) {
 			// When the element is already inside a block formatting context (except one from the root),

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -871,7 +871,8 @@ adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnfor
 			self.applyComputedStyles(result, computedStyle);
 		    var widows = computedStyle["widows"];
 		    var orphans = computedStyle["orphans"];
-		    if (widows || orphans) {
+			var boxDecorationBreak = computedStyle["box-decoration-break"];
+		    if (widows || orphans || boxDecorationBreak) {
 		    	if (self.nodeContext.parent) {
 			    	self.nodeContext.inheritedProps = {};
 			    	for (var n in self.nodeContext.parent.inheritedProps) {
@@ -884,11 +885,19 @@ adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnfor
 		    	if (orphans instanceof adapt.css.Int) {
 		    		self.nodeContext.inheritedProps["orphans"] = (/** @type {adapt.css.Int} */ (orphans)).num;
 		    	}
+				if (boxDecorationBreak instanceof adapt.css.Ident) {
+					self.nodeContext.inheritedProps["box-decoration-break"] = (/** @type {adapt.css.Ident} */ (boxDecorationBreak)).name;
+				}
 		    }
 			if (!self.nodeContext.inline) {
 				var blackList = null;
 				if (!firstTime) {
-					blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeBlackListVert : adapt.vgen.frontEdgeBlackListHor;
+					if (boxDecorationBreak !== adapt.css.getName("clone")) {
+						blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeBlackListVert : adapt.vgen.frontEdgeBlackListHor;
+					} else {
+						// When box-decoration-break: clone, cloned margins are always truncated to zero.
+						blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeUnforcedBreakBlackListVert : adapt.vgen.frontEdgeUnforcedBreakBlackListHor;
+					}
 				} else if (atUnforcedBreak) {
 					blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeUnforcedBreakBlackListVert : adapt.vgen.frontEdgeUnforcedBreakBlackListHor;
 				}

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -1303,6 +1303,26 @@ adapt.vgen.ViewFactory.prototype.applyFootnoteStyle = function(vertical, target)
 };
 
 /**
+ * @override
+ */
+adapt.vgen.ViewFactory.prototype.processFragmentedBlockEdge = function(nodeContext) {
+	nodeContext.walkBlocksUpToBFC(function(block) {
+		var boxDecorationBreak = block.inheritedProps["box-decoration-break"];
+		if (!boxDecorationBreak || boxDecorationBreak === "slice") {
+			var elem = block.viewNode;
+			goog.asserts.assert(elem instanceof Element);
+			if (block.vertical) {
+				adapt.base.setCSSProperty(elem, "padding-left", "0");
+				adapt.base.setCSSProperty(elem, "border-left", "none");
+			} else {
+				adapt.base.setCSSProperty(elem, "padding-bottom", "0");
+				adapt.base.setCSSProperty(elem, "border-bottom", "none");
+			}
+		}
+	});
+};
+
+/**
  * Returns if two NodePositionStep are equivalent.
  * @param {!adapt.vtree.NodePositionStep} step1
  * @param {!adapt.vtree.NodePositionStep} step2

--- a/src/adapt/vtree.js
+++ b/src/adapt/vtree.js
@@ -487,6 +487,12 @@ adapt.vtree.LayoutContext.prototype.applyFootnoteStyle = function(vertical, elem
 adapt.vtree.LayoutContext.prototype.peelOff = function(nodeContext, nodeOffset) {};
 
 /**
+ * Process a block-end edge of a fragmented block.
+ * @param {adapt.vtree.NodeContext} nodeContext
+ */
+adapt.vtree.LayoutContext.prototype.processFragmentedBlockEdge = function(nodeContext) {};
+
+/**
  * Returns if two NodePositions represents the same position in the document.
  * @param {!adapt.vtree.NodePosition} nodePosition1
  * @param {!adapt.vtree.NodePosition} nodePosition2

--- a/src/adapt/vtree.js
+++ b/src/adapt/vtree.js
@@ -835,6 +835,23 @@ adapt.vtree.NodeContext.prototype.getContainingBlockForAbsolute = function() {
 };
 
 /**
+ * Walk up NodeContext tree (starting from itself) and call the callback for each block,
+ * until a NodeContext which establishes a block formatting context is reached.
+ * @param {!function(!adapt.vtree.NodeContext)} callback
+ */
+adapt.vtree.NodeContext.prototype.walkBlocksUpToBFC = function(callback) {
+	var nodeContext = this;
+	while (nodeContext) {
+		if (!nodeContext.inline) {
+			callback(nodeContext);
+		}
+		if (nodeContext.establishesBFC)
+			break;
+		nodeContext = nodeContext.parent;
+	}
+};
+
+/**
  * @param {adapt.vtree.NodePosition} primary
  * @constructor
  */

--- a/src/vivliostyle/display.js
+++ b/src/vivliostyle/display.js
@@ -99,13 +99,18 @@ goog.scope(function() {
      * @param {adapt.css.Ident} position
      * @param {adapt.css.Ident} float
      * @param {adapt.css.Ident} overflow
+     * @param {adapt.css.Ident=} writingMode
+     * @param {adapt.css.Ident=} parentWritingMode
      * @returns {boolean}
      */
-    vivliostyle.display.establishesBFC = function(display, position, float, overflow) {
+    vivliostyle.display.establishesBFC = function(display, position, float, overflow, writingMode, parentWritingMode) {
+        writingMode = writingMode || parentWritingMode || adapt.css.ident.horizontal_tb;
         return (!!float && float !== adapt.css.ident.none) ||
             vivliostyle.display.isAbsolutelyPositioned(position) ||
             (display === adapt.css.ident.inline_block || display === adapt.css.ident.table_cell || display === adapt.css.ident.table_caption) ||
-            ((display === adapt.css.ident.block || display === adapt.css.ident.list_item ) && !!overflow && overflow !== adapt.css.ident.visible);
+            ((display === adapt.css.ident.block || display === adapt.css.ident.list_item ) &&
+                (!!overflow && overflow !== adapt.css.ident.visible) ||
+                (!!parentWritingMode && writingMode !== parentWritingMode));
     };
 
     /**

--- a/test/files/box-decoration-break.html
+++ b/test/files/box-decoration-break.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>box-decoration-break</title>
+    <style>
+        @page {
+        }
+        @-epubx-page-template {
+            @-epubx-page-master {
+                -epubx-page: 1;
+                @-epubx-partition {
+                    -epubx-flow-from: body;
+                    column-count: 3;
+                    column-gap: 10px;
+                    column-rule: 1px solid black;
+                    width: 620px;
+                    height: 300px;
+                    border: 2px solid blue;
+                    margin: 30px;
+                    overflow: visible;
+                }
+            }
+            @-epubx-page-master {
+                -epubx-page: 2;
+                @-epubx-partition {
+                    -epubx-flow-from: body;
+                    column-count: 3;
+                    column-gap: 10px;
+                    column-rule: 1px solid black;
+                    writing-mode: vertical-rl;
+                    width: 300px;
+                    height: 620px;
+                    border: 2px solid blue;
+                    margin: 30px;
+                    overflow: visible;
+                }
+            }
+        }
+
+        * {
+            margin: 0;
+        }
+        html {
+            widows: 1;
+            orphans: 1;
+            line-height: 25px;
+        }
+        section {
+            page-break-after: always;
+        }
+        section.vertical {
+            writing-mode: vertical-rl;
+        }
+        div {
+            margin: 10px;
+            border: 3px solid green;
+            padding: 3px;
+        }
+        .horizontal div {
+            margin-bottom: 20px;
+            border-top: 4px solid brown;
+            border-bottom: 6px solid orange;
+            padding-top: 10px;
+            padding-bottom: 15px;
+            background: linear-gradient(56deg, rgb(0, 255, 94), rgb(255, 255, 250) 77%);
+            box-shadow: 3px 5px 1px gold;
+        }
+        .vertical div {
+            margin-left: 20px;
+            border-right: 4px solid brown;
+            border-left: 6px solid orange;
+            padding-right: 10px;
+            padding-left: 15px;
+            background: linear-gradient(124deg, rgb(0, 255, 94), rgb(255, 255, 250) 77%);
+            box-shadow: -3px 5px 1px gold;
+        }
+        .slice {
+            box-decoration-break: slice;
+        }
+        .clone {
+            box-decoration-break: clone;
+        }
+    </style>
+</head>
+<body>
+<section class="horizontal">
+    <div class="slice">
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+    </div>
+    <div class="clone">
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+    </div>
+</section>
+<section class="vertical">
+    <div class="slice">
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+        box-decoration-break: slice<br>
+    </div>
+    <div class="clone">
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+        box-decoration-break: clone<br>
+    </div>
+</section>
+</body>
+</html>

--- a/test/files/box-decoration-break.html
+++ b/test/files/box-decoration-break.html
@@ -11,10 +11,10 @@
                 -epubx-page: 1;
                 @-epubx-partition {
                     -epubx-flow-from: body;
-                    column-count: 3;
+                    column-count: 4;
                     column-gap: 10px;
                     column-rule: 1px solid black;
-                    width: 620px;
+                    width: 820px;
                     height: 300px;
                     border: 2px solid blue;
                     margin: 30px;
@@ -25,12 +25,12 @@
                 -epubx-page: 2;
                 @-epubx-partition {
                     -epubx-flow-from: body;
-                    column-count: 3;
+                    column-count: 4;
                     column-gap: 10px;
                     column-rule: 1px solid black;
                     writing-mode: vertical-rl;
                     width: 300px;
-                    height: 620px;
+                    height: 820px;
                     border: 2px solid blue;
                     margin: 30px;
                     overflow: visible;
@@ -100,7 +100,12 @@
         box-decoration-break: clone<br>
         box-decoration-break: clone<br>
         box-decoration-break: clone<br>
-        box-decoration-break: clone<br>
+    </div>
+    <div class="slice">
+        (slice) not fragmented, should have bottom padding &amp; border
+    </div>
+    <div class="clone">
+        Another block not fragmented (box-decoration-break: clone)
     </div>
 </section>
 <section class="vertical">
@@ -119,7 +124,12 @@
         box-decoration-break: clone<br>
         box-decoration-break: clone<br>
         box-decoration-break: clone<br>
-        box-decoration-break: clone<br>
+    </div>
+    <div class="slice">
+        (slice) not fragmented, should have left padding &amp; border
+    </div>
+    <div class="clone">
+        Another block not fragmented (box-decoration-break: clone)
     </div>
 </section>
 </body>

--- a/test/files/box-decoration-break.html
+++ b/test/files/box-decoration-break.html
@@ -56,6 +56,7 @@
             margin: 10px;
             border: 3px solid green;
             padding: 3px;
+            border-radius: 10px;
         }
         .horizontal div {
             margin-bottom: 20px;

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -44,6 +44,7 @@
     <li><a href="relative_floats.html">Floats with position: relative</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/relative_floats.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/relative_floats.html">prod</a>]</li>
     <li><a href="target-counter.html">target-counter</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/target-counter.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/target-counter.html">prod</a>]</li>
     <li><a href="exclusion_with_printer_marks.html">Exclusion with printer marks</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/exclusion_with_printer_marks.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/exclusion_with_printer_marks.html">prod</a>]</li>
+    <li><a href="box-decoration-break.html">box-decoration-break</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/box-decoration-break.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/box-decoration-break.html">prod</a>]</li>
 </ul>
 <h2>Page breaks</h2>
 <ul>


### PR DESCRIPTION
- Resolves #180.
- Also fixes handling of padding and border of a block fragmented by a page/column break (with `box-decoration-break: slice`)
- Note: Background, box-shadow and border images on inline-start/end borders are always rendered as if `box-decoration-break: clone` is specified.
