### PR TITLE
Page-based counter operation from a page master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/250>
   - Spec: [CSS Fragmentation Module Level 3 - Fragmented Borders and Backgrounds: the box-decoration-break property](https://drafts.csswg.org/css-break/#break-decoration)
 
+### Changed
+- `counter-reset` and `counter-increment` specified in a page master (`@-epubx-page-master`) are now effective to page-based counters
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/251>
+  - Note that these values, if specified, always override values specified in page contexts.
+
 ### Fixed
 - Fix a bug that `clear` is ignored when `white-space` property is used before the element
   - <https://github.com/vivliostyle/vivliostyle.js/pull/222>

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -1891,17 +1891,27 @@ vivliostyle.page.PageManager.prototype.generatePageRuleMaster = function(style) 
  */
 vivliostyle.page.PageManager.prototype.generateCascadedPageMaster = function(style, pageMaster) {
     var newPageMaster = pageMaster.clone({pseudoName: vivliostyle.page.pageRuleMasterPseudoName});
+    var pageMasterStyle = newPageMaster.specified;
+
     var size = style["size"];
     if (size) {
         var pageSize = vivliostyle.page.resolvePageSizeAndBleed(style);
         var priority = size.priority;
-        newPageMaster.specified["width"] = adapt.csscasc.cascadeValues(
-            this.context, newPageMaster.specified["width"],
+        pageMasterStyle["width"] = adapt.csscasc.cascadeValues(
+            this.context, pageMasterStyle["width"],
             new adapt.csscasc.CascadeValue(pageSize.width, priority));
-        newPageMaster.specified["height"] = adapt.csscasc.cascadeValues(
-            this.context, newPageMaster.specified["height"],
+        pageMasterStyle["height"] = adapt.csscasc.cascadeValues(
+            this.context, pageMasterStyle["height"],
             new adapt.csscasc.CascadeValue(pageSize.height, priority));
     }
+
+    // Transfer counter properties to the page style so that these specified in the page master are
+    // also effective. Note that these values (if specified) always override values in page contexts.
+    ["counter-reset", "counter-increment"].forEach(function(name) {
+        if (pageMasterStyle[name]) {
+            style[name] = pageMasterStyle[name];
+        }
+    });
 
     var pageMasterInstance = newPageMaster.createInstance(this.rootPageBoxInstance);
     // Do the same initialization as in adapt.ops.StyleInstance.prototype.init


### PR DESCRIPTION
`counter-reset` and `counter-increment` specified in a page master (`@-epubx-page-master`) are now effective to page-based counters.

Note that these values, if specified, always override values specified in page contexts.
