### PR TITLE
Fix incorrect page breaks with cross references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/268>
 - Respect `target="_blank"` on links to external URLs
   - <https://github.com/vivliostyle/vivliostyle.js/pull/269>
+- Fix incorrect page breaks with cross references
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/271>
 
 ## [2016.7](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.7) - 2016-07-04
 

--- a/build/wpt-sauce.sh
+++ b/build/wpt-sauce.sh
@@ -30,6 +30,8 @@ EOS
 # setup environment
 virtualenv .
 source bin/activate
+pip install --upgrade setuptools
+pip install --upgrade pip
 pip install -e wptrunner
 pip install -r wptrunner/requirements_sauce.txt
 

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1861,12 +1861,6 @@ adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
 					// Non-displayable content, skip
 					break;
 				}
-				if (!self.layoutConstraint.allowLayout(nodeContext)) {
-					nodeContext = nodeContext.modify();
-					nodeContext.overflow = true;
-					loopFrame.breakLoop();
-					return;
-				}
 				if (nodeContext.inline && nodeContext.viewNode.nodeType != 1) {
 					if (adapt.vtree.canIgnore(nodeContext.viewNode, nodeContext.whitespace)) {
 						// Ignorable text content, skip
@@ -1899,7 +1893,7 @@ adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
 						// check if a forced break must occur before the block.
 						if (needForcedBreak()) {
 							processForcedBreak();
-						} else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge)) {
+						} else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge) || !self.layoutConstraint.allowLayout(nodeContext)) {
 							// overflow
 					    	nodeContext = (lastAfterNodeContext || nodeContext).modify();
 					    	nodeContext.overflow = true;
@@ -1950,6 +1944,13 @@ adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
 					// Leading edge
 					leadingEdgeContexts.push(nodeContext.copy());
 					breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
+					if (!self.layoutConstraint.allowLayout(nodeContext)) {
+						self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, false, breakAtTheEdge);
+						nodeContext = nodeContext.modify();
+						nodeContext.overflow = true;
+						loopFrame.breakLoop();
+						return;
+					}
 					var viewTag = nodeContext.viewNode.localName;
 					if (adapt.layout.mediaTags[viewTag]) {
 						// elements that have inherent content

--- a/src/vivliostyle/counters.js
+++ b/src/vivliostyle/counters.js
@@ -598,6 +598,9 @@ goog.scope(function() {
         if (!id) {
             return true;
         }
+        if (!this.counterStore.resolvedReferences[id] && !this.counterStore.unresolvedReferences[id]) {
+            return true;
+        }
         var pageIndex = this.counterStore.pageIndicesById[id];
         if (!pageIndex) {
             return true;

--- a/test/files/target-counter.html
+++ b/test/files/target-counter.html
@@ -35,6 +35,10 @@
             page-break-before: always;
         }
 
+        .ref-page::after {
+            content: target-counter(attr(data-href, url), page);
+        }
+
         .foo {
             counter-increment: foo;
         }
@@ -152,6 +156,10 @@
         #qux-target, #quxx-target {
             border: 1px solid blue;
         }
+
+        #no-reffed-id, #xxx2-target {
+            margin-top: 400px;
+        }
     </style>
 </head>
 <body>
@@ -217,6 +225,19 @@
 
 <section>
     <p>#qux-target is on qux <span class="ref-qux" data-href="#qux-target"></span>. <span id="quxx-target">quxx-target</span></p>
+</section>
+
+<section>
+    <p>#xxx1-target is on page <span class="ref-page" data-href="#xxx1-target"></span>. ← This reference should be "page 17".</p>
+    <p id="no-reffed-id">no-reffed-id</p>
+    <p>#no-reffed-id is on this page (page 17). <span id="xxx1-target">xxx1-target</span></p>
+</section>
+
+<section>
+    <p>#xxx2-target is on page <span class="ref-page" data-href="#xxx2-target"></span>. ← This reference should be "page 19".</p>
+    <p>#xxx3-target is on page <span class="ref-page" data-href="#xxx3-target"></span>. ← This reference should be "page 19".</p>
+    <p id="xxx2-target">xxx2-target</p>
+    <p>#xxx2-target is on this page (page 19). <span id="xxx3-target">xxx3-target</span></p>
 </section>
 </body>
 </html>


### PR DESCRIPTION
- Exclude elements with an id from layout constraint when the elements are not referred by any cross references.
  - An element referred by cross references is under layout constraint that forbiddens it to be laid out on a page before one which it used to be on before the relayout. No such constraint should be imposed on elements which are not referred by any cross references.
- Save appropriate break opportunities before aborting layout due to a layout constraint.
