### PR TITLE
Fix cross reference bug with name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/275>
 - Fix image-resolution to take box-sizing into account
   - <https://github.com/vivliostyle/vivliostyle.js/issues/276>
+- Fix cross reference bug with name attribute
+  - <https://github.com/vivliostyle/vivliostyle.js/issues/278>
 
 ## [2016.7](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.7) - 2016-07-04
 

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -2707,7 +2707,7 @@ adapt.csscasc.CascadeInstance.prototype.pushElement = function(element, baseStyl
     	}
     }
     this.pushCounters(this.currentStyle);
-	var id = this.currentId || this.currentXmlId || "";
+	var id = this.currentId || this.currentXmlId || element.getAttribute("name") || "";
 	if (isRoot || id) {
 		/** @type {!Object<string, Array<number>>} */ var counters = {};
 		Object.keys(this.counters).forEach(function(name) {


### PR DESCRIPTION
A cross reference by target-counter was not resolved when the target element has `name` attribute but not `id` attribute.
