### PR TITLE
Support specifying start page number for each source document

### DIFF
--- a/src/vivliostyle/counters.js
+++ b/src/vivliostyle/counters.js
@@ -341,6 +341,19 @@ goog.scope(function() {
     };
 
     /**
+     * Forcefully set the `page` page-based counter to the specified value.
+     * @param {number} pageNumber
+     */
+    vivliostyle.counters.CounterStore.prototype.forceSetPageCounter = function(pageNumber) {
+        var counters = this.currentPageCounters["page"];
+        if (!counters || !counters.length) {
+            this.currentPageCounters["page"] = [pageNumber];
+        } else {
+            counters[counters.length - 1] = pageNumber;
+        }
+    };
+
+    /**
      * Update the page-based counters with 'counter-reset' and 'counter-increment' properties within the page context. Call before starting layout of the page.
      * @param {!adapt.csscasc.ElementStyle} cascadedPageStyle
      * @param {!adapt.expr.Context} context

--- a/test/wpt/wpt.js
+++ b/test/wpt/wpt.js
@@ -30,7 +30,7 @@
 
         var config = {
             "a": "loadXML",
-            "url": docURL,
+            "url": [{"url": docURL, "startPage": null, "skipPagesBefore": null}],
             "autoresize": false,
             "fragment": null,
             "renderAllPages": true,


### PR DESCRIPTION
The first argument of `vivliostyle.viewer.Viewer.prototype.loadDocument` can be an object of the following form (or an array of such objects):

```
{
    url: string,
    startPage: (number|undefined),
    skipPagesBefore: (number|undefined)
}
```

where
- `url`: the URL of the source document.
- `startPage`: If specified, the `page` page-based counter is set to the specified value on the first page of the document. It is equivalent to specifying `counter-reset: page [specified value - 1]` on that page.
- `skipPagesBefore`: If specified, the `page` page-based counter is incremented by the specified value _before_ updating page-based counters on the first page of the document. This option is ignored if `startPageNumber` option is also specified.

A few notes:
- A string or an array of strings are also accepted as before.
- These options affect `:left`/`:right`/`:first` page selectors since they modify not only the `page` counter but also an internal page number counter, which is used by these selectors.
- These options do not modify page-based counters other than `page`.
- The current behavior is suitable for cases where `counter-increment` value of `page` is always 1 and `counter-reset` is never used for `page`. When these assumptions are not met, result may look "strange".
