### PR TITLE
Introduce ESLint; fix indentation and white spacing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+
+[*.js]
+indent_size= 4
+trim_trailing_whitespace = true

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+src/wrapper.js
+src/closure

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,245 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "jasmine": true
+    },
+    "globals": {
+        "adapt": false,
+        "goog": false,
+        "vivliostyle": false
+    },
+    // "extends": "eslint:recommended",
+    "rules": {
+        // Possible Errors
+        // (in recommended)
+        // "no-constant-condition": [
+        //     "error",
+        //     {
+        //         "checkLoops": false
+        //     }
+        // ],
+        // "no-inner-declarations": [
+        //     "error",
+        //     "functions"
+        // ],
+        // (not in recommended)
+        // "no-extra-parens": "off",
+        // "no-prototype-builtins": "off",
+        // "no-template-curly-in-string": "error",
+        // "no-unsafe-negation": "error",
+        // "valid-jsdoc": "off",
+
+        // Best Practices
+        // (not in recommended)
+        // "accessor-pairs": "error",
+        // "array-callback-return": "error",
+        // "block-scoped-var": "off",
+        // "complexity": "off",
+        // "consistent-return": "error",
+        // "curly": "off",
+        // "default-case": "off",
+        // "dot-location": [
+        //     "error",
+        //     "property"
+        // ],
+        // "dot-notation": "off",
+        // "eqeqeq": "off",
+        // "guard-for-in": "off",
+        // "no-alert": "error",
+        // "no-caller": "error",
+        // "no-div-regex": "error",
+        // "no-else-return": "off",
+        // "no-empty-function": "off",
+        // "no-eq-null": "off",
+        // "no-eval": "error",
+        // "no-extend-native": "error",
+        // "no-extra-bind": "error",
+        // "no-extra-label": "error",
+        // "no-floating-decimal": "error",
+        // "no-global-assign": "error",
+        // "no-implicit-globals": "off",
+        // "no-implied-eval": "error",
+        // "no-invalid-this": "error",
+        // "no-iterator": "error",
+        // "no-labels": [
+        //     "error",
+        //     {
+        //         "allowLoop": true,
+        //         "allowSwitch": true
+        //     }
+        // ],
+        // "no-lone-blocks": "error",
+        // "no-loop-func": "off",
+        // "no-magic-numbers": "off",
+        // "no-multi-spaces": "off",
+        // "no-multi-str": "error",
+        // "no-new-func": "error",
+        // "no-new-wrappers": "error",
+        // "no-new": "error",
+        // "no-octal-escape": "error",
+        // "no-param-reassign": "off",
+        // "no-proto": "error",
+        // "no-return-assign": "off",
+        // "no-script-url": "error",
+        // "no-self-compare": "error",
+        // "no-sequences": "off",
+        // "no-throw-literal": "off",
+        // "no-unmodified-loop-condition": "off",
+        // "no-unused-expressions": "off",
+        // "no-useless-call": "error",
+        // "no-useless-concat": "error",
+        // "no-useless-escape": "off",
+        // "no-void": "error",
+        // "no-warning-comments": "off",
+        // "no-with": "error",
+        // "radix": [
+        //     "error",
+        //     "always"
+        // ],
+        // "vars-on-top": "off",
+
+        // Strict Mode
+        // (not in recommended)
+        // "strict": "off",
+
+        // Variables
+        // (not in recommended)
+        // "init-declarations": "off",
+        // "no-catch-shadow": "error",
+        // "no-label-var": "error",
+        // "no-restricted-globals": "error",
+        // "no-shadow-restricted-names": "error",
+        // "no-shadow": "off",
+        // "no-undef-init": "error",
+        // "no-undefined": "off",
+        // "no-use-before-define": "off",
+
+        // Node.js and CommonJS
+        // (not in recommended)
+        // "callback-return": "off",
+        // "global-require": "error",
+        // "handle-callback-err": "error",
+        // "no-mixed-requires": "error",
+        // "no-new-require": "error",
+        // "no-path-concat": "error",
+        // "no-process-env": "error",
+        // "no-process-exit": "error",
+        // "no-restricted-modules": "error",
+        // "no-sync": "error",
+
+        // Stylistic Issues
+        // (in recommended)
+        "no-mixed-spaces-and-tabs": "warn",
+        // (not in recommended)
+        // "array-bracket-spacing": [
+        //     "error",
+        //     "never"
+        // ],
+        // "block-spacing": "off",
+        // "brace-style": "off",
+        // "camelcase": "off",
+        // "comma-dangle": "error",
+        // "comma-spacing": "off",
+        // "comma-style": [
+        //     "error",
+        //     "last"
+        // ],
+        // "computed-property-spacing": "off",
+        // "consistent-this": "off",
+        "eol-last": "warn",
+        // "func-call-spacing": [
+        //     "error",
+        //     "never"
+        // ],
+        // "func-names": [
+        //     "error",
+        //     "never"
+        // ],
+        // "func-style": "off",
+        // "id-blacklist": "error",
+        // "id-length": "off",
+        // "id-match": "error",
+        "indent": [
+            "warn",
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        // "jsx-quotes": "error",
+        // "key-spacing": "off",
+        // "keyword-spacing": "off",
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        // "lines-around-comment": "off",
+        // "max-depth": "off",
+        // "max-len": "off",
+        // "max-lines": "off",
+        // "max-nested-callbacks": "error",
+        // "max-params": "off",
+        // "max-statements-per-line": "off",
+        // "max-statements": "off",
+        // "multiline-ternary": "off",
+        // "new-parens": "error",
+        // "newline-after-var": "off",
+        // "newline-before-return": "off",
+        // "newline-per-chained-call": "off",
+        // "no-array-constructor": "error",
+        // "no-bitwise": "off",
+        // "no-continue": "off",
+        // "no-inline-comments": "off",
+        // "no-lonely-if": "off",
+        // "no-mixed-operators": "off",
+        // "no-multiple-empty-lines": "off",
+        // "no-negated-condition": "off",
+        // "no-nested-ternary": "off",
+        // "no-new-object": "error",
+        // "no-plusplus": "off",
+        // "no-restricted-syntax": "error",
+        // "no-tabs": "off",
+        // "no-ternary": "off",
+        "no-trailing-spaces": "warn",
+        // "no-underscore-dangle": "off",
+        // "no-unneeded-ternary": [
+        //     "error",
+        //     {
+        //         "defaultAssignment": true
+        //     }
+        // ],
+        // "no-whitespace-before-property": "error",
+        // "object-curly-newline": "off",
+        // "object-curly-spacing": "off",
+        // "object-property-newline": "off",
+        // "one-var-declaration-per-line": "off",
+        // "one-var": "off",
+        // "operator-assignment": "off",
+        // "operator-linebreak": "off",
+        // "padded-blocks": "off",
+        // "quote-props": "off",
+        // "quotes": "off",
+        // "require-jsdoc": "off",
+        // "semi-spacing": "off",
+        // "semi": "off",
+        // "sort-keys": "off",
+        // "sort-vars": "off",
+        // "space-before-blocks": "off",
+        // "space-before-function-paren": "off",
+        // "space-in-parens": "off",
+        // "space-infix-ops": "off",
+        // "space-unary-ops": [
+        //     "error",
+        //     {
+        //         "nonwords": false,
+        //         "words": false
+        //     }
+        // ],
+        // "spaced-comment": "off",
+        // "unicode-bom": [
+        //     "error",
+        //     "never"
+        // ],
+        // "wrap-regex": "error",
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,96 +6,104 @@ module.exports = {
     "globals": {
         "adapt": false,
         "goog": false,
-        "vivliostyle": false
+        "vivliostyle": false,
+        "DataView": false
     },
     // "extends": "eslint:recommended",
     "rules": {
         // Possible Errors
         // (in recommended)
-        // "no-constant-condition": [
-        //     "error",
-        //     {
-        //         "checkLoops": false
-        //     }
-        // ],
-        // "no-inner-declarations": [
-        //     "error",
-        //     "functions"
-        // ],
+        "no-console": "error",
+        "no-constant-condition": [
+            "error",
+            {
+                "checkLoops": false
+            }
+        ],
+        "no-empty": [
+            "error",
+            {
+                "allowEmptyCatch": true
+            }
+        ],
+        "no-inner-declarations": [
+            "error",
+            "functions"
+        ],
         // (not in recommended)
         // "no-extra-parens": "off",
         // "no-prototype-builtins": "off",
-        // "no-template-curly-in-string": "error",
-        // "no-unsafe-negation": "error",
+        "no-template-curly-in-string": "error",
+        "no-unsafe-negation": "error",
         // "valid-jsdoc": "off",
 
         // Best Practices
         // (not in recommended)
-        // "accessor-pairs": "error",
-        // "array-callback-return": "error",
+        "accessor-pairs": "error",
+        "array-callback-return": "error",
         // "block-scoped-var": "off",
         // "complexity": "off",
-        // "consistent-return": "error",
+        "consistent-return": "error",
         // "curly": "off",
         // "default-case": "off",
-        // "dot-location": [
-        //     "error",
-        //     "property"
-        // ],
+        "dot-location": [
+            "error",
+            "property"
+        ],
         // "dot-notation": "off",
         // "eqeqeq": "off",
         // "guard-for-in": "off",
-        // "no-alert": "error",
-        // "no-caller": "error",
-        // "no-div-regex": "error",
+        "no-alert": "error",
+        "no-caller": "error",
+        "no-div-regex": "error",
         // "no-else-return": "off",
         // "no-empty-function": "off",
         // "no-eq-null": "off",
-        // "no-eval": "error",
-        // "no-extend-native": "error",
-        // "no-extra-bind": "error",
-        // "no-extra-label": "error",
-        // "no-floating-decimal": "error",
-        // "no-global-assign": "error",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-label": "error",
+        "no-floating-decimal": "error",
+        "no-global-assign": "error",
         // "no-implicit-globals": "off",
-        // "no-implied-eval": "error",
-        // "no-invalid-this": "error",
-        // "no-iterator": "error",
-        // "no-labels": [
-        //     "error",
-        //     {
-        //         "allowLoop": true,
-        //         "allowSwitch": true
-        //     }
-        // ],
-        // "no-lone-blocks": "error",
+        "no-implied-eval": "error",
+        "no-invalid-this": "error",
+        "no-iterator": "error",
+        "no-labels": [
+            "error",
+            {
+                "allowLoop": true,
+                "allowSwitch": true
+            }
+        ],
+        "no-lone-blocks": "error",
         // "no-loop-func": "off",
         // "no-magic-numbers": "off",
         // "no-multi-spaces": "off",
-        // "no-multi-str": "error",
-        // "no-new-func": "error",
-        // "no-new-wrappers": "error",
-        // "no-new": "error",
-        // "no-octal-escape": "error",
+        "no-multi-str": "error",
+        "no-new-func": "error",
+        "no-new-wrappers": "error",
+        "no-new": "error",
+        "no-octal-escape": "error",
         // "no-param-reassign": "off",
-        // "no-proto": "error",
+        "no-proto": "error",
         // "no-return-assign": "off",
-        // "no-script-url": "error",
-        // "no-self-compare": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
         // "no-sequences": "off",
         // "no-throw-literal": "off",
         // "no-unmodified-loop-condition": "off",
         // "no-unused-expressions": "off",
-        // "no-useless-call": "error",
-        // "no-useless-concat": "error",
+        "no-useless-call": "error",
+        "no-useless-concat": "error",
         // "no-useless-escape": "off",
-        // "no-void": "error",
+        "no-void": "error",
         // "no-warning-comments": "off",
-        // "no-with": "error",
-        // "radix": [
-        //     "error",
-        //     "always"
-        // ],
+        "no-with": "error",
+        "radix": [
+            "error",
+            "always"
+        ],
         // "vars-on-top": "off",
 
         // Strict Mode
@@ -103,62 +111,65 @@ module.exports = {
         // "strict": "off",
 
         // Variables
+        // (in recommended)
+        "no-undef": "error",
+        "no-unused-vars": "off",
         // (not in recommended)
         // "init-declarations": "off",
-        // "no-catch-shadow": "error",
-        // "no-label-var": "error",
-        // "no-restricted-globals": "error",
-        // "no-shadow-restricted-names": "error",
+        "no-catch-shadow": "error",
+        "no-label-var": "error",
+        "no-restricted-globals": "error",
+        "no-shadow-restricted-names": "error",
         // "no-shadow": "off",
-        // "no-undef-init": "error",
+        "no-undef-init": "error",
         // "no-undefined": "off",
         // "no-use-before-define": "off",
 
         // Node.js and CommonJS
         // (not in recommended)
         // "callback-return": "off",
-        // "global-require": "error",
-        // "handle-callback-err": "error",
-        // "no-mixed-requires": "error",
-        // "no-new-require": "error",
-        // "no-path-concat": "error",
-        // "no-process-env": "error",
-        // "no-process-exit": "error",
-        // "no-restricted-modules": "error",
-        // "no-sync": "error",
+        "global-require": "error",
+        "handle-callback-err": "error",
+        "no-mixed-requires": "error",
+        "no-new-require": "error",
+        "no-path-concat": "error",
+        "no-process-env": "error",
+        "no-process-exit": "error",
+        "no-restricted-modules": "error",
+        "no-sync": "error",
 
         // Stylistic Issues
         // (in recommended)
         "no-mixed-spaces-and-tabs": "warn",
         // (not in recommended)
-        // "array-bracket-spacing": [
-        //     "error",
-        //     "never"
-        // ],
+        "array-bracket-spacing": [
+            "error",
+            "never"
+        ],
         // "block-spacing": "off",
         // "brace-style": "off",
         // "camelcase": "off",
-        // "comma-dangle": "error",
-        // "comma-spacing": "off",
-        // "comma-style": [
-        //     "error",
-        //     "last"
-        // ],
+        "comma-dangle": "error",
+        "comma-spacing": "error",
+        "comma-style": [
+            "error",
+            "last"
+        ],
         // "computed-property-spacing": "off",
         // "consistent-this": "off",
         "eol-last": "warn",
-        // "func-call-spacing": [
-        //     "error",
-        //     "never"
-        // ],
-        // "func-names": [
-        //     "error",
-        //     "never"
-        // ],
+        "func-call-spacing": [
+            "error",
+            "never"
+        ],
+        "func-names": [
+            "error",
+            "never"
+        ],
         // "func-style": "off",
-        // "id-blacklist": "error",
+        "id-blacklist": "error",
         // "id-length": "off",
-        // "id-match": "error",
+        "id-match": "error",
         "indent": [
             "warn",
             4,
@@ -166,9 +177,8 @@ module.exports = {
                 "SwitchCase": 1
             }
         ],
-        // "jsx-quotes": "error",
         // "key-spacing": "off",
-        // "keyword-spacing": "off",
+        "keyword-spacing": "error",
         "linebreak-style": [
             "error",
             "unix"
@@ -177,16 +187,16 @@ module.exports = {
         // "max-depth": "off",
         // "max-len": "off",
         // "max-lines": "off",
-        // "max-nested-callbacks": "error",
+        "max-nested-callbacks": "error",
         // "max-params": "off",
         // "max-statements-per-line": "off",
         // "max-statements": "off",
         // "multiline-ternary": "off",
-        // "new-parens": "error",
+        "new-parens": "error",
         // "newline-after-var": "off",
         // "newline-before-return": "off",
         // "newline-per-chained-call": "off",
-        // "no-array-constructor": "error",
+        "no-array-constructor": "error",
         // "no-bitwise": "off",
         // "no-continue": "off",
         // "no-inline-comments": "off",
@@ -195,20 +205,20 @@ module.exports = {
         // "no-multiple-empty-lines": "off",
         // "no-negated-condition": "off",
         // "no-nested-ternary": "off",
-        // "no-new-object": "error",
+        "no-new-object": "error",
         // "no-plusplus": "off",
-        // "no-restricted-syntax": "error",
+        "no-restricted-syntax": "error",
         // "no-tabs": "off",
         // "no-ternary": "off",
         "no-trailing-spaces": "warn",
         // "no-underscore-dangle": "off",
-        // "no-unneeded-ternary": [
-        //     "error",
-        //     {
-        //         "defaultAssignment": true
-        //     }
-        // ],
-        // "no-whitespace-before-property": "error",
+        "no-unneeded-ternary": [
+            "error",
+            {
+                "defaultAssignment": true
+            }
+        ],
+        "no-whitespace-before-property": "error",
         // "object-curly-newline": "off",
         // "object-curly-spacing": "off",
         // "object-property-newline": "off",
@@ -220,26 +230,23 @@ module.exports = {
         // "quote-props": "off",
         // "quotes": "off",
         // "require-jsdoc": "off",
-        // "semi-spacing": "off",
-        // "semi": "off",
+        "semi-spacing": "error",
+        "semi": "error",
         // "sort-keys": "off",
         // "sort-vars": "off",
-        // "space-before-blocks": "off",
-        // "space-before-function-paren": "off",
-        // "space-in-parens": "off",
+        "space-before-blocks": "error",
+        "space-before-function-paren": [
+            "error",
+            "never"
+        ],
+        "space-in-parens": "error",
         // "space-infix-ops": "off",
-        // "space-unary-ops": [
-        //     "error",
-        //     {
-        //         "nonwords": false,
-        //         "words": false
-        //     }
-        // ],
+        "space-unary-ops": "error",
         // "spaced-comment": "off",
-        // "unicode-bom": [
-        //     "error",
-        //     "never"
-        // ],
-        // "wrap-regex": "error",
+        "unicode-bom": [
+            "error",
+            "never"
+        ],
+        "wrap-regex": "error"
     }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
 - sudo pip install virtualenv
 script:
 - build/update-version.sh
+- npm run lint
 - npm run build
 - npm test
 - build/wpt-sauce.sh

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2016.7.1-pre",
   "description": "Library for web sites with rich paged viewing and EPUB support, shared with Vivliostyle Formatter & Browser",
   "scripts": {
+    "lint": "eslint src test",
     "build": "mkdirp lib && java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level ADVANCED_OPTIMIZATIONS --language_in ECMASCRIPT5 --warning_level VERBOSE --output_wrapper_file src/wrapper.js --externs src/externs.js --js_output_file lib/vivliostyle.min.js src/closure/goog/base.js src/closure/goog/*/*.js src/adapt/*.js src/vivliostyle/*.js",
     "test": "karma start test/conf/karma-sauce.conf.js",
     "test:local": "karma start test/conf/karma-local.conf.js"
@@ -26,6 +27,7 @@
   "main": "lib/vivliostyle.min.js",
   "homepage": "https://github.com/vivliostyle/vivliostyle.js",
   "devDependencies": {
+    "eslint": "^3.3.1",
     "google-closure-compiler": "^20150315.0.2",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.7",

--- a/src/adapt/base.js
+++ b/src/adapt/base.js
@@ -17,7 +17,7 @@ adapt.base.JSON;
  * @return {string}
  */
 adapt.base.jsonToString = function(json) {
-	return JSON.stringify(json);
+    return JSON.stringify(json);
 };
 
 /**
@@ -25,7 +25,7 @@ adapt.base.jsonToString = function(json) {
  * @return {adapt.base.JSON}
  */
 adapt.base.stringToJSON = function(str) {
-	return JSON.parse(str);
+    return JSON.parse(str);
 };
 
 /**
@@ -35,7 +35,7 @@ adapt.base.stringToJSON = function(str) {
 adapt.base.stripFragment = function(url) {
     var r = url.match(/^([^#]*)/);
     if (r)
-        return r[1];	
+        return r[1];
     return url;
 };
 
@@ -46,7 +46,7 @@ adapt.base.stripFragment = function(url) {
 adapt.base.stripFragmentAndQuery = function(url) {
     var r = url.match(/^([^#?]*)/);
     if (r)
-        return r[1];	
+        return r[1];
     return url;
 };
 
@@ -63,9 +63,9 @@ adapt.base.resourceBaseURL = window.location.href;
  */
 adapt.base.resolveURL = function(relURL, baseURL) {
     if (!baseURL || relURL.match(/^\w{2,}:/)) {
-    	if (relURL.toLowerCase().match("^javascript:")) {
-    		return "#";
-    	}
+        if (relURL.toLowerCase().match("^javascript:")) {
+            return "#";
+        }
         return relURL;
     }
     if (baseURL.match(/^\w{2,}:\/\/[^\/]+$/))
@@ -74,7 +74,7 @@ adapt.base.resolveURL = function(relURL, baseURL) {
     if (relURL.match(/^\/\//)) {
         r = baseURL.match(/^(\w{2,}:)\/\//);
         if (r)
-        return r[1] + relURL;
+            return r[1] + relURL;
         return relURL;
     }
     if (relURL.match(/^\//)) {
@@ -134,17 +134,17 @@ adapt.base.DocumentURLTransformer.prototype.restoreURL = function(encoded) {};
  * @enum {string}
  */
 adapt.base.NS = {
-	FB2: "http://www.gribuser.ru/xml/fictionbook/2.0",
-	epub: "http://www.idpf.org/2007/ops",
-	EV: "http://www.w3.org/2001/xml-events",
-	MATHML: "http://www.w3.org/1998/Math/MathML",
-	XML: "http://www.w3.org/XML/1998/namespace",
-	XHTML: "http://www.w3.org/1999/xhtml",
-	XLINK: "http://www.w3.org/1999/xlink",
-	SHADOW: "http://www.pyroxy.com/ns/shadow",
-	SVG: "http://www.w3.org/2000/svg",
-	DC: "http://purl.org/dc/elements/1.1/",
-	NCX: "http://www.daisy.org/z3986/2005/ncx/",
+    FB2: "http://www.gribuser.ru/xml/fictionbook/2.0",
+    epub: "http://www.idpf.org/2007/ops",
+    EV: "http://www.w3.org/2001/xml-events",
+    MATHML: "http://www.w3.org/1998/Math/MathML",
+    XML: "http://www.w3.org/XML/1998/namespace",
+    XHTML: "http://www.w3.org/1999/xhtml",
+    XLINK: "http://www.w3.org/1999/xlink",
+    SHADOW: "http://www.pyroxy.com/ns/shadow",
+    SVG: "http://www.w3.org/2000/svg",
+    DC: "http://purl.org/dc/elements/1.1/",
+    NCX: "http://www.daisy.org/z3986/2005/ncx/",
     SSE: "http://example.com/sse" // temporary dummy namespace
 };
 
@@ -173,14 +173,14 @@ adapt.base.setURLParam = function(url, name, value) {
     var rg = new RegExp('#(.*&)?' + adapt.base.escapeRegExp(name) + '=([^#&]*)');
     var r = url.match(rg);
     if (r) {
-    	var length = r[2].length;
-    	var index = r.index + r[0].length - length;
-    	return url.substr(0, index) + value + url.substr(index + length);
+        var length = r[2].length;
+        var index = r.index + r[0].length - length;
+        return url.substr(0, index) + value + url.substr(index + length);
     }
     if (!url.match(/#/)) {
-    	return url + "#" + name + "=" + value;
+        return url + "#" + name + "=" + value;
     } else {
-    	return url + "&" + name + "=" + value;
+        return url + "&" + name + "=" + value;
     }
 };
 
@@ -189,9 +189,9 @@ adapt.base.setURLParam = function(url, name, value) {
  * @return ?string
  */
 adapt.base.asString = function(v) {
-	if (v == null)
-		return v;
-	return v.toString();
+    if (v == null)
+        return v;
+    return v.toString();
 };
 
 /**
@@ -211,14 +211,14 @@ adapt.base.Comparable.prototype.compare = function(other) {};
  * @constructor
  */
 adapt.base.PriorityQueue = function() {
-	/** @type {Array.<adapt.base.Comparable>} */ this.queue = [null];
+    /** @type {Array.<adapt.base.Comparable>} */ this.queue = [null];
 };
 
 /**
  * @return {number}
  */
 adapt.base.PriorityQueue.prototype.length = function() {
-	return this.queue.length - 1;
+    return this.queue.length - 1;
 };
 
 /**
@@ -244,7 +244,7 @@ adapt.base.PriorityQueue.prototype.add = function(item) {
  * @return {adapt.base.Comparable} highest priority Comparable.
  */
 adapt.base.PriorityQueue.prototype.peek = function() {
-	return this.queue[1];
+    return this.queue[1];
 };
 
 
@@ -258,25 +258,25 @@ adapt.base.PriorityQueue.prototype.remove = function() {
     var size = this.queue.length;
     if (size > 1) {
         var index = 1;
-        while( true ) {
+        while (true) {
             var childIndex = index*2;
-            if( childIndex >= size )
+            if (childIndex >= size)
                 break;
-            if( this.queue[childIndex].compare(curr) > 0 ) {
-                if( childIndex+1 < size && 
+            if (this.queue[childIndex].compare(curr) > 0) {
+                if (childIndex+1 < size &&
                     this.queue[childIndex+1].compare(
-                        /** @type {!adapt.base.Comparable} */ (this.queue[childIndex])) > 0 ) {
+                        /** @type {!adapt.base.Comparable} */ (this.queue[childIndex])) > 0) {
                     childIndex++;
                 }
-            } else if( childIndex+1 < size && this.queue[childIndex+1].compare(curr) > 0 ) {
-              childIndex++;
+            } else if (childIndex+1 < size && this.queue[childIndex+1].compare(curr) > 0) {
+                childIndex++;
             } else {
-              break;
+                break;
             }
             this.queue[index] = this.queue[childIndex];
             index = childIndex;
-       }
-       this.queue[index] = curr;
+        }
+        this.queue[index] = curr;
     }
     return result;
 };
@@ -295,7 +295,7 @@ adapt.base.cssToJSProp = function(prefix, cssPropName) {
             prefix = "Moz";
         }
     }
-	return prefix + cssPropName.replace(/-[a-z]/g, function(txt) {return txt.substr(1).toUpperCase();});
+    return prefix + cssPropName.replace(/-[a-z]/g, function(txt) {return txt.substr(1).toUpperCase();});
 };
 
 /**
@@ -343,20 +343,20 @@ adapt.base.getPrefixedProperty = function(prop) {
         return prefixed;
     }
     switch (prop) {
-    case "writing-mode":
-        // Special case: prefer '-ms-writing-mode' to 'writing-mode'
-        if (adapt.base.checkIfPropertySupported("-ms-", "writing-mode")) {
-            adapt.base.propNameMap[prop] = "-ms-writing-mode";
-            return "-ms-writing-mode";
-        }
-        break;
-    case "filter":
-        // Special case: prefer '-webkit-filter' to 'filter'        
-        if (adapt.base.checkIfPropertySupported("-webkit-", "filter")) {
-            adapt.base.propNameMap[prop] = "-webkit-filter";
-            return "-webkit-filter";
-        }
-        break;
+        case "writing-mode":
+            // Special case: prefer '-ms-writing-mode' to 'writing-mode'
+            if (adapt.base.checkIfPropertySupported("-ms-", "writing-mode")) {
+                adapt.base.propNameMap[prop] = "-ms-writing-mode";
+                return "-ms-writing-mode";
+            }
+            break;
+        case "filter":
+            // Special case: prefer '-webkit-filter' to 'filter'
+            if (adapt.base.checkIfPropertySupported("-webkit-", "filter")) {
+                adapt.base.propNameMap[prop] = "-webkit-filter";
+                return "-webkit-filter";
+            }
+            break;
     }
 
 
@@ -416,7 +416,7 @@ adapt.base.setCSSProperty = function(elem, prop, value) {
 adapt.base.getCSSProperty = function(elem, prop, opt_value) {
     try {
         return (/** @type {HTMLElement} */ (elem)).style.getPropertyValue(
-        		adapt.base.propNameMap[prop] || prop);
+            adapt.base.propNameMap[prop] || prop);
     } catch (err) {
     }
     return opt_value || "";
@@ -434,8 +434,8 @@ adapt.base.StringBuffer = function() {
  * @return {!adapt.base.StringBuffer}
  */
 adapt.base.StringBuffer.prototype.append = function(str) {
-	this.list.push(str);
-	return this;
+    this.list.push(str);
+    return this;
 };
 
 /**
@@ -493,7 +493,7 @@ adapt.base.lightURLEncode = function(str) {
  * @return {boolean}
  */
 adapt.base.isLetter = function(ch) {
-	return !!ch.match(/^[a-zA-Z\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]$/);
+    return !!ch.match(/^[a-zA-Z\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]$/);
 };
 
 /**
@@ -518,11 +518,11 @@ adapt.base.escapeRegExp = function(str) {
  */
 adapt.base.assert = function(cond) {
     if (!cond) {
-    	throw "Assert failed";
+        throw "Assert failed";
     }
 };
 
-/** 
+/**
  * Function good is defined for ints from 0 to high-1. It is such that for
  * each i between 1 and high-1 !good(i-1) || good(i) is true. In other words,
  * it goes like false ... false true ... true.
@@ -536,11 +536,11 @@ adapt.base.binarySearch = function(high, good) {
     var l = 0;
     var h = high;
     while (true) {
-    	if (goog.DEBUG) {
-    		adapt.base.assert(l <= h);
-    		adapt.base.assert(l == 0 || !good(l - 1));
-    		adapt.base.assert(h == high || good(h));
-    	}
+        if (goog.DEBUG) {
+            adapt.base.assert(l <= h);
+            adapt.base.assert(l == 0 || !good(l - 1));
+            adapt.base.assert(h == high || good(h));
+        }
         if (l == h)
             return l;
         var m = (l + h) >> 1;
@@ -558,7 +558,7 @@ adapt.base.binarySearch = function(high, good) {
  * @return {number}
  */
 adapt.base.numberCompare = function(a, b) {
-	return a - b;
+    return a - b;
 };
 
 /** @const */
@@ -570,33 +570,33 @@ adapt.base.base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01
  * @return {void}
  */
 adapt.base.appendBase64 = function(sb, data) {
-	var length = data.length;
+    var length = data.length;
     var length3 = Math.floor(length / 3) * 3;
-    for( var i = 0 ; i < length3 ; i += 3) {
-    	var c1 = data.charCodeAt(i) & 0xFF;
-    	var c2 = data.charCodeAt(i+1) & 0xFF;
-    	var c3 = data.charCodeAt(i+2) & 0xFF;
-    	sb.append(adapt.base.base64Chars.charAt(c1 >> 2));
-    	sb.append(adapt.base.base64Chars.charAt(((c1 << 4) | (c2 >> 4)) & 0x3F));
-    	sb.append(adapt.base.base64Chars.charAt(((c2 << 2) | (c3 >> 6)) & 0x3F));
-    	sb.append(adapt.base.base64Chars.charAt(c3 & 0x3F));
+    for (var i = 0; i < length3; i += 3) {
+        var c1 = data.charCodeAt(i) & 0xFF;
+        var c2 = data.charCodeAt(i+1) & 0xFF;
+        var c3 = data.charCodeAt(i+2) & 0xFF;
+        sb.append(adapt.base.base64Chars.charAt(c1 >> 2));
+        sb.append(adapt.base.base64Chars.charAt(((c1 << 4) | (c2 >> 4)) & 0x3F));
+        sb.append(adapt.base.base64Chars.charAt(((c2 << 2) | (c3 >> 6)) & 0x3F));
+        sb.append(adapt.base.base64Chars.charAt(c3 & 0x3F));
     }
     switch (length - length3) {
-    case 1:
-    	var p1 = data.charCodeAt(length3) & 0xFF;
-    	sb.append(adapt.base.base64Chars.charAt(p1 >> 2));
-    	sb.append(adapt.base.base64Chars.charAt((p1 << 4) & 0x3F));
-    	sb.append("==");
-    	break;
-    case 2:
-    	var q1 = data.charCodeAt(length3) & 0xFF;
-    	var q2 = data.charCodeAt(length3+1) & 0xFF;
-    	sb.append(adapt.base.base64Chars.charAt(q1 >> 2));
-    	sb.append(adapt.base.base64Chars.charAt(((q1 << 4) | (q2 >> 4)) & 0x3F));
-    	sb.append(adapt.base.base64Chars.charAt((q2 << 2) & 0x3F));
-    	sb.append("=");
-    	break;
-    };
+        case 1:
+            var p1 = data.charCodeAt(length3) & 0xFF;
+            sb.append(adapt.base.base64Chars.charAt(p1 >> 2));
+            sb.append(adapt.base.base64Chars.charAt((p1 << 4) & 0x3F));
+            sb.append("==");
+            break;
+        case 2:
+            var q1 = data.charCodeAt(length3) & 0xFF;
+            var q2 = data.charCodeAt(length3+1) & 0xFF;
+            sb.append(adapt.base.base64Chars.charAt(q1 >> 2));
+            sb.append(adapt.base.base64Chars.charAt(((q1 << 4) | (q2 >> 4)) & 0x3F));
+            sb.append(adapt.base.base64Chars.charAt((q2 << 2) & 0x3F));
+            sb.append("=");
+            break;
+    }
 };
 
 /**
@@ -615,15 +615,15 @@ adapt.base.identity = function(param) {return param;};
  * @return {Object.<string,T>}
  */
 adapt.base.indexArray = function(arr, key) {
-	var map = {};
-	for (var i = 0; i < arr.length; i++) {
-		var v = arr[i];
-		var k = key(v);
-		if (k && !map[k]) {
-			map[k] = v;
-		}
-	}
-	return map;
+    var map = {};
+    for (var i = 0; i < arr.length; i++) {
+        var v = arr[i];
+        var k = key(v);
+        if (k && !map[k]) {
+            map[k] = v;
+        }
+    }
+    return map;
 };
 
 /** @const */
@@ -635,11 +635,11 @@ adapt.base.emptyObj = {};
  * @return {Object.<string,boolean>}
  */
 adapt.base.arrayToSet = function(arr) {
-	var set = {};
-	for (var i = 0; i < arr.length; i++) {
-		set[arr[i]] = true;
-	}
-	return set;
+    var set = {};
+    for (var i = 0; i < arr.length; i++) {
+        set[arr[i]] = true;
+    }
+    return set;
 };
 
 /**
@@ -651,19 +651,19 @@ adapt.base.arrayToSet = function(arr) {
  * @return {Object.<string,Array.<T>>}
  */
 adapt.base.multiIndexArray = function(arr, key) {
-	var map = {};
-	for (var i = 0; i < arr.length; i++) {
-		var v = arr[i];
-		var k = key(v);
-		if (k) {
-			if (map[k]) {
-				map[k].push(v);
-			} else {
-				map[k] = [v];
-			}
-		}
-	}
-	return map;
+    var map = {};
+    for (var i = 0; i < arr.length; i++) {
+        var v = arr[i];
+        var k = key(v);
+        if (k) {
+            if (map[k]) {
+                map[k].push(v);
+            } else {
+                map[k] = [v];
+            }
+        }
+    }
+    return map;
 };
 
 /**
@@ -674,11 +674,11 @@ adapt.base.multiIndexArray = function(arr, key) {
  * @return {Array.<R>}
  */
 adapt.base.map = function(arr, fn) {
-	var res = Array(arr.length);
-	for (var i = 0; i < arr.length; i++) {
-		res[i] = fn(arr[i], i);
-	}
-	return res;
+    var res = Array(arr.length);
+    for (var i = 0; i < arr.length; i++) {
+        res[i] = fn(arr[i], i);
+    }
+    return res;
 };
 
 /**
@@ -689,11 +689,11 @@ adapt.base.map = function(arr, fn) {
  * @return {Object.<string, R>}
  */
 adapt.base.mapObj = function(obj, fn) {
-	var res = {};
-	for (var n in obj) {
-		res[n] = fn(obj[n], n);
-	}
-	return res;
+    var res = {};
+    for (var n in obj) {
+        res[n] = fn(obj[n], n);
+    }
+    return res;
 };
 
 /**
@@ -701,11 +701,11 @@ adapt.base.mapObj = function(obj, fn) {
  * @return {number}
  */
 adapt.base.mapSize = function(obj) {
-	var n = 0;
-	for (var key in obj) {
-		n++;
-	}
-	return n;
+    var n = 0;
+    for (var key in obj) {
+        n++;
+    }
+    return n;
 };
 
 /**
@@ -720,11 +720,11 @@ adapt.base.EventListener;
 
 /**
  * Extemely simple-minded EventTarget implementation. Consider using
- * goog.events.EventTarget if you are using Closure library. 
+ * goog.events.EventTarget if you are using Closure library.
  * @constructor
  */
 adapt.base.SimpleEventTarget = function() {
-	/** @type {Object.<string,Array.<adapt.base.EventListener>>} */ this.listeners = {};
+    /** @type {Object.<string,Array.<adapt.base.EventListener>>} */ this.listeners = {};
 };
 
 /**
@@ -732,14 +732,14 @@ adapt.base.SimpleEventTarget = function() {
  * @return {void}
  */
 adapt.base.SimpleEventTarget.prototype.dispatchEvent = function(evt) {
-	var list = this.listeners[evt.type];
-	if (list) {
-		evt.target = this;
-		evt.currentTarget = this;
-		for (var i = 0; i < list.length; i++) {
-			list[i](evt);
-		}
-	}
+    var list = this.listeners[evt.type];
+    if (list) {
+        evt.target = this;
+        evt.currentTarget = this;
+        for (var i = 0; i < list.length; i++) {
+            list[i](evt);
+        }
+    }
 };
 
 /**
@@ -749,15 +749,15 @@ adapt.base.SimpleEventTarget.prototype.dispatchEvent = function(evt) {
  * @return {void}
  */
 adapt.base.SimpleEventTarget.prototype.addEventListener = function(type, listener, capture) {
-	if (capture) {
-		return;
-	}
-	var list = this.listeners[type];
-	if (list) {
-		list.push(listener);
-	} else {
-		this.listeners[type] = [listener];
-	}
+    if (capture) {
+        return;
+    }
+    var list = this.listeners[type];
+    if (list) {
+        list.push(listener);
+    } else {
+        this.listeners[type] = [listener];
+    }
 };
 
 /**
@@ -767,16 +767,16 @@ adapt.base.SimpleEventTarget.prototype.addEventListener = function(type, listene
  * @return {void}
  */
 adapt.base.SimpleEventTarget.prototype.removeEventListener = function(type, listener, capture) {
-	if (capture) {
-		return;
-	}
-	var list = this.listeners[type];
-	if (list) {
-		var index = list.indexOf(listener);
-		if (index >= 0) {
-			list.splice(index, 1);
-		}
-	}
+    if (capture) {
+        return;
+    }
+    var list = this.listeners[type];
+    if (list) {
+        var index = list.indexOf(listener);
+        if (index >= 0) {
+            list.splice(index, 1);
+        }
+    }
 };
 
 /**
@@ -795,39 +795,39 @@ adapt.base.hasLShapeFloatBug = null;
  * @return {boolean}
  */
 adapt.base.checkLShapeFloatBug = function(body) {
-	if (adapt.base.hasLShapeFloatBug == null) {
-		var doc = body.ownerDocument;
-		var container = /** @type {HTMLElement} */ (doc.createElement("div"));
-		container.style.position = "absolute";
-		container.style.top = "0px";
-		container.style.left = "0px";
-		container.style.width = "100px";
-		container.style.height = "100px";
-		container.style.overflow = "hidden";
-		container.style.lineHeight = "16px";
-		container.style.fontSize = "16px";
-		body.appendChild(container);
-		var f1 = /** @type {HTMLElement} */ (doc.createElement("div"));
-		f1.style.width = "0px";
-		f1.style.height = "14px";
-		f1.style.cssFloat = "left";
-		container.appendChild(f1);
-		var f2 = /** @type {HTMLElement} */ (doc.createElement("div"));
-		f2.style.width = "50px";
-		f2.style.height = "50px";
-		f2.style.cssFloat = "left";
-		f2.style.clear = "left";
-		container.appendChild(f2);
-		var t = doc.createTextNode("a a a a a a a a a a a a a a a a");
-		container.appendChild(t);
-		var range = doc.createRange();
-		range.setStart(t, 0);
-		range.setEnd(t, 1);
-		var leftEdge = range.getBoundingClientRect().left;
-		adapt.base.hasLShapeFloatBug = leftEdge < 40;
-		body.removeChild(container);
-	}
-	return adapt.base.hasLShapeFloatBug;
+    if (adapt.base.hasLShapeFloatBug == null) {
+        var doc = body.ownerDocument;
+        var container = /** @type {HTMLElement} */ (doc.createElement("div"));
+        container.style.position = "absolute";
+        container.style.top = "0px";
+        container.style.left = "0px";
+        container.style.width = "100px";
+        container.style.height = "100px";
+        container.style.overflow = "hidden";
+        container.style.lineHeight = "16px";
+        container.style.fontSize = "16px";
+        body.appendChild(container);
+        var f1 = /** @type {HTMLElement} */ (doc.createElement("div"));
+        f1.style.width = "0px";
+        f1.style.height = "14px";
+        f1.style.cssFloat = "left";
+        container.appendChild(f1);
+        var f2 = /** @type {HTMLElement} */ (doc.createElement("div"));
+        f2.style.width = "50px";
+        f2.style.height = "50px";
+        f2.style.cssFloat = "left";
+        f2.style.clear = "left";
+        container.appendChild(f2);
+        var t = doc.createTextNode("a a a a a a a a a a a a a a a a");
+        container.appendChild(t);
+        var range = doc.createRange();
+        range.setStart(t, 0);
+        range.setEnd(t, 1);
+        var leftEdge = range.getBoundingClientRect().left;
+        adapt.base.hasLShapeFloatBug = leftEdge < 40;
+        body.removeChild(container);
+    }
+    return adapt.base.hasLShapeFloatBug;
 };
 
 /**
@@ -845,27 +845,27 @@ adapt.base.hasVerticalBBoxBug = null;
  * @return {boolean}
  */
 adapt.base.checkVerticalBBoxBug = function(body) {
-	if (adapt.base.hasVerticalBBoxBug == null) {
-		var doc = body.ownerDocument;
-		var container = /** @type {HTMLElement} */ (doc.createElement("div"));
-		container.style.position = "absolute";
-		container.style.top = "0px";
-		container.style.left = "0px";
-		container.style.width = "100px";
-		container.style.height = "100px";
-		container.style.overflow = "hidden";
-		container.style.lineHeight = "16px";
-		container.style.fontSize = "16px";
-		adapt.base.setCSSProperty(container, "writing-mode", "vertical-rl");
-		body.appendChild(container);
-		var t = doc.createTextNode("a a a a a a a a a a a a a a a a");
-		container.appendChild(t);
-		var range = doc.createRange();
-		range.setStart(t, 0);
-		range.setEnd(t, 1);
-		var box = range.getBoundingClientRect();
-		adapt.base.hasVerticalBBoxBug = (box.right - box.left < 10);
-		body.removeChild(container);
-	}
-	return adapt.base.hasVerticalBBoxBug;
+    if (adapt.base.hasVerticalBBoxBug == null) {
+        var doc = body.ownerDocument;
+        var container = /** @type {HTMLElement} */ (doc.createElement("div"));
+        container.style.position = "absolute";
+        container.style.top = "0px";
+        container.style.left = "0px";
+        container.style.width = "100px";
+        container.style.height = "100px";
+        container.style.overflow = "hidden";
+        container.style.lineHeight = "16px";
+        container.style.fontSize = "16px";
+        adapt.base.setCSSProperty(container, "writing-mode", "vertical-rl");
+        body.appendChild(container);
+        var t = doc.createTextNode("a a a a a a a a a a a a a a a a");
+        container.appendChild(t);
+        var range = doc.createRange();
+        range.setStart(t, 0);
+        range.setEnd(t, 1);
+        var box = range.getBoundingClientRect();
+        adapt.base.hasVerticalBBoxBug = (box.right - box.left < 10);
+        body.removeChild(container);
+    }
+    return adapt.base.hasVerticalBBoxBug;
 };

--- a/src/adapt/cfi.js
+++ b/src/adapt/cfi.js
@@ -23,13 +23,13 @@ adapt.cfi.Position;
  * @return {?string}
  */
 adapt.cfi.getId = function(node) {
-	if (node.nodeType == 1) {
-		var idtxt = (/** @type {Element} */ (node)).getAttribute("id");
-		if (idtxt && idtxt.match(/^[-a-zA-Z_0-9.\u007F-\uFFFF]+$/)) {
-			return idtxt;
-		}
-	}
-	return null;
+    if (node.nodeType == 1) {
+        var idtxt = (/** @type {Element} */ (node)).getAttribute("id");
+        if (idtxt && idtxt.match(/^[-a-zA-Z_0-9.\u007F-\uFFFF]+$/)) {
+            return idtxt;
+        }
+    }
+    return null;
 };
 
 /**
@@ -37,7 +37,7 @@ adapt.cfi.getId = function(node) {
  * @return {string}
  */
 adapt.cfi.escapeChar = function(ch) {
-	return "^" + ch;
+    return "^" + ch;
 };
 
 /**
@@ -45,7 +45,7 @@ adapt.cfi.escapeChar = function(ch) {
  * @return {string}
  */
 adapt.cfi.escape = function(str) {
-	return str.replace(/[\[\]\(\),=;^]/g, adapt.cfi.escapeChar);
+    return str.replace(/[\[\]\(\),=;^]/g, adapt.cfi.escapeChar);
 };
 
 /**
@@ -53,7 +53,7 @@ adapt.cfi.escape = function(str) {
  * @return {string}
  */
 adapt.cfi.unescapeChar = function(str) {
-	return str.substr(1);
+    return str.substr(1);
 };
 
 
@@ -62,9 +62,9 @@ adapt.cfi.unescapeChar = function(str) {
  * @return {string}
  */
 adapt.cfi.unescape = function(str) {
-	if (!str)
-		return str;
-	return str.replace(/\^[\[\]\(\),=;^]/g, adapt.cfi.unescapeChar);
+    if (!str)
+        return str;
+    return str.replace(/\^[\[\]\(\),=;^]/g, adapt.cfi.unescapeChar);
 };
 
 /**
@@ -72,16 +72,16 @@ adapt.cfi.unescape = function(str) {
  * @return {string|Array.<string>}
  */
 adapt.cfi.parseExtVal = function(extstr) {
-	var result = [];
-	do {
-		var r = extstr.match(/^(\^,|[^,])*/);
-		var p = adapt.cfi.unescape(r[0]);
-		extstr = extstr.substr(r[0].length + 1);
-		if (!extstr && !result.length)
-			return p;
-		result.push(p);
-	} while (extstr);
-	return result;
+    var result = [];
+    do {
+        var r = extstr.match(/^(\^,|[^,])*/);
+        var p = adapt.cfi.unescape(r[0]);
+        extstr = extstr.substr(r[0].length + 1);
+        if (!extstr && !result.length)
+            return p;
+        result.push(p);
+    } while (extstr);
+    return result;
 };
 
 /**
@@ -89,16 +89,16 @@ adapt.cfi.parseExtVal = function(extstr) {
  * @return {Object.<string,string|Array.<string>>}
  */
 adapt.cfi.parseExt = function(extstr) {
-	var ext = {};
-	while(extstr) {
-		var r = extstr.match(/^;([^;=]+)=(([^;]|\^;)*)/);
-		if (!r) {
-			return ext;
-		}
-		ext[r[1]] = adapt.cfi.parseExtVal(r[2]);
-		extstr = extstr.substr(r[0].length);
-	}
-	return ext;
+    var ext = {};
+    while (extstr) {
+        var r = extstr.match(/^;([^;=]+)=(([^;]|\^;)*)/);
+        if (!r) {
+            return ext;
+        }
+        ext[r[1]] = adapt.cfi.parseExtVal(r[2]);
+        extstr = extstr.substr(r[0].length);
+    }
+    return ext;
 };
 
 /**
@@ -128,14 +128,14 @@ adapt.cfi.RefStep = function() {};
  * @param {adapt.base.StringBuffer} sb
  */
 adapt.cfi.RefStep.prototype.appendTo = function(sb) {
-	sb.append("!");
+    sb.append("!");
 };
 
 /**
  * @override
  */
 adapt.cfi.RefStep.prototype.applyTo = function(pos) {
-	return false;
+    return false;
 };
 
 /**
@@ -146,62 +146,62 @@ adapt.cfi.RefStep.prototype.applyTo = function(pos) {
  * @implements {adapt.cfi.Step}
  */
 adapt.cfi.ChildStep = function(index, id, sideBias) {
-	/** @const */ this.index = index;
-	/** @const */ this.id = id;
-	/** @const */ this.sideBias = sideBias;
+    /** @const */ this.index = index;
+    /** @const */ this.id = id;
+    /** @const */ this.sideBias = sideBias;
 };
 
 /**
  * @override
  */
 adapt.cfi.ChildStep.prototype.appendTo = function(sb) {
-	sb.append("/");
-	sb.append(this.index.toString());
-	if (this.id || this.sideBias) {
-		sb.append("[");
-		if (this.id) {
-			sb.append(this.id);
-		}
-		if (this.sideBias) {
-			sb.append(";s=");
-			sb.append(this.sideBias);
-		}
-		sb.append("]");
-	}
+    sb.append("/");
+    sb.append(this.index.toString());
+    if (this.id || this.sideBias) {
+        sb.append("[");
+        if (this.id) {
+            sb.append(this.id);
+        }
+        if (this.sideBias) {
+            sb.append(";s=");
+            sb.append(this.sideBias);
+        }
+        sb.append("]");
+    }
 };
 
 /**
  * @override
  */
 adapt.cfi.ChildStep.prototype.applyTo = function(pos) {
-	if (pos.node.nodeType != 1) {
-		throw new Error("E_CFI_NOT_ELEMENT");
-	}
-	var elem = /** @type {Element} */ (pos.node);
-	var childElements = elem.children;
-	var childElementCount = childElements.length;
-	var child;
-	var childIndex = Math.floor(this.index / 2) - 1;
-	if (childIndex < 0 || childElementCount == 0) {
-		child = elem.firstChild;
-		pos.node = child || elem;
-	} else {
-		child = childElements[Math.min(childIndex, childElementCount - 1)];
-		if (this.index & 1) {
-			var next = child.nextSibling;
-			if (!next || next.nodeType == 1) {
-				pos.after = true;
-			} else {
-				child = next;
-			}
-		}
-		pos.node = child;
-	}
-	if (this.id && (pos.after || this.id != adapt.cfi.getId(pos.node))) {
-		throw new Error("E_CFI_ID_MISMATCH");		
-	}
-	pos.sideBias = this.sideBias;
-	return true;
+    if (pos.node.nodeType != 1) {
+        throw new Error("E_CFI_NOT_ELEMENT");
+    }
+    var elem = /** @type {Element} */ (pos.node);
+    var childElements = elem.children;
+    var childElementCount = childElements.length;
+    var child;
+    var childIndex = Math.floor(this.index / 2) - 1;
+    if (childIndex < 0 || childElementCount == 0) {
+        child = elem.firstChild;
+        pos.node = child || elem;
+    } else {
+        child = childElements[Math.min(childIndex, childElementCount - 1)];
+        if (this.index & 1) {
+            var next = child.nextSibling;
+            if (!next || next.nodeType == 1) {
+                pos.after = true;
+            } else {
+                child = next;
+            }
+        }
+        pos.node = child;
+    }
+    if (this.id && (pos.after || this.id != adapt.cfi.getId(pos.node))) {
+        throw new Error("E_CFI_ID_MISMATCH");
+    }
+    pos.sideBias = this.sideBias;
+    return true;
 };
 
 
@@ -214,69 +214,69 @@ adapt.cfi.ChildStep.prototype.applyTo = function(pos) {
  * @implements {adapt.cfi.Step}
  */
 adapt.cfi.OffsetStep = function(offset, textBefore, textAfter, sideBias) {
-	/** @const */ this.offset = offset;
-	/** @const */ this.textBefore = textBefore;
-	/** @const */ this.textAfter = textAfter;
-	/** @const */ this.sideBias = sideBias;
+    /** @const */ this.offset = offset;
+    /** @const */ this.textBefore = textBefore;
+    /** @const */ this.textAfter = textAfter;
+    /** @const */ this.sideBias = sideBias;
 };
 
 adapt.cfi.OffsetStep.prototype.applyTo = function(pos) {
-	if (this.offset > 0 && !pos.after) {
-		var offset = this.offset;
-		var node = pos.node;
-		while (true) {
-			var nodeType = node.nodeType;
-			if (nodeType == 1) {
-				break;
-			}
-			var next = node.nextSibling;
-			if (3 <= nodeType && nodeType <= 5) {
-				var textLength = node.textContent.length;
-				if (offset <= textLength) {
-					break;
-				}
-				if (!next) {
-					offset = textLength;
-					break;
-				}
-				offset -= textLength;
-			}
-			if (!next) {
-				offset = 0;
-				break;
-			}
-			node = next;
-		}
-		pos.node = node;
-		pos.offset = offset;
-	}
-	pos.sideBias = this.sideBias;
-	return true;	
+    if (this.offset > 0 && !pos.after) {
+        var offset = this.offset;
+        var node = pos.node;
+        while (true) {
+            var nodeType = node.nodeType;
+            if (nodeType == 1) {
+                break;
+            }
+            var next = node.nextSibling;
+            if (3 <= nodeType && nodeType <= 5) {
+                var textLength = node.textContent.length;
+                if (offset <= textLength) {
+                    break;
+                }
+                if (!next) {
+                    offset = textLength;
+                    break;
+                }
+                offset -= textLength;
+            }
+            if (!next) {
+                offset = 0;
+                break;
+            }
+            node = next;
+        }
+        pos.node = node;
+        pos.offset = offset;
+    }
+    pos.sideBias = this.sideBias;
+    return true;
 };
 
 /**
  * @override
  */
 adapt.cfi.OffsetStep.prototype.appendTo = function(sb) {
-	sb.append(":");
-	sb.append(this.offset.toString());
-	if (this.textBefore || this.textAfter || this.sideBias) {
-		sb.append("[");
-		if (this.textBefore || this.textAfter) {
-			if (this.textBefore) {
-				sb.append(adapt.cfi.escape(this.textBefore));
-			}
-			sb.append(",");
-			if (this.textAfter) {
-				sb.append(adapt.cfi.escape(this.textAfter));
-			}
-		}
-		if (this.sideBias) {
-			sb.append(";s=");
-			sb.append(this.sideBias);
-		}
-		sb.append("]");
-	}
+    sb.append(":");
+    sb.append(this.offset.toString());
+    if (this.textBefore || this.textAfter || this.sideBias) {
+        sb.append("[");
+        if (this.textBefore || this.textAfter) {
+            if (this.textBefore) {
+                sb.append(adapt.cfi.escape(this.textBefore));
+            }
+            sb.append(",");
+            if (this.textAfter) {
+                sb.append(adapt.cfi.escape(this.textAfter));
+            }
+        }
+        if (this.sideBias) {
+            sb.append(";s=");
+            sb.append(this.sideBias);
+        }
+        sb.append("]");
+    }
 };
 
 
@@ -284,7 +284,7 @@ adapt.cfi.OffsetStep.prototype.appendTo = function(sb) {
  * @constructor
  */
 adapt.cfi.Fragment = function() {
-	/** @type {Array.<adapt.cfi.Step>} */ this.steps = null;
+    /** @type {Array.<adapt.cfi.Step>} */ this.steps = null;
 };
 
 /**
@@ -292,62 +292,62 @@ adapt.cfi.Fragment = function() {
  * @return {void}
  */
 adapt.cfi.Fragment.prototype.fromString = function(fragstr) {
-	var r = fragstr.match(/^#?epubcfi\((.*)\)$/);
-	if (!r) {
-		throw new Error("E_CFI_NOT_CFI");
-	}
-	var str = r[1];
-	var i = 0;
-	var steps = [];
-	while(true) {
-		switch (str.charAt(i)) {
-		case "/":
-			i++;
-			r = str.substr(i).match(/^(0|[1-9][0-9]*)(\[([-a-zA-Z_0-9.\u007F-\uFFFF]+)(;([^\]]|\^\])*)?\])?/);
-			if (!r) {
-				throw new Error("E_CFI_NUMBER_EXPECTED");				
-			}
-			i += r[0].length;
-			var index = parseInt(r[1], 10);
-			var id = r[3];
-			var ext = adapt.cfi.parseExt(r[4]);
-			steps.push(new adapt.cfi.ChildStep(index, id, adapt.base.asString(ext["s"])));
-			break;
-		case ":":
-			i++;
-			r = str.substr(i).match(/^(0|[1-9][0-9]*)(\[((([^\];,]|\^[\];,])*)(,(([^\];,]|\^[\];,])*))?)(;([^]]|\^\])*)?\])?/);
-			if (!r) {
-				throw new Error("E_CFI_NUMBER_EXPECTED");				
-			}
-			i += r[0].length;
-			var offset = parseInt(r[1], 10);
-			var textBefore = r[4];
-			if (textBefore) {
-				textBefore = adapt.cfi.unescape(textBefore);
-			}
-			var textAfter = r[7];
-			if (textAfter) {
-				textAfter = adapt.cfi.unescape(textAfter);
-			}
-			var ext = adapt.cfi.parseExt(r[10]);
-			steps.push(new adapt.cfi.OffsetStep(offset, textBefore, textAfter, adapt.base.asString(ext["s"])));
-			break;			
-		case "!":
-			i++;
-			steps.push(new adapt.cfi.RefStep());
-			break;
-		case "~":
-		case "@":
-			// Time/space terminus; only useful for highlights/selections which are not yet
-			// supported, skip for now.
-			// fall through
-		case "":
-			this.steps = steps;
-			return;
-		default:
-			throw new Error("E_CFI_PARSE_ERROR");				
-		}
-	}
+    var r = fragstr.match(/^#?epubcfi\((.*)\)$/);
+    if (!r) {
+        throw new Error("E_CFI_NOT_CFI");
+    }
+    var str = r[1];
+    var i = 0;
+    var steps = [];
+    while (true) {
+        switch (str.charAt(i)) {
+            case "/":
+                i++;
+                r = str.substr(i).match(/^(0|[1-9][0-9]*)(\[([-a-zA-Z_0-9.\u007F-\uFFFF]+)(;([^\]]|\^\])*)?\])?/);
+                if (!r) {
+                    throw new Error("E_CFI_NUMBER_EXPECTED");
+                }
+                i += r[0].length;
+                var index = parseInt(r[1], 10);
+                var id = r[3];
+                var ext = adapt.cfi.parseExt(r[4]);
+                steps.push(new adapt.cfi.ChildStep(index, id, adapt.base.asString(ext["s"])));
+                break;
+            case ":":
+                i++;
+                r = str.substr(i).match(/^(0|[1-9][0-9]*)(\[((([^\];,]|\^[\];,])*)(,(([^\];,]|\^[\];,])*))?)(;([^]]|\^\])*)?\])?/);
+                if (!r) {
+                    throw new Error("E_CFI_NUMBER_EXPECTED");
+                }
+                i += r[0].length;
+                var offset = parseInt(r[1], 10);
+                var textBefore = r[4];
+                if (textBefore) {
+                    textBefore = adapt.cfi.unescape(textBefore);
+                }
+                var textAfter = r[7];
+                if (textAfter) {
+                    textAfter = adapt.cfi.unescape(textAfter);
+                }
+                var ext = adapt.cfi.parseExt(r[10]);
+                steps.push(new adapt.cfi.OffsetStep(offset, textBefore, textAfter, adapt.base.asString(ext["s"])));
+                break;
+            case "!":
+                i++;
+                steps.push(new adapt.cfi.RefStep());
+                break;
+            case "~":
+            case "@":
+            // Time/space terminus; only useful for highlights/selections which are not yet
+            // supported, skip for now.
+            // fall through
+            case "":
+                this.steps = steps;
+                return;
+            default:
+                throw new Error("E_CFI_PARSE_ERROR");
+        }
+    }
 };
 
 /**
@@ -355,17 +355,17 @@ adapt.cfi.Fragment.prototype.fromString = function(fragstr) {
  * @return {adapt.cfi.Position}
  */
 adapt.cfi.Fragment.prototype.navigate = function(doc) {
-	var pos = {node:doc.documentElement, offset:0, after:false, sideBias:null, ref:null};
-	for (var i = 0; i < this.steps.length; i++) {
-		if (!this.steps[i].applyTo(pos)) {
-			if (++i < this.steps.length) {
-				pos.ref = new adapt.cfi.Fragment();
-				pos.ref.steps = this.steps.slice(i);
-			}
-			break;
-		}
-	}
-	return pos;
+    var pos = {node:doc.documentElement, offset:0, after:false, sideBias:null, ref:null};
+    for (var i = 0; i < this.steps.length; i++) {
+        if (!this.steps[i].applyTo(pos)) {
+            if (++i < this.steps.length) {
+                pos.ref = new adapt.cfi.Fragment();
+                pos.ref.steps = this.steps.slice(i);
+            }
+            break;
+        }
+    }
+    return pos;
 };
 
 /**
@@ -374,9 +374,9 @@ adapt.cfi.Fragment.prototype.navigate = function(doc) {
  * @return {string}
  */
 adapt.cfi.Fragment.prototype.trim = function(text, after) {
-	return text.replace(/\s+/g, " ").match(
-			after ? /^[ -\uD7FF\uE000-\uFFFF]{0,8}/ : /[ -\uD7FF\uE000-\uFFFF]{0,8}$/
-		)[0].replace(/^\s/, "").replace(/\s$/, "");
+    return text.replace(/\s+/g, " ").match(
+        after ? /^[ -\uD7FF\uE000-\uFFFF]{0,8}/ : /[ -\uD7FF\uE000-\uFFFF]{0,8}$/
+    )[0].replace(/^\s/, "").replace(/\s$/, "");
 };
 
 /**
@@ -387,79 +387,79 @@ adapt.cfi.Fragment.prototype.trim = function(text, after) {
  * @param {?string} sideBias
  */
 adapt.cfi.Fragment.prototype.prependPathFromNode = function(node, offset, after, sideBias) {
-	var steps = [];
-	var parent = node.parentNode;
-	var textBefore = "";
-	var textAfter = "";
-	while(node) {
-		switch (node.nodeType) {
-		case 3:  // Text nodes
-		case 4:
-		case 5:
-			var text = node.textContent;
-			var textLength = text.length;
-			if (after) {
-				offset += textLength;
-				if (!textBefore) {
-					textBefore = text;
-				}
-			} else {
-				if (offset > textLength) {
-					offset = textLength;
-				}
-				after = true;
-				textBefore = text.substr(0, offset);
-				textAfter = text.substr(offset);
-			}
-			node = node.previousSibling;
-			continue;
-		case 8:  // Comment Node
+    var steps = [];
+    var parent = node.parentNode;
+    var textBefore = "";
+    var textAfter = "";
+    while (node) {
+        switch (node.nodeType) {
+            case 3:  // Text nodes
+            case 4:
+            case 5:
+                var text = node.textContent;
+                var textLength = text.length;
+                if (after) {
+                    offset += textLength;
+                    if (!textBefore) {
+                        textBefore = text;
+                    }
+                } else {
+                    if (offset > textLength) {
+                        offset = textLength;
+                    }
+                    after = true;
+                    textBefore = text.substr(0, offset);
+                    textAfter = text.substr(offset);
+                }
+                node = node.previousSibling;
+                continue;
+            case 8:  // Comment Node
+                node = node.previousSibling;
+                continue;
+        }
+        break;
+    }
+    if (offset > 0 || textBefore || textAfter) {
+        textBefore = this.trim(textBefore, false);
+        textAfter = this.trim(textAfter, true);
+        steps.push(new adapt.cfi.OffsetStep(offset, textBefore, textAfter, sideBias));
+        sideBias = null;
+    }
+    while (parent) {
+        if (!parent || parent.nodeType == 9) {
+            break;
+        }
+        var id = after ? null : adapt.cfi.getId(node);
+        var index = after ? 1 : 0;
+        while (node) {
+            if (node.nodeType == 1) {
+                index += 2;
+            }
             node = node.previousSibling;
-			continue;
-		}
-		break;
-	}
-	if (offset > 0 || textBefore || textAfter) {
-		textBefore = this.trim(textBefore, false);
-		textAfter = this.trim(textAfter, true);
- 		steps.push(new adapt.cfi.OffsetStep(offset, textBefore, textAfter, sideBias));
- 		sideBias = null;
-	}
-	while (parent) {
-		if (!parent || parent.nodeType == 9) {
-			break;
-		}
- 		var id = after ? null : adapt.cfi.getId(node);
- 		var index = after ? 1 : 0;
- 		while (node) {
- 			if (node.nodeType == 1) {
- 				index += 2;
- 			}
- 			node = node.previousSibling;
- 		}
- 		steps.push(new adapt.cfi.ChildStep(index, id, sideBias));
- 		sideBias = null;
-		node = parent;
-		parent = parent.parentNode;
-		after = false;
-	}
-	steps.reverse();
-	if (this.steps) {
-		steps.push(new adapt.cfi.RefStep());
-		this.steps = steps.concat(this.steps);
-	} else {
-		this.steps = steps;
-	}
+        }
+        steps.push(new adapt.cfi.ChildStep(index, id, sideBias));
+        sideBias = null;
+        node = parent;
+        parent = parent.parentNode;
+        after = false;
+    }
+    steps.reverse();
+    if (this.steps) {
+        steps.push(new adapt.cfi.RefStep());
+        this.steps = steps.concat(this.steps);
+    } else {
+        this.steps = steps;
+    }
 };
 
 adapt.cfi.Fragment.prototype.toString = function() {
-	if (!this.steps)
-		return "";
-	var sb = new adapt.base.StringBuffer();
-	sb.append("epubcfi(");
-	for (var i = 0; i < this.steps.length; i++) {
-		this.steps[i].appendTo(sb);
-	}
-	sb.append(")");
-	return sb.toString();	
+    if (!this.steps)
+        return "";
+    var sb = new adapt.base.StringBuffer();
+    sb.append("epubcfi(");
+    for (var i = 0; i < this.steps.length; i++) {
+        this.steps[i].appendTo(sb);
+    }
+    sb.append(")");
+    return sb.toString();
 };

--- a/src/adapt/css.js
+++ b/src/adapt/css.js
@@ -28,7 +28,7 @@ adapt.css.Visitor = function() {
  * @return void
  */
 adapt.css.Visitor.prototype.visitValues = function(values) {
-    for (var i = 0 ; i < values.length ; i++) {
+    for (var i = 0; i < values.length; i++) {
         values[i].visit(this);
     }
 };
@@ -46,7 +46,7 @@ adapt.css.Visitor.prototype.visitEmpty = function(empty) {
  * @return {adapt.css.Val}
  */
 adapt.css.Visitor.prototype.visitSlash = function(slash) {
-	throw new Error("E_CSS_SLASH_NOT_ALLOWED");
+    throw new Error("E_CSS_SLASH_NOT_ALLOWED");
 };
 
 /**
@@ -142,7 +142,7 @@ adapt.css.Visitor.prototype.visitExpr = function(expr) {
  * @extends {adapt.css.Visitor}
  */
 adapt.css.FilterVisitor = function() {
-	adapt.css.Visitor.call(this);
+    adapt.css.Visitor.call(this);
 };
 goog.inherits(adapt.css.FilterVisitor, adapt.css.Visitor);
 
@@ -152,14 +152,14 @@ goog.inherits(adapt.css.FilterVisitor, adapt.css.Visitor);
  */
 adapt.css.FilterVisitor.prototype.visitValues = function(values) {
     /** @type {Array.<adapt.css.Val>} */ var arr = null;
-    for (var i = 0 ; i < values.length ; i++) {
+    for (var i = 0; i < values.length; i++) {
         var before = values[i];
         var after = before.visit(this);
         if (arr) {
             arr[i] = after;
         } else if (before !== after) {
             arr = new Array(values.length);
-            for (var k = 0 ; k < i ; k++) {
+            for (var k = 0; k < i; k++) {
                 arr[k] = values[k];
             }
             arr[i] = after;
@@ -450,13 +450,13 @@ adapt.css.Str.prototype.toExpr = function(scope, ref) {
  * @override
  */
 adapt.css.Str.prototype.appendTo = function(buf, toString) {
-	if (toString) {
-	    buf.append('"');
-	    buf.append(adapt.base.escapeCSSStr(this.str));
-	    buf.append('"');
-	} else {
-	    buf.append(this.str);		
-	}
+    if (toString) {
+        buf.append('"');
+        buf.append(adapt.base.escapeCSSStr(this.str));
+        buf.append('"');
+    } else {
+        buf.append(this.str);
+    }
 };
 
 /**
@@ -487,16 +487,16 @@ goog.inherits(adapt.css.Ident, adapt.css.Val);
 adapt.css.Ident.prototype.toExpr = function(scope, ref) {
     return new adapt.expr.Const(scope, this.name);
 };
-    
+
 /**
  * @override
  */
 adapt.css.Ident.prototype.appendTo = function(buf, toString) {
-	if (toString) {
-		buf.append(adapt.base.escapeCSSIdent(this.name));
-	} else {
-		buf.append(this.name);
-	}
+    if (toString) {
+        buf.append(adapt.base.escapeCSSIdent(this.name));
+    } else {
+        buf.append(this.name);
+    }
 };
 
 /**
@@ -521,7 +521,7 @@ adapt.css.Ident.prototype.isIdent = function() {
 adapt.css.getName = function(name) {
     var r = adapt.css.nameTable[name];
     if (!r) {
-    	r = new adapt.css.Ident(name);
+        r = new adapt.css.Ident(name);
     }
     return r;
 };
@@ -707,7 +707,7 @@ adapt.css.URL.prototype.visit = function(visitor) {
 adapt.css.appendList = function(buf, values, separator, toString) {
     var length = values.length;
     values[0].appendTo(buf, toString);
-    for (var i = 1 ; i < length ; i++) {
+    for (var i = 1; i < length; i++) {
         buf.append(separator);
         values[i].appendTo(buf, toString);
     }
@@ -762,7 +762,7 @@ goog.inherits(adapt.css.CommaList, adapt.css.Val);
  * @override
  */
 adapt.css.CommaList.prototype.appendTo = function(buf, toString) {
-	adapt.css.appendList(buf, this.values, ",", toString);
+    adapt.css.appendList(buf, this.values, ",", toString);
 };
 
 /**
@@ -848,19 +848,19 @@ adapt.css.Expr.prototype.isExpr = function() {
 /**
  * @param {adapt.css.Val} val
  * @param {adapt.expr.Context} context
- * @return {number} 
+ * @return {number}
  */
 adapt.css.toNumber = function(val, context) {
-	if (val) {
-	    if (val.isNumeric()) {
-	        var numeric = /** @type {adapt.css.Numeric} */ (val);
-	        return context.queryUnitSize(numeric.unit, false) * numeric.num;
-	    }
-	    if (val.isNum()) {
-	        return (/** @type {adapt.css.Num} */ (val)).num;
-	    }
-	}
-	return 0;
+    if (val) {
+        if (val.isNumeric()) {
+            var numeric = /** @type {adapt.css.Numeric} */ (val);
+            return context.queryUnitSize(numeric.unit, false) * numeric.num;
+        }
+        if (val.isNum()) {
+            return (/** @type {adapt.css.Num} */ (val)).num;
+        }
+    }
+    return 0;
 };
 
 /**
@@ -879,11 +879,11 @@ adapt.css.convertNumericToPx = function(val, context) {
  * @type {Object.<string,adapt.css.Ident>}
  */
 adapt.css.ident = {
-	absolute: adapt.css.getName("absolute"),
-	all: adapt.css.getName("all"),
+    absolute: adapt.css.getName("absolute"),
+    all: adapt.css.getName("all"),
     always: adapt.css.getName("always"),
-	auto: adapt.css.getName("auto"),
-	avoid: adapt.css.getName("avoid"),
+    auto: adapt.css.getName("auto"),
+    avoid: adapt.css.getName("avoid"),
     block: adapt.css.getName("block"),
     block_end: adapt.css.getName("block-end"),
     block_start: adapt.css.getName("block-start"),
@@ -918,14 +918,14 @@ adapt.css.ident = {
     scale: adapt.css.getName("scale"),
     _static: adapt.css.getName("static"),
     rtl: adapt.css.getName("rtl"),
-	table: adapt.css.getName("table"),
+    table: adapt.css.getName("table"),
     table_caption: adapt.css.getName("table-caption"),
     table_cell: adapt.css.getName("table-cell"),
-	table_row: adapt.css.getName("table-row"),
+    table_row: adapt.css.getName("table-row"),
     top: adapt.css.getName("top"),
-	transparent: adapt.css.getName("transparent"),
+    transparent: adapt.css.getName("transparent"),
     vertical_lr: adapt.css.getName("vertical-lr"),
-	vertical_rl: adapt.css.getName("vertical-rl"),
+    vertical_rl: adapt.css.getName("vertical-rl"),
     visible: adapt.css.getName("visible"),
     _true: adapt.css.getName("true")
 };
@@ -955,8 +955,8 @@ adapt.css.fullHeight = new adapt.css.Numeric(100, "vh");
 adapt.css.numericZero = new adapt.css.Numeric(0, "px");
 
 adapt.css.processingOrder = {
-	"font-size": 1,
-	"color": 2
+    "font-size": 1,
+    "color": 2
 };
 
 /**
@@ -966,8 +966,8 @@ adapt.css.processingOrder = {
  * @return {number}
  */
 adapt.css.processingOrderFn = function(name1, name2) {
-	var n1 = adapt.css.processingOrder[name1] || Number.MAX_VALUE;
-	var n2 = adapt.css.processingOrder[name2] || Number.MAX_VALUE;
-	return n1 - n2;
+    var n1 = adapt.css.processingOrder[name1] || Number.MAX_VALUE;
+    var n2 = adapt.css.processingOrder[name2] || Number.MAX_VALUE;
+    return n1 - n2;
 };
 

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -16,99 +16,99 @@ goog.require('adapt.cssparse');
 goog.require('adapt.cssvalid');
 
 adapt.csscasc.inheritedProps = {
-	"azimuth": true,
-	"border-collapse": true,
-	"border-spacing": true,
-	"caption-side": true,
-	"color": true,
-	"cursor": true,
-	"direction": true,
-	"elevation": true,
-	"empty-cells": true,
+    "azimuth": true,
+    "border-collapse": true,
+    "border-spacing": true,
+    "caption-side": true,
+    "color": true,
+    "cursor": true,
+    "direction": true,
+    "elevation": true,
+    "empty-cells": true,
     "font-kerning": true,
-	"font-size": true,
-	"font-size-adjust": true,
-	"font-family": true,
+    "font-size": true,
+    "font-size-adjust": true,
+    "font-family": true,
     "font-feature-settings": true,
     "font-style": true,
-	"font-variant": true,
-	"font-weight": true,
-	"image-resolution": true,
-	"letter-spacing": true,
+    "font-variant": true,
+    "font-weight": true,
+    "image-resolution": true,
+    "letter-spacing": true,
     "line-break": true,
-	"line-height": true,
-	"list-style-image": true,
-	"list-style-position": true,
-	"list-style-type": true,
-	"orphans": true,
+    "line-height": true,
+    "list-style-image": true,
+    "list-style-position": true,
+    "list-style-type": true,
+    "orphans": true,
     "overflow-wrap": true,
-	"pitch-range": true,
-	"quotes": true,
-	"richness": true,
+    "pitch-range": true,
+    "quotes": true,
+    "richness": true,
     "ruby-align": true,
     "ruby-position": true,
-	"speak-header": true,
-	"speak-numeral": true,
-	"speak-punctuation": true,
-	"speech-rate": true,
-	"stress": true,
+    "speak-header": true,
+    "speak-numeral": true,
+    "speak-punctuation": true,
+    "speech-rate": true,
+    "stress": true,
     "tab-size": true,
-	"text-align": true,
+    "text-align": true,
     "text-align-last": true,
     "text-decoration-skip": true,
     "text-emphasis-color": true,
     "text-emphasis-position": true,
     "text-emphasis-style": true,
     "text-combine-upright": true,
-	"text-indent": true,
+    "text-indent": true,
     "text-justify": true,
     "text-size-adjust": true,
-	"text-transform": true,
+    "text-transform": true,
     "text-underline-position": true,
-	"visibility": true,
-	"voice-family": true,
-	"volume": true,
-	"white-space": true,
-	"widows": true,
+    "visibility": true,
+    "voice-family": true,
+    "volume": true,
+    "white-space": true,
+    "widows": true,
     "word-break": true,
-	"word-spacing": true,
+    "word-spacing": true,
     "word-wrap": true,
-	"writing-mode": true
+    "writing-mode": true
 };
 
 /** @const */
 adapt.csscasc.polyfilledInheritedProps = [
-	"box-decoration-break", // TODO: box-decoration-block should not be inherited. https://github.com/vivliostyle/vivliostyle.js/issues/259
-	"image-resolution",
-	"orphans",
-	"widows"
+    "box-decoration-break", // TODO: box-decoration-block should not be inherited. https://github.com/vivliostyle/vivliostyle.js/issues/259
+    "image-resolution",
+    "orphans",
+    "widows"
 ];
 
 /** @const */
 adapt.csscasc.supportedNamespaces = {
-	"http://www.idpf.org/2007/ops": true,
-	"http://www.w3.org/1999/xhtml": true,
-	"http://www.w3.org/2000/svg": true
+    "http://www.idpf.org/2007/ops": true,
+    "http://www.w3.org/1999/xhtml": true,
+    "http://www.w3.org/2000/svg": true
 };
 
 /** @const */
 adapt.csscasc.coupledPatterns = ["margin-%", "padding-%", "border-%-width", "border-%-style",
-                                "border-%-color", "%"];
+    "border-%-color", "%"];
 
 /**
  * @const
  * @type {Object.<string,boolean>}
  */
 adapt.csscasc.geomNames = (function() {
-	var sides = ["left", "right", "top", "bottom"];
-	var names = {"width": true, "height": true};
-	for (var i = 0; i < adapt.csscasc.coupledPatterns.length; i++) {
-		for (var k = 0; k < sides.length; k++) {
-			var name = adapt.csscasc.coupledPatterns[i].replace("%", sides[k]);
-			names[name] = true;
-		}
-	}
-	return names;
+    var sides = ["left", "right", "top", "bottom"];
+    var names = {"width": true, "height": true};
+    for (var i = 0; i < adapt.csscasc.coupledPatterns.length; i++) {
+        for (var k = 0; k < sides.length; k++) {
+            var name = adapt.csscasc.coupledPatterns[i].replace("%", sides[k]);
+            names[name] = true;
+        }
+    }
+    return names;
 })();
 
 /**
@@ -116,31 +116,31 @@ adapt.csscasc.geomNames = (function() {
  * @return {Object.<string,string>}
  */
 adapt.csscasc.buildCouplingMap = function(sideMap) {
-	var map = {};
-	for (var i = 0; i < adapt.csscasc.coupledPatterns.length; i++) {
-		for (var side in sideMap) {
-			var name1 = adapt.csscasc.coupledPatterns[i].replace("%", side);
-			var name2 = adapt.csscasc.coupledPatterns[i].replace("%", sideMap[side]);
-			map[name1] = name2;
-			map[name2] = name1;
-		}
-	}
-	return map;
+    var map = {};
+    for (var i = 0; i < adapt.csscasc.coupledPatterns.length; i++) {
+        for (var side in sideMap) {
+            var name1 = adapt.csscasc.coupledPatterns[i].replace("%", side);
+            var name2 = adapt.csscasc.coupledPatterns[i].replace("%", sideMap[side]);
+            map[name1] = name2;
+            map[name2] = name1;
+        }
+    }
+    return map;
 };
 
 /** @const */
 adapt.csscasc.couplingMapVert = adapt.csscasc.buildCouplingMap({
-	"before": "right",
-	"after": "left",
-	"start": "top",
-	"end": "bottom"});
+    "before": "right",
+    "after": "left",
+    "start": "top",
+    "end": "bottom"});
 
 /** @const */
 adapt.csscasc.couplingMapHor = adapt.csscasc.buildCouplingMap({
-	"before": "top",
-	"after": "bottom",
-	"start": "left",
-	"end": "right"});
+    "before": "top",
+    "after": "bottom",
+    "start": "left",
+    "end": "right"});
 
 /**
  * @param {adapt.css.Val} value
@@ -148,8 +148,8 @@ adapt.csscasc.couplingMapHor = adapt.csscasc.buildCouplingMap({
  * @constructor
  */
 adapt.csscasc.CascadeValue = function(value, priority) {
-	/** @const */ this.value = value;
-	/** @const */ this.priority = priority;
+    /** @const */ this.value = value;
+    /** @const */ this.priority = priority;
 };
 
 /**
@@ -206,8 +206,8 @@ adapt.csscasc.CascadeValue.prototype.isEnabled = function(context) {
  * @extends {adapt.csscasc.CascadeValue}
  */
 adapt.csscasc.ConditionalCascadeValue = function(value, priority, condition) {
-	adapt.csscasc.CascadeValue.call(this, value, priority);
-	/** @const */ this.condition = condition;
+    adapt.csscasc.CascadeValue.call(this, value, priority);
+    /** @const */ this.condition = condition;
 };
 goog.inherits(adapt.csscasc.ConditionalCascadeValue, adapt.csscasc.CascadeValue);
 
@@ -215,7 +215,7 @@ goog.inherits(adapt.csscasc.ConditionalCascadeValue, adapt.csscasc.CascadeValue)
  * @override
  */
 adapt.csscasc.ConditionalCascadeValue.prototype.getBaseValue = function() {
-	return new adapt.csscasc.CascadeValue(this.value, this.priority);
+    return new adapt.csscasc.CascadeValue(this.value, this.priority);
 };
 
 /**
@@ -235,7 +235,7 @@ adapt.csscasc.ConditionalCascadeValue.prototype.increaseSpecificity = function(s
     if (specificity == 0)
         return this;
     return new adapt.csscasc.ConditionalCascadeValue(this.value, this.priority + specificity,
-    		this.condition);
+        this.condition);
 };
 
 /**
@@ -253,10 +253,10 @@ adapt.csscasc.ConditionalCascadeValue.prototype.isEnabled = function(context) {
  * @return {adapt.csscasc.CascadeValue}
  */
 adapt.csscasc.cascadeValues = function(context, tv, av) {
-	if ((tv == null || av.priority > tv.priority) && av.isEnabled(context)) {
-		return av.getBaseValue();
-	}
-	return tv;
+    if ((tv == null || av.priority > tv.priority) && av.isEnabled(context)) {
+        return av.getBaseValue();
+    }
+    return tv;
 };
 
 /**
@@ -282,21 +282,21 @@ adapt.csscasc.SPECIALS = {
  * @param {string} name
  */
 adapt.csscasc.isSpecialName = function(name) {
-	return !!adapt.csscasc.SPECIALS[name];
+    return !!adapt.csscasc.SPECIALS[name];
 };
 
 /**
  * @param {string} name
  */
 adapt.csscasc.isMapName = function(name) {
-	return name.charAt(0) == "_";
+    return name.charAt(0) == "_";
 };
 
 /**
  * @param {string} name
  */
 adapt.csscasc.isPropName = function(name) {
-	return name.charAt(0) != "_" && !adapt.csscasc.SPECIALS[name];
+    return name.charAt(0) != "_" && !adapt.csscasc.SPECIALS[name];
 };
 
 /**
@@ -304,7 +304,7 @@ adapt.csscasc.isPropName = function(name) {
  * @return {boolean}
  */
 adapt.csscasc.isInherited = function(name) {
-	return !!adapt.csscasc.inheritedProps[name];
+    return !!adapt.csscasc.inheritedProps[name];
 };
 
 /**
@@ -313,7 +313,7 @@ adapt.csscasc.isInherited = function(name) {
  * @return {adapt.csscasc.CascadeValue}
  */
 adapt.csscasc.getProp = function(style, name) {
-	return /** @type {adapt.csscasc.CascadeValue} */ (style[name]);
+    return /** @type {adapt.csscasc.CascadeValue} */ (style[name]);
 };
 
 
@@ -324,11 +324,11 @@ adapt.csscasc.getProp = function(style, name) {
  * @return void
  */
 adapt.csscasc.setProp = function(style, name, value) {
-	if (!value) {
-		delete style[name];
-	} else {
-		style[name] = value;
-	}
+    if (!value) {
+        delete style[name];
+    } else {
+        style[name] = value;
+    }
 };
 
 /**
@@ -337,7 +337,7 @@ adapt.csscasc.setProp = function(style, name, value) {
  * @return {adapt.csscasc.ElementStyleMap}
  */
 adapt.csscasc.getStyleMap = function(style, name) {
-	return /** @type {adapt.csscasc.ElementStyleMap} */ (style[name]);
+    return /** @type {adapt.csscasc.ElementStyleMap} */ (style[name]);
 };
 
 /**
@@ -346,12 +346,12 @@ adapt.csscasc.getStyleMap = function(style, name) {
  * @return {adapt.csscasc.ElementStyleMap}
  */
 adapt.csscasc.getMutableStyleMap = function(style, name) {
-	var r = /** @type {adapt.csscasc.ElementStyleMap} */ (style[name]);
-	if (!r) {
-		r = {};
-		style[name] = r;
-	}
-	return r;
+    var r = /** @type {adapt.csscasc.ElementStyleMap} */ (style[name]);
+    if (!r) {
+        r = {};
+        style[name] = r;
+    }
+    return r;
 };
 
 /**
@@ -360,7 +360,7 @@ adapt.csscasc.getMutableStyleMap = function(style, name) {
  * @return {Array.<adapt.csscasc.CascadeValue>}
  */
 adapt.csscasc.getSpecial = function(style, name) {
-	return /** @type {Array.<adapt.csscasc.CascadeValue>} */ (style[name]);
+    return /** @type {Array.<adapt.csscasc.CascadeValue>} */ (style[name]);
 };
 
 /**
@@ -369,12 +369,12 @@ adapt.csscasc.getSpecial = function(style, name) {
  * @return {Array.<adapt.csscasc.CascadeValue>}
  */
 adapt.csscasc.getMutableSpecial = function(style, name) {
-	var r = /** @type {Array.<adapt.csscasc.CascadeValue>} */ (style[name]);
-	if (!r) {
-		r = [];
-		style[name] = r;
-	}
-	return r;
+    var r = /** @type {Array.<adapt.csscasc.CascadeValue>} */ (style[name]);
+    if (!r) {
+        r = [];
+        style[name] = r;
+    }
+    return r;
 };
 
 
@@ -408,15 +408,15 @@ adapt.csscasc.mergeIn = function(context, target, style, specificity, pseudoelem
         if (adapt.csscasc.isMapName(prop))
             continue;
         if (adapt.csscasc.isSpecialName(prop)) {
-        	// special properties: list of all assigned values
-        	var as = adapt.csscasc.getSpecial(style, prop);
-        	var ts = adapt.csscasc.getMutableSpecial(target, prop);
-        	Array.prototype.push.apply(ts, as);
+            // special properties: list of all assigned values
+            var as = adapt.csscasc.getSpecial(style, prop);
+            var ts = adapt.csscasc.getMutableSpecial(target, prop);
+            Array.prototype.push.apply(ts, as);
         } else {
-        	// regular properties: higher priority wins
-	        var av = adapt.csscasc.getProp(style, prop).increaseSpecificity(specificity);
-	        var tv = adapt.csscasc.getProp(target, prop);
-	        adapt.csscasc.setProp(target, prop, adapt.csscasc.cascadeValues(context, tv, av));
+            // regular properties: higher priority wins
+            var av = adapt.csscasc.getProp(style, prop).increaseSpecificity(specificity);
+            var tv = adapt.csscasc.getProp(target, prop);
+            adapt.csscasc.setProp(target, prop, adapt.csscasc.cascadeValues(context, tv, av));
         }
     }
 };
@@ -427,19 +427,19 @@ adapt.csscasc.mergeIn = function(context, target, style, specificity, pseudoelem
  * @return {adapt.csscasc.ElementStyle}
  */
 adapt.csscasc.mergeAll = function(context, styles) {
-	var target = /** @type {adapt.csscasc.ElementStyle} */ ({});
-	for (var k = 0; k < styles.length; k++) {
-		adapt.csscasc.mergeIn(context, target, styles[k], 0, null, null);
-	}
-	return target;
+    var target = /** @type {adapt.csscasc.ElementStyle} */ ({});
+    for (var k = 0; k < styles.length; k++) {
+        adapt.csscasc.mergeIn(context, target, styles[k], 0, null, null);
+    }
+    return target;
 };
 
 /**
  * @protected
  * @param {Array.<adapt.csscasc.ChainedAction>} chain
  * @param {adapt.csscasc.CascadeAction} action
- * @return {adapt.csscasc.CascadeAction} 
-*/
+ * @return {adapt.csscasc.CascadeAction}
+ */
 adapt.csscasc.chainActions = function(chain, action) {
     if (chain.length > 0) {
         chain.sort(
@@ -452,7 +452,7 @@ adapt.csscasc.chainActions = function(chain, action) {
                 return b.getPriority() - a.getPriority();
             });
         var chained = null;
-        for (var i = chain.length - 1 ; i >= 0 ; i--) {
+        for (var i = chain.length - 1; i >= 0; i--) {
             chained = chain[i];
             chained.chained = action;
             action = chained;
@@ -460,7 +460,7 @@ adapt.csscasc.chainActions = function(chain, action) {
         return chained;
     }
     return action;
-}
+};
 
 
 /**
@@ -470,10 +470,10 @@ adapt.csscasc.chainActions = function(chain, action) {
  * @extends {adapt.css.FilterVisitor}
  */
 adapt.csscasc.InheritanceVisitor = function(props, context) {
-	adapt.css.Visitor.call(this);
-	/** @const */ this.props = props;
-	/** @const */ this.context = context;
-	/** @type {string} */ this.propName = "";
+    adapt.css.Visitor.call(this);
+    /** @const */ this.props = props;
+    /** @const */ this.context = context;
+    /** @type {string} */ this.propName = "";
 };
 goog.inherits(adapt.csscasc.InheritanceVisitor, adapt.css.FilterVisitor);
 
@@ -482,18 +482,18 @@ goog.inherits(adapt.csscasc.InheritanceVisitor, adapt.css.FilterVisitor);
  * @return {void}
  */
 adapt.csscasc.InheritanceVisitor.prototype.setPropName = function(name) {
-	this.propName = name;
+    this.propName = name;
 };
 
 /**
  * @private
  */
 adapt.csscasc.InheritanceVisitor.prototype.getFontSize = function() {
-	var cascval = adapt.csscasc.getProp(this.props, "font-size");
-	var n = /** @type {adapt.css.Numeric} */ (cascval.value);
-	if (!adapt.expr.isAbsoluteLengthUnit(n.unit)) {
-		throw new Error("Unexpected state");
-	}
+    var cascval = adapt.csscasc.getProp(this.props, "font-size");
+    var n = /** @type {adapt.css.Numeric} */ (cascval.value);
+    if (!adapt.expr.isAbsoluteLengthUnit(n.unit)) {
+        throw new Error("Unexpected state");
+    }
     return n.num * adapt.expr.defaultUnitSizes[n.unit];
 };
 
@@ -501,16 +501,16 @@ adapt.csscasc.InheritanceVisitor.prototype.getFontSize = function() {
  * @override
  */
 adapt.csscasc.InheritanceVisitor.prototype.visitNumeric = function(numeric) {
-	if (numeric.unit == "em" || numeric.unit == "ex") {
-		var ratio = this.context.queryUnitSize(numeric.unit, false) / this.context.queryUnitSize("em", false);
-		return new adapt.css.Numeric(numeric.num * ratio * this.getFontSize(), "px");
-	} else if (numeric.unit == "%") {
+    if (numeric.unit == "em" || numeric.unit == "ex") {
+        var ratio = this.context.queryUnitSize(numeric.unit, false) / this.context.queryUnitSize("em", false);
+        return new adapt.css.Numeric(numeric.num * ratio * this.getFontSize(), "px");
+    } else if (numeric.unit == "%") {
         if (this.propName === "font-size") {
             return new adapt.css.Numeric(numeric.num / 100 * this.getFontSize(), "px");
         }
-		var unit = this.propName.match(/height|^(top|bottom)$/) ? "vh" : "vw";
-		return new adapt.css.Numeric(numeric.num, unit);
-	}
+        var unit = this.propName.match(/height|^(top|bottom)$/) ? "vh" : "vw";
+        return new adapt.css.Numeric(numeric.num, unit);
+    }
     return numeric;
 };
 
@@ -518,11 +518,11 @@ adapt.csscasc.InheritanceVisitor.prototype.visitNumeric = function(numeric) {
  * @override
  */
 adapt.csscasc.InheritanceVisitor.prototype.visitExpr = function(expr) {
-	if (this.propName == "font-size") {
-		var val = adapt.cssparse.evaluateCSSToCSS(this.context, expr, this.propName);
-		return val.visit(this);
-	}
-	return expr;
+    if (this.propName == "font-size") {
+        var val = adapt.cssparse.evaluateCSSToCSS(this.context, expr, this.propName);
+        return val.visit(this);
+    }
+    return expr;
 };
 
 
@@ -555,8 +555,8 @@ adapt.csscasc.CascadeAction.prototype.mergeWith = function(other) {
  * @return {adapt.csscasc.CascadeAction}
  */
 adapt.csscasc.CascadeAction.prototype.clone = function() {
-	// Mutable actions will override
-	return this;
+    // Mutable actions will override
+    return this;
 };
 
 /**
@@ -565,7 +565,7 @@ adapt.csscasc.CascadeAction.prototype.clone = function() {
  * @extends {adapt.csscasc.CascadeAction}
  */
 adapt.csscasc.ConditionItemAction = function(conditionItem) {
-	adapt.csscasc.CascadeAction.call(this);
+    adapt.csscasc.CascadeAction.call(this);
     /** @const */ this.conditionItem = conditionItem;
 };
 goog.inherits(adapt.csscasc.ConditionItemAction, adapt.csscasc.CascadeAction);
@@ -584,8 +584,8 @@ adapt.csscasc.ConditionItemAction.prototype.apply = function(cascadeInstance) {
  * @extends {adapt.csscasc.CascadeAction}
  */
 adapt.csscasc.CompoundAction = function(list) {
-	adapt.csscasc.CascadeAction.call(this);
-	/** @const */ this.list = list;
+    adapt.csscasc.CascadeAction.call(this);
+    /** @const */ this.list = list;
 };
 goog.inherits(adapt.csscasc.CompoundAction, adapt.csscasc.CascadeAction);
 
@@ -594,7 +594,7 @@ goog.inherits(adapt.csscasc.CompoundAction, adapt.csscasc.CascadeAction);
  * @override
  */
 adapt.csscasc.CompoundAction.prototype.apply = function(cascadeInstance) {
-    for (var i = 0 ; i < this.list.length ; i++)
+    for (var i = 0; i < this.list.length; i++)
         this.list[i].apply(cascadeInstance);
 };
 
@@ -610,7 +610,7 @@ adapt.csscasc.CompoundAction.prototype.mergeWith = function(other) {
  * @override
  */
 adapt.csscasc.CompoundAction.prototype.clone = function() {
-	return new adapt.csscasc.CompoundAction([].concat(this.list));
+    return new adapt.csscasc.CompoundAction([].concat(this.list));
 };
 
 /**
@@ -622,11 +622,11 @@ adapt.csscasc.CompoundAction.prototype.clone = function() {
  * @extends {adapt.csscasc.CascadeAction}
  */
 adapt.csscasc.ApplyRuleAction = function(style, specificity, pseudoelement, regionId) {
-	adapt.csscasc.CascadeAction.call(this);
-	/** @const */ this.style = style;
-	/** @const */ this.specificity = specificity;
-	/** @const */ this.pseudoelement = pseudoelement;
-	/** @const */ this.regionId = regionId;
+    adapt.csscasc.CascadeAction.call(this);
+    /** @const */ this.style = style;
+    /** @const */ this.specificity = specificity;
+    /** @const */ this.pseudoelement = pseudoelement;
+    /** @const */ this.regionId = regionId;
 };
 goog.inherits(adapt.csscasc.ApplyRuleAction, adapt.csscasc.CascadeAction);
 
@@ -634,8 +634,8 @@ goog.inherits(adapt.csscasc.ApplyRuleAction, adapt.csscasc.CascadeAction);
  * @override
  */
 adapt.csscasc.ApplyRuleAction.prototype.apply = function(cascadeInstance) {
-	adapt.csscasc.mergeIn(cascadeInstance.context, cascadeInstance.currentStyle,
-			this.style, this.specificity, this.pseudoelement, this.regionId);
+    adapt.csscasc.mergeIn(cascadeInstance.context, cascadeInstance.currentStyle,
+        this.style, this.specificity, this.pseudoelement, this.regionId);
 };
 
 
@@ -644,8 +644,8 @@ adapt.csscasc.ApplyRuleAction.prototype.apply = function(cascadeInstance) {
  * @extends {adapt.csscasc.CascadeAction}
  */
 adapt.csscasc.ChainedAction = function() {
-	adapt.csscasc.CascadeAction.call(this);
-	/** @type {adapt.csscasc.CascadeAction} */ this.chained = null;
+    adapt.csscasc.CascadeAction.call(this);
+    /** @type {adapt.csscasc.CascadeAction} */ this.chained = null;
 };
 goog.inherits(adapt.csscasc.ChainedAction, adapt.csscasc.CascadeAction);
 
@@ -677,8 +677,8 @@ adapt.csscasc.ChainedAction.prototype.makePrimary = function(cascade) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckClassAction = function(className) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.className = className;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.className = className;
 };
 goog.inherits(adapt.csscasc.CheckClassAction, adapt.csscasc.ChainedAction);
 
@@ -701,9 +701,9 @@ adapt.csscasc.CheckClassAction.prototype.getPriority = function() {
  * @override
  */
 adapt.csscasc.CheckClassAction.prototype.makePrimary = function(cascade) {
-	if (this.chained) {
-		cascade.insertInTable(cascade.classes, this.className, this.chained);
-	}
+    if (this.chained) {
+        cascade.insertInTable(cascade.classes, this.className, this.chained);
+    }
     return true;
 };
 
@@ -714,8 +714,8 @@ adapt.csscasc.CheckClassAction.prototype.makePrimary = function(cascade) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckIdAction = function(id) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.id = id;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.id = id;
 };
 goog.inherits(adapt.csscasc.CheckIdAction, adapt.csscasc.ChainedAction);
 
@@ -738,9 +738,9 @@ adapt.csscasc.CheckIdAction.prototype.getPriority = function() {
  * @override
  */
 adapt.csscasc.CheckIdAction.prototype.makePrimary = function(cascade) {
-	if (this.chained) {
-		cascade.insertInTable(cascade.ids, this.id, this.chained);
-	}
+    if (this.chained) {
+        cascade.insertInTable(cascade.ids, this.id, this.chained);
+    }
     return true;
 };
 
@@ -751,8 +751,8 @@ adapt.csscasc.CheckIdAction.prototype.makePrimary = function(cascade) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckLocalNameAction = function(localName) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.localName = localName;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.localName = localName;
 };
 goog.inherits(adapt.csscasc.CheckLocalNameAction, adapt.csscasc.ChainedAction);
 
@@ -775,9 +775,9 @@ adapt.csscasc.CheckLocalNameAction.prototype.getPriority = function() {
  * @override
  */
 adapt.csscasc.CheckLocalNameAction.prototype.makePrimary = function(cascade) {
-	if (this.chained) {
-		cascade.insertInTable(cascade.tags, this.localName, this.chained);
-	}
+    if (this.chained) {
+        cascade.insertInTable(cascade.tags, this.localName, this.chained);
+    }
     return true;
 };
 
@@ -789,9 +789,9 @@ adapt.csscasc.CheckLocalNameAction.prototype.makePrimary = function(cascade) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckNSTagAction = function(ns, localName) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.ns = ns;
-	/** @const */ this.localName = localName;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.ns = ns;
+    /** @const */ this.localName = localName;
 };
 goog.inherits(adapt.csscasc.CheckNSTagAction, adapt.csscasc.ChainedAction);
 
@@ -814,15 +814,15 @@ adapt.csscasc.CheckNSTagAction.prototype.getPriority = function() {
  * @override
  */
 adapt.csscasc.CheckNSTagAction.prototype.makePrimary = function(cascade) {
-	if (this.chained) {
-		var prefix = cascade.nsPrefix[this.ns];
-		if (!prefix) {
-			prefix = "ns" + (cascade.nsCount++) + ":";
-			cascade.nsPrefix[this.ns] = prefix;
-		}
-		var nsTag = prefix + this.localName;
-		cascade.insertInTable(cascade.nstags, nsTag, this.chained);
-	}
+    if (this.chained) {
+        var prefix = cascade.nsPrefix[this.ns];
+        if (!prefix) {
+            prefix = "ns" + (cascade.nsCount++) + ":";
+            cascade.nsPrefix[this.ns] = prefix;
+        }
+        var nsTag = prefix + this.localName;
+        cascade.insertInTable(cascade.nstags, nsTag, this.chained);
+    }
     return true;
 };
 
@@ -833,8 +833,8 @@ adapt.csscasc.CheckNSTagAction.prototype.makePrimary = function(cascade) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckTargetEpubTypeAction = function(epubTypePatt) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.epubTypePatt = epubTypePatt;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.epubTypePatt = epubTypePatt;
 };
 goog.inherits(adapt.csscasc.CheckTargetEpubTypeAction, adapt.csscasc.ChainedAction);
 
@@ -844,17 +844,17 @@ goog.inherits(adapt.csscasc.CheckTargetEpubTypeAction, adapt.csscasc.ChainedActi
 adapt.csscasc.CheckTargetEpubTypeAction.prototype.apply = function(cascadeInstance) {
     var elem = cascadeInstance.currentElement;
     if (elem && cascadeInstance.currentLocalName == "a") {
-    	var href = elem.getAttribute("href");
-    	if (href && href.match(/^#/)) {
-    		var id = href.substring(1);
-    		var target = elem.ownerDocument.getElementById(id);
-    		if (target) {
-    			var epubType = target.getAttributeNS(adapt.base.NS.epub, "type");
-    			if (epubType && epubType.match(this.epubTypePatt)) {
-    				this.chained.apply(cascadeInstance);
-    			}
-    		}
-    	}
+        var href = elem.getAttribute("href");
+        if (href && href.match(/^#/)) {
+            var id = href.substring(1);
+            var target = elem.ownerDocument.getElementById(id);
+            if (target) {
+                var epubType = target.getAttributeNS(adapt.base.NS.epub, "type");
+                if (epubType && epubType.match(this.epubTypePatt)) {
+                    this.chained.apply(cascadeInstance);
+                }
+            }
+        }
     }
 };
 
@@ -865,8 +865,8 @@ adapt.csscasc.CheckTargetEpubTypeAction.prototype.apply = function(cascadeInstan
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckNamespaceAction = function(ns) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.ns = ns;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.ns = ns;
 };
 goog.inherits(adapt.csscasc.CheckNamespaceAction, adapt.csscasc.ChainedAction);
 
@@ -886,9 +886,9 @@ adapt.csscasc.CheckNamespaceAction.prototype.apply = function(cascadeInstance) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckAttributePresentAction = function(ns, name) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.ns = ns;
-	/** @const */ this.name = name;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.ns = ns;
+    /** @const */ this.name = name;
 };
 goog.inherits(adapt.csscasc.CheckAttributePresentAction, adapt.csscasc.ChainedAction);
 
@@ -897,7 +897,7 @@ goog.inherits(adapt.csscasc.CheckAttributePresentAction, adapt.csscasc.ChainedAc
  */
 adapt.csscasc.CheckAttributePresentAction.prototype.apply = function(cascadeInstance) {
     if (cascadeInstance.currentElement &&
-    		cascadeInstance.currentElement.hasAttributeNS(this.ns, this.name)) {
+        cascadeInstance.currentElement.hasAttributeNS(this.ns, this.name)) {
         this.chained.apply(cascadeInstance);
     }
 };
@@ -911,10 +911,10 @@ adapt.csscasc.CheckAttributePresentAction.prototype.apply = function(cascadeInst
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckAttributeEqAction = function(ns, name, value) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.ns = ns;
-	/** @const */ this.name = name;
-	/** @const */ this.value = value;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.ns = ns;
+    /** @const */ this.name = name;
+    /** @const */ this.value = value;
 };
 goog.inherits(adapt.csscasc.CheckAttributeEqAction, adapt.csscasc.ChainedAction);
 
@@ -930,23 +930,23 @@ adapt.csscasc.CheckAttributeEqAction.prototype.apply = function(cascadeInstance)
  * @override
  */
 adapt.csscasc.CheckAttributeEqAction.prototype.getPriority = function() {
-	if (this.name == "type" && this.ns == adapt.base.NS.epub) {
-		return 9; // epub:type is a pretty good thing to check
-	}
-	return 0;
+    if (this.name == "type" && this.ns == adapt.base.NS.epub) {
+        return 9; // epub:type is a pretty good thing to check
+    }
+    return 0;
 };
 
 /**
  * @override
  */
 adapt.csscasc.CheckAttributeEqAction.prototype.makePrimary = function(cascade) {
-	if (this.name == "type" && this.ns == adapt.base.NS.epub) {
-		if (this.chained) {
-			cascade.insertInTable(cascade.epubtypes, this.value, this.chained);
-		}
-		return true;
-	}
-	return false;
+    if (this.name == "type" && this.ns == adapt.base.NS.epub) {
+        if (this.chained) {
+            cascade.insertInTable(cascade.epubtypes, this.value, this.chained);
+        }
+        return true;
+    }
+    return false;
 };
 
 /**
@@ -956,9 +956,9 @@ adapt.csscasc.CheckAttributeEqAction.prototype.makePrimary = function(cascade) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckNamespaceSupportedAction = function(ns, name) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.ns = ns;
-	/** @const */ this.name = name;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.ns = ns;
+    /** @const */ this.name = name;
 };
 goog.inherits(adapt.csscasc.CheckNamespaceSupportedAction, adapt.csscasc.ChainedAction);
 
@@ -967,10 +967,10 @@ goog.inherits(adapt.csscasc.CheckNamespaceSupportedAction, adapt.csscasc.Chained
  */
 adapt.csscasc.CheckNamespaceSupportedAction.prototype.apply = function(cascadeInstance) {
     if (cascadeInstance.currentElement) {
-    	var ns = cascadeInstance.currentElement.getAttributeNS(this.ns, this.name);
-    	if (ns && adapt.csscasc.supportedNamespaces[ns]) {
-    		this.chained.apply(cascadeInstance);
-    	}
+        var ns = cascadeInstance.currentElement.getAttributeNS(this.ns, this.name);
+        if (ns && adapt.csscasc.supportedNamespaces[ns]) {
+            this.chained.apply(cascadeInstance);
+        }
     }
 };
 
@@ -978,14 +978,14 @@ adapt.csscasc.CheckNamespaceSupportedAction.prototype.apply = function(cascadeIn
  * @override
  */
 adapt.csscasc.CheckNamespaceSupportedAction.prototype.getPriority = function() {
-	return 0;
+    return 0;
 };
 
 /**
  * @override
  */
 adapt.csscasc.CheckNamespaceSupportedAction.prototype.makePrimary = function(cascade) {
-	return false;
+    return false;
 };
 
 
@@ -997,10 +997,10 @@ adapt.csscasc.CheckNamespaceSupportedAction.prototype.makePrimary = function(cas
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckAttributeRegExpAction = function(ns, name, regexp) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.ns = ns;
-	/** @const */ this.name = name;
-	/** @const */ this.regexp = regexp;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.ns = ns;
+    /** @const */ this.name = name;
+    /** @const */ this.regexp = regexp;
 };
 goog.inherits(adapt.csscasc.CheckAttributeRegExpAction, adapt.csscasc.ChainedAction);
 
@@ -1008,11 +1008,11 @@ goog.inherits(adapt.csscasc.CheckAttributeRegExpAction, adapt.csscasc.ChainedAct
  * @override
  */
 adapt.csscasc.CheckAttributeRegExpAction.prototype.apply = function(cascadeInstance) {
-	if (cascadeInstance.currentElement) {
-	    var attr = cascadeInstance.currentElement.getAttributeNS(this.ns, this.name);
-	    if (attr && attr.match(this.regexp))
-	        this.chained.apply(cascadeInstance);
-	}
+    if (cascadeInstance.currentElement) {
+        var attr = cascadeInstance.currentElement.getAttributeNS(this.ns, this.name);
+        if (attr && attr.match(this.regexp))
+            this.chained.apply(cascadeInstance);
+    }
 };
 
 /**
@@ -1021,8 +1021,8 @@ adapt.csscasc.CheckAttributeRegExpAction.prototype.apply = function(cascadeInsta
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckLangAction = function(langRegExp) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.langRegExp = langRegExp;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.langRegExp = langRegExp;
 };
 goog.inherits(adapt.csscasc.CheckLangAction, adapt.csscasc.ChainedAction);
 
@@ -1040,7 +1040,7 @@ adapt.csscasc.CheckLangAction.prototype.apply = function(cascadeInstance) {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.IsFirstAction = function() {
-	adapt.csscasc.ChainedAction.call(this);
+    adapt.csscasc.ChainedAction.call(this);
 };
 goog.inherits(adapt.csscasc.IsFirstAction, adapt.csscasc.ChainedAction);
 
@@ -1091,9 +1091,9 @@ adapt.csscasc.IsRootAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.IsNthAction = function(a, b) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.a = a;
-	/** @const */ this.b = b;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.a = a;
+    /** @const */ this.b = b;
 };
 goog.inherits(adapt.csscasc.IsNthAction, adapt.csscasc.ChainedAction);
 
@@ -1104,13 +1104,13 @@ goog.inherits(adapt.csscasc.IsNthAction, adapt.csscasc.ChainedAction);
  * @returns {boolean}
  */
 adapt.csscasc.IsNthAction.prototype.matchANPlusB = function(order) {
-	var a = this.a;
-	order -= this.b;
-	if (a === 0) {
-		return order === 0;
-	} else {
-		return (order % a === 0) && (order / a >= 0);
-	}
+    var a = this.a;
+    order -= this.b;
+    if (a === 0) {
+        return order === 0;
+    } else {
+        return (order % a === 0) && (order / a >= 0);
+    }
 };
 
 /**
@@ -1120,7 +1120,7 @@ adapt.csscasc.IsNthAction.prototype.matchANPlusB = function(order) {
  * @extends {adapt.csscasc.IsNthAction}
  */
 adapt.csscasc.IsNthSiblingAction = function(a, b) {
-	adapt.csscasc.IsNthAction.call(this, a, b);
+    adapt.csscasc.IsNthAction.call(this, a, b);
 };
 goog.inherits(adapt.csscasc.IsNthSiblingAction, adapt.csscasc.IsNthAction);
 
@@ -1128,15 +1128,15 @@ goog.inherits(adapt.csscasc.IsNthSiblingAction, adapt.csscasc.IsNthAction);
  * @override
  */
 adapt.csscasc.IsNthSiblingAction.prototype.apply = function(cascadeInstance) {
-	if (this.matchANPlusB(cascadeInstance.currentSiblingOrder))
-		this.chained.apply(cascadeInstance);
+    if (this.matchANPlusB(cascadeInstance.currentSiblingOrder))
+        this.chained.apply(cascadeInstance);
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsNthSiblingAction.prototype.getPriority = function() {
-	return 5;
+    return 5;
 };
 
 /**
@@ -1146,7 +1146,7 @@ adapt.csscasc.IsNthSiblingAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.IsNthAction}
  */
 adapt.csscasc.IsNthSiblingOfTypeAction = function(a, b) {
-	adapt.csscasc.IsNthAction.call(this, a, b);
+    adapt.csscasc.IsNthAction.call(this, a, b);
 };
 goog.inherits(adapt.csscasc.IsNthSiblingOfTypeAction, adapt.csscasc.IsNthAction);
 
@@ -1154,16 +1154,16 @@ goog.inherits(adapt.csscasc.IsNthSiblingOfTypeAction, adapt.csscasc.IsNthAction)
  * @override
  */
 adapt.csscasc.IsNthSiblingOfTypeAction.prototype.apply = function(cascadeInstance) {
-	var order = cascadeInstance.currentSiblingTypeCounts[cascadeInstance.currentNamespace][cascadeInstance.currentLocalName];
-	if (this.matchANPlusB(order))
-		this.chained.apply(cascadeInstance);
+    var order = cascadeInstance.currentSiblingTypeCounts[cascadeInstance.currentNamespace][cascadeInstance.currentLocalName];
+    if (this.matchANPlusB(order))
+        this.chained.apply(cascadeInstance);
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsNthSiblingOfTypeAction.prototype.getPriority = function() {
-	return 5;
+    return 5;
 };
 
 /**
@@ -1173,7 +1173,7 @@ adapt.csscasc.IsNthSiblingOfTypeAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.IsNthAction}
  */
 adapt.csscasc.IsNthLastSiblingAction = function(a, b) {
-	adapt.csscasc.IsNthAction.call(this, a, b);
+    adapt.csscasc.IsNthAction.call(this, a, b);
 };
 goog.inherits(adapt.csscasc.IsNthLastSiblingAction, adapt.csscasc.IsNthAction);
 
@@ -1181,19 +1181,19 @@ goog.inherits(adapt.csscasc.IsNthLastSiblingAction, adapt.csscasc.IsNthAction);
  * @override
  */
 adapt.csscasc.IsNthLastSiblingAction.prototype.apply = function(cascadeInstance) {
-	var order = cascadeInstance.currentFollowingSiblingOrder;
-	if (order === null) {
-		order = cascadeInstance.currentFollowingSiblingOrder = cascadeInstance.currentElement.parentNode.childElementCount - cascadeInstance.currentSiblingOrder + 1;
-	}
-	if (this.matchANPlusB(order))
-		this.chained.apply(cascadeInstance);
+    var order = cascadeInstance.currentFollowingSiblingOrder;
+    if (order === null) {
+        order = cascadeInstance.currentFollowingSiblingOrder = cascadeInstance.currentElement.parentNode.childElementCount - cascadeInstance.currentSiblingOrder + 1;
+    }
+    if (this.matchANPlusB(order))
+        this.chained.apply(cascadeInstance);
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsNthLastSiblingAction.prototype.getPriority = function() {
-	return 4;
+    return 4;
 };
 
 /**
@@ -1203,7 +1203,7 @@ adapt.csscasc.IsNthLastSiblingAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.IsNthAction}
  */
 adapt.csscasc.IsNthLastSiblingOfTypeAction = function(a, b) {
-	adapt.csscasc.IsNthAction.call(this, a, b);
+    adapt.csscasc.IsNthAction.call(this, a, b);
 };
 goog.inherits(adapt.csscasc.IsNthLastSiblingOfTypeAction, adapt.csscasc.IsNthAction);
 
@@ -1211,28 +1211,28 @@ goog.inherits(adapt.csscasc.IsNthLastSiblingOfTypeAction, adapt.csscasc.IsNthAct
  * @override
  */
 adapt.csscasc.IsNthLastSiblingOfTypeAction.prototype.apply = function(cascadeInstance) {
-	var counts = cascadeInstance.currentFollowingSiblingTypeCounts;
-	if (!counts[cascadeInstance.currentNamespace]) {
-		var elem = cascadeInstance.currentElement;
-		do {
-			var ns = elem.namespaceURI;
-			var localName = elem.localName;
-			var nsCounts = counts[ns];
-			if (!nsCounts) {
-				nsCounts = counts[ns] = {};
-			}
-			nsCounts[localName] = (nsCounts[localName] || 0) + 1;
-		} while (elem = elem.nextElementSibling)
-	}
-	if (this.matchANPlusB(counts[cascadeInstance.currentNamespace][cascadeInstance.currentLocalName]))
-		this.chained.apply(cascadeInstance);
+    var counts = cascadeInstance.currentFollowingSiblingTypeCounts;
+    if (!counts[cascadeInstance.currentNamespace]) {
+        var elem = cascadeInstance.currentElement;
+        do {
+            var ns = elem.namespaceURI;
+            var localName = elem.localName;
+            var nsCounts = counts[ns];
+            if (!nsCounts) {
+                nsCounts = counts[ns] = {};
+            }
+            nsCounts[localName] = (nsCounts[localName] || 0) + 1;
+        } while (elem = elem.nextElementSibling);
+    }
+    if (this.matchANPlusB(counts[cascadeInstance.currentNamespace][cascadeInstance.currentLocalName]))
+        this.chained.apply(cascadeInstance);
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsNthLastSiblingOfTypeAction.prototype.getPriority = function() {
-	return 4;
+    return 4;
 };
 
 /**
@@ -1240,7 +1240,7 @@ adapt.csscasc.IsNthLastSiblingOfTypeAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.IsEmptyAction = function() {
-	adapt.csscasc.ChainedAction.call(this);
+    adapt.csscasc.ChainedAction.call(this);
 };
 goog.inherits(adapt.csscasc.IsEmptyAction, adapt.csscasc.ChainedAction);
 
@@ -1248,26 +1248,26 @@ goog.inherits(adapt.csscasc.IsEmptyAction, adapt.csscasc.ChainedAction);
  * @override
  */
 adapt.csscasc.IsEmptyAction.prototype.apply = function(cascadeInstance) {
-	var node = cascadeInstance.currentElement.firstChild;
-	while (node) {
-		switch (node.nodeType) {
-			case Node.ELEMENT_NODE:
-				return;
-			case Node.TEXT_NODE:
-				if (/** @type {Text} */ (node).length > 0) {
-					return;
-				}
-		}
-		node = node.nextSibling;
-	}
-	this.chained.apply(cascadeInstance);
+    var node = cascadeInstance.currentElement.firstChild;
+    while (node) {
+        switch (node.nodeType) {
+            case Node.ELEMENT_NODE:
+                return;
+            case Node.TEXT_NODE:
+                if (/** @type {Text} */ (node).length > 0) {
+                    return;
+                }
+        }
+        node = node.nextSibling;
+    }
+    this.chained.apply(cascadeInstance);
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsEmptyAction.prototype.getPriority = function() {
-	return 4;
+    return 4;
 };
 
 /**
@@ -1275,7 +1275,7 @@ adapt.csscasc.IsEmptyAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.IsEnabledAction = function() {
-	adapt.csscasc.ChainedAction.call(this);
+    adapt.csscasc.ChainedAction.call(this);
 };
 goog.inherits(adapt.csscasc.IsEnabledAction, adapt.csscasc.ChainedAction);
 
@@ -1283,17 +1283,17 @@ goog.inherits(adapt.csscasc.IsEnabledAction, adapt.csscasc.ChainedAction);
  * @override
  */
 adapt.csscasc.IsEnabledAction.prototype.apply = function(cascadeInstance) {
-	var elem = cascadeInstance.currentElement;
-	if (elem.disabled === false) {
-		this.chained.apply(cascadeInstance);
-	}
+    var elem = cascadeInstance.currentElement;
+    if (elem.disabled === false) {
+        this.chained.apply(cascadeInstance);
+    }
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsEnabledAction.prototype.getPriority = function() {
-	return 5;
+    return 5;
 };
 
 /**
@@ -1301,7 +1301,7 @@ adapt.csscasc.IsEnabledAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.IsDisabledAction = function() {
-	adapt.csscasc.ChainedAction.call(this);
+    adapt.csscasc.ChainedAction.call(this);
 };
 goog.inherits(adapt.csscasc.IsDisabledAction, adapt.csscasc.ChainedAction);
 
@@ -1309,17 +1309,17 @@ goog.inherits(adapt.csscasc.IsDisabledAction, adapt.csscasc.ChainedAction);
  * @override
  */
 adapt.csscasc.IsDisabledAction.prototype.apply = function(cascadeInstance) {
-	var elem = cascadeInstance.currentElement;
-	if (elem.disabled === true) {
-		this.chained.apply(cascadeInstance);
-	}
+    var elem = cascadeInstance.currentElement;
+    if (elem.disabled === true) {
+        this.chained.apply(cascadeInstance);
+    }
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsDisabledAction.prototype.getPriority = function() {
-	return 5;
+    return 5;
 };
 
 /**
@@ -1327,7 +1327,7 @@ adapt.csscasc.IsDisabledAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.IsCheckedAction = function() {
-	adapt.csscasc.ChainedAction.call(this);
+    adapt.csscasc.ChainedAction.call(this);
 };
 goog.inherits(adapt.csscasc.IsCheckedAction, adapt.csscasc.ChainedAction);
 
@@ -1335,17 +1335,17 @@ goog.inherits(adapt.csscasc.IsCheckedAction, adapt.csscasc.ChainedAction);
  * @override
  */
 adapt.csscasc.IsCheckedAction.prototype.apply = function(cascadeInstance) {
-	var elem = cascadeInstance.currentElement;
-	if (elem.selected === true || elem.checked === true) {
-		this.chained.apply(cascadeInstance);
-	}
+    var elem = cascadeInstance.currentElement;
+    if (elem.selected === true || elem.checked === true) {
+        this.chained.apply(cascadeInstance);
+    }
 };
 
 /**
  * @override
  */
 adapt.csscasc.IsCheckedAction.prototype.getPriority = function() {
-	return 5;
+    return 5;
 };
 
 /**
@@ -1354,8 +1354,8 @@ adapt.csscasc.IsCheckedAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.ChainedAction}
  */
 adapt.csscasc.CheckConditionAction = function(condition) {
-	adapt.csscasc.ChainedAction.call(this);
-	/** @const */ this.condition = condition;
+    adapt.csscasc.ChainedAction.call(this);
+    /** @const */ this.condition = condition;
 };
 goog.inherits(adapt.csscasc.CheckConditionAction, adapt.csscasc.ChainedAction);
 
@@ -1379,8 +1379,8 @@ adapt.csscasc.CheckConditionAction.prototype.getPriority = function() {
  * @extends {adapt.csscasc.CascadeAction}
  */
 adapt.csscasc.CheckAppliedAction = function() {
-  adapt.csscasc.CascadeAction.call(this);  
-  this.applied = false;
+    adapt.csscasc.CascadeAction.call(this);
+    this.applied = false;
 };
 goog.inherits(adapt.csscasc.CheckAppliedAction, adapt.csscasc.CascadeAction);
 
@@ -1388,17 +1388,17 @@ goog.inherits(adapt.csscasc.CheckAppliedAction, adapt.csscasc.CascadeAction);
  * @override
  */
 adapt.csscasc.CheckAppliedAction.prototype.apply = function(cascadeInstance) {
-  this.applied = true;
+    this.applied = true;
 };
 
 /**
  * @override
  */
 adapt.csscasc.CheckAppliedAction.prototype.clone = function() {
-  var cloned = new adapt.csscasc.CheckAppliedAction();
-  cloned.applied = this.applied;
-  return cloned;
-}
+    var cloned = new adapt.csscasc.CheckAppliedAction();
+    cloned.applied = this.applied;
+    return cloned;
+};
 
 /**
  * @param {Array.<adapt.csscasc.ChainedAction>} list
@@ -1464,35 +1464,35 @@ adapt.csscasc.ConditionItem.prototype.pop = function(cascadeInstance, depth) {};
  * @implements {adapt.csscasc.ConditionItem}
  */
 adapt.csscasc.DescendantConditionItem = function(condition) {
-	/** @const */ this.condition = condition;
+    /** @const */ this.condition = condition;
 };
 
 /**
  * @override
  */
 adapt.csscasc.DescendantConditionItem.prototype.fresh = function() {
-	return this;
+    return this;
 };
 
 /**
  * @override
  */
 adapt.csscasc.DescendantConditionItem.prototype.push = function(cascade, depth) {
-	if (depth == 0) {
-	    cascade.increment(this.condition);
-	}
-	return false;
+    if (depth == 0) {
+        cascade.increment(this.condition);
+    }
+    return false;
 };
 
 /**
  * @override
  */
 adapt.csscasc.DescendantConditionItem.prototype.pop = function(cascade, depth) {
-	if (depth == 0) {
-	    cascade.decrement(this.condition);
-		return true;
-	}
-	return false;
+    if (depth == 0) {
+        cascade.decrement(this.condition);
+        return true;
+    }
+    return false;
 };
 
 /**
@@ -1501,39 +1501,39 @@ adapt.csscasc.DescendantConditionItem.prototype.pop = function(cascade, depth) {
  * @implements {adapt.csscasc.ConditionItem}
  */
 adapt.csscasc.ChildConditionItem = function(condition) {
-	/** @const */ this.condition = condition;
+    /** @const */ this.condition = condition;
 };
 
 /**
  * @override
  */
 adapt.csscasc.ChildConditionItem.prototype.fresh = function() {
-	return this;
+    return this;
 };
 
 /**
  * @override
  */
 adapt.csscasc.ChildConditionItem.prototype.push = function(cascade, depth) {
-	if (depth == 0) {
-		cascade.increment(this.condition);
-	} else if (depth == 1) {
-	    cascade.decrement(this.condition);
-	}
-	return false;
+    if (depth == 0) {
+        cascade.increment(this.condition);
+    } else if (depth == 1) {
+        cascade.decrement(this.condition);
+    }
+    return false;
 };
 
 /**
  * @override
  */
 adapt.csscasc.ChildConditionItem.prototype.pop = function(cascade, depth) {
-	if (depth == 0) {
-		cascade.decrement(this.condition);
-		return true;
-	} else if (depth == 1) {
-	    cascade.increment(this.condition);
-	}
-	return false;
+    if (depth == 0) {
+        cascade.decrement(this.condition);
+        return true;
+    } else if (depth == 1) {
+        cascade.increment(this.condition);
+    }
+    return false;
 };
 
 /**
@@ -1542,15 +1542,15 @@ adapt.csscasc.ChildConditionItem.prototype.pop = function(cascade, depth) {
  * @implements {adapt.csscasc.ConditionItem}
  */
 adapt.csscasc.AdjacentSiblingConditionItem = function(condition) {
-	/** @const */ this.condition = condition;
-	/** @type {boolean} */ this.fired = false;
+    /** @const */ this.condition = condition;
+    /** @type {boolean} */ this.fired = false;
 };
 
 /**
  * @override
  */
 adapt.csscasc.AdjacentSiblingConditionItem.prototype.fresh = function() {
-	return new adapt.csscasc.AdjacentSiblingConditionItem(this.condition);
+    return new adapt.csscasc.AdjacentSiblingConditionItem(this.condition);
 };
 
 /**
@@ -1558,8 +1558,8 @@ adapt.csscasc.AdjacentSiblingConditionItem.prototype.fresh = function() {
  */
 adapt.csscasc.AdjacentSiblingConditionItem.prototype.push = function(cascade, depth) {
     if (this.fired) {
-		cascade.decrement(this.condition);
-		return true;
+        cascade.decrement(this.condition);
+        return true;
     }
     return false;
 };
@@ -1568,15 +1568,15 @@ adapt.csscasc.AdjacentSiblingConditionItem.prototype.push = function(cascade, de
  * @override
  */
 adapt.csscasc.AdjacentSiblingConditionItem.prototype.pop = function(cascade, depth) {
-	if (this.fired) {
-	    cascade.decrement(this.condition);
-		return true;
-	}
-	if (depth == 0) {  // Leaving element that triggered this item.
-		this.fired = true;
-    	cascade.increment(this.condition);
-	}
-	return false;
+    if (this.fired) {
+        cascade.decrement(this.condition);
+        return true;
+    }
+    if (depth == 0) {  // Leaving element that triggered this item.
+        this.fired = true;
+        cascade.increment(this.condition);
+    }
+    return false;
 };
 
 
@@ -1586,15 +1586,15 @@ adapt.csscasc.AdjacentSiblingConditionItem.prototype.pop = function(cascade, dep
  * @implements {adapt.csscasc.ConditionItem}
  */
 adapt.csscasc.FollowingSiblingConditionItem = function(condition) {
-	/** @const */ this.condition = condition;
-	/** @type {boolean} */ this.fired = false;
+    /** @const */ this.condition = condition;
+    /** @type {boolean} */ this.fired = false;
 };
 
 /**
  * @override
  */
 adapt.csscasc.FollowingSiblingConditionItem.prototype.fresh = function() {
-	return new adapt.csscasc.FollowingSiblingConditionItem(this.condition);
+    return new adapt.csscasc.FollowingSiblingConditionItem(this.condition);
 };
 
 /**
@@ -1602,11 +1602,11 @@ adapt.csscasc.FollowingSiblingConditionItem.prototype.fresh = function() {
  */
 adapt.csscasc.FollowingSiblingConditionItem.prototype.push = function(cascade, depth) {
     if (this.fired) {
-		if (depth == -1) {
-			cascade.increment(this.condition);
-		} else if (depth == 0) {
-		    cascade.decrement(this.condition);
-		}
+        if (depth == -1) {
+            cascade.increment(this.condition);
+        } else if (depth == 0) {
+            cascade.decrement(this.condition);
+        }
     }
     return false;
 };
@@ -1615,21 +1615,21 @@ adapt.csscasc.FollowingSiblingConditionItem.prototype.push = function(cascade, d
  * @override
  */
 adapt.csscasc.FollowingSiblingConditionItem.prototype.pop = function(cascade, depth) {
-	if (this.fired) {
-		if (depth == -1) {
-			cascade.decrement(this.condition);
-			return true;
-		} else if (depth == 0) {
-		    cascade.increment(this.condition);
-		}
-	} else {
-		if (depth == 0) {
-			// Leaving element that triggered this item.
-			this.fired = true;
-	    	cascade.increment(this.condition);
-		}
-	}
-	return false;
+    if (this.fired) {
+        if (depth == -1) {
+            cascade.decrement(this.condition);
+            return true;
+        } else if (depth == 0) {
+            cascade.increment(this.condition);
+        }
+    } else {
+        if (depth == 0) {
+            // Leaving element that triggered this item.
+            this.fired = true;
+            cascade.increment(this.condition);
+        }
+    }
+    return false;
 };
 
 
@@ -1641,15 +1641,15 @@ adapt.csscasc.FollowingSiblingConditionItem.prototype.pop = function(cascade, de
  * @implements {adapt.csscasc.ConditionItem}
  */
 adapt.csscasc.AfterPseudoelementItem = function(afterprop, element) {
-	/** @const */ this.afterprop = afterprop;
-	/** @const */ this.element = element;
+    /** @const */ this.afterprop = afterprop;
+    /** @const */ this.element = element;
 };
 
 /**
  * @override
  */
 adapt.csscasc.AfterPseudoelementItem.prototype.fresh = function() {
-	return this;
+    return this;
 };
 
 /**
@@ -1663,11 +1663,11 @@ adapt.csscasc.AfterPseudoelementItem.prototype.push = function(cascade, depth) {
  * @override
  */
 adapt.csscasc.AfterPseudoelementItem.prototype.pop = function(cascade, depth) {
-	if (depth == 0) {
-		cascade.processPseudoelementProps(this.afterprop, this.element);
-		return true;
-	}
-	return false;
+    if (depth == 0) {
+        cascade.processPseudoelementProps(this.afterprop, this.element);
+        return true;
+    }
+    return false;
 };
 
 
@@ -1678,14 +1678,14 @@ adapt.csscasc.AfterPseudoelementItem.prototype.pop = function(cascade, depth) {
  * @implements {adapt.csscasc.ConditionItem}
  */
 adapt.csscasc.RestoreLangItem = function(lang) {
-	/** @const */ this.lang = lang;
+    /** @const */ this.lang = lang;
 };
 
 /**
  * @override
  */
 adapt.csscasc.RestoreLangItem.prototype.fresh = function() {
-	return this;
+    return this;
 };
 
 /**
@@ -1699,11 +1699,11 @@ adapt.csscasc.RestoreLangItem.prototype.push = function(cascade, depth) {
  * @override
  */
 adapt.csscasc.RestoreLangItem.prototype.pop = function(cascade, depth) {
-	if (depth == 0) {
-		cascade.lang = this.lang;
-		return true;
-	}
-	return false;
+    if (depth == 0) {
+        cascade.lang = this.lang;
+        return true;
+    }
+    return false;
 };
 
 
@@ -1714,32 +1714,32 @@ adapt.csscasc.RestoreLangItem.prototype.pop = function(cascade, depth) {
  * @implements {adapt.csscasc.ConditionItem}
  */
 adapt.csscasc.QuotesScopeItem = function(oldQuotes) {
-	/** @const */ this.oldQuotes = oldQuotes;
+    /** @const */ this.oldQuotes = oldQuotes;
 };
 
 /**
  * @override
  */
 adapt.csscasc.QuotesScopeItem.prototype.fresh = function() {
-	return this;
+    return this;
 };
 
 /**
  * @override
  */
 adapt.csscasc.QuotesScopeItem.prototype.push = function(cascade, depth) {
-	return false;
+    return false;
 };
 
 /**
  * @override
  */
 adapt.csscasc.QuotesScopeItem.prototype.pop = function(cascade, depth) {
-	if (depth == 0) {
-		cascade.quotes = this.oldQuotes;
-		return true;
-	}
-	return false;
+    if (depth == 0) {
+        cascade.quotes = this.oldQuotes;
+        return true;
+    }
+    return false;
 };
 
 /**
@@ -1803,8 +1803,8 @@ adapt.csscasc.CounterResolver.prototype.getTargetCountersVal = function(url, nam
  * @extends {adapt.css.FilterVisitor}
  */
 adapt.csscasc.AttrValueFilterVisitor = function(element) {
-	adapt.css.FilterVisitor.call(this);
-	this.element = element;
+    adapt.css.FilterVisitor.call(this);
+    this.element = element;
 };
 goog.inherits(adapt.csscasc.AttrValueFilterVisitor, adapt.css.FilterVisitor);
 
@@ -1813,22 +1813,22 @@ goog.inherits(adapt.csscasc.AttrValueFilterVisitor, adapt.css.FilterVisitor);
  * @param {?string} str
  * @param {string} type
  * @return {adapt.css.Val}
-*/
+ */
 adapt.csscasc.AttrValueFilterVisitor.prototype.createValueFromString = function(str, type) {
     switch (type) {
-    case "url":
-        if (str)
-            return new adapt.css.URL(str); // TODO should convert to absolute path
-        return new adapt.css.URL("about:invalid");
-        break;
-    case "string":
-    default:
-        if (str)
-            return new adapt.css.Str(str);
-        return new adapt.css.Str("");
-        break;
+        case "url":
+            if (str)
+                return new adapt.css.URL(str); // TODO should convert to absolute path
+            return new adapt.css.URL("about:invalid");
+            break;
+        case "string":
+        default:
+            if (str)
+                return new adapt.css.Str(str);
+            return new adapt.css.Str("");
+            break;
     }
-}
+};
 /**
  * @override
  */
@@ -1838,19 +1838,19 @@ adapt.csscasc.AttrValueFilterVisitor.prototype.visitFunc = function(func) {
     var type = "string";
     var attributeName = null;
     /** @type {adapt.css.Val} */ var defaultValue = null;
-    
+
     if (func.values[0] instanceof adapt.css.SpaceList) {
-        if (func.values[0].values.length >= 2) 
+        if (func.values[0].values.length >= 2)
             type = func.values[0].values[1].stringValue();
         attributeName = func.values[0].values[0].stringValue();
     } else {
-        attributeName = func.values[0].stringValue()        
+        attributeName = func.values[0].stringValue();
     }
 
     if (func.values.length > 1) {
         defaultValue = this.createValueFromString(func.values[1].stringValue(), type);
     } else {
-        defaultValue = this.createValueFromString(null, type);        
+        defaultValue = this.createValueFromString(null, type);
     }
     if (this.element && this.element.hasAttribute(attributeName)) {
         return this.createValueFromString(this.element.getAttribute(attributeName), type);
@@ -1866,10 +1866,10 @@ adapt.csscasc.AttrValueFilterVisitor.prototype.visitFunc = function(func) {
  * @extends {adapt.css.FilterVisitor}
  */
 adapt.csscasc.ContentPropVisitor = function(cascade, element, counterResolver) {
-	adapt.css.FilterVisitor.call(this);
-	this.cascade = cascade;
-	this.element = element;
-	/** @const */ this.counterResolver = counterResolver;
+    adapt.css.FilterVisitor.call(this);
+    this.cascade = cascade;
+    this.element = element;
+    /** @const */ this.counterResolver = counterResolver;
 };
 goog.inherits(adapt.csscasc.ContentPropVisitor, adapt.css.FilterVisitor);
 
@@ -1877,7 +1877,7 @@ goog.inherits(adapt.csscasc.ContentPropVisitor, adapt.css.FilterVisitor);
  * @override
  */
 adapt.csscasc.ContentPropVisitor.prototype.visitIdent = function(ident) {
-	var cascade = this.cascade;
+    var cascade = this.cascade;
     var quotes = cascade.quotes;
     var maxDepth = Math.floor(quotes.length / 2) - 1;
     switch (ident.name) {
@@ -1901,78 +1901,78 @@ adapt.csscasc.ContentPropVisitor.prototype.visitIdent = function(ident) {
 };
 
 adapt.csscasc.roman = function(num) {
-	if (num <= 0 || num != Math.round(num) || num > 3999) {
-		return "";
-	}
-	var digits = ['I', 'V', 'X', 'L', 'C', 'D', 'M'];
-	var offset = 0;
-	var acc = "";
-	while (num > 0) {
-		var digit = num % 10;
-		num = (num - digit) / 10;
-		var result = "";
-		if (digit == 9) {
-			result += digits[offset] + digits[offset+2];
-		} else if (digit == 4) {
-			result += digits[offset] + digits[offset+1];
-		} else {
-			if (digit >= 5) {
-				result += digits[offset+1];
-				digit -= 5;
-			}
-			while (digit > 0) {
-				result += digits[offset];
-				digit--;
-			}
-		}
-		acc = result + acc;
-		offset += 2;
-	}
-	return acc;
+    if (num <= 0 || num != Math.round(num) || num > 3999) {
+        return "";
+    }
+    var digits = ['I', 'V', 'X', 'L', 'C', 'D', 'M'];
+    var offset = 0;
+    var acc = "";
+    while (num > 0) {
+        var digit = num % 10;
+        num = (num - digit) / 10;
+        var result = "";
+        if (digit == 9) {
+            result += digits[offset] + digits[offset+2];
+        } else if (digit == 4) {
+            result += digits[offset] + digits[offset+1];
+        } else {
+            if (digit >= 5) {
+                result += digits[offset+1];
+                digit -= 5;
+            }
+            while (digit > 0) {
+                result += digits[offset];
+                digit--;
+            }
+        }
+        acc = result + acc;
+        offset += 2;
+    }
+    return acc;
 };
 
 /** @const */
 adapt.csscasc.additiveNumbering = {
-	"roman": [4999, 1000, 'M', 900, 'CM', 500, 'D', 400, 'CD', 100, 'C', 90, 'XC',
-	          50, 'L', 40, 'XL', 10, 'X', 9, 'IX', 5, 'V', 4, 'IV', 1, 'I'],
-	"armenian": [9999, 9000, '\u0584', 8000, '\u0583', 7000, '\u0582', 6000, '\u0581',
-	             5000, '\u0580', 4000, '\u057F', 3000, '\u057E', 2000, '\u057D',
-	             1000, '\u057C', 900, '\u057B', 800, '\u057A', 700, '\u0579', 600, '\u0578',
-	             500, '\u0577', 400, '\u0576', 300, '\u0575', 200, '\u0574', 100, '\u0573',
-	             90, '\u0572', 80, '\u0571', 70, '\u0570', 60, '\u056F', 50, '\u056E',
-	             40, '\u056D', 30, '\u056C', 20, '\u056B', 10, '\u056A', 9, '\u0569',
-	             8, '\u0568', 7, '\u0567', 6, '\u0566', 5, '\u0565', 4, '\u0564',
-	             3, '\u0563', 2, '\u0562', 1, '\u0561'],
-	"georgian": [19999, 10000, '\u10F5', 9000, '\u10F0', 8000, '\u10EF', 7000, '\u10F4',
-	             6000, '\u10EE', 5000, '\u10ED', 4000, '\u10EC', 3000, '\u10EB',
-	             2000, '\u10EA', 1000, '\u10E9', 900, '\u10E8', 800, '\u10E7', 700, '\u10E6',
-	             600, '\u10E5', 500, '\u10E4', 400, '\u10F3', 300, '\u10E2', 200, '\u10E1',
-	             100, '\u10E0', 90, '\u10DF', 80, '\u10DE', 70, '\u10DD', 60, '\u10F2',
-	             50, '\u10DC', 40, '\u10DB', 30, '\u10DA', 20, '\u10D9', 10, '\u10D8',
-	             9, '\u10D7', 8, '\u10F1', 7, '\u10D6', 6, '\u10D5', 5, '\u10D4', 4, '\u10D3',
-	             3, '\u10D2', 2, '\u10D1', 1, '\u10D0'],
-	"hebrew": [999, 400, '\u05EA', 300, '\u05E9', 200, '\u05E8', 100, '\u05E7', 90, '\u05E6',
-	           80, '\u05E4', 70, '\u05E2', 60, '\u05E1', 50, '\u05E0', 40, '\u05DE', 30, '\u05DC',
-	           20, '\u05DB', 19, '\u05D9\u05D8', 18, '\u05D9\u05D7', 17, '\u05D9\u05D6',
-	           16, '\u05D8\u05D6', 15, '\u05D8\u05D5', 10, '\u05D9', 9, '\u05D8', 8, '\u05D7',
-	           7, '\u05D6', 6, '\u05D5', 5, '\u05D4', 4, '\u05D3', 3, '\u05D2', 2, '\u05D1',
-	           1, '\u05D0']
+    "roman": [4999, 1000, 'M', 900, 'CM', 500, 'D', 400, 'CD', 100, 'C', 90, 'XC',
+        50, 'L', 40, 'XL', 10, 'X', 9, 'IX', 5, 'V', 4, 'IV', 1, 'I'],
+    "armenian": [9999, 9000, '\u0584', 8000, '\u0583', 7000, '\u0582', 6000, '\u0581',
+        5000, '\u0580', 4000, '\u057F', 3000, '\u057E', 2000, '\u057D',
+        1000, '\u057C', 900, '\u057B', 800, '\u057A', 700, '\u0579', 600, '\u0578',
+        500, '\u0577', 400, '\u0576', 300, '\u0575', 200, '\u0574', 100, '\u0573',
+        90, '\u0572', 80, '\u0571', 70, '\u0570', 60, '\u056F', 50, '\u056E',
+        40, '\u056D', 30, '\u056C', 20, '\u056B', 10, '\u056A', 9, '\u0569',
+        8, '\u0568', 7, '\u0567', 6, '\u0566', 5, '\u0565', 4, '\u0564',
+        3, '\u0563', 2, '\u0562', 1, '\u0561'],
+    "georgian": [19999, 10000, '\u10F5', 9000, '\u10F0', 8000, '\u10EF', 7000, '\u10F4',
+        6000, '\u10EE', 5000, '\u10ED', 4000, '\u10EC', 3000, '\u10EB',
+        2000, '\u10EA', 1000, '\u10E9', 900, '\u10E8', 800, '\u10E7', 700, '\u10E6',
+        600, '\u10E5', 500, '\u10E4', 400, '\u10F3', 300, '\u10E2', 200, '\u10E1',
+        100, '\u10E0', 90, '\u10DF', 80, '\u10DE', 70, '\u10DD', 60, '\u10F2',
+        50, '\u10DC', 40, '\u10DB', 30, '\u10DA', 20, '\u10D9', 10, '\u10D8',
+        9, '\u10D7', 8, '\u10F1', 7, '\u10D6', 6, '\u10D5', 5, '\u10D4', 4, '\u10D3',
+        3, '\u10D2', 2, '\u10D1', 1, '\u10D0'],
+    "hebrew": [999, 400, '\u05EA', 300, '\u05E9', 200, '\u05E8', 100, '\u05E7', 90, '\u05E6',
+        80, '\u05E4', 70, '\u05E2', 60, '\u05E1', 50, '\u05E0', 40, '\u05DE', 30, '\u05DC',
+        20, '\u05DB', 19, '\u05D9\u05D8', 18, '\u05D9\u05D7', 17, '\u05D9\u05D6',
+        16, '\u05D8\u05D6', 15, '\u05D8\u05D5', 10, '\u05D9', 9, '\u05D8', 8, '\u05D7',
+        7, '\u05D6', 6, '\u05D5', 5, '\u05D4', 4, '\u05D3', 3, '\u05D2', 2, '\u05D1',
+        1, '\u05D0']
 };
 
 /** @const */
 adapt.csscasc.alphabeticNumbering = {
-	"latin": 'a-z',
-	"alpha": 'a-z',
-	"greek": '\u03B1-\u03C1\u03C3-\u03C9',
-	'russian': '\u0430-\u0438\u043A-\u0449\u044D-\u044F'
+    "latin": 'a-z',
+    "alpha": 'a-z',
+    "greek": '\u03B1-\u03C1\u03C3-\u03C9',
+    'russian': '\u0430-\u0438\u043A-\u0449\u044D-\u044F'
 };
 
 /** @const */
 adapt.csscasc.fixed = {
-	"square": '\u25A0',
+    "square": '\u25A0',
     "disc": '\u2022',
     "circle": '\u25E6',
-	"none": ''
+    "none": ''
 };
 
 /**
@@ -1980,40 +1980,40 @@ adapt.csscasc.fixed = {
  * @param {number} num
  */
 adapt.csscasc.additiveFormat = function(entries, num) {
-	var max = /** @type {number} */ (entries[0]);
-	if (num > max || num <= 0 || num != Math.round(num))
-		return "";
-	var result = "";
-	for (var i = 1; i < entries.length ; i+=2) {
-		var value = /** @type {number} */ (entries[i]);
-		var count = Math.floor(num / value);
-		if (count > 20)
-			return "";
-		num -= count * value;
-		while (count > 0) {
-			result += entries[i+1];
-			count--;
-		}
-	}
-	return result;
+    var max = /** @type {number} */ (entries[0]);
+    if (num > max || num <= 0 || num != Math.round(num))
+        return "";
+    var result = "";
+    for (var i = 1; i < entries.length; i+=2) {
+        var value = /** @type {number} */ (entries[i]);
+        var count = Math.floor(num / value);
+        if (count > 20)
+            return "";
+        num -= count * value;
+        while (count > 0) {
+            result += entries[i+1];
+            count--;
+        }
+    }
+    return result;
 };
 
 adapt.csscasc.expandAlphabet = function(str) {
-	var arr = [];
-	var i = 0;
-	while (i < str.length) {
-		if (str.substr(i+1, 1) == "-") {
-			var first = str.charCodeAt(i);
-			var last = str.charCodeAt(i+2);
-			i += 3;
-			for (var k = first; k <= last; k++) {
-				arr.push(String.fromCharCode(k));
-			}
-		} else {
-			arr.push(str.substr(i++, 1));
-		}
-	}
-	return arr;
+    var arr = [];
+    var i = 0;
+    while (i < str.length) {
+        if (str.substr(i+1, 1) == "-") {
+            var first = str.charCodeAt(i);
+            var last = str.charCodeAt(i+2);
+            i += 3;
+            for (var k = first; k <= last; k++) {
+                arr.push(String.fromCharCode(k));
+            }
+        } else {
+            arr.push(str.substr(i++, 1));
+        }
+    }
+    return arr;
 };
 
 /**
@@ -2021,17 +2021,17 @@ adapt.csscasc.expandAlphabet = function(str) {
  * @param {number} num
  */
 adapt.csscasc.alphabeticFormat = function(alphabetStr, num) {
-	if (num <= 0 || num != Math.round(num))
-		return "";
-	var alphabet = adapt.csscasc.expandAlphabet(alphabetStr);
-	var result = "";
-	do {
-		num--;
-		var digit = num % alphabet.length;
-		result = alphabet[digit] + result;
-		num = (num - digit) / alphabet.length;
-	} while (num > 0);
-	return result;
+    if (num <= 0 || num != Math.round(num))
+        return "";
+    var alphabet = adapt.csscasc.expandAlphabet(alphabetStr);
+    var result = "";
+    do {
+        num--;
+        var digit = num % alphabet.length;
+        result = alphabet[digit] + result;
+        num = (num - digit) / alphabet.length;
+    } while (num > 0);
+    return result;
 };
 
 /**
@@ -2045,10 +2045,10 @@ adapt.csscasc.ChineseNumbering;
  * @type {adapt.csscasc.ChineseNumbering}
  */
 adapt.csscasc.chineseTradInformal = {
-	formal: false,
-	digits: "\u96F6\u4E00\u4E8C\u4E09\u56DB\u4E94\u516D\u4E03\u516B\u4E5D",
-	markers: "\u5341\u767E\u5343",
-	negative: "\u8CA0"
+    formal: false,
+    digits: "\u96F6\u4E00\u4E8C\u4E09\u56DB\u4E94\u516D\u4E03\u516B\u4E5D",
+    markers: "\u5341\u767E\u5343",
+    negative: "\u8CA0"
 };
 
 /**
@@ -2056,45 +2056,45 @@ adapt.csscasc.chineseTradInformal = {
  * @param {adapt.csscasc.ChineseNumbering} numbering
  */
 adapt.csscasc.chineseCounter = function(num, numbering) {
-	if (num > 9999 || num < -9999)
-		return "" + num;  // TODO: should be cjk-decimal
-	if (num == 0)
-		return numbering.digits.charAt(0);
-	var res = new adapt.base.StringBuffer();
-	if (num < 0) {
-		res.append(numbering.negative);
-		num = -num;
-	}
-	if (num < 10) {
-		res.append(numbering.digits.charAt(num));
-	} else if (numbering.informal && num <= 19) {
-		res.append(numbering.markers.charAt(0));
-		if (num != 0) {
-			res.append(numbering.markers.charAt(num - 10));
-		}
-	} else {
-		var thousands = Math.floor(num/1000);
-		if (thousands) {
-			res.append(numbering.digits.charAt(thousands));
-			res.append(numbering.markers.charAt(2));
-		}
-		var hundreds = Math.floor(num/100) % 10;
-		if (hundreds) {
-			res.append(numbering.digits.charAt(hundreds));
-			res.append(numbering.markers.charAt(1));
-		}
-		var tens = Math.floor(num/10) % 10;
-		if (tens) {
-			res.append(numbering.digits.charAt(tens));
-			res.append(numbering.markers.charAt(0));
-		}
-		var ones = num % 10;
-		if (ones) {
-			res.append(numbering.digits.charAt(ones));
-		}
-	}
-	// res.append("\u3001");
-	return res.toString();
+    if (num > 9999 || num < -9999)
+        return "" + num;  // TODO: should be cjk-decimal
+    if (num == 0)
+        return numbering.digits.charAt(0);
+    var res = new adapt.base.StringBuffer();
+    if (num < 0) {
+        res.append(numbering.negative);
+        num = -num;
+    }
+    if (num < 10) {
+        res.append(numbering.digits.charAt(num));
+    } else if (numbering.informal && num <= 19) {
+        res.append(numbering.markers.charAt(0));
+        if (num != 0) {
+            res.append(numbering.markers.charAt(num - 10));
+        }
+    } else {
+        var thousands = Math.floor(num/1000);
+        if (thousands) {
+            res.append(numbering.digits.charAt(thousands));
+            res.append(numbering.markers.charAt(2));
+        }
+        var hundreds = Math.floor(num/100) % 10;
+        if (hundreds) {
+            res.append(numbering.digits.charAt(hundreds));
+            res.append(numbering.markers.charAt(1));
+        }
+        var tens = Math.floor(num/10) % 10;
+        if (tens) {
+            res.append(numbering.digits.charAt(tens));
+            res.append(numbering.markers.charAt(0));
+        }
+        var ones = num % 10;
+        if (ones) {
+            res.append(numbering.digits.charAt(ones));
+        }
+    }
+    // res.append("\u3001");
+    return res.toString();
 };
 
 /**
@@ -2104,39 +2104,39 @@ adapt.csscasc.chineseCounter = function(num, numbering) {
  * @return {string}
  */
 adapt.csscasc.ContentPropVisitor.prototype.format = function(num, type) {
-	var upper = false; // type == "armenian"; // content-counter-10.xht assumes armenian is uppercase, enable if desired
-	var lower = false;
-	var r;
-	if ((r = type.match(/^upper-(.*)/)) != null) {
-		upper = true;
-		type = r[1];
-	} else if ((r = type.match(/^lower-(.*)/)) != null) {
-		lower = true;
-		type = r[1];
-	}
-	var result = "";
-	if (adapt.csscasc.additiveNumbering[type]) {
-		result = adapt.csscasc.additiveFormat(adapt.csscasc.additiveNumbering[type], num);
-	} else if (adapt.csscasc.alphabeticNumbering[type]) {
-		result = adapt.csscasc.alphabeticFormat(adapt.csscasc.alphabeticNumbering[type], num);
-	} else if (adapt.csscasc.fixed[type] != null) {
-		result = adapt.csscasc.fixed[type];
-	} else if (type == "decimal-leading-zero") {
-		result = num + "";
-		if (result.length == 1)
-			result = "0" + result;
-	} else if (type == "cjk-ideographic" || type == "trad-chinese-informal") {
-		result = adapt.csscasc.chineseCounter(num, adapt.csscasc.chineseTradInformal);
-	} else {
-		result = num + "";
-	}
-	if (upper) {
-		return result.toUpperCase();
-	}
-	if (lower) {
-		return result.toLowerCase();
-	}
-	return result;
+    var upper = false; // type == "armenian"; // content-counter-10.xht assumes armenian is uppercase, enable if desired
+    var lower = false;
+    var r;
+    if ((r = type.match(/^upper-(.*)/)) != null) {
+        upper = true;
+        type = r[1];
+    } else if ((r = type.match(/^lower-(.*)/)) != null) {
+        lower = true;
+        type = r[1];
+    }
+    var result = "";
+    if (adapt.csscasc.additiveNumbering[type]) {
+        result = adapt.csscasc.additiveFormat(adapt.csscasc.additiveNumbering[type], num);
+    } else if (adapt.csscasc.alphabeticNumbering[type]) {
+        result = adapt.csscasc.alphabeticFormat(adapt.csscasc.alphabeticNumbering[type], num);
+    } else if (adapt.csscasc.fixed[type] != null) {
+        result = adapt.csscasc.fixed[type];
+    } else if (type == "decimal-leading-zero") {
+        result = num + "";
+        if (result.length == 1)
+            result = "0" + result;
+    } else if (type == "cjk-ideographic" || type == "trad-chinese-informal") {
+        result = adapt.csscasc.chineseCounter(num, adapt.csscasc.chineseTradInformal);
+    } else {
+        result = num + "";
+    }
+    if (upper) {
+        return result.toUpperCase();
+    }
+    if (lower) {
+        return result.toLowerCase();
+    }
+    return result;
 };
 
 /**
@@ -2147,16 +2147,16 @@ adapt.csscasc.ContentPropVisitor.prototype.visitFuncCounter = function(values) {
     var counterName = values[0].toString();
     var type = values.length > 1 ? values[1].stringValue() : "decimal";
     var arr = this.cascade.counters[counterName];
-	if (arr && arr.length) {
-		var numval = (arr && arr.length && arr[arr.length - 1]) || 0;
-		return new adapt.css.Str(this.format(numval, type));
-	} else {
-		var self = this;
-		var c = new adapt.css.Expr(this.counterResolver.getPageCounterVal(counterName, function(numval) {
-			return self.format(numval || 0, type);
-		}));
-		return new adapt.css.SpaceList([c]);
-	}
+    if (arr && arr.length) {
+        var numval = (arr && arr.length && arr[arr.length - 1]) || 0;
+        return new adapt.css.Str(this.format(numval, type));
+    } else {
+        var self = this;
+        var c = new adapt.css.Expr(this.counterResolver.getPageCounterVal(counterName, function(numval) {
+            return self.format(numval || 0, type);
+        }));
+        return new adapt.css.SpaceList([c]);
+    }
 };
 
 /**
@@ -2170,31 +2170,31 @@ adapt.csscasc.ContentPropVisitor.prototype.visitFuncCounters = function(values) 
     var arr = this.cascade.counters[counterName];
     var sb = new adapt.base.StringBuffer();
     if (arr && arr.length) {
-	    for (var i = 0; i < arr.length; i++) {
-	    	if (i > 0)
-	    		sb.append(separator);
-	    	sb.append(this.format(arr[i], type));
-	    }
-	}
-	var self = this;
-	var c = new adapt.css.Expr(this.counterResolver.getPageCountersVal(counterName, function(numvals) {
-		var parts = /** @type {Array.<string>} */ ([]);
-		if (numvals.length) {
-			for (var i = 0; i < numvals.length; i++) {
-				parts.push(self.format(numvals[i], type));
-			}
-		}
-		var elementCounters = sb.toString();
-		if (elementCounters.length) {
-			parts.push(elementCounters);
-		}
-		if (parts.length) {
-			return parts.join(separator);
-		} else {
-			return self.format(0, type);
-		}
-	}));
-	return new adapt.css.SpaceList([c]);
+        for (var i = 0; i < arr.length; i++) {
+            if (i > 0)
+                sb.append(separator);
+            sb.append(this.format(arr[i], type));
+        }
+    }
+    var self = this;
+    var c = new adapt.css.Expr(this.counterResolver.getPageCountersVal(counterName, function(numvals) {
+        var parts = /** @type {Array.<string>} */ ([]);
+        if (numvals.length) {
+            for (var i = 0; i < numvals.length; i++) {
+                parts.push(self.format(numvals[i], type));
+            }
+        }
+        var elementCounters = sb.toString();
+        if (elementCounters.length) {
+            parts.push(elementCounters);
+        }
+        if (parts.length) {
+            return parts.join(separator);
+        } else {
+            return self.format(0, type);
+        }
+    }));
+    return new adapt.css.SpaceList([c]);
 };
 
 /**
@@ -2202,21 +2202,21 @@ adapt.csscasc.ContentPropVisitor.prototype.visitFuncCounters = function(values) 
  * @return {adapt.css.Val}
  */
 adapt.csscasc.ContentPropVisitor.prototype.visitFuncTargetCounter = function(values) {
-	var targetUrl = values[0];
-	var targetUrlStr;
-	if (targetUrl instanceof adapt.css.URL) {
-		targetUrlStr = targetUrl.url;
-	} else {
-		targetUrlStr = targetUrl.stringValue();
-	}
-	var counterName = values[1].toString();
-	var type = values.length > 2 ? values[2].stringValue() : "decimal";
+    var targetUrl = values[0];
+    var targetUrlStr;
+    if (targetUrl instanceof adapt.css.URL) {
+        targetUrlStr = targetUrl.url;
+    } else {
+        targetUrlStr = targetUrl.stringValue();
+    }
+    var counterName = values[1].toString();
+    var type = values.length > 2 ? values[2].stringValue() : "decimal";
 
-	var self = this;
-	var c = new adapt.css.Expr(this.counterResolver.getTargetCounterVal(targetUrlStr, counterName, function(numval) {
-		return self.format(numval || 0, type);
-	}));
-	return new adapt.css.SpaceList([c]);
+    var self = this;
+    var c = new adapt.css.Expr(this.counterResolver.getTargetCounterVal(targetUrlStr, counterName, function(numval) {
+        return self.format(numval || 0, type);
+    }));
+    return new adapt.css.SpaceList([c]);
 };
 
 /**
@@ -2224,29 +2224,29 @@ adapt.csscasc.ContentPropVisitor.prototype.visitFuncTargetCounter = function(val
  * @returns {adapt.css.Val}
  */
 adapt.csscasc.ContentPropVisitor.prototype.visitFuncTargetCounters = function(values) {
-	var targetUrl = values[0];
-	var targetUrlStr;
-	if (targetUrl instanceof adapt.css.URL) {
-		targetUrlStr = targetUrl.url;
-	} else {
-		targetUrlStr = targetUrl.stringValue();
-	}
-	var counterName = values[1].toString();
-	var separator = values[2].stringValue();
-	var type = values.length > 3 ? values[3].stringValue() : "decimal";
+    var targetUrl = values[0];
+    var targetUrlStr;
+    if (targetUrl instanceof adapt.css.URL) {
+        targetUrlStr = targetUrl.url;
+    } else {
+        targetUrlStr = targetUrl.stringValue();
+    }
+    var counterName = values[1].toString();
+    var separator = values[2].stringValue();
+    var type = values.length > 3 ? values[3].stringValue() : "decimal";
 
-	var self = this;
-	var c = new adapt.css.Expr(this.counterResolver.getTargetCountersVal(targetUrlStr, counterName, function(numvals) {
-		var parts = numvals.map(function(numval) {
-			return self.format(numval, type);
-		});
-		if (parts.length) {
-			return parts.join(separator);
-		} else {
-			return self.format(0, type);
-		}
-	}));
-	return new adapt.css.SpaceList([c]);
+    var self = this;
+    var c = new adapt.css.Expr(this.counterResolver.getTargetCountersVal(targetUrlStr, counterName, function(numvals) {
+        var parts = numvals.map(function(numval) {
+            return self.format(numval, type);
+        });
+        if (parts.length) {
+            return parts.join(separator);
+        } else {
+            return self.format(0, type);
+        }
+    }));
+    return new adapt.css.SpaceList([c]);
 };
 
 /**
@@ -2256,26 +2256,26 @@ adapt.csscasc.ContentPropVisitor.prototype.visitFunc = function(func) {
     switch (func.name) {
         case "counter" :
             if (func.values.length <= 2) {
-            	return this.visitFuncCounter(func.values);
+                return this.visitFuncCounter(func.values);
             }
             break;
         case "counters" :
             if (func.values.length <= 3) {
-            	return this.visitFuncCounters(func.values);
+                return this.visitFuncCounters(func.values);
             }
             break;
-		case "target-counter":
-			if (func.values.length <= 3) {
-				return this.visitFuncTargetCounter(func.values);
-			}
-			break;
-		case "target-counters":
-			if (func.values.length <= 4) {
-				return this.visitFuncTargetCounters(func.values);
-			}
-			break;
+        case "target-counter":
+            if (func.values.length <= 3) {
+                return this.visitFuncTargetCounter(func.values);
+            }
+            break;
+        case "target-counters":
+            if (func.values.length <= 4) {
+                return this.visitFuncTargetCounters(func.values);
+            }
+            break;
     }
-	vivliostyle.logging.logger.warn("E_CSS_CONTENT_PROP:", func.toString());
+    vivliostyle.logging.logger.warn("E_CSS_CONTENT_PROP:", func.toString());
     return new adapt.css.Str("");
 };
 
@@ -2297,9 +2297,9 @@ adapt.csscasc.ORDER_INCREMENT = 1 / 0x100000;
  * @return {void}
  */
 adapt.csscasc.copyTable = function(src, dst) {
-	for (var n in src) {
-		dst[n] = src[n].clone();
-	}
+    for (var n in src) {
+        dst[n] = src[n].clone();
+    }
 };
 
 
@@ -2307,8 +2307,8 @@ adapt.csscasc.copyTable = function(src, dst) {
  * @constructor
  */
 adapt.csscasc.Cascade = function() {
-	/** @type {number} */ this.nsCount = 0;
-	/** @type {!Object.<string,string>} */ this.nsPrefix = {};
+    /** @type {number} */ this.nsCount = 0;
+    /** @type {!Object.<string,string>} */ this.nsPrefix = {};
     /** @type {!adapt.csscasc.ActionTable} */ this.tags = {};
     /** @type {!adapt.csscasc.ActionTable} */ this.nstags = {};
     /** @type {!adapt.csscasc.ActionTable} */ this.epubtypes = {};
@@ -2322,19 +2322,19 @@ adapt.csscasc.Cascade = function() {
  * @return {adapt.csscasc.Cascade}
  */
 adapt.csscasc.Cascade.prototype.clone = function() {
-	var r = new adapt.csscasc.Cascade();
-	r.nsCount = this.nsCount;
-	for (var p in this.nsPrefix) {
-		r.nsPrefix[p] = this.nsPrefix[p];
-	}
-	adapt.csscasc.copyTable(this.tags, r.tags);
-	adapt.csscasc.copyTable(this.nstags, r.nstags);
-	adapt.csscasc.copyTable(this.epubtypes, r.epubtypes);
-	adapt.csscasc.copyTable(this.classes, r.classes);
-	adapt.csscasc.copyTable(this.ids, r.ids);
+    var r = new adapt.csscasc.Cascade();
+    r.nsCount = this.nsCount;
+    for (var p in this.nsPrefix) {
+        r.nsPrefix[p] = this.nsPrefix[p];
+    }
+    adapt.csscasc.copyTable(this.tags, r.tags);
+    adapt.csscasc.copyTable(this.nstags, r.nstags);
+    adapt.csscasc.copyTable(this.epubtypes, r.epubtypes);
+    adapt.csscasc.copyTable(this.classes, r.classes);
+    adapt.csscasc.copyTable(this.ids, r.ids);
     adapt.csscasc.copyTable(this.pagetypes, r.pagetypes);
-	r.order = this.order;
-	return r;
+    r.order = this.order;
+    return r;
 };
 
 /**
@@ -2377,13 +2377,13 @@ adapt.csscasc.Cascade.prototype.nextOrder = function() {
  * @constructor
  */
 adapt.csscasc.CascadeInstance = function(cascade, context, counterListener, counterResolver, lang) {
-	/** @const */ this.code = cascade;
-	/** @const */ this.context = context;
-	/** @const */ this.counterListener = counterListener;
-	/** @const */ this.counterResolver = counterResolver;
-	/** @const */ this.stack = /** @type {Array.<Array.<adapt.csscasc.ConditionItem>>} */ ([[],[]]);
-	/** @const */ this.conditions = /** @type {Object.<string,number>} */ ({});
-	/** @type {Element} */ this.currentElement = null;
+    /** @const */ this.code = cascade;
+    /** @const */ this.context = context;
+    /** @const */ this.counterListener = counterListener;
+    /** @const */ this.counterResolver = counterResolver;
+    /** @const */ this.stack = /** @type {Array.<Array.<adapt.csscasc.ConditionItem>>} */ ([[], []]);
+    /** @const */ this.conditions = /** @type {Object.<string,number>} */ ({});
+    /** @type {Element} */ this.currentElement = null;
     /** @type {adapt.csscasc.ElementStyle} */ this.currentStyle = null;
     /** @type {Array.<string>} */ this.currentClassNames = null;
     /** @type {string} */ this.currentLocalName = "";
@@ -2398,20 +2398,20 @@ adapt.csscasc.CascadeInstance = function(cascade, context, counterListener, coun
     /** @type {!Object.<string,!Array.<number>>} */ this.counters = {};
     /** @type {Array.<Object.<string,boolean>>} */ this.counterScoping = [{}];
     /** @type {Array.<adapt.css.Str>} */ this.quotes =
-    	[new adapt.css.Str("\u201C"), new adapt.css.Str("\u201D"),
-    	  new adapt.css.Str("\u2018"), new adapt.css.Str("\u2019")];
+        [new adapt.css.Str("\u201C"), new adapt.css.Str("\u201D"),
+            new adapt.css.Str("\u2018"), new adapt.css.Str("\u2019")];
     /** @type {number} */ this.quoteDepth = 0;
     /** @type {string} */ this.lang = "";
-	/** @type {Array.<number>} */ this.siblingOrderStack = [0];
-	/** @type {number} */ this.currentSiblingOrder = 0;
-	/** @const {!Array<!Object<string, !Object<string, number>>>} */ this.siblingTypeCountsStack = [{}];
-	/** @type {!Object<string, !Object<string, number>>} */ this.currentSiblingTypeCounts = this.siblingTypeCountsStack[0];
-	/** @type {?number} */ this.currentFollowingSiblingOrder = null;
-	/** @type {Array.<?number>} */ this.followingSiblingOrderStack = [this.currentFollowingSiblingOrder];
-	/** @const {!Array<!Object<string, !Object<string, number>>>} */ this.followingSiblingTypeCountsStack = [{}];
-	/** @type {!Object<string, !Object<string, number>>} */ this.currentFollowingSiblingTypeCounts = this.siblingTypeCountsStack[0];
+    /** @type {Array.<number>} */ this.siblingOrderStack = [0];
+    /** @type {number} */ this.currentSiblingOrder = 0;
+    /** @const {!Array<!Object<string, !Object<string, number>>>} */ this.siblingTypeCountsStack = [{}];
+    /** @type {!Object<string, !Object<string, number>>} */ this.currentSiblingTypeCounts = this.siblingTypeCountsStack[0];
+    /** @type {?number} */ this.currentFollowingSiblingOrder = null;
+    /** @type {Array.<?number>} */ this.followingSiblingOrderStack = [this.currentFollowingSiblingOrder];
+    /** @const {!Array<!Object<string, !Object<string, number>>>} */ this.followingSiblingTypeCountsStack = [{}];
+    /** @type {!Object<string, !Object<string, number>>} */ this.currentFollowingSiblingTypeCounts = this.siblingTypeCountsStack[0];
     if (goog.DEBUG) {
-    	/** @type {Array.<Element>} */ this.elementStack = [];
+        /** @type {Array.<Element>} */ this.elementStack = [];
     }
 };
 
@@ -2485,8 +2485,8 @@ adapt.csscasc.CascadeInstance.prototype.defineCounter = function(counterName, va
         this.counters[counterName] = [value];
     var scoping = this.counterScoping[this.counterScoping.length - 1];
     if (!scoping) {
-    	scoping = {};
-    	this.counterScoping[this.counterScoping.length - 1] = scoping;
+        scoping = {};
+        this.counterScoping[this.counterScoping.length - 1] = scoping;
     }
     scoping[counterName] = true;
 };
@@ -2496,22 +2496,22 @@ adapt.csscasc.CascadeInstance.prototype.defineCounter = function(counterName, va
  * @return {void}
  */
 adapt.csscasc.CascadeInstance.prototype.pushCounters = function(props) {
-	var displayVal = adapt.css.ident.inline;
-	var display = props["display"];
-	if (display) {
-		displayVal = display.evaluate(this.context);
-	}
-	var resetMap = null;
-	var incrementMap = null;
+    var displayVal = adapt.css.ident.inline;
+    var display = props["display"];
+    if (display) {
+        displayVal = display.evaluate(this.context);
+    }
+    var resetMap = null;
+    var incrementMap = null;
     var setMap = null;
 
-	var reset = props["counter-reset"];
-	if (reset) {
-		var resetVal = reset.evaluate(this.context);
-		if (resetVal) {
-			resetMap = adapt.cssprop.toCounters(resetVal, true);
-		}
-	}
+    var reset = props["counter-reset"];
+    if (reset) {
+        var resetVal = reset.evaluate(this.context);
+        if (resetVal) {
+            resetMap = adapt.cssprop.toCounters(resetVal, true);
+        }
+    }
     var set = props["counter-set"];
     if (set) {
         var setVal = set.evaluate(this.context);
@@ -2519,74 +2519,74 @@ adapt.csscasc.CascadeInstance.prototype.pushCounters = function(props) {
             setMap = adapt.cssprop.toCounters(setVal, false);
         }
     }
-	var increment = props["counter-increment"];
-	if (increment) {
-		var incrementVal = increment.evaluate(this.context);
-		if (incrementVal) {
-			incrementMap = adapt.cssprop.toCounters(incrementVal, false);
-		}
-	}
-	if ((this.currentLocalName == "ol" || this.currentLocalName == "ul") &&
-			this.currentNamespace == adapt.base.NS.XHTML) {
-		if (!resetMap)
-			resetMap = {};
-		resetMap["ua-list-item"] = 0;
-	}
-	if (displayVal === adapt.css.ident.list_item) {
-		if (!incrementMap)
-			incrementMap = {};
-		incrementMap["ua-list-item"] = 1;
-	}
-	if (resetMap) {
-	    for (var resetCounterName in resetMap) {
-	        this.defineCounter(resetCounterName, resetMap[resetCounterName]);
-	    }
-	}
-	if (setMap) {
-	    for (var setCounterName in setMap) {
-	        if (!this.counters[setCounterName]) {
-	            this.defineCounter(setCounterName, setMap[setCounterName]);
-	        } else {
-	            var counterValues = this.counters[setCounterName];                
-	            counterValues[counterValues.length - 1] = setMap[setCounterName];
+    var increment = props["counter-increment"];
+    if (increment) {
+        var incrementVal = increment.evaluate(this.context);
+        if (incrementVal) {
+            incrementMap = adapt.cssprop.toCounters(incrementVal, false);
+        }
+    }
+    if ((this.currentLocalName == "ol" || this.currentLocalName == "ul") &&
+        this.currentNamespace == adapt.base.NS.XHTML) {
+        if (!resetMap)
+            resetMap = {};
+        resetMap["ua-list-item"] = 0;
+    }
+    if (displayVal === adapt.css.ident.list_item) {
+        if (!incrementMap)
+            incrementMap = {};
+        incrementMap["ua-list-item"] = 1;
+    }
+    if (resetMap) {
+        for (var resetCounterName in resetMap) {
+            this.defineCounter(resetCounterName, resetMap[resetCounterName]);
+        }
+    }
+    if (setMap) {
+        for (var setCounterName in setMap) {
+            if (!this.counters[setCounterName]) {
+                this.defineCounter(setCounterName, setMap[setCounterName]);
+            } else {
+                var counterValues = this.counters[setCounterName];
+                counterValues[counterValues.length - 1] = setMap[setCounterName];
             }
-	    }
-	}
-	if (incrementMap) {
-	    for (var incrementCounterName in incrementMap) {
-	        if (!this.counters[incrementCounterName]) {
-	            this.defineCounter(incrementCounterName, 0);
-	        }
-	        var counterValues = this.counters[incrementCounterName];
-	        counterValues[counterValues.length - 1] += incrementMap[incrementCounterName];
-	    }
-	}
-	if (displayVal === adapt.css.ident.list_item) {
-		var listItemCounts = this.counters["ua-list-item"];
-		var listItemCount = listItemCounts[listItemCounts.length - 1];
-		props["ua-list-item-count"] =
-			new adapt.csscasc.CascadeValue(new adapt.css.Num(listItemCount), 0);
-	}
-	this.counterScoping.push(null);
+        }
+    }
+    if (incrementMap) {
+        for (var incrementCounterName in incrementMap) {
+            if (!this.counters[incrementCounterName]) {
+                this.defineCounter(incrementCounterName, 0);
+            }
+            var counterValues = this.counters[incrementCounterName];
+            counterValues[counterValues.length - 1] += incrementMap[incrementCounterName];
+        }
+    }
+    if (displayVal === adapt.css.ident.list_item) {
+        var listItemCounts = this.counters["ua-list-item"];
+        var listItemCount = listItemCounts[listItemCounts.length - 1];
+        props["ua-list-item-count"] =
+            new adapt.csscasc.CascadeValue(new adapt.css.Num(listItemCount), 0);
+    }
+    this.counterScoping.push(null);
 };
 
 /**
  * @return {void}
  */
 adapt.csscasc.CascadeInstance.prototype.popCounters = function() {
-	var scoping = this.counterScoping.pop();
-	if (scoping) {
-		for (var counterName in scoping) {
-	        var arr = this.counters[counterName];
-	        if (arr) {
-	            if (arr.length == 1) {
-	                delete this.counters[counterName];
-	            } else {
-	            	arr.pop();
-	            }
-	        }
-		}
-	}
+    var scoping = this.counterScoping.pop();
+    if (scoping) {
+        for (var counterName in scoping) {
+            var arr = this.counters[counterName];
+            if (arr) {
+                if (arr.length == 1) {
+                    delete this.counters[counterName];
+                } else {
+                    arr.pop();
+                }
+            }
+        }
+    }
 };
 
 /**
@@ -2598,7 +2598,7 @@ adapt.csscasc.CascadeInstance.prototype.processPseudoelementProps = function(pse
     this.pushCounters(pseudoprops);
     if (pseudoprops["content"]) {
         pseudoprops["content"] = pseudoprops["content"].filterValue(
-        		new adapt.csscasc.ContentPropVisitor(this, element, this.counterResolver));
+            new adapt.csscasc.ContentPropVisitor(this, element, this.counterResolver));
     }
     this.popCounters();
 };
@@ -2609,8 +2609,8 @@ adapt.csscasc.CascadeInstance.prototype.processPseudoelementProps = function(pse
  * @const
  */
 adapt.csscasc.pseudoNames = ["before", "transclusion-before",
-                  "footnote-call", "footnote-marker", "inner", "first-letter", "first-line",
-                             "" /* content */, "transclusion-after", "after"];
+    "footnote-call", "footnote-marker", "inner", "first-letter", "first-line",
+    "" /* content */, "transclusion-after", "after"];
 
 /**
  * @param {Element} element
@@ -2618,9 +2618,9 @@ adapt.csscasc.pseudoNames = ["before", "transclusion-before",
  * @return {void}
  */
 adapt.csscasc.CascadeInstance.prototype.pushElement = function(element, baseStyle) {
-	if (goog.DEBUG) {
-		this.elementStack.push(element);
-	}
+    if (goog.DEBUG) {
+        this.elementStack.push(element);
+    }
     // do not apply page rules
     this.currentPageType = null;
     this.currentElement = element;
@@ -2629,9 +2629,9 @@ adapt.csscasc.CascadeInstance.prototype.pushElement = function(element, baseStyl
     this.currentLocalName = element.localName;
     var prefix = this.code.nsPrefix[this.currentNamespace];
     if (prefix) {
-    	this.currentNSTag = prefix + this.currentLocalName;
+        this.currentNSTag = prefix + this.currentLocalName;
     } else {
-    	this.currentNSTag = "";
+        this.currentNSTag = "";
     }
     this.currentId = element.getAttribute("id");
     this.currentXmlId = element.getAttributeNS(adapt.base.NS.XML, "id");
@@ -2643,108 +2643,108 @@ adapt.csscasc.CascadeInstance.prototype.pushElement = function(element, baseStyl
     }
     var types = element.getAttributeNS(adapt.base.NS.epub, "type");
     if (types) {
-    	this.currentEpubTypes = types.split(/\s+/);
+        this.currentEpubTypes = types.split(/\s+/);
     } else {
         this.currentEpubTypes = adapt.csscasc.EMPTY;
     }
     if (this.currentLocalName == "style" && this.currentNamespace == adapt.base.NS.FB2) {
-    	// special case
-    	var className = element.getAttribute("name") || "";
-    	this.currentClassNames = [className];
+        // special case
+        var className = element.getAttribute("name") || "";
+        this.currentClassNames = [className];
     }
     var lang = element.getAttributeNS(adapt.base.NS.XML, "lang");
     if (!lang && this.currentNamespace == adapt.base.NS.XHTML) {
-    	lang = element.getAttribute("lang");
+        lang = element.getAttribute("lang");
     }
     if (lang) {
-    	this.stack[this.stack.length - 1].push(
-        		new adapt.csscasc.RestoreLangItem(this.lang));
-    	this.lang = lang.toLowerCase();
+        this.stack[this.stack.length - 1].push(
+            new adapt.csscasc.RestoreLangItem(this.lang));
+        this.lang = lang.toLowerCase();
     }
-	var isRoot = this.isRoot;
+    var isRoot = this.isRoot;
 
-	var siblingOrderStack = this.siblingOrderStack;
-	this.currentSiblingOrder = ++siblingOrderStack[siblingOrderStack.length - 1];
-	siblingOrderStack.push(0);
+    var siblingOrderStack = this.siblingOrderStack;
+    this.currentSiblingOrder = ++siblingOrderStack[siblingOrderStack.length - 1];
+    siblingOrderStack.push(0);
 
-	var siblingTypeCountsStack = this.siblingTypeCountsStack;
-	var currentSiblingTypeCounts = this.currentSiblingTypeCounts = siblingTypeCountsStack[siblingTypeCountsStack.length - 1];
-	var currentNamespaceTypeCounts = currentSiblingTypeCounts[this.currentNamespace];
-	if (!currentNamespaceTypeCounts) {
-		currentNamespaceTypeCounts = currentSiblingTypeCounts[this.currentNamespace] = {};
-	}
-	currentNamespaceTypeCounts[this.currentLocalName] = (currentNamespaceTypeCounts[this.currentLocalName] || 0) + 1;
-	siblingTypeCountsStack.push({});
+    var siblingTypeCountsStack = this.siblingTypeCountsStack;
+    var currentSiblingTypeCounts = this.currentSiblingTypeCounts = siblingTypeCountsStack[siblingTypeCountsStack.length - 1];
+    var currentNamespaceTypeCounts = currentSiblingTypeCounts[this.currentNamespace];
+    if (!currentNamespaceTypeCounts) {
+        currentNamespaceTypeCounts = currentSiblingTypeCounts[this.currentNamespace] = {};
+    }
+    currentNamespaceTypeCounts[this.currentLocalName] = (currentNamespaceTypeCounts[this.currentLocalName] || 0) + 1;
+    siblingTypeCountsStack.push({});
 
-	var followingSiblingOrderStack = this.followingSiblingOrderStack;
-	if (followingSiblingOrderStack[followingSiblingOrderStack.length - 1] !== null) {
-		this.currentFollowingSiblingOrder = --followingSiblingOrderStack[followingSiblingOrderStack.length - 1];
-	} else {
-		this.currentFollowingSiblingOrder = null;
-	}
-	followingSiblingOrderStack.push(null);
+    var followingSiblingOrderStack = this.followingSiblingOrderStack;
+    if (followingSiblingOrderStack[followingSiblingOrderStack.length - 1] !== null) {
+        this.currentFollowingSiblingOrder = --followingSiblingOrderStack[followingSiblingOrderStack.length - 1];
+    } else {
+        this.currentFollowingSiblingOrder = null;
+    }
+    followingSiblingOrderStack.push(null);
 
-	var followingSiblingTypeCountsStack = this.followingSiblingTypeCountsStack;
-	var currentFollowingSiblingTypeCounts = this.currentFollowingSiblingTypeCounts = followingSiblingTypeCountsStack[followingSiblingTypeCountsStack.length - 1];
-	if (currentFollowingSiblingTypeCounts && currentFollowingSiblingTypeCounts[this.currentNamespace]) {
-		currentFollowingSiblingTypeCounts[this.currentNamespace][this.currentLocalName]--;
-	}
-	followingSiblingTypeCountsStack.push({});
+    var followingSiblingTypeCountsStack = this.followingSiblingTypeCountsStack;
+    var currentFollowingSiblingTypeCounts = this.currentFollowingSiblingTypeCounts = followingSiblingTypeCountsStack[followingSiblingTypeCountsStack.length - 1];
+    if (currentFollowingSiblingTypeCounts && currentFollowingSiblingTypeCounts[this.currentNamespace]) {
+        currentFollowingSiblingTypeCounts[this.currentNamespace][this.currentLocalName]--;
+    }
+    followingSiblingTypeCountsStack.push({});
 
     this.applyActions();
     this.applyAttrFilter(element);
     var quotesCasc = baseStyle["quotes"];
     var itemToPushLast = null;
     if (quotesCasc) {
-    	var quotesVal = quotesCasc.evaluate(this.context);
-    	if (quotesVal) {
+        var quotesVal = quotesCasc.evaluate(this.context);
+        if (quotesVal) {
             itemToPushLast = new adapt.csscasc.QuotesScopeItem(this.quotes);
-	    	if (quotesVal === adapt.css.ident.none)
-	    		this.quotes = [new adapt.css.Str(""), new adapt.css.Str("")];
-	    	else if (quotesVal instanceof adapt.css.SpaceList)
-	    		this.quotes = /** @type {Array.<adapt.css.Str>} */
-	    			((/** @type {adapt.css.SpaceList} */ (quotesVal)).values);
-    	}
+            if (quotesVal === adapt.css.ident.none)
+                this.quotes = [new adapt.css.Str(""), new adapt.css.Str("")];
+            else if (quotesVal instanceof adapt.css.SpaceList)
+                this.quotes = /** @type {Array.<adapt.css.Str>} */
+                    ((/** @type {adapt.css.SpaceList} */ (quotesVal)).values);
+        }
     }
     this.pushCounters(this.currentStyle);
-	var id = this.currentId || this.currentXmlId || element.getAttribute("name") || "";
-	if (isRoot || id) {
-		/** @type {!Object<string, Array<number>>} */ var counters = {};
-		Object.keys(this.counters).forEach(function(name) {
-			counters[name] = Array.from(this.counters[name]);
-		}, this);
-		this.counterListener.countersOfId(id, counters);
-	}
+    var id = this.currentId || this.currentXmlId || element.getAttribute("name") || "";
+    if (isRoot || id) {
+        /** @type {!Object<string, Array<number>>} */ var counters = {};
+        Object.keys(this.counters).forEach(function(name) {
+            counters[name] = Array.from(this.counters[name]);
+        }, this);
+        this.counterListener.countersOfId(id, counters);
+    }
     var pseudos = adapt.csscasc.getStyleMap(this.currentStyle, "_pseudos");
     if (pseudos) {
-    	var before = true;
-    	for (var k = 0; k < adapt.csscasc.pseudoNames.length; k++) {
-    		var pseudoName = adapt.csscasc.pseudoNames[k];
-    		if (!pseudoName) {
-    			// content
-    			before = false;
-    		}
-	    	var pseudoProps = pseudos[pseudoName];
-	    	if (pseudoProps) {
-	    		if (before) {
-	    			this.processPseudoelementProps(pseudoProps, element);
-	    		} else {
-	                this.stack[this.stack.length - 2].push(
-	                		new adapt.csscasc.AfterPseudoelementItem(pseudoProps, element));
-	    		}
-	    	}
-    	}
+        var before = true;
+        for (var k = 0; k < adapt.csscasc.pseudoNames.length; k++) {
+            var pseudoName = adapt.csscasc.pseudoNames[k];
+            if (!pseudoName) {
+                // content
+                before = false;
+            }
+            var pseudoProps = pseudos[pseudoName];
+            if (pseudoProps) {
+                if (before) {
+                    this.processPseudoelementProps(pseudoProps, element);
+                } else {
+                    this.stack[this.stack.length - 2].push(
+                        new adapt.csscasc.AfterPseudoelementItem(pseudoProps, element));
+                }
+            }
+        }
     }
     if (itemToPushLast) {
-    	this.stack[this.stack.length - 2].push(itemToPushLast);
+        this.stack[this.stack.length - 2].push(itemToPushLast);
     }
 };
 
 
 /**
-* @private
-* @return {void}
-*/
+ * @private
+ * @return {void}
+ */
 adapt.csscasc.CascadeInstance.prototype.applyAttrFilterInner = function(visitor, elementStyle) {
     for (var propName in elementStyle) {
         if (adapt.csscasc.isPropName(propName))
@@ -2752,24 +2752,24 @@ adapt.csscasc.CascadeInstance.prototype.applyAttrFilterInner = function(visitor,
     }
 };
 /**
-* @private
-* @return {void}
-*/
+ * @private
+ * @return {void}
+ */
 adapt.csscasc.CascadeInstance.prototype.applyAttrFilter = function(element) {
     var visitor = new adapt.csscasc.AttrValueFilterVisitor(element);
     var currentStyle = this.currentStyle;
-    var pseudoMap = adapt.csscasc.getStyleMap(currentStyle, "_pseudos");        
+    var pseudoMap = adapt.csscasc.getStyleMap(currentStyle, "_pseudos");
     for (var pseudoName in pseudoMap) {
         this.applyAttrFilterInner(visitor, pseudoMap[pseudoName]);
     }
     this.applyAttrFilterInner(visitor, currentStyle);
-}
+};
 /**
  * @private
  * @return {void}
  */
 adapt.csscasc.CascadeInstance.prototype.applyActions = function() {
-	var i;
+    var i;
     for (i = 0; i < this.currentClassNames.length; i++) {
         this.applyAction(this.code.classes, this.currentClassNames[i]);
     }
@@ -2779,8 +2779,8 @@ adapt.csscasc.CascadeInstance.prototype.applyActions = function() {
     this.applyAction(this.code.ids, this.currentId);
     this.applyAction(this.code.tags, this.currentLocalName);
     if (this.currentLocalName != "") {
-    	// Universal selector does not apply to page-master-related rules.
-    	this.applyAction(this.code.tags, "*");
+        // Universal selector does not apply to page-master-related rules.
+        this.applyAction(this.code.tags, "*");
     }
     this.applyAction(this.code.nstags, this.currentNSTag);
     // Apply page rules only when currentPageType is not null
@@ -2794,15 +2794,15 @@ adapt.csscasc.CascadeInstance.prototype.applyActions = function() {
     this.stack.push([]);
     for (var depth = 1; depth >= -1; --depth) {
         var list = this.stack[this.stack.length - depth - 2];
-	    i = 0;
-	    while(i < list.length) {
-	        if (list[i].push(this, depth)) {
-	        	// done
-	        	list.splice(i, 1);
-	        } else {
-	        	i++;
-	        }
-	    }
+        i = 0;
+        while (i < list.length) {
+            if (list[i].push(this, depth)) {
+                // done
+                list.splice(i, 1);
+            } else {
+                i++;
+            }
+        }
     }
     this.isFirst = true;
     this.isRoot = false;
@@ -2815,15 +2815,15 @@ adapt.csscasc.CascadeInstance.prototype.applyActions = function() {
 adapt.csscasc.CascadeInstance.prototype.pop = function() {
     for (var depth = 1; depth >= -1; --depth) {
         var list = this.stack[this.stack.length - depth - 2];
-	    var i = 0;
-	    while(i < list.length) {
-	        if (list[i].pop(this, depth)) {
-	        	// done
-	        	list.splice(i, 1);
-	        } else {
-	        	i++;
-	        }
-	    }
+        var i = 0;
+        while (i < list.length) {
+            if (list[i].pop(this, depth)) {
+                // done
+                list.splice(i, 1);
+            } else {
+                i++;
+            }
+        }
     }
     this.stack.pop();
     this.isFirst = false;
@@ -2833,7 +2833,7 @@ adapt.csscasc.CascadeInstance.prototype.pop = function() {
  * @return {void}
  */
 adapt.csscasc.CascadeInstance.prototype.popRule = function() {
-	this.pop();
+    this.pop();
 };
 
 /**
@@ -2841,27 +2841,27 @@ adapt.csscasc.CascadeInstance.prototype.popRule = function() {
  * @return {void}
  */
 adapt.csscasc.CascadeInstance.prototype.popElement = function(element) {
-	if (goog.DEBUG) {
-		var e = this.elementStack.pop();
-		if (e !== element) {
-			throw new Error("Invalid call to popElement");
-		}
-	}
-	this.siblingOrderStack.pop();
-	this.siblingTypeCountsStack.pop();
-	this.followingSiblingOrderStack.pop();
-	this.followingSiblingTypeCountsStack.pop();
-	this.pop();
-	this.popCounters();
+    if (goog.DEBUG) {
+        var e = this.elementStack.pop();
+        if (e !== element) {
+            throw new Error("Invalid call to popElement");
+        }
+    }
+    this.siblingOrderStack.pop();
+    this.siblingTypeCountsStack.pop();
+    this.followingSiblingOrderStack.pop();
+    this.followingSiblingTypeCountsStack.pop();
+    this.pop();
+    this.popCounters();
 };
 
 /**
  * @enum {number}
  */
 adapt.csscasc.ParseState = {
-	TOP: 0,
-	SELECTOR: 1,
-	RULE: 2
+    TOP: 0,
+    SELECTOR: 1,
+    RULE: 2
 };
 
 /**
@@ -2885,18 +2885,18 @@ adapt.csscasc.uaBaseCascade = null;
  * @implements {adapt.cssvalid.PropertyReceiver}
  */
 adapt.csscasc.CascadeParserHandler = function(scope, owner, condition, parent, regionId,
-		validatorSet, topLevel) {
-	adapt.cssparse.SlaveParserHandler.call(this, scope, owner, topLevel);
+                                              validatorSet, topLevel) {
+    adapt.cssparse.SlaveParserHandler.call(this, scope, owner, topLevel);
     /** @type {Array.<adapt.csscasc.ChainedAction>} */ this.chain = null;
     /** @type {number} */ this.specificity = 0;
     /** @type {adapt.csscasc.ElementStyle} */ this.elementStyle = null;
     /** @type {number} */ this.conditionCount = 0;
     /** @type {?string} */ this.pseudoelement = null;
     /** @type {boolean} */ this.footnoteContent = false;
-	/** @const */ this.condition = condition;
+    /** @const */ this.condition = condition;
     /** @const */ this.cascade = parent ? parent.cascade :
-    	(adapt.csscasc.uaBaseCascade ? adapt.csscasc.uaBaseCascade.clone() :
-    		new adapt.csscasc.Cascade());
+        (adapt.csscasc.uaBaseCascade ? adapt.csscasc.uaBaseCascade.clone() :
+            new adapt.csscasc.Cascade());
     /** @const */ this.regionId = regionId;
     /** @const */ this.validatorSet = validatorSet;
     /** @type {adapt.csscasc.ParseState} */ this.state = adapt.csscasc.ParseState.TOP;
@@ -2928,25 +2928,25 @@ adapt.csscasc.CascadeParserHandler.prototype.processChain = function(action) {
  * @return {boolean}
  */
 adapt.csscasc.CascadeParserHandler.prototype.isInsideSelectorRule = function(mnemonics) {
-	if (this.state != adapt.csscasc.ParseState.TOP) {
-		this.reportAndSkip(mnemonics);
-		return true;
-	}
-	return false;
+    if (this.state != adapt.csscasc.ParseState.TOP) {
+        this.reportAndSkip(mnemonics);
+        return true;
+    }
+    return false;
 };
 
 /**
  * @override
  */
 adapt.csscasc.CascadeParserHandler.prototype.tagSelector = function(ns, name) {
-	if (!name && !ns) {
-		return;
-	}
+    if (!name && !ns) {
+        return;
+    }
     this.specificity += 1;
     if (name && ns) {
-    	this.chain.push(new adapt.csscasc.CheckNSTagAction(ns, name.toLowerCase()));
+        this.chain.push(new adapt.csscasc.CheckNSTagAction(ns, name.toLowerCase()));
     } else if (name) {
-    	this.chain.push(new adapt.csscasc.CheckLocalNameAction(name.toLowerCase()));
+        this.chain.push(new adapt.csscasc.CheckLocalNameAction(name.toLowerCase()));
     } else {
         this.chain.push(new adapt.csscasc.CheckNamespaceAction(/** @type {string} */ (ns)));
     }
@@ -2957,9 +2957,9 @@ adapt.csscasc.CascadeParserHandler.prototype.tagSelector = function(ns, name) {
  */
 adapt.csscasc.CascadeParserHandler.prototype.classSelector = function(name) {
     if (this.pseudoelement) {
-		vivliostyle.logging.logger.warn("::" + this.pseudoelement, "followed by ." + name);
+        vivliostyle.logging.logger.warn("::" + this.pseudoelement, "followed by ." + name);
         this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
-    	return;
+        return;
     }
     this.specificity += 0x100;
     this.chain.push(new adapt.csscasc.CheckClassAction(name));
@@ -2970,10 +2970,10 @@ adapt.csscasc.CascadeParserHandler.prototype.classSelector = function(name) {
  * @const {!Object<string, function(new: adapt.csscasc.IsNthAction, number, number)>}
  */
 adapt.csscasc.nthSelectorActionClasses = {
-	"nth-child": adapt.csscasc.IsNthSiblingAction,
-	"nth-of-type": adapt.csscasc.IsNthSiblingOfTypeAction,
-	"nth-last-child": adapt.csscasc.IsNthLastSiblingAction,
-	"nth-last-of-type": adapt.csscasc.IsNthLastSiblingOfTypeAction
+    "nth-child": adapt.csscasc.IsNthSiblingAction,
+    "nth-of-type": adapt.csscasc.IsNthSiblingOfTypeAction,
+    "nth-last-child": adapt.csscasc.IsNthLastSiblingAction,
+    "nth-last-of-type": adapt.csscasc.IsNthLastSiblingOfTypeAction
 };
 
 /**
@@ -2981,20 +2981,20 @@ adapt.csscasc.nthSelectorActionClasses = {
  */
 adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name, params) {
     if (this.pseudoelement) {
-		vivliostyle.logging.logger.warn("::" + this.pseudoelement, "followed by :" + name);
+        vivliostyle.logging.logger.warn("::" + this.pseudoelement, "followed by :" + name);
         this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
-    	return;
+        return;
     }
     switch (name.toLowerCase()) {
-		case "enabled":
-			this.chain.push(new adapt.csscasc.IsEnabledAction());
-			break;
-		case "disabled":
-			this.chain.push(new adapt.csscasc.IsDisabledAction());
-			break;
-		case "checked":
-			this.chain.push(new adapt.csscasc.IsCheckedAction());
-			break;
+        case "enabled":
+            this.chain.push(new adapt.csscasc.IsEnabledAction());
+            break;
+        case "disabled":
+            this.chain.push(new adapt.csscasc.IsDisabledAction());
+            break;
+        case "checked":
+            this.chain.push(new adapt.csscasc.IsCheckedAction());
+            break;
         case "root":
             this.chain.push(new adapt.csscasc.IsRootAction());
             break;
@@ -3004,19 +3004,19 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
             break;
         case "-adapt-href-epub-type":
         case "href-epub-type":
-	    	if (params && params.length == 1 && typeof params[0] == "string") {
-	    		var value = /** @type {string} */ (params[0]);
-	    		var patt = new RegExp("(^|\s)" + adapt.base.escapeRegExp(value) + "($|\s)");
-	    		this.chain.push(new adapt.csscasc.CheckTargetEpubTypeAction(patt));
-	    	} else {
-	            this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
-	    	}
+            if (params && params.length == 1 && typeof params[0] == "string") {
+                var value = /** @type {string} */ (params[0]);
+                var patt = new RegExp("(^|\s)" + adapt.base.escapeRegExp(value) + "($|\s)");
+                this.chain.push(new adapt.csscasc.CheckTargetEpubTypeAction(patt));
+            } else {
+                this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
+            }
             break;
         case "-adapt-footnote-content":
         case "footnote-content":
-        	// content inside the footnote
-        	this.footnoteContent = true;
-        	break;
+            // content inside the footnote
+            this.footnoteContent = true;
+            break;
         case "visited":
         case "active":
         case "hover":
@@ -3024,48 +3024,48 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
             this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
             break;
         case "lang":
-	    	if (params && params.length == 1 && typeof params[0] == "string") {
-	    		var langValue = /** @type {string} */ (params[0]);
-	    		this.chain.push(new adapt.csscasc.CheckLangAction(
-	    				new RegExp("^" + adapt.base.escapeRegExp(langValue.toLowerCase()) + "($|-)")));
-	    	} else {
-	            this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fais
-	    	}
-	    	break;
-		case "nth-child":
-		case "nth-last-child":
-		case "nth-of-type":
-		case "nth-last-of-type":
-			var ActionClass = adapt.csscasc.nthSelectorActionClasses[name.toLowerCase()];
-			if (params && params.length == 2) {
-				this.chain.push(new ActionClass(/** @type {number} */ (params[0]), /** @type {number} */ (params[1])));
-			} else {
-				this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
-			}
-			break;
-		case "first-child":
-			this.chain.push(new adapt.csscasc.IsFirstAction());
-			break;
-		case "last-child":
-			this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
-			break;
-		case "first-of-type":
-			this.chain.push(new adapt.csscasc.IsNthSiblingOfTypeAction(0, 1));
-			break;
-		case "last-of-type":
-			this.chain.push(new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 1));
-			break;
-		case "only-child":
-			this.chain.push(new adapt.csscasc.IsFirstAction());
-			this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
-			break;
-		case "only-of-type":
-			this.chain.push(new adapt.csscasc.IsNthSiblingOfTypeAction(0, 1));
-			this.chain.push(new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 1));
-			break;
-		case "empty":
-			this.chain.push(new adapt.csscasc.IsEmptyAction());
-			break;
+            if (params && params.length == 1 && typeof params[0] == "string") {
+                var langValue = /** @type {string} */ (params[0]);
+                this.chain.push(new adapt.csscasc.CheckLangAction(
+                    new RegExp("^" + adapt.base.escapeRegExp(langValue.toLowerCase()) + "($|-)")));
+            } else {
+                this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fais
+            }
+            break;
+        case "nth-child":
+        case "nth-last-child":
+        case "nth-of-type":
+        case "nth-last-of-type":
+            var ActionClass = adapt.csscasc.nthSelectorActionClasses[name.toLowerCase()];
+            if (params && params.length == 2) {
+                this.chain.push(new ActionClass(/** @type {number} */ (params[0]), /** @type {number} */ (params[1])));
+            } else {
+                this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
+            }
+            break;
+        case "first-child":
+            this.chain.push(new adapt.csscasc.IsFirstAction());
+            break;
+        case "last-child":
+            this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
+            break;
+        case "first-of-type":
+            this.chain.push(new adapt.csscasc.IsNthSiblingOfTypeAction(0, 1));
+            break;
+        case "last-of-type":
+            this.chain.push(new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 1));
+            break;
+        case "only-child":
+            this.chain.push(new adapt.csscasc.IsFirstAction());
+            this.chain.push(new adapt.csscasc.IsNthLastSiblingAction(0, 1));
+            break;
+        case "only-of-type":
+            this.chain.push(new adapt.csscasc.IsNthSiblingOfTypeAction(0, 1));
+            this.chain.push(new adapt.csscasc.IsNthLastSiblingOfTypeAction(0, 1));
+            break;
+        case "empty":
+            this.chain.push(new adapt.csscasc.IsEmptyAction());
+            break;
         case "before":
         case "after":
         case "first-line":
@@ -3073,7 +3073,7 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoclassSelector = function(name
             this.pseudoelementSelector(name, params);
             return;
         default:
-			vivliostyle.logging.logger.warn("unknown pseudo-class selector: " + name);
+            vivliostyle.logging.logger.warn("unknown pseudo-class selector: " + name);
             this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
             break;
     }
@@ -3091,29 +3091,29 @@ adapt.csscasc.CascadeParserHandler.prototype.pseudoelementSelector = function(na
         case "first-letter":
         case "footnote-call":
         case "footnote-marker":
-	    case "inner":
+        case "inner":
             if (!this.pseudoelement) {
                 this.pseudoelement = name;
             } else {
-				vivliostyle.logging.logger.warn("Double pseudoelement ::" + this.pseudoelement + "::" + name);
-	            this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
+                vivliostyle.logging.logger.warn("Double pseudoelement ::" + this.pseudoelement + "::" + name);
+                this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
             }
             break;
-	    case "first-n-lines":
-	    	if (params && params.length == 1 && typeof params[0] == "number") {
-	    		var n = Math.round(params[0]);
-	    		if ( n > 0 && n == params[0]) {
-	                if (!this.pseudoelement) {
-	                    this.pseudoelement = "first-" + n + "-lines";
-	                } else {
-	    	        	vivliostyle.logging.logger.warn("Double pseudoelement ::" + this.pseudoelement + "::" + name);
-	    	            this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
-	                }
-	    			break;
-	    		}
-	    	}
+        case "first-n-lines":
+            if (params && params.length == 1 && typeof params[0] == "number") {
+                var n = Math.round(params[0]);
+                if (n > 0 && n == params[0]) {
+                    if (!this.pseudoelement) {
+                        this.pseudoelement = "first-" + n + "-lines";
+                    } else {
+                        vivliostyle.logging.logger.warn("Double pseudoelement ::" + this.pseudoelement + "::" + name);
+                        this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
+                    }
+                    break;
+                }
+            }
         default:
-        	vivliostyle.logging.logger.warn("Unrecognized pseudoelement: ::" + name);
+            vivliostyle.logging.logger.warn("Unrecognized pseudoelement: ::" + name);
             this.chain.push(new adapt.csscasc.CheckConditionAction("")); // always fails
             break;
     }
@@ -3133,65 +3133,65 @@ adapt.csscasc.CascadeParserHandler.prototype.idSelector = function(id) {
  */
 adapt.csscasc.CascadeParserHandler.prototype.attributeSelector = function(ns, name, op, value) {
     this.specificity += 0x100;
-		name = name.toLowerCase();
+    name = name.toLowerCase();
     value = value || "";
-	var action;
+    var action;
     switch (op) {
         case adapt.csstok.TokenType.EOF:
             action = new adapt.csscasc.CheckAttributePresentAction(ns, name);
             break;
         case adapt.csstok.TokenType.EQ:
-			action = new adapt.csscasc.CheckAttributeEqAction(ns, name, value);
+            action = new adapt.csscasc.CheckAttributeEqAction(ns, name, value);
             break;
         case adapt.csstok.TokenType.TILDE_EQ:
-			if (!value || value.match(/\s/)) {
-				action = new adapt.csscasc.CheckConditionAction(""); // always fails
-			} else {
-				action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
-					new RegExp("(^|\\s)" + adapt.base.escapeRegExp(value) + "($|\\s)"));
-			}
+            if (!value || value.match(/\s/)) {
+                action = new adapt.csscasc.CheckConditionAction(""); // always fails
+            } else {
+                action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+                    new RegExp("(^|\\s)" + adapt.base.escapeRegExp(value) + "($|\\s)"));
+            }
             break;
         case adapt.csstok.TokenType.BAR_EQ:
-			action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
-				new RegExp("^" + adapt.base.escapeRegExp(value) + "($|-)"));
+            action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+                new RegExp("^" + adapt.base.escapeRegExp(value) + "($|-)"));
             break;
-		case adapt.csstok.TokenType.HAT_EQ:
-			if (!value) {
-				action = new adapt.csscasc.CheckConditionAction(""); // always fails
-			} else {
-				action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
-					new RegExp("^" + adapt.base.escapeRegExp(value)));
-			}
-			break;
-		case adapt.csstok.TokenType.DOLLAR_EQ:
-			if (!value) {
-				action = new adapt.csscasc.CheckConditionAction(""); // always fails
-			} else {
-				action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
-					new RegExp(adapt.base.escapeRegExp(value) + "$"));
-			}
-			break;
-		case adapt.csstok.TokenType.STAR_EQ:
-			if (!value) {
-				action = new adapt.csscasc.CheckConditionAction(""); // always fails
-			} else {
-				action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
-					new RegExp(adapt.base.escapeRegExp(value)));
-			}
-			break;
+        case adapt.csstok.TokenType.HAT_EQ:
+            if (!value) {
+                action = new adapt.csscasc.CheckConditionAction(""); // always fails
+            } else {
+                action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+                    new RegExp("^" + adapt.base.escapeRegExp(value)));
+            }
+            break;
+        case adapt.csstok.TokenType.DOLLAR_EQ:
+            if (!value) {
+                action = new adapt.csscasc.CheckConditionAction(""); // always fails
+            } else {
+                action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+                    new RegExp(adapt.base.escapeRegExp(value) + "$"));
+            }
+            break;
+        case adapt.csstok.TokenType.STAR_EQ:
+            if (!value) {
+                action = new adapt.csscasc.CheckConditionAction(""); // always fails
+            } else {
+                action = new adapt.csscasc.CheckAttributeRegExpAction(ns, name,
+                    new RegExp(adapt.base.escapeRegExp(value)));
+            }
+            break;
         case adapt.csstok.TokenType.COL_COL:
-        	if (value == "supported") {
-				action = new adapt.csscasc.CheckNamespaceSupportedAction(ns, name);
-        	} else {
-				vivliostyle.logging.logger.warn("Unsupported :: attr selector op:", value);
-				action = new adapt.csscasc.CheckConditionAction(""); // always fails
-        	}
-        	break;
+            if (value == "supported") {
+                action = new adapt.csscasc.CheckNamespaceSupportedAction(ns, name);
+            } else {
+                vivliostyle.logging.logger.warn("Unsupported :: attr selector op:", value);
+                action = new adapt.csscasc.CheckConditionAction(""); // always fails
+            }
+            break;
         default:
-			vivliostyle.logging.logger.warn("Unsupported attr selector:", op);
-			action = new adapt.csscasc.CheckConditionAction(""); // always fails
+            vivliostyle.logging.logger.warn("Unsupported attr selector:", op);
+            action = new adapt.csscasc.CheckConditionAction(""); // always fails
     }
-	this.chain.push(action);
+    this.chain.push(action);
 };
 
 /**
@@ -3206,7 +3206,7 @@ adapt.csscasc.conditionCount = 0;
 adapt.csscasc.CascadeParserHandler.prototype.descendantSelector = function() {
     var condition = "d" + (adapt.csscasc.conditionCount++);
     this.processChain(new adapt.csscasc.ConditionItemAction(
-    		new adapt.csscasc.DescendantConditionItem(condition)));
+        new adapt.csscasc.DescendantConditionItem(condition)));
     this.chain = [new adapt.csscasc.CheckConditionAction(condition)];
 };
 
@@ -3216,7 +3216,7 @@ adapt.csscasc.CascadeParserHandler.prototype.descendantSelector = function() {
 adapt.csscasc.CascadeParserHandler.prototype.childSelector = function() {
     var condition = "c" + (adapt.csscasc.conditionCount++);
     this.processChain(new adapt.csscasc.ConditionItemAction(
-    		new adapt.csscasc.ChildConditionItem(condition)));
+        new adapt.csscasc.ChildConditionItem(condition)));
     this.chain = [new adapt.csscasc.CheckConditionAction(condition)];
 };
 
@@ -3226,7 +3226,7 @@ adapt.csscasc.CascadeParserHandler.prototype.childSelector = function() {
 adapt.csscasc.CascadeParserHandler.prototype.adjacentSiblingSelector = function() {
     var condition = "a" + (adapt.csscasc.conditionCount++);
     this.processChain(new adapt.csscasc.ConditionItemAction(
-    		new adapt.csscasc.AdjacentSiblingConditionItem(condition)));
+        new adapt.csscasc.AdjacentSiblingConditionItem(condition)));
     this.chain = [new adapt.csscasc.CheckConditionAction(condition)];
 };
 
@@ -3236,7 +3236,7 @@ adapt.csscasc.CascadeParserHandler.prototype.adjacentSiblingSelector = function(
 adapt.csscasc.CascadeParserHandler.prototype.followingSiblingSelector = function() {
     var condition = "f" + (adapt.csscasc.conditionCount++);
     this.processChain(new adapt.csscasc.ConditionItemAction(
-    		new adapt.csscasc.FollowingSiblingConditionItem(condition)));
+        new adapt.csscasc.FollowingSiblingConditionItem(condition)));
     this.chain = [new adapt.csscasc.CheckConditionAction(condition)];
 };
 
@@ -3255,10 +3255,10 @@ adapt.csscasc.CascadeParserHandler.prototype.nextSelector = function() {
  * @override
  */
 adapt.csscasc.CascadeParserHandler.prototype.startSelectorRule = function() {
-	if (this.isInsideSelectorRule("E_CSS_UNEXPECTED_SELECTOR")) {
-		return;
-	}
-	this.state = adapt.csscasc.ParseState.SELECTOR;
+    if (this.isInsideSelectorRule("E_CSS_UNEXPECTED_SELECTOR")) {
+        return;
+    }
+    this.state = adapt.csscasc.ParseState.SELECTOR;
     this.elementStyle = /** @type {adapt.csscasc.ElementStyle} */ ({});
     this.pseudoelement = null;
     this.specificity = 0;
@@ -3272,7 +3272,7 @@ adapt.csscasc.CascadeParserHandler.prototype.startSelectorRule = function() {
 adapt.csscasc.CascadeParserHandler.prototype.error = function(message, token) {
     adapt.cssparse.SlaveParserHandler.prototype.error.call(this, message, token);
     if (this.state == adapt.csscasc.ParseState.SELECTOR) {
-    	this.state = adapt.csscasc.ParseState.TOP;
+        this.state = adapt.csscasc.ParseState.TOP;
     }
 };
 
@@ -3281,7 +3281,7 @@ adapt.csscasc.CascadeParserHandler.prototype.error = function(message, token) {
  */
 adapt.csscasc.CascadeParserHandler.prototype.startStylesheet = function(flavor) {
     adapt.cssparse.SlaveParserHandler.prototype.startStylesheet.call(this, flavor);
-	this.state = adapt.csscasc.ParseState.TOP;
+    this.state = adapt.csscasc.ParseState.TOP;
 };
 
 /**
@@ -3291,7 +3291,7 @@ adapt.csscasc.CascadeParserHandler.prototype.startRuleBody = function() {
     this.finishChain();
     adapt.cssparse.SlaveParserHandler.prototype.startRuleBody.call(this);
     if (this.state == adapt.csscasc.ParseState.SELECTOR) {
-    	this.state = adapt.csscasc.ParseState.TOP;
+        this.state = adapt.csscasc.ParseState.TOP;
     }
 };
 
@@ -3299,8 +3299,8 @@ adapt.csscasc.CascadeParserHandler.prototype.startRuleBody = function() {
  * @override
  */
 adapt.csscasc.CascadeParserHandler.prototype.endRule = function() {
-	adapt.cssparse.SlaveParserHandler.prototype.endRule.call(this);
-	this.insideSelectorRule = adapt.csscasc.ParseState.TOP;
+    adapt.cssparse.SlaveParserHandler.prototype.endRule.call(this);
+    this.insideSelectorRule = adapt.csscasc.ParseState.TOP;
 };
 
 /**
@@ -3308,7 +3308,7 @@ adapt.csscasc.CascadeParserHandler.prototype.endRule = function() {
  */
 adapt.csscasc.CascadeParserHandler.prototype.finishChain = function() {
     if (this.chain) {
-		/** @type {number} */ var specificity = this.specificity + this.cascade.nextOrder();
+        /** @type {number} */ var specificity = this.specificity + this.cascade.nextOrder();
         this.processChain(this.makeApplyRuleAction(specificity));
         this.chain = null;
         this.pseudoelement = null;
@@ -3323,15 +3323,15 @@ adapt.csscasc.CascadeParserHandler.prototype.finishChain = function() {
  * @return {adapt.csscasc.ApplyRuleAction}
  */
 adapt.csscasc.CascadeParserHandler.prototype.makeApplyRuleAction = function(specificity) {
-	var regionId = this.regionId;
-	if (this.footnoteContent) {
-		if (regionId)
-			regionId = "xxx-bogus-xxx";
-		else
-			regionId = "footnote";
-	}
-	return new adapt.csscasc.ApplyRuleAction(this.elementStyle, specificity,
-		this.pseudoelement, regionId);
+    var regionId = this.regionId;
+    if (this.footnoteContent) {
+        if (regionId)
+            regionId = "xxx-bogus-xxx";
+        else
+            regionId = "footnote";
+    }
+    return new adapt.csscasc.ApplyRuleAction(this.elementStyle, specificity,
+        this.pseudoelement, regionId);
 };
 
 /**
@@ -3373,27 +3373,27 @@ adapt.csscasc.CascadeParserHandler.prototype.unknownProperty = function(name, va
  * @override
  */
 adapt.csscasc.CascadeParserHandler.prototype.simpleProperty = function(name, value, important) {
-	if (name == "display" && (value === adapt.css.ident.oeb_page_head ||
-			value === adapt.css.ident.oeb_page_foot)) {
-		this.simpleProperty("flow-options", new adapt.css.SpaceList([
-		           adapt.css.ident.exclusive, adapt.css.ident._static]), important);
-		this.simpleProperty("flow-into", value, important);
-		value = adapt.css.ident.block;
-	}
+    if (name == "display" && (value === adapt.css.ident.oeb_page_head ||
+        value === adapt.css.ident.oeb_page_foot)) {
+        this.simpleProperty("flow-options", new adapt.css.SpaceList([
+            adapt.css.ident.exclusive, adapt.css.ident._static]), important);
+        this.simpleProperty("flow-into", value, important);
+        value = adapt.css.ident.block;
+    }
 
-	var hooks = vivliostyle.plugin.getHooksForName("SIMPLE_PROPERTY");
-	hooks.forEach(function(hook) {
-		var original = {"name": name, "value": value, "important": important};
-		var converted = hook(original);
-		name = converted["name"];
-		value = converted["value"];
-		important = converted["important"];
-	});
+    var hooks = vivliostyle.plugin.getHooksForName("SIMPLE_PROPERTY");
+    hooks.forEach(function(hook) {
+        var original = {"name": name, "value": value, "important": important};
+        var converted = hook(original);
+        name = converted["name"];
+        value = converted["value"];
+        important = converted["important"];
+    });
 
     var specificity = important ? this.getImportantSpecificity() : this.getBaseSpecificity();
     var cascval = this.condition
-    		? new adapt.csscasc.ConditionalCascadeValue(value, specificity, this.condition)
-    		: new adapt.csscasc.CascadeValue(value, specificity);
+        ? new adapt.csscasc.ConditionalCascadeValue(value, specificity, this.condition)
+        : new adapt.csscasc.CascadeValue(value, specificity);
     adapt.csscasc.setProp(this.elementStyle, name, cascval);
 };
 
@@ -3406,18 +3406,18 @@ adapt.csscasc.CascadeParserHandler.prototype.finish = function() {
 
 
 /**
-* @override
-*/
+ * @override
+ */
 adapt.csscasc.CascadeParserHandler.prototype.startFuncWithSelector = function(funcName) {
     switch (funcName) {
-    case "not":
-        var notParserHandler = new adapt.csscasc.NotParameterParserHandler(this);
-        notParserHandler.startSelectorRule();
-        this.owner.pushHandler(notParserHandler);
-        break;
-    default:
-        // TODO
-        break;
+        case "not":
+            var notParserHandler = new adapt.csscasc.NotParameterParserHandler(this);
+            notParserHandler.startSelectorRule();
+            this.owner.pushHandler(notParserHandler);
+            break;
+        default:
+            // TODO
+            break;
     }
 };
 
@@ -3425,7 +3425,7 @@ adapt.csscasc.CascadeParserHandler.prototype.startFuncWithSelector = function(fu
  * @param {adapt.csscasc.CascadeParserHandler} parent
  * @constructor
  * @extends {adapt.csscasc.CascadeParserHandler}
-*/
+ */
 adapt.csscasc.NotParameterParserHandler = function(parent) {
     adapt.csscasc.CascadeParserHandler.call(this, parent.scope, parent.owner, parent.condition, parent, parent.regionId, parent.validatorSet, false);
     /** @const */ this.parent = parent;
@@ -3434,30 +3434,30 @@ adapt.csscasc.NotParameterParserHandler = function(parent) {
 goog.inherits(adapt.csscasc.NotParameterParserHandler, adapt.csscasc.CascadeParserHandler);
 
 /**
-* @override
-*/
+ * @override
+ */
 adapt.csscasc.NotParameterParserHandler.prototype.startFuncWithSelector = function(funcName) {
     if (funcName == "not")
         this.reportAndSkip("E_CSS_UNEXPECTED_NOT");
 };
 
 /**
-* @override
-*/
+ * @override
+ */
 adapt.csscasc.NotParameterParserHandler.prototype.startRuleBody = function() {
-  this.reportAndSkip("E_CSS_UNEXPECTED_RULE_BODY");
+    this.reportAndSkip("E_CSS_UNEXPECTED_RULE_BODY");
 };
 
 /**
-* @override
-*/
+ * @override
+ */
 adapt.csscasc.NotParameterParserHandler.prototype.nextSelector = function() {
-  this.reportAndSkip("E_CSS_UNEXPECTED_NEXT_SELECTOR");  
-}
+    this.reportAndSkip("E_CSS_UNEXPECTED_NEXT_SELECTOR");
+};
 
 /**
-* @override
-*/
+ * @override
+ */
 adapt.csscasc.NotParameterParserHandler.prototype.endFuncWithSelector = function() {
     if (this.chain && this.chain.length > 0) {
         this.parentChain.push(new adapt.csscasc.NegateActionsSet(this.chain));
@@ -3467,8 +3467,8 @@ adapt.csscasc.NotParameterParserHandler.prototype.endFuncWithSelector = function
 };
 
 /**
-* @override
-*/
+ * @override
+ */
 adapt.csscasc.NotParameterParserHandler.prototype.error = function(mnemonics, token) {
     adapt.csscasc.CascadeParserHandler.prototype.error.call(this, mnemonics, token);
     this.owner.popHandler();
@@ -3487,7 +3487,7 @@ adapt.csscasc.NotParameterParserHandler.prototype.error = function(mnemonics, to
  * @extends {adapt.cssparse.SlaveParserHandler}
  */
 adapt.csscasc.DefineParserHandler = function(scope, owner) {
-	adapt.cssparse.SlaveParserHandler.call(this, scope, owner, false);
+    adapt.cssparse.SlaveParserHandler.call(this, scope, owner, false);
 };
 goog.inherits(adapt.csscasc.DefineParserHandler, adapt.cssparse.SlaveParserHandler);
 
@@ -3498,7 +3498,7 @@ adapt.csscasc.DefineParserHandler.prototype.property = function(propName, value,
     if (this.scope.values[propName]) {
         this.error("E_CSS_NAME_REDEFINED " + propName, this.getCurrentToken());
     } else {
-    	var unit = propName.match(/height|^(top|bottom)$/) ? "vh" : "vw";
+        var unit = propName.match(/height|^(top|bottom)$/) ? "vh" : "vw";
         var dim = new adapt.expr.Numeric(this.scope, 100, unit);
         this.scope.defineName(propName, value.toExpr(this.scope, dim));
     }
@@ -3516,7 +3516,7 @@ adapt.csscasc.DefineParserHandler.prototype.property = function(propName, value,
  * @implements {adapt.cssvalid.PropertyReceiver}
  */
 adapt.csscasc.PropSetParserHandler = function(scope, owner, condition, elementStyle, validatorSet) {
-	adapt.cssparse.SlaveParserHandler.call(this, scope, owner, false);
+    adapt.cssparse.SlaveParserHandler.call(this, scope, owner, false);
     /** @const */ this.elementStyle = elementStyle;
     /** @const */ this.condition = condition;
     /** @const */ this.validatorSet = validatorSet;
@@ -3527,24 +3527,24 @@ goog.inherits(adapt.csscasc.PropSetParserHandler, adapt.cssparse.SlaveParserHand
  * @override
  */
 adapt.csscasc.PropSetParserHandler.prototype.property = function(name, value, important) {
-	if (important)
-		vivliostyle.logging.logger.warn("E_IMPORTANT_NOT_ALLOWED");
-	else
-		this.validatorSet.validatePropertyAndHandleShorthand(name, value, important, this);
+    if (important)
+        vivliostyle.logging.logger.warn("E_IMPORTANT_NOT_ALLOWED");
+    else
+        this.validatorSet.validatePropertyAndHandleShorthand(name, value, important, this);
 };
 
 /**
  * @override
  */
 adapt.csscasc.PropSetParserHandler.prototype.invalidPropertyValue = function(name, value) {
-	vivliostyle.logging.logger.warn("E_INVALID_PROPERTY_VALUE", name + ":", value.toString());
+    vivliostyle.logging.logger.warn("E_INVALID_PROPERTY_VALUE", name + ":", value.toString());
 };
 
 /**
  * @override
  */
 adapt.csscasc.PropSetParserHandler.prototype.unknownProperty = function(name, value) {
-	vivliostyle.logging.logger.warn("E_INVALID_PROPERTY", name + ":", value.toString());
+    vivliostyle.logging.logger.warn("E_INVALID_PROPERTY", name + ":", value.toString());
 };
 
 /**
@@ -3555,8 +3555,8 @@ adapt.csscasc.PropSetParserHandler.prototype.simpleProperty = function(name, val
     specificity += this.order;
     this.order += adapt.csscasc.ORDER_INCREMENT;
     var av = this.condition
-		? new adapt.csscasc.ConditionalCascadeValue(value, specificity, this.condition)
-		: new adapt.csscasc.CascadeValue(value, specificity);
+        ? new adapt.csscasc.ConditionalCascadeValue(value, specificity, this.condition)
+        : new adapt.csscasc.CascadeValue(value, specificity);
     adapt.csscasc.setProp(this.elementStyle, name, av);
 };
 
@@ -3569,7 +3569,7 @@ adapt.csscasc.PropSetParserHandler.prototype.simpleProperty = function(name, val
  * @implements {adapt.cssvalid.PropertyReceiver}
  */
 adapt.csscasc.PropertyParserHandler = function(scope, validatorSet) {
-	adapt.cssparse.ErrorHandler.call(this, scope);
+    adapt.cssparse.ErrorHandler.call(this, scope);
     /** @const */ this.elementStyle = /** @type {adapt.csscasc.ElementStyle} */ ({});
     /** @const */ this.validatorSet = validatorSet;
     /** @type {number} */ this.order = 0;
@@ -3587,14 +3587,14 @@ adapt.csscasc.PropertyParserHandler.prototype.property = function(name, value, i
  * @override
  */
 adapt.csscasc.PropertyParserHandler.prototype.invalidPropertyValue = function(name, value) {
-	vivliostyle.logging.logger.warn("E_INVALID_PROPERTY_VALUE", name + ":", value.toString());
+    vivliostyle.logging.logger.warn("E_INVALID_PROPERTY_VALUE", name + ":", value.toString());
 };
 
 /**
  * @override
  */
 adapt.csscasc.PropertyParserHandler.prototype.unknownProperty = function(name, value) {
-	vivliostyle.logging.logger.warn("E_INVALID_PROPERTY", name + ":", value.toString());
+    vivliostyle.logging.logger.warn("E_INVALID_PROPERTY", name + ":", value.toString());
 };
 
 /**
@@ -3617,14 +3617,14 @@ adapt.csscasc.PropertyParserHandler.prototype.simpleProperty = function(name, va
  * @return {adapt.csscasc.ElementStyle}
  */
 adapt.csscasc.parseStyleAttribute = function(scope, validatorSet, baseURL, styleAttrValue) {
-	var handler = new adapt.csscasc.PropertyParserHandler(scope, validatorSet);
-	var tokenizer = new adapt.csstok.Tokenizer(styleAttrValue, handler);
-	try {
-		adapt.cssparse.parseStyleAttribute(tokenizer, handler, baseURL);
-	} catch (err) {
-		vivliostyle.logging.logger.warn(err, "Style attribute parse error:");
-	}
-	return handler.elementStyle;
+    var handler = new adapt.csscasc.PropertyParserHandler(scope, validatorSet);
+    var tokenizer = new adapt.csstok.Tokenizer(styleAttrValue, handler);
+    try {
+        adapt.cssparse.parseStyleAttribute(tokenizer, handler, baseURL);
+    } catch (err) {
+        vivliostyle.logging.logger.warn(err, "Style attribute parse error:");
+    }
+    return handler.elementStyle;
 };
 
 /**
@@ -3636,10 +3636,10 @@ adapt.csscasc.parseStyleAttribute = function(scope, validatorSet, baseURL, style
 adapt.csscasc.isVertical = function(cascaded, context, vertical) {
     var writingModeCasc = cascaded["writing-mode"];
     if (writingModeCasc) {
-    	var writingMode = writingModeCasc.evaluate(context, "writing-mode");
-    	if (writingMode && writingMode !== adapt.css.ident.inherit) {
-	    	return writingMode === adapt.css.ident.vertical_rl;
-    	}
+        var writingMode = writingModeCasc.evaluate(context, "writing-mode");
+        if (writingMode && writingMode !== adapt.css.ident.inherit) {
+            return writingMode === adapt.css.ident.vertical_rl;
+        }
     }
     return vertical;
 };
@@ -3659,13 +3659,13 @@ adapt.csscasc.flattenCascadedStyle = function(style, context, regionIds, isFootn
     }
     var regions = adapt.csscasc.getStyleMap(style, "_regions");
     if ((regionIds || isFootnote) && regions) {
-    	if (isFootnote) {
-    		var footnoteRegion = ["footnote"];
-    		if (!regionIds)
-    			regionIds = footnoteRegion;
-    		else
-    			regionIds = regionIds.concat(footnoteRegion);
-    	}
+        if (isFootnote) {
+            var footnoteRegion = ["footnote"];
+            if (!regionIds)
+                regionIds = footnoteRegion;
+            else
+                regionIds = regionIds.concat(footnoteRegion);
+        }
         for (var i = 0; i < regionIds.length; i++) {
             var regionId = regionIds[i];
             var regionStyle = regions[regionId];
@@ -3674,7 +3674,7 @@ adapt.csscasc.flattenCascadedStyle = function(style, context, regionIds, isFootn
                     var newVal = adapt.csscasc.getProp(regionStyle, rn);
                     var oldVal = cascMap[rn];
                     cascMap[rn] = adapt.csscasc.cascadeValues(context, oldVal,
-                                /** @type {!adapt.csscasc.CascadeValue} */ (newVal));
+                        /** @type {!adapt.csscasc.CascadeValue} */ (newVal));
                 }
             }
         }

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -65,9 +65,9 @@ adapt.cssparse.SPECIFICITY_USER_IMPORTANT = 0x6000000; // User stylesheet !impor
  * @enum {string}
  */
 adapt.cssparse.StylesheetFlavor = {
-	USER_AGENT: "UA",
-	USER: "User",
-	AUTHOR: "Author"
+    USER_AGENT: "UA",
+    USER: "User",
+    AUTHOR: "Author"
 };
 
 
@@ -84,7 +84,7 @@ adapt.cssparse.colorFromHash = function(text) {
         return new adapt.css.Color(num);
     if (text.length == 3) {
         num = (num & 0xF) | ((num & 0xF) << 4) | ((num & 0xF0) << 4) | ((num & 0xF0) << 8) |
-                ((num & 0xF00) << 8) | ((num & 0xF00) << 12);
+            ((num & 0xF00) << 8) | ((num & 0xF00) << 12);
         return new adapt.css.Color(num);
     }
     throw new Error("E_CSS_COLOR");
@@ -96,7 +96,7 @@ adapt.cssparse.colorFromHash = function(text) {
  * @implements {adapt.csstok.TokenizerHandler}
  */
 adapt.cssparse.ParserHandler = function(scope) {
-	/** @type {adapt.expr.LexicalScope} */ this.scope = scope;
+    /** @type {adapt.expr.LexicalScope} */ this.scope = scope;
     /** @type {adapt.cssparse.StylesheetFlavor} */ this.flavor = adapt.cssparse.StylesheetFlavor.AUTHOR;
 };
 
@@ -127,7 +127,7 @@ adapt.cssparse.ParserHandler.prototype.error = function(mnemonics, token) {
  * @return {void}
  */
 adapt.cssparse.ParserHandler.prototype.startStylesheet = function(flavor) {
-	this.flavor = flavor;
+    this.flavor = flavor;
 };
 
 /**
@@ -354,12 +354,12 @@ adapt.cssparse.ParserHandler.prototype.endFuncWithSelector = function() {
  */
 adapt.cssparse.ParserHandler.prototype.getImportantSpecificity = function() {
     switch (this.flavor) {
-    case adapt.cssparse.StylesheetFlavor.USER_AGENT:
-        return adapt.cssparse.SPECIFICITY_USER_AGENT;
-    case adapt.cssparse.StylesheetFlavor.USER:
-        return adapt.cssparse.SPECIFICITY_USER_IMPORTANT;
-    default:
-        return adapt.cssparse.SPECIFICITY_AUTHOR_IMPORTANT;
+        case adapt.cssparse.StylesheetFlavor.USER_AGENT:
+            return adapt.cssparse.SPECIFICITY_USER_AGENT;
+        case adapt.cssparse.StylesheetFlavor.USER:
+            return adapt.cssparse.SPECIFICITY_USER_IMPORTANT;
+        default:
+            return adapt.cssparse.SPECIFICITY_AUTHOR_IMPORTANT;
     }
 };
 
@@ -368,12 +368,12 @@ adapt.cssparse.ParserHandler.prototype.getImportantSpecificity = function() {
  */
 adapt.cssparse.ParserHandler.prototype.getBaseSpecificity = function() {
     switch (this.flavor) {
-    case adapt.cssparse.StylesheetFlavor.USER_AGENT:
-        return adapt.cssparse.SPECIFICITY_USER_AGENT;
-    case adapt.cssparse.StylesheetFlavor.USER:
-        return adapt.cssparse.SPECIFICITY_USER;
-    default:
-        return adapt.cssparse.SPECIFICITY_AUTHOR;
+        case adapt.cssparse.StylesheetFlavor.USER_AGENT:
+            return adapt.cssparse.SPECIFICITY_USER_AGENT;
+        case adapt.cssparse.StylesheetFlavor.USER:
+            return adapt.cssparse.SPECIFICITY_USER;
+        default:
+            return adapt.cssparse.SPECIFICITY_AUTHOR;
     }
 };
 
@@ -383,7 +383,7 @@ adapt.cssparse.ParserHandler.prototype.getBaseSpecificity = function() {
  * @extends {adapt.cssparse.ParserHandler}
  */
 adapt.cssparse.DispatchParserHandler = function() {
-	adapt.cssparse.ParserHandler.call(this, null);
+    adapt.cssparse.ParserHandler.call(this, null);
     /** @type {Array.<adapt.cssparse.ParserHandler>} */ this.stack = [];
     /** @type {adapt.csstok.Tokenizer} */ this.tokenizer = null;
     /** @type {adapt.cssparse.ParserHandler} */ this.slave = null;
@@ -427,7 +427,7 @@ adapt.cssparse.DispatchParserHandler.prototype.getScope = function() {
  * @override
  */
 adapt.cssparse.DispatchParserHandler.prototype.error = function(mnemonics, token) {
-	this.slave.error(mnemonics, token);
+    this.slave.error(mnemonics, token);
 };
 
 /**
@@ -444,11 +444,11 @@ adapt.cssparse.DispatchParserHandler.prototype.errorMsg = function(mnemonics, to
  * @override
  */
 adapt.cssparse.DispatchParserHandler.prototype.startStylesheet = function(flavor) {
-	adapt.cssparse.ParserHandler.prototype.startStylesheet.call(this, flavor);
+    adapt.cssparse.ParserHandler.prototype.startStylesheet.call(this, flavor);
     if (this.stack.length > 0) {
-    	// This can occur as a result of an error
-    	this.slave = this.stack[0];
-    	this.stack = [];
+        // This can occur as a result of an error
+        this.slave = this.stack[0];
+        this.stack = [];
     }
     this.slave.startStylesheet(flavor);
 };
@@ -653,7 +653,7 @@ adapt.cssparse.DispatchParserHandler.prototype.endRule = function() {
  * @override
  */
 adapt.cssparse.DispatchParserHandler.prototype.startFuncWithSelector = function(funcName) {
-  this.slave.startFuncWithSelector(funcName);
+    this.slave.startFuncWithSelector(funcName);
 };
 
 
@@ -661,7 +661,7 @@ adapt.cssparse.DispatchParserHandler.prototype.startFuncWithSelector = function(
  * @override
  */
 adapt.cssparse.DispatchParserHandler.prototype.endFuncWithSelector = function() {
-  this.slave.endFuncWithSelector();
+    this.slave.endFuncWithSelector();
 };
 
 /**
@@ -671,8 +671,8 @@ adapt.cssparse.DispatchParserHandler.prototype.endFuncWithSelector = function() 
  * @extends {adapt.cssparse.ParserHandler}
  */
 adapt.cssparse.SkippingParserHandler = function(scope, owner, topLevel) {
-	adapt.cssparse.ParserHandler.call(this, scope);
-	/** @const */ this.topLevel = topLevel;
+    adapt.cssparse.ParserHandler.call(this, scope);
+    /** @const */ this.topLevel = topLevel;
     /** @type {number} */ this.depth = 0;
     /** @type {adapt.cssparse.DispatchParserHandler} */ this.owner = owner;
 };
@@ -717,7 +717,7 @@ adapt.cssparse.SkippingParserHandler.prototype.endRule = function() {
  * @extends {adapt.cssparse.SkippingParserHandler}
  */
 adapt.cssparse.SlaveParserHandler = function(scope, owner, topLevel) {
-	adapt.cssparse.SkippingParserHandler.call(this, scope, owner, topLevel);
+    adapt.cssparse.SkippingParserHandler.call(this, scope, owner, topLevel);
 };
 goog.inherits(adapt.cssparse.SlaveParserHandler, adapt.cssparse.SkippingParserHandler);
 
@@ -989,7 +989,7 @@ adapt.cssparse.Action = {
     ERROR_SEMICOL: 53,
     VAL_PLUS: 54,
     SELECTOR_PSEUDOCLASS_1: 55,
-    SELECTOR_FOLLOWING_SIBLING: 56,    
+    SELECTOR_FOLLOWING_SIBLING: 56,
     DONE: 200
 };
 
@@ -1000,7 +1000,7 @@ adapt.cssparse.Action = {
 adapt.cssparse.OP_MEDIA_AND = adapt.csstok.TokenType.LAST + 1;
 
 (function() {
-	var actionsBase = adapt.cssparse.actionsBase;
+    var actionsBase = adapt.cssparse.actionsBase;
     actionsBase[adapt.csstok.TokenType.IDENT] = adapt.cssparse.Action.IDENT;
     actionsBase[adapt.csstok.TokenType.STAR] = adapt.cssparse.Action.SELECTOR_START;
     actionsBase[adapt.csstok.TokenType.HASH] = adapt.cssparse.Action.SELECTOR_START;
@@ -1010,7 +1010,7 @@ adapt.cssparse.OP_MEDIA_AND = adapt.csstok.TokenType.LAST + 1;
     actionsBase[adapt.csstok.TokenType.AT] = adapt.cssparse.Action.AT;
     actionsBase[adapt.csstok.TokenType.C_BRC] = adapt.cssparse.Action.RULE_END;
     actionsBase[adapt.csstok.TokenType.EOF] = adapt.cssparse.Action.DONE;
-	var actionsStyleAttribute = adapt.cssparse.actionsStyleAttribute;
+    var actionsStyleAttribute = adapt.cssparse.actionsStyleAttribute;
     actionsStyleAttribute[adapt.csstok.TokenType.IDENT] = adapt.cssparse.Action.PROP;
     actionsStyleAttribute[adapt.csstok.TokenType.EOF] = adapt.cssparse.Action.DONE;
     var actionsSelectorStart = adapt.cssparse.actionsSelectorStart;
@@ -1167,10 +1167,10 @@ adapt.cssparse.ExprContext = {
  * @constructor
  */
 adapt.cssparse.Parser = function(actions, tokenizer, handler, baseURL) {
-	/** @type {!Array.<adapt.cssparse.Action>} */ this.actions = actions;
-	/** @type {adapt.csstok.Tokenizer} */ this.tokenizer = tokenizer;
-	/** @const */ this.handler = handler;
-	/** @type {string} baseURL */ this.baseURL = baseURL;
+    /** @type {!Array.<adapt.cssparse.Action>} */ this.actions = actions;
+    /** @type {adapt.csstok.Tokenizer} */ this.tokenizer = tokenizer;
+    /** @const */ this.handler = handler;
+    /** @type {string} baseURL */ this.baseURL = baseURL;
     /** @type {Array.<*>} */ this.valStack = [];
     /** @type {Object.<string,string>} */ this.namespacePrefixToURI = {};
     /** @type {?string} */ this.defaultNamespaceURI = null;
@@ -1210,8 +1210,8 @@ adapt.cssparse.Parser.prototype.extractVals = function(sep, index) {
  * @param {adapt.csstok.Token} token
  * @return {adapt.css.Val}
  */
-adapt.cssparse.Parser.prototype.valStackReduce = function (sep, token) {
-	var valStack = this.valStack;
+adapt.cssparse.Parser.prototype.valStackReduce = function(sep, token) {
+    var valStack = this.valStack;
     var index = valStack.length;
     var v;
     do {
@@ -1255,24 +1255,24 @@ adapt.cssparse.Parser.prototype.valStackReduce = function (sep, token) {
  * @param {adapt.csstok.Token} token
  */
 adapt.cssparse.Parser.prototype.exprError = function(mnemonics, token) {
-	this.actions = this.propName ? adapt.cssparse.actionsErrorDecl : adapt.cssparse.actionsError;
+    this.actions = this.propName ? adapt.cssparse.actionsErrorDecl : adapt.cssparse.actionsError;
     this.handler.error(mnemonics, token);
 };
 
 /**
  * @param {number} op
  * @param {adapt.csstok.Token} token
- * @return {boolean} 
+ * @return {boolean}
  */
 adapt.cssparse.Parser.prototype.exprStackReduce = function(op, token) {
-	var valStack = this.valStack;
-	var handler = this.handler;
+    var valStack = this.valStack;
+    var handler = this.handler;
     var val = /** @type {adapt.expr.Val} */ (valStack.pop());
     /** @type {adapt.expr.Val} */ var val2;
     while (true) {
         var tok = valStack.pop();
         if (op == adapt.csstok.TokenType.C_PAR) {
-        	/** @type {Array.<adapt.expr.Val>} */ var args = [val];
+            /** @type {Array.<adapt.expr.Val>} */ var args = [val];
             while (tok == adapt.csstok.TokenType.COMMA) {
                 args.unshift(valStack.pop());
                 tok = valStack.pop();
@@ -1292,8 +1292,8 @@ adapt.cssparse.Parser.prototype.exprStackReduce = function(op, token) {
                     // call
                     var name2 = /** @type {string} */ (valStack.pop());
                     var name1 = /** @type {?string} */ (valStack.pop());
-                    val = new adapt.expr.Call(handler.getScope(), 
-                    		adapt.expr.makeQualifiedName(name1, name2), args);
+                    val = new adapt.expr.Call(handler.getScope(),
+                        adapt.expr.makeQualifiedName(name1, name2), args);
                     op = adapt.csstok.TokenType.EOF;
                     continue;
                 }
@@ -1378,12 +1378,12 @@ adapt.cssparse.Parser.prototype.exprStackReduce = function(op, token) {
                         switch (valStack[valStack.length - 1]) {
                             case adapt.csstok.TokenType.QMARK:
                                 valStack.pop();
-                                val = new adapt.expr.Cond(handler.getScope(), 
+                                val = new adapt.expr.Cond(handler.getScope(),
                                     /** @type {adapt.expr.Val} */ (valStack.pop()), val2, val);
                                 break;
                             case adapt.csstok.TokenType.O_PAR:
                                 if (val2.isMediaName()) {
-                                    val = new adapt.expr.MediaTest(handler.getScope(), 
+                                    val = new adapt.expr.MediaTest(handler.getScope(),
                                         /** @type {adapt.expr.MediaName} */ (val2), val);
                                 } else {
                                     this.exprError("E_CSS_MEDIA_TEST", token);
@@ -1401,7 +1401,7 @@ adapt.cssparse.Parser.prototype.exprStackReduce = function(op, token) {
                         this.exprError("E_CSS_EXPR_COND", token);
                         return false;
                     }
-                    // fall through
+                // fall through
                 case adapt.csstok.TokenType.O_PAR:
                     // don't reduce
                     valStack.push(val2);
@@ -1422,25 +1422,25 @@ adapt.cssparse.Parser.prototype.exprStackReduce = function(op, token) {
  * @return {Array.<number|string>}
  */
 adapt.cssparse.Parser.prototype.readPseudoParams = function() {
-	var arr = [];
-	while (true) {
-		var token = this.tokenizer.token();
-		switch (token.type) {
-		case adapt.csstok.TokenType.IDENT:
-			arr.push(token.text);
-			break;
-		case adapt.csstok.TokenType.PLUS:
-			arr.push("+");
-			break;
-		case adapt.csstok.TokenType.NUM:
-		case adapt.csstok.TokenType.INT:
-			arr.push(token.num);
-			break;
-		default:
-			return arr;
-		}
-		this.tokenizer.consume();
-	}
+    var arr = [];
+    while (true) {
+        var token = this.tokenizer.token();
+        switch (token.type) {
+            case adapt.csstok.TokenType.IDENT:
+                arr.push(token.text);
+                break;
+            case adapt.csstok.TokenType.PLUS:
+                arr.push("+");
+                break;
+            case adapt.csstok.TokenType.NUM:
+            case adapt.csstok.TokenType.INT:
+                arr.push(token.num);
+                break;
+            default:
+                return arr;
+        }
+        this.tokenizer.consume();
+    }
 };
 
 /**
@@ -1470,7 +1470,7 @@ adapt.cssparse.Parser.prototype.readNthPseudoParams = function() {
                 // reject '+-an'
                 return null;
             }
-            // FALLTHROUGH
+        // FALLTHROUGH
         case adapt.csstok.TokenType.IDENT:
             if (hasLeadingPlus && token.text.charAt(0) === "-") {
                 // reject '+-n'
@@ -1572,64 +1572,64 @@ adapt.cssparse.Parser.prototype.readNthPseudoParams = function() {
  * @return {adapt.css.Expr}
  */
 adapt.cssparse.Parser.prototype.makeCondition = function(classes, condition) {
-	var scope = this.handler.getScope();
-	if (!scope)
-		return null;
-	condition = condition || scope._true;
-	if (classes) {
-		var classList = classes.split(/\s+/);
-		for (var i = 0; i < classList.length; i++) {
-			var className = classList[i];
-			switch(className) {
-			case "vertical":
-				condition = adapt.expr.and(scope, condition, new adapt.expr.Not(scope, new adapt.expr.Named(scope, "pref-horizontal")));
-				break;
-			case "horizontal":
-				condition = adapt.expr.and(scope, condition, new adapt.expr.Named(scope, "pref-horizontal"));
-				break;
-			case "day":
-				condition = adapt.expr.and(scope, condition, new adapt.expr.Not(scope, new adapt.expr.Named(scope, "pref-night-mode")));
-				break;
-			case "night":
-				condition = adapt.expr.and(scope, condition, new adapt.expr.Named(scope, "pref-night-mode"));
-				break;
-			default:
-				condition = scope._false;
-			}
-		}
-	}
-	if (condition === scope._true) {
-		return null;
-	}
-	return new adapt.css.Expr(condition);
+    var scope = this.handler.getScope();
+    if (!scope)
+        return null;
+    condition = condition || scope._true;
+    if (classes) {
+        var classList = classes.split(/\s+/);
+        for (var i = 0; i < classList.length; i++) {
+            var className = classList[i];
+            switch (className) {
+                case "vertical":
+                    condition = adapt.expr.and(scope, condition, new adapt.expr.Not(scope, new adapt.expr.Named(scope, "pref-horizontal")));
+                    break;
+                case "horizontal":
+                    condition = adapt.expr.and(scope, condition, new adapt.expr.Named(scope, "pref-horizontal"));
+                    break;
+                case "day":
+                    condition = adapt.expr.and(scope, condition, new adapt.expr.Not(scope, new adapt.expr.Named(scope, "pref-night-mode")));
+                    break;
+                case "night":
+                    condition = adapt.expr.and(scope, condition, new adapt.expr.Named(scope, "pref-night-mode"));
+                    break;
+                default:
+                    condition = scope._false;
+            }
+        }
+    }
+    if (condition === scope._true) {
+        return null;
+    }
+    return new adapt.css.Expr(condition);
 };
 
 /**
  * @returns {boolean}
  */
 adapt.cssparse.Parser.prototype.isInsidePropertyOnlyRule = function() {
-	switch (this.ruleStack[this.ruleStack.length-1]) {
-	case "[selector]":
-	case "font-face":
-	case "-epubx-flow":
-	case "-epubx-viewport":
-	case "-epubx-define":
-	case "-adapt-footnote-area":
-		return true;
-	}
-	return false;
+    switch (this.ruleStack[this.ruleStack.length-1]) {
+        case "[selector]":
+        case "font-face":
+        case "-epubx-flow":
+        case "-epubx-viewport":
+        case "-epubx-define":
+        case "-adapt-footnote-area":
+            return true;
+    }
+    return false;
 };
 
 /**
  * @param {number} count
  * @param {boolean} parsingStyleAttr
- * @return {boolean} 
+ * @return {boolean}
  */
 adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsingStyleAttr, parsingMediaQuery, parsingFunctionParam) {
-	var handler = this.handler;
-	var tokenizer = this.tokenizer;
+    var handler = this.handler;
+    var tokenizer = this.tokenizer;
     var valStack = this.valStack;
-    
+
     /** @type {adapt.csstok.Token} */ var token;
     /** @type {adapt.csstok.Token} */ var token1;
     /** @type {?string} */ var ns;
@@ -1642,64 +1642,64 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
         this.exprContext = adapt.cssparse.ExprContext.MEDIA;
         this.valStack.push("{");
     }
-    
-    parserLoop: for(; count > 0; --count) {
+
+    parserLoop: for (; count > 0; --count) {
         token = tokenizer.token();
         switch (this.actions[token.type]) {
-	        case adapt.cssparse.Action.IDENT:
-	            // figure out if this is a property assignment or selector
-	            if (tokenizer.nthToken(1).type != adapt.csstok.TokenType.COLON) {
-	                // cannot be property assignment
-	            	if (this.isInsidePropertyOnlyRule()) {
-                		handler.error("E_CSS_COLON_EXPECTED", tokenizer.nthToken(1));
-                    	this.actions = adapt.cssparse.actionsErrorDecl;	            		
-	            	} else {
-	            		this.actions = adapt.cssparse.actionsSelectorStart;
-	            		handler.startSelectorRule();
-	            	}
-	                continue;
-	            }
-	            token1 = tokenizer.nthToken(2);
-	            if (token1.precededBySpace || (token1.type != adapt.csstok.TokenType.IDENT &&
-	                    token1.type != adapt.csstok.TokenType.FUNC)) {
-	                        // cannot be a selector
-	            } else {
-	                // can be either a selector or a property assignment
-	                tokenizer.mark();
-	            }
-	            this.propName = token.text;
-	            this.propImportant = false;
-	            tokenizer.consume();
-	            tokenizer.consume();
-	            this.actions = adapt.cssparse.actionsPropVal;
-	            valStack.splice(0, valStack.length);
-	            continue;
-	        case adapt.cssparse.Action.PROP:
-	            // figure out if this is a property assignment or selector
-	            if (tokenizer.nthToken(1).type != adapt.csstok.TokenType.COLON) {
-	                // cannot be property assignment
+            case adapt.cssparse.Action.IDENT:
+                // figure out if this is a property assignment or selector
+                if (tokenizer.nthToken(1).type != adapt.csstok.TokenType.COLON) {
+                    // cannot be property assignment
+                    if (this.isInsidePropertyOnlyRule()) {
+                        handler.error("E_CSS_COLON_EXPECTED", tokenizer.nthToken(1));
+                        this.actions = adapt.cssparse.actionsErrorDecl;
+                    } else {
+                        this.actions = adapt.cssparse.actionsSelectorStart;
+                        handler.startSelectorRule();
+                    }
+                    continue;
+                }
+                token1 = tokenizer.nthToken(2);
+                if (token1.precededBySpace || (token1.type != adapt.csstok.TokenType.IDENT &&
+                    token1.type != adapt.csstok.TokenType.FUNC)) {
+                    // cannot be a selector
+                } else {
+                    // can be either a selector or a property assignment
+                    tokenizer.mark();
+                }
+                this.propName = token.text;
+                this.propImportant = false;
+                tokenizer.consume();
+                tokenizer.consume();
+                this.actions = adapt.cssparse.actionsPropVal;
+                valStack.splice(0, valStack.length);
+                continue;
+            case adapt.cssparse.Action.PROP:
+                // figure out if this is a property assignment or selector
+                if (tokenizer.nthToken(1).type != adapt.csstok.TokenType.COLON) {
+                    // cannot be property assignment
                     this.actions = adapt.cssparse.actionsErrorDecl;
                     handler.error("E_CSS_COLON_EXPECTED", tokenizer.nthToken(1));
-	                continue;
-	            }
-	            this.propName = token.text;
-	            this.propImportant = false;
-	            tokenizer.consume();
-	            tokenizer.consume();
-	            this.actions = adapt.cssparse.actionsPropVal;
-	            valStack.splice(0, valStack.length);
-	            continue;
+                    continue;
+                }
+                this.propName = token.text;
+                this.propImportant = false;
+                tokenizer.consume();
+                tokenizer.consume();
+                this.actions = adapt.cssparse.actionsPropVal;
+                valStack.splice(0, valStack.length);
+                continue;
             case adapt.cssparse.Action.SELECTOR_START:
                 // don't consume, process again
                 this.actions = adapt.cssparse.actionsSelectorStart;
                 handler.startSelectorRule();
                 continue;
             case adapt.cssparse.Action.SELECTOR_NAME_1:
-            	if (!token.precededBySpace) {
+                if (!token.precededBySpace) {
                     this.actions = adapt.cssparse.actionsErrorSelector;
                     handler.error("E_CSS_SPACE_EXPECTED", token);
                     continue;
-            	}
+                }
                 handler.descendantSelector();
             // fall through
             case adapt.cssparse.Action.SELECTOR_NAME:
@@ -1713,17 +1713,17 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                             case adapt.csstok.TokenType.IDENT:
                                 handler.tagSelector(ns, token.text);
                                 if (parsingFunctionParam)
-                                  this.actions = adapt.cssparse.actionsSelectorInFunc;
+                                    this.actions = adapt.cssparse.actionsSelectorInFunc;
                                 else
-                                  this.actions = adapt.cssparse.actionsSelector;
+                                    this.actions = adapt.cssparse.actionsSelector;
                                 tokenizer.consume();
                                 break;
                             case adapt.csstok.TokenType.STAR:
                                 handler.tagSelector(ns, null);
                                 if (parsingFunctionParam)
-                                  this.actions = adapt.cssparse.actionsSelectorInFunc;
+                                    this.actions = adapt.cssparse.actionsSelectorInFunc;
                                 else
-                                  this.actions = adapt.cssparse.actionsSelector;
+                                    this.actions = adapt.cssparse.actionsSelector;
                                 tokenizer.consume();
                                 break;
                             default:
@@ -1737,18 +1737,18 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 } else {
                     handler.tagSelector(this.defaultNamespaceURI, token.text);
                     if (parsingFunctionParam)
-                      this.actions = adapt.cssparse.actionsSelectorInFunc;
+                        this.actions = adapt.cssparse.actionsSelectorInFunc;
                     else
-                      this.actions = adapt.cssparse.actionsSelector;
+                        this.actions = adapt.cssparse.actionsSelector;
                     tokenizer.consume();
                 }
                 continue;
             case adapt.cssparse.Action.SELECTOR_ANY_1:
-            	if (!token.precededBySpace) {
+                if (!token.precededBySpace) {
                     this.actions = adapt.cssparse.actionsErrorSelector;
                     handler.error("E_CSS_SPACE_EXPECTED", token);
                     continue;
-            	}
+                }
                 handler.descendantSelector();
             // fall through
             case adapt.cssparse.Action.SELECTOR_ANY:
@@ -1760,17 +1760,17 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                         case adapt.csstok.TokenType.IDENT:
                             handler.tagSelector(null, token.text);
                             if (parsingFunctionParam)
-                              this.actions = adapt.cssparse.actionsSelectorInFunc;
+                                this.actions = adapt.cssparse.actionsSelectorInFunc;
                             else
-                              this.actions = adapt.cssparse.actionsSelector;
+                                this.actions = adapt.cssparse.actionsSelector;
                             tokenizer.consume();
                             break;
                         case adapt.csstok.TokenType.STAR:
                             handler.tagSelector(null, null);
                             if (parsingFunctionParam)
-                              this.actions = adapt.cssparse.actionsSelectorInFunc;
+                                this.actions = adapt.cssparse.actionsSelectorInFunc;
                             else
-                              this.actions = adapt.cssparse.actionsSelector;
+                                this.actions = adapt.cssparse.actionsSelector;
                             tokenizer.consume();
                             break;
                         default:
@@ -1780,40 +1780,40 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 } else {
                     handler.tagSelector(this.defaultNamespaceURI, null);
                     if (parsingFunctionParam)
-                       this.actions = adapt.cssparse.actionsSelectorInFunc;
+                        this.actions = adapt.cssparse.actionsSelectorInFunc;
                     else
-                       this.actions = adapt.cssparse.actionsSelector;
+                        this.actions = adapt.cssparse.actionsSelector;
                     tokenizer.consume();
                 }
                 continue;
             case adapt.cssparse.Action.SELECTOR_ID_1:
                 if (token.precededBySpace)
                     handler.descendantSelector();
-                // fall through
+            // fall through
             case adapt.cssparse.Action.SELECTOR_ID:
                 handler.idSelector(token.text);
                 if (parsingFunctionParam)
-                   this.actions = adapt.cssparse.actionsSelectorInFunc;
+                    this.actions = adapt.cssparse.actionsSelectorInFunc;
                 else
-                   this.actions = adapt.cssparse.actionsSelector;
+                    this.actions = adapt.cssparse.actionsSelector;
                 tokenizer.consume();
                 continue;
             case adapt.cssparse.Action.SELECTOR_CLASS_1:
                 if (token.precededBySpace)
                     handler.descendantSelector();
-                // fall through
+            // fall through
             case adapt.cssparse.Action.SELECTOR_CLASS:
                 handler.classSelector(token.text);
                 if (parsingFunctionParam)
-                   this.actions = adapt.cssparse.actionsSelectorInFunc;
+                    this.actions = adapt.cssparse.actionsSelectorInFunc;
                 else
-                   this.actions = adapt.cssparse.actionsSelector;
+                    this.actions = adapt.cssparse.actionsSelector;
                 tokenizer.consume();
                 continue;
             case adapt.cssparse.Action.SELECTOR_PSEUDOCLASS_1:
                 if (token.precededBySpace)
                     handler.descendantSelector();
-                // fall through
+            // fall through
             case adapt.cssparse.Action.SELECTOR_PSEUDOCLASS:
                 tokenizer.consume();
                 token = tokenizer.token();
@@ -1822,23 +1822,23 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                         handler.pseudoclassSelector(token.text, null);
                         tokenizer.consume();
                         if (parsingFunctionParam)
-                           this.actions = adapt.cssparse.actionsSelectorInFunc;
+                            this.actions = adapt.cssparse.actionsSelectorInFunc;
                         else
-                           this.actions = adapt.cssparse.actionsSelector;
+                            this.actions = adapt.cssparse.actionsSelector;
                         continue;
                     case adapt.csstok.TokenType.FUNC:
                         text = token.text;
                         tokenizer.consume();
                         switch (text) {
-                          case "not":
-                               this.actions = adapt.cssparse.actionsSelectorStart;
-                               handler.startFuncWithSelector("not");
-                               if (this.runParser(Number.POSITIVE_INFINITY, false, false, false, true)) {
-                                   this.actions = adapt.cssparse.actionsSelector;
-                               } else {
-                                   this.actions = adapt.cssparse.actionsErrorSelector;
-                               }
-                               break parserLoop;
+                            case "not":
+                                this.actions = adapt.cssparse.actionsSelectorStart;
+                                handler.startFuncWithSelector("not");
+                                if (this.runParser(Number.POSITIVE_INFINITY, false, false, false, true)) {
+                                    this.actions = adapt.cssparse.actionsSelector;
+                                } else {
+                                    this.actions = adapt.cssparse.actionsErrorSelector;
+                                }
+                                break parserLoop;
                             case "lang":
                             case "href-epub-type":
                                 token = tokenizer.token();
@@ -1867,9 +1867,9 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                             handler.pseudoclassSelector(/** @type {string} */ (text), params);
                             tokenizer.consume();
                             if (parsingFunctionParam)
-                              this.actions = adapt.cssparse.actionsSelectorInFunc;
+                                this.actions = adapt.cssparse.actionsSelectorInFunc;
                             else
-                              this.actions = adapt.cssparse.actionsSelector;
+                                this.actions = adapt.cssparse.actionsSelector;
                             continue;
                         }
                         break;
@@ -1884,9 +1884,9 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     case adapt.csstok.TokenType.IDENT:
                         handler.pseudoelementSelector(token.text, null);
                         if (parsingFunctionParam)
-                          this.actions = adapt.cssparse.actionsSelectorInFunc;
+                            this.actions = adapt.cssparse.actionsSelectorInFunc;
                         else
-                          this.actions = adapt.cssparse.actionsSelector;
+                            this.actions = adapt.cssparse.actionsSelector;
                         tokenizer.consume();
                         continue;
                     case adapt.csstok.TokenType.FUNC:
@@ -1897,9 +1897,9 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                         if (token.type == adapt.csstok.TokenType.C_PAR) {
                             handler.pseudoelementSelector(/** @type {string} */ (text), params);
                             if (parsingFunctionParam)
-                              this.actions = adapt.cssparse.actionsSelectorInFunc;
+                                this.actions = adapt.cssparse.actionsSelectorInFunc;
                             else
-                              this.actions = adapt.cssparse.actionsSelector;
+                                this.actions = adapt.cssparse.actionsSelector;
                             tokenizer.consume();
                             continue;
                         }
@@ -1965,11 +1965,11 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                         break;
                     case adapt.csstok.TokenType.C_BRK:
                         handler.attributeSelector(/** @type {string} */ (ns),
-                        		/** @type {string} */ (text), adapt.csstok.TokenType.EOF, null);
+                            /** @type {string} */ (text), adapt.csstok.TokenType.EOF, null);
                         if (parsingFunctionParam)
-                          this.actions = adapt.cssparse.actionsSelectorInFunc;
+                            this.actions = adapt.cssparse.actionsSelectorInFunc;
                         else
-                          this.actions = adapt.cssparse.actionsSelector;
+                            this.actions = adapt.cssparse.actionsSelector;
                         tokenizer.consume();
                         continue;
                     default:
@@ -1981,7 +1981,7 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     case adapt.csstok.TokenType.IDENT:
                     case adapt.csstok.TokenType.STR:
                         handler.attributeSelector(/** @type {string} */ (ns),
-                        		/** @type {string} */ (text), num, token.text);
+                            /** @type {string} */ (text), num, token.text);
                         tokenizer.consume();
                         token = tokenizer.token();
                         break;
@@ -1996,9 +1996,9 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     continue;
                 }
                 if (parsingFunctionParam)
-                  this.actions = adapt.cssparse.actionsSelectorInFunc;
+                    this.actions = adapt.cssparse.actionsSelectorInFunc;
                 else
-                  this.actions = adapt.cssparse.actionsSelector;
+                    this.actions = adapt.cssparse.actionsSelector;
                 tokenizer.consume();
                 continue;
             case adapt.cssparse.Action.SELECTOR_CHILD:
@@ -2017,15 +2017,15 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 tokenizer.consume();
                 continue;
             case adapt.cssparse.Action.SELECTOR_BODY:
-            	if (this.regionRule) {
-                	this.ruleStack.push("-epubx-region");            		
-                	this.regionRule = false;
+                if (this.regionRule) {
+                    this.ruleStack.push("-epubx-region");
+                    this.regionRule = false;
                 } else if (this.pageRule) {
                     this.ruleStack.push("page");
                     this.pageRule = false;
-            	} else {
-            		this.ruleStack.push("[selector]");
-            	}
+                } else {
+                    this.ruleStack.push("[selector]");
+                }
                 handler.startRuleBody();
                 this.actions = adapt.cssparse.actionsBase;
                 tokenizer.consume();
@@ -2099,28 +2099,28 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 tokenizer.consume();
                 token = tokenizer.token();
                 token1 = tokenizer.nthToken(1);
-                if (token.type == adapt.csstok.TokenType.IDENT && 
-                	token.text.toLowerCase() == "important" && 
-                	(token1.type == adapt.csstok.TokenType.SEMICOL || 
-                			token1.type == adapt.csstok.TokenType.EOF ||
-                			token1.type == adapt.csstok.TokenType.C_BRC)) {
+                if (token.type == adapt.csstok.TokenType.IDENT &&
+                    token.text.toLowerCase() == "important" &&
+                    (token1.type == adapt.csstok.TokenType.SEMICOL ||
+                    token1.type == adapt.csstok.TokenType.EOF ||
+                    token1.type == adapt.csstok.TokenType.C_BRC)) {
                     tokenizer.consume();
-                	this.propImportant = true;
-                	continue;
+                    this.propImportant = true;
+                    continue;
                 }
                 this.exprError("E_CSS_SYNTAX", token);
                 continue;
             case adapt.cssparse.Action.VAL_PLUS:
                 token1 = tokenizer.nthToken(1);
                 switch (token1.type) {
-                case adapt.csstok.TokenType.NUM:
-                case adapt.csstok.TokenType.NUMERIC:
-                case adapt.csstok.TokenType.INT:
-                	if (!token1.precededBySpace) {
-                		// Plus before number, ignore
-                        tokenizer.consume();
-                        continue;
-                	}
+                    case adapt.csstok.TokenType.NUM:
+                    case adapt.csstok.TokenType.NUMERIC:
+                    case adapt.csstok.TokenType.INT:
+                        if (!token1.precededBySpace) {
+                            // Plus before number, ignore
+                            tokenizer.consume();
+                            continue;
+                        }
                 }
                 if (this.actions === adapt.cssparse.actionsPropVal && tokenizer.hasMark()) {
                     tokenizer.reset();
@@ -2133,30 +2133,30 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 }
             case adapt.cssparse.Action.VAL_END:
                 tokenizer.consume();
-                // fall through
+            // fall through
             case adapt.cssparse.Action.VAL_BRC:
                 tokenizer.unmark();
                 val = this.valStackReduce(";", token);
                 if (val && this.propName) {
                     handler.property(/** @type {string} */ (this.propName), val, this.propImportant);
                 }
-                this.actions = parsingStyleAttr ? 
-                    	adapt.cssparse.actionsStyleAttribute : adapt.cssparse.actionsBase;
+                this.actions = parsingStyleAttr ?
+                    adapt.cssparse.actionsStyleAttribute : adapt.cssparse.actionsBase;
                 continue;
-             case adapt.cssparse.Action.VAL_FINISH:
+            case adapt.cssparse.Action.VAL_FINISH:
                 tokenizer.consume();
                 tokenizer.unmark();
                 val = this.valStackReduce(";", token);
                 if (parsingValue) {
-                	this.result = val;
-                	return true;
+                    this.result = val;
+                    return true;
                 }
                 if (this.propName && val) {
-                	handler.property(/** @type {string} */ (this.propName), val, this.propImportant);
+                    handler.property(/** @type {string} */ (this.propName), val, this.propImportant);
                 }
                 if (parsingStyleAttr) {
-                	return true;
-                }	
+                    return true;
+                }
                 this.exprError("E_CSS_SYNTAX", token);
                 continue;
             case adapt.cssparse.Action.EXPR_IDENT:
@@ -2173,7 +2173,7 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     tokenizer.consume();
                 } else {
                     if (this.exprContext == adapt.cssparse.ExprContext.MEDIA
-                    		|| this.exprContext == adapt.cssparse.ExprContext.IMPORT) {
+                        || this.exprContext == adapt.cssparse.ExprContext.IMPORT) {
                         if (token.text.toLowerCase() == "not") {
                             tokenizer.consume();
                             valStack.push(new adapt.expr.MediaName(handler.getScope(), true, token1.text));
@@ -2267,7 +2267,7 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                             handler.startWhenRule(/** @type {adapt.css.Expr} */ (valStack.pop()));
                         else
                             handler.startMediaRule(/** @type {adapt.css.Expr} */ (valStack.pop()));
-                    	this.ruleStack.push("media");
+                        this.ruleStack.push("media");
                         handler.startRuleBody();
                         this.actions = adapt.cssparse.actionsBase;
                     }
@@ -2277,10 +2277,10 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
             case adapt.cssparse.Action.EXPR_SEMICOL:
                 if (this.exprStackReduce(adapt.csstok.TokenType.C_PAR, token)) {
                     if (this.propName || this.exprContext != adapt.cssparse.ExprContext.IMPORT) {
-                    	this.exprError("E_CSS_UNEXPECTED_SEMICOL", token);
+                        this.exprError("E_CSS_UNEXPECTED_SEMICOL", token);
                     } else {
-                    	this.importCondition = /** @type {adapt.css.Expr} */ (valStack.pop());
-                    	this.importReady = true;
+                        this.importCondition = /** @type {adapt.css.Expr} */ (valStack.pop());
+                        this.importReady = true;
                         this.actions = adapt.cssparse.actionsBase;
                         tokenizer.consume();
                         return false;
@@ -2297,83 +2297,83 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 tokenizer.consume();
                 handler.endRule();
                 if (this.ruleStack.length) {
-                	this.ruleStack.pop();
+                    this.ruleStack.pop();
                 }
                 continue;
             case adapt.cssparse.Action.AT:
                 text = token.text.toLowerCase();
                 switch (text) {
-            		case "import":
-                		tokenizer.consume();
-                		token = tokenizer.token();
-                		if (token.type == adapt.csstok.TokenType.STR ||
-                				token.type == adapt.csstok.TokenType.URL) {
-                			this.importURL = token.text;
-                    		tokenizer.consume();
-                    		token = tokenizer.token();
-                    		if (token.type == adapt.csstok.TokenType.SEMICOL || token.type == adapt.csstok.TokenType.EOF) {
-                    			this.importReady = true;
-                        		tokenizer.consume();
-                    			return false;
-                    		} else {
+                    case "import":
+                        tokenizer.consume();
+                        token = tokenizer.token();
+                        if (token.type == adapt.csstok.TokenType.STR ||
+                            token.type == adapt.csstok.TokenType.URL) {
+                            this.importURL = token.text;
+                            tokenizer.consume();
+                            token = tokenizer.token();
+                            if (token.type == adapt.csstok.TokenType.SEMICOL || token.type == adapt.csstok.TokenType.EOF) {
+                                this.importReady = true;
+                                tokenizer.consume();
+                                return false;
+                            } else {
                                 this.propName = null; // signals @ rule
                                 this.exprContext = adapt.cssparse.ExprContext.IMPORT;
                                 this.actions = adapt.cssparse.actionsExprVal;
                                 valStack.push("{");
                                 continue;
-                    		}
-                		}
+                            }
+                        }
                         handler.error("E_CSS_IMPORT_SYNTAX", token);
                         this.actions = adapt.cssparse.actionsError;
                         continue;
-            		case "namespace":
-                		tokenizer.consume();
-                		token = tokenizer.token();
-                		switch (token.type) {
-                			case adapt.csstok.TokenType.IDENT:
-                				text = token.text;  // Prefix
-                        		tokenizer.consume();
-                        		token = tokenizer.token();
-                				if ((token.type == adapt.csstok.TokenType.STR || 
-                						token.type == adapt.csstok.TokenType.URL) &&
-                						tokenizer.nthToken(1).type == adapt.csstok.TokenType.SEMICOL) {
-                					this.namespacePrefixToURI[text] = token.text;
-                            		tokenizer.consume();
-                            		tokenizer.consume();
-                            		continue;
-                				}
-                				break;
-                			case adapt.csstok.TokenType.STR:
-                			case adapt.csstok.TokenType.URL:
-                				if (tokenizer.nthToken(1).type == adapt.csstok.TokenType.SEMICOL) {
-	                				this.defaultNamespaceURI = token.text;
-	                        		tokenizer.consume();
-	                        		tokenizer.consume();
-	                        		continue;
-                				}
-                				break;
-                		}
+                    case "namespace":
+                        tokenizer.consume();
+                        token = tokenizer.token();
+                        switch (token.type) {
+                            case adapt.csstok.TokenType.IDENT:
+                                text = token.text;  // Prefix
+                                tokenizer.consume();
+                                token = tokenizer.token();
+                                if ((token.type == adapt.csstok.TokenType.STR ||
+                                    token.type == adapt.csstok.TokenType.URL) &&
+                                    tokenizer.nthToken(1).type == adapt.csstok.TokenType.SEMICOL) {
+                                    this.namespacePrefixToURI[text] = token.text;
+                                    tokenizer.consume();
+                                    tokenizer.consume();
+                                    continue;
+                                }
+                                break;
+                            case adapt.csstok.TokenType.STR:
+                            case adapt.csstok.TokenType.URL:
+                                if (tokenizer.nthToken(1).type == adapt.csstok.TokenType.SEMICOL) {
+                                    this.defaultNamespaceURI = token.text;
+                                    tokenizer.consume();
+                                    tokenizer.consume();
+                                    continue;
+                                }
+                                break;
+                        }
                         handler.error("E_CSS_NAMESPACE_SYNTAX", token);
                         this.actions = adapt.cssparse.actionsError;
                         continue;
-            		case "charset":
-            			// Useless in EPUB (only UTF-8 or UTF-16 is allowed anyway and
-            			// we are at the mercy of the browser charset handling anyway).
-                		tokenizer.consume();
-                		token = tokenizer.token();
-                		if (token.type == adapt.csstok.TokenType.STR && 
-                				tokenizer.nthToken(1).type == adapt.csstok.TokenType.SEMICOL) {
-            				text = token.text.toLowerCase();
-            				if (text != "utf-8" && text != "utf-16") {
-                                handler.error("E_CSS_UNEXPECTED_CHARSET " + text, token);            					
-            				}
-            				tokenizer.consume();
-            				tokenizer.consume();
-            				continue;
-                		}
+                    case "charset":
+                        // Useless in EPUB (only UTF-8 or UTF-16 is allowed anyway and
+                        // we are at the mercy of the browser charset handling anyway).
+                        tokenizer.consume();
+                        token = tokenizer.token();
+                        if (token.type == adapt.csstok.TokenType.STR &&
+                            tokenizer.nthToken(1).type == adapt.csstok.TokenType.SEMICOL) {
+                            text = token.text.toLowerCase();
+                            if (text != "utf-8" && text != "utf-16") {
+                                handler.error("E_CSS_UNEXPECTED_CHARSET " + text, token);
+                            }
+                            tokenizer.consume();
+                            tokenizer.consume();
+                            continue;
+                        }
                         handler.error("E_CSS_CHARSET_SYNTAX", token);
                         this.actions = adapt.cssparse.actionsError;
-                        continue;                		
+                        continue;
                     case "font-face":
                     case "-epubx-page-template":
                     case "-epubx-define":
@@ -2395,37 +2395,37 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                                     handler.startViewportRule();
                                     break;
                             }
-                        	this.ruleStack.push(text);
+                            this.ruleStack.push(text);
                             handler.startRuleBody();
                             continue;
                         }
                         break;
                     case "-adapt-footnote-area":
                         tokenizer.consume();
-                		token = tokenizer.token();
-                		switch (token.type) {
-                			case adapt.csstok.TokenType.O_BRC:
+                        token = tokenizer.token();
+                        switch (token.type) {
+                            case adapt.csstok.TokenType.O_BRC:
                                 tokenizer.consume();
-		                    	handler.startFootnoteRule(null);
-		                    	this.ruleStack.push(text);		                    	
-		                    	handler.startRuleBody();
-		                    	continue;
-                			case adapt.csstok.TokenType.COL_COL:
+                                handler.startFootnoteRule(null);
+                                this.ruleStack.push(text);
+                                handler.startRuleBody();
+                                continue;
+                            case adapt.csstok.TokenType.COL_COL:
                                 tokenizer.consume();
-                        		token = tokenizer.token();
-                        		if (token.type == adapt.csstok.TokenType.IDENT &&
-                        				tokenizer.nthToken(1).type == adapt.csstok.TokenType.O_BRC) {
-                        			text = token.text;
+                                token = tokenizer.token();
+                                if (token.type == adapt.csstok.TokenType.IDENT &&
+                                    tokenizer.nthToken(1).type == adapt.csstok.TokenType.O_BRC) {
+                                    text = token.text;
                                     tokenizer.consume();
                                     tokenizer.consume();
-    		                    	handler.startFootnoteRule(text);
-    		                    	this.ruleStack.push("-adapt-footnote-area");		                    	
-    		                    	handler.startRuleBody();
-    		                    	continue;                        			
-                        		}
-                				break;
-                		}
-                    	break;
+                                    handler.startFootnoteRule(text);
+                                    this.ruleStack.push("-adapt-footnote-area");
+                                    handler.startRuleBody();
+                                    continue;
+                                }
+                                break;
+                        }
+                        break;
                     case "-epubx-region":
                         tokenizer.consume();
                         handler.startRegionRule();
@@ -2479,13 +2479,13 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                         valStack.push("{");
                         continue;
                     case "-epubx-flow":
-                        if (tokenizer.nthToken(1).type == adapt.csstok.TokenType.IDENT && 
+                        if (tokenizer.nthToken(1).type == adapt.csstok.TokenType.IDENT &&
                             tokenizer.nthToken(2).type == adapt.csstok.TokenType.O_BRC) {
                             handler.startFlowRule(tokenizer.nthToken(1).text);
                             tokenizer.consume();
                             tokenizer.consume();
                             tokenizer.consume();
-                        	this.ruleStack.push(text);
+                            this.ruleStack.push(text);
                             handler.startRuleBody();
                             continue;
                         }
@@ -2504,15 +2504,15 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                             token = tokenizer.token();
                         }
                         if (token.type == adapt.csstok.TokenType.COLON &&
-                        		tokenizer.nthToken(1).type == adapt.csstok.TokenType.IDENT) {
-                        	rulePseudoName = tokenizer.nthToken(1).text;
+                            tokenizer.nthToken(1).type == adapt.csstok.TokenType.IDENT) {
+                            rulePseudoName = tokenizer.nthToken(1).text;
                             tokenizer.consume();
                             tokenizer.consume();
                             token = tokenizer.token();
                         }
                         while (token.type == adapt.csstok.TokenType.FUNC && token.text.toLowerCase() == "class" &&
-                                tokenizer.nthToken(1).type == adapt.csstok.TokenType.IDENT &&
-                                tokenizer.nthToken(2).type == adapt.csstok.TokenType.C_PAR) {
+                        tokenizer.nthToken(1).type == adapt.csstok.TokenType.IDENT &&
+                        tokenizer.nthToken(2).type == adapt.csstok.TokenType.C_PAR) {
                             classes.push(tokenizer.nthToken(1).text);
                             tokenizer.consume();
                             tokenizer.consume();
@@ -2532,17 +2532,17 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                                     handler.startPartitionGroupRule(ruleName, rulePseudoName, classes);
                                     break;
                             }
-                        	this.ruleStack.push(text);
+                            this.ruleStack.push(text);
                             handler.startRuleBody();
                             continue;
                         }
                         break;
-					case "":
-						// No text after @
+                    case "":
+                        // No text after @
                         handler.error("E_CSS_UNEXPECTED_AT" + text, token);
                         // Error recovery using selector rules.
                         this.actions = adapt.cssparse.actionsErrorSelector;
-						continue;
+                        continue;
                     default:
                         handler.error("E_CSS_AT_UNKNOWN " + text, token);
                         this.actions = adapt.cssparse.actionsError;
@@ -2552,47 +2552,47 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 this.actions = adapt.cssparse.actionsError;
                 continue;
             case adapt.cssparse.Action.ERROR_PUSH:  // Open bracket while skipping error syntax
-            	if (parsingValue || parsingStyleAttr)
-            		return true;
-            	this.errorBrackets.push(token.type + 1);  // Expected closing bracket
+                if (parsingValue || parsingStyleAttr)
+                    return true;
+                this.errorBrackets.push(token.type + 1);  // Expected closing bracket
                 tokenizer.consume();
                 continue;
             case adapt.cssparse.Action.ERROR_POP_DECL:  // Close bracket while skipping error syntax in declaration
-            	if (parsingValue || parsingStyleAttr)
-            		return true;
-            	if (this.errorBrackets.length == 0) {
+                if (parsingValue || parsingStyleAttr)
+                    return true;
+                if (this.errorBrackets.length == 0) {
                     this.actions = adapt.cssparse.actionsBase;
                     // Don't consume closing brace
                     continue;
-            	}
-            	// fall through
-            case adapt.cssparse.Action.ERROR_POP:  // Close bracket while skipping error syntax            
+                }
+            // fall through
+            case adapt.cssparse.Action.ERROR_POP:  // Close bracket while skipping error syntax
                 if (this.errorBrackets.length > 0 &&
-                		this.errorBrackets[this.errorBrackets.length-1] == token.type) {
-	                this.errorBrackets.pop();
+                    this.errorBrackets[this.errorBrackets.length-1] == token.type) {
+                    this.errorBrackets.pop();
                 }
-            	if (this.errorBrackets.length == 0 && token.type == adapt.csstok.TokenType.C_BRC) {
+                if (this.errorBrackets.length == 0 && token.type == adapt.csstok.TokenType.C_BRC) {
                     this.actions = adapt.cssparse.actionsBase;
-            	}
-                tokenizer.consume();
-            	continue;
-            case adapt.cssparse.Action.ERROR_SEMICOL:
-            	if (parsingValue || parsingStyleAttr)
-            		return true;
-                if (this.errorBrackets.length == 0) {
-                    this.actions = adapt.cssparse.actionsBase;                	
                 }
-	            tokenizer.consume();
-	            continue;          
+                tokenizer.consume();
+                continue;
+            case adapt.cssparse.Action.ERROR_SEMICOL:
+                if (parsingValue || parsingStyleAttr)
+                    return true;
+                if (this.errorBrackets.length == 0) {
+                    this.actions = adapt.cssparse.actionsBase;
+                }
+                tokenizer.consume();
+                continue;
             case adapt.cssparse.Action.DONE:
                 if (parsingFunctionParam) {
-                      tokenizer.consume();
-                      handler.endFuncWithSelector();
+                    tokenizer.consume();
+                    handler.endFuncWithSelector();
                 }
                 return true;
             default:
-            	if (parsingValue || parsingStyleAttr)
-            		return true;
+                if (parsingValue || parsingStyleAttr)
+                    return true;
                 if (parsingMediaQuery) {
                     if (this.exprStackReduce(adapt.csstok.TokenType.C_PAR, token)) {
                         this.result = /** @type {adapt.css.Val} */ (valStack.pop());
@@ -2602,12 +2602,12 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 }
                 if (parsingFunctionParam) {
                     if (token.type == adapt.csstok.TokenType.INVALID)
-                      handler.error(token.text, token);                    
+                        handler.error(token.text, token);
                     else
-                      handler.error("E_CSS_SYNTAX", token);
+                        handler.error("E_CSS_SYNTAX", token);
                     return false;
                 }
-        
+
                 if (this.actions === adapt.cssparse.actionsPropVal && tokenizer.hasMark()) {
                     tokenizer.reset();
                     this.actions = adapt.cssparse.actionsSelectorStart;
@@ -2615,17 +2615,17 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                     continue;
                 }
                 if (this.actions !== adapt.cssparse.actionsError &&
-                		this.actions !== adapt.cssparse.actionsErrorSelector && 
-                		this.actions !== adapt.cssparse.actionsErrorDecl) {
-                	if (token.type == adapt.csstok.TokenType.INVALID)
-                		handler.error(token.text, token);
-                	else
-                		handler.error("E_CSS_SYNTAX", token);
-                	if (this.isInsidePropertyOnlyRule()) {
-                		this.actions = adapt.cssparse.actionsErrorDecl;
-                	} else {
-                    	this.actions = adapt.cssparse.actionsErrorSelector;
-                	}
+                    this.actions !== adapt.cssparse.actionsErrorSelector &&
+                    this.actions !== adapt.cssparse.actionsErrorDecl) {
+                    if (token.type == adapt.csstok.TokenType.INVALID)
+                        handler.error(token.text, token);
+                    else
+                        handler.error("E_CSS_SYNTAX", token);
+                    if (this.isInsidePropertyOnlyRule()) {
+                        this.actions = adapt.cssparse.actionsErrorDecl;
+                    } else {
+                        this.actions = adapt.cssparse.actionsErrorSelector;
+                    }
                     continue;  // Let error-recovery to re-process the offending token
                 }
                 tokenizer.consume();
@@ -2642,8 +2642,8 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
  * @extends {adapt.cssparse.ParserHandler}
  */
 adapt.cssparse.ErrorHandler = function(scope) {
-	adapt.cssparse.ParserHandler.call(this, null);
-	/** @const */ this.scope = scope;
+    adapt.cssparse.ParserHandler.call(this, null);
+    /** @const */ this.scope = scope;
 };
 goog.inherits(adapt.cssparse.ErrorHandler, adapt.cssparse.ParserHandler);
 
@@ -2670,52 +2670,52 @@ adapt.cssparse.ErrorHandler.prototype.getScope = function() {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.cssparse.parseStylesheet = function(tokenizer, handler, baseURL, classes, media) {
-	/** @type {adapt.task.Frame.<boolean>} */ var frame =
-		adapt.task.newFrame("parseStylesheet");
-	var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsBase, tokenizer, handler, baseURL);
+    /** @type {adapt.task.Frame.<boolean>} */ var frame =
+        adapt.task.newFrame("parseStylesheet");
+    var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsBase, tokenizer, handler, baseURL);
 
     var condition = null;
     if (media) {
         condition = adapt.cssparse.parseMediaQuery(new adapt.csstok.Tokenizer(media, handler), handler, baseURL);
     }
     condition = parser.makeCondition(classes, condition && condition.toExpr());
-	if (condition) {
-		handler.startMediaRule(condition);
-		handler.startRuleBody();		
-	}
-	frame.loop(function() {
-	    while (!parser.runParser(100, false, false, false, false)) {
-			if (parser.importReady) {
-				var resolvedURL = adapt.base.resolveURL(/** @type {string} */ (parser.importURL), baseURL);
-				if (parser.importCondition) {
-					handler.startMediaRule(parser.importCondition);
-					handler.startRuleBody();
-				}
-				/** @type {adapt.task.Frame.<boolean>} */ var innerFrame =
-					adapt.task.newFrame("parseStylesheet.import");
-				adapt.cssparse.parseStylesheetFromURL(resolvedURL, handler, null, null).then(function() {
-					if (parser.importCondition) {
-						handler.endRule();
-					}					
-					parser.importReady = false;
-					parser.importURL = null;
-					parser.importCondition = null;
-					innerFrame.finish(true);
-				});
-				return innerFrame.result();
-			}
-			var r = frame.timeSlice();
-			if (r.isPending)
-				return r;
-		}
-		return adapt.task.newResult(false);
-	}).then(function() {
-		if (condition) {
-			handler.endRule();
-		}					
-		frame.finish(true);
-	});
-	return frame.result();
+    if (condition) {
+        handler.startMediaRule(condition);
+        handler.startRuleBody();
+    }
+    frame.loop(function() {
+        while (!parser.runParser(100, false, false, false, false)) {
+            if (parser.importReady) {
+                var resolvedURL = adapt.base.resolveURL(/** @type {string} */ (parser.importURL), baseURL);
+                if (parser.importCondition) {
+                    handler.startMediaRule(parser.importCondition);
+                    handler.startRuleBody();
+                }
+                /** @type {adapt.task.Frame.<boolean>} */ var innerFrame =
+                    adapt.task.newFrame("parseStylesheet.import");
+                adapt.cssparse.parseStylesheetFromURL(resolvedURL, handler, null, null).then(function() {
+                    if (parser.importCondition) {
+                        handler.endRule();
+                    }
+                    parser.importReady = false;
+                    parser.importURL = null;
+                    parser.importCondition = null;
+                    innerFrame.finish(true);
+                });
+                return innerFrame.result();
+            }
+            var r = frame.timeSlice();
+            if (r.isPending)
+                return r;
+        }
+        return adapt.task.newResult(false);
+    }).then(function() {
+        if (condition) {
+            handler.endRule();
+        }
+        frame.finish(true);
+    });
+    return frame.result();
 };
 
 /**
@@ -2731,10 +2731,9 @@ adapt.cssparse.parseStylesheetFromText = function(text, handler, baseURL, classe
         var tok = new adapt.csstok.Tokenizer(text, handler);
         adapt.cssparse.parseStylesheet(tok, handler, baseURL, classes, media).thenFinish(frame);
     }, function(frame, err) {
-            vivliostyle.logging.logger.warn(err, "Failed to parse stylesheet text: " + text);
-            frame.finish(false);
-        }
-    );
+        vivliostyle.logging.logger.warn(err, "Failed to parse stylesheet text: " + text);
+        frame.finish(false);
+    });
 };
 
 /**
@@ -2745,37 +2744,37 @@ adapt.cssparse.parseStylesheetFromText = function(text, handler, baseURL, classe
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.cssparse.parseStylesheetFromURL = function(url, handler, classes, media) {
-    return adapt.task.handle("parseStylesheetFromURL", 
-    	/**
-    	 * @param {!adapt.task.Frame.<boolean>} frame
-    	 * @return {void}
-    	 */
-    	function(frame) {
-		    adapt.net.ajax(url).then(function (xhrParam) {
-		    	var xhr = /** @type {XMLHttpRequest} */ (xhrParam);
-		        if (!xhr.responseText) {
-		            frame.finish(true);
-		        } else {
-		        	adapt.cssparse.parseStylesheetFromText(xhr.responseText,
-		        			handler, url, classes, media)
+    return adapt.task.handle("parseStylesheetFromURL",
+        /**
+         * @param {!adapt.task.Frame.<boolean>} frame
+         * @return {void}
+         */
+        function(frame) {
+            adapt.net.ajax(url).then(function(xhrParam) {
+                var xhr = /** @type {XMLHttpRequest} */ (xhrParam);
+                if (!xhr.responseText) {
+                    frame.finish(true);
+                } else {
+                    adapt.cssparse.parseStylesheetFromText(xhr.responseText,
+                        handler, url, classes, media)
                         .then(function(result) {
                             if (!result) {
                                 vivliostyle.logging.logger.warn("Failed to parse stylesheet from " + url);
                             }
                             frame.finish(true);
                         });
-		        }
-		    });
-    	},
-    	/**
-    	 * @param {!adapt.task.Frame.<boolean>} frame
-    	 * @param {Error} err
-    	 * @return {void}
-    	 */
-    	function(frame, err) {
+                }
+            });
+        },
+        /**
+         * @param {!adapt.task.Frame.<boolean>} frame
+         * @param {Error} err
+         * @return {void}
+         */
+        function(frame, err) {
             vivliostyle.logging.logger.warn(err, "Exception while fetching and parsing:", url);
-	    	frame.finish(true);
-	    });
+            frame.finish(true);
+        });
 };
 
 /**
@@ -2785,10 +2784,10 @@ adapt.cssparse.parseStylesheetFromURL = function(url, handler, classes, media) {
  * @return {adapt.css.Val}
  */
 adapt.cssparse.parseValue = function(scope, tokenizer, baseURL) {
-	var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsPropVal, tokenizer, 
-    		new adapt.cssparse.ErrorHandler(scope), baseURL);
+    var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsPropVal, tokenizer,
+        new adapt.cssparse.ErrorHandler(scope), baseURL);
     parser.runParser(Number.POSITIVE_INFINITY, true, false, false, false);
-	return parser.result;
+    return parser.result;
 };
 
 /**
@@ -2798,8 +2797,8 @@ adapt.cssparse.parseValue = function(scope, tokenizer, baseURL) {
  * @return {void}
  */
 adapt.cssparse.parseStyleAttribute = function(tokenizer, handler, baseURL) {
-	var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsStyleAttribute, tokenizer, 
-    		handler, baseURL);
+    var parser = new adapt.cssparse.Parser(adapt.cssparse.actionsStyleAttribute, tokenizer,
+        handler, baseURL);
     parser.runParser(Number.POSITIVE_INFINITY, false, true, false, false);
 };
 

--- a/src/adapt/cssprop.js
+++ b/src/adapt/cssprop.js
@@ -21,8 +21,8 @@ goog.require('adapt.geom');
  * @extends {adapt.css.Visitor}
  */
 adapt.cssprop.SetVisitor = function() {
-	adapt.css.Visitor.call(this);
-	/** @type {Object.<string,boolean>} */ this.propSet = {};
+    adapt.css.Visitor.call(this);
+    /** @type {Object.<string,boolean>} */ this.propSet = {};
 };
 goog.inherits(adapt.cssprop.SetVisitor, adapt.css.Visitor);
 
@@ -66,8 +66,8 @@ adapt.cssprop.toSet = function(val) {
  * @extends {adapt.css.Visitor}
  */
 adapt.cssprop.IntVisitor = function(value) {
-	adapt.css.Visitor.call(this);
-	/** @type {number} */ this.value = value;
+    adapt.css.Visitor.call(this);
+    /** @type {number} */ this.value = value;
 };
 goog.inherits(adapt.cssprop.IntVisitor, adapt.css.Visitor);
 
@@ -104,10 +104,10 @@ adapt.cssprop.toInt = function(val, def) {
  * @extends {adapt.css.Visitor}
  */
 adapt.cssprop.ShapeVisitor = function() {
-	adapt.css.Visitor.call(this);
-	/** @type {boolean} */ this.collect = false;
-	/** @type {Array.<adapt.css.Numeric>} */ this.coords = [];
-	/** @type {?string} */ this.name = null;
+    adapt.css.Visitor.call(this);
+    /** @type {boolean} */ this.collect = false;
+    /** @type {Array.<adapt.css.Numeric>} */ this.coords = [];
+    /** @type {?string} */ this.name = null;
 };
 goog.inherits(adapt.cssprop.ShapeVisitor, adapt.css.Visitor);
 
@@ -231,10 +231,10 @@ adapt.cssprop.toShape = function(val, x, y, width, height, context) {
  * @extends {adapt.css.Visitor}
  */
 adapt.cssprop.CountersVisitor = function(reset) {
-	adapt.css.Visitor.call(this);
-	/** @const */ this.reset = reset;
-	/** @type {Object.<string,number>} */ this.counters = {};
-	/** @type {?string} */ this.name = null;
+    adapt.css.Visitor.call(this);
+    /** @const */ this.reset = reset;
+    /** @type {Object.<string,number>} */ this.counters = {};
+    /** @type {?string} */ this.name = null;
 };
 goog.inherits(adapt.cssprop.CountersVisitor, adapt.css.Visitor);
 
@@ -242,18 +242,18 @@ goog.inherits(adapt.cssprop.CountersVisitor, adapt.css.Visitor);
 adapt.cssprop.CountersVisitor.prototype.visitIdent = function(ident) {
     this.name = ident.toString();
     if (this.reset) {
-    	this.counters[this.name] = 0;
+        this.counters[this.name] = 0;
     } else {
-    	this.counters[this.name] = (this.counters[this.name] || 0) + 1;    	
+        this.counters[this.name] = (this.counters[this.name] || 0) + 1;
     }
     return ident;
 };
 
 /** @override */
 adapt.cssprop.CountersVisitor.prototype.visitInt = function(num) {
-	if (this.name) {
-		this.counters[this.name] += num.num - (this.reset ? 0 : 1);
-	}
+    if (this.name) {
+        this.counters[this.name] += num.num - (this.reset ? 0 : 1);
+    }
     return num;
 };
 

--- a/src/adapt/cssstyler.js
+++ b/src/adapt/cssstyler.js
@@ -15,9 +15,9 @@ goog.require('adapt.cssprop');
  * @constructor
  */
 adapt.cssstyler.SlipRange = function(endStuckFixed, endFixed, endSlipped) {
-	/** @type {number} */ this.endStuckFixed = endStuckFixed;
-	/** @type {number} */ this.endFixed = endFixed;
-	/** @type {number} */ this.endSlipped = endSlipped;	
+    /** @type {number} */ this.endStuckFixed = endStuckFixed;
+    /** @type {number} */ this.endFixed = endFixed;
+    /** @type {number} */ this.endSlipped = endSlipped;
 };
 
 /**
@@ -85,7 +85,7 @@ adapt.cssstyler.SlipMap.prototype.addSlippedRange = function(endFixed) {
  * @return {number}
  */
 adapt.cssstyler.SlipMap.prototype.slippedByFixed = function(fixed) {
-	var self = this;
+    var self = this;
     var index = adapt.base.binarySearch(this.map.length, function(index) {
         return fixed <= self.map[index].endFixed;
     });
@@ -99,7 +99,7 @@ adapt.cssstyler.SlipMap.prototype.slippedByFixed = function(fixed) {
  * @return {number}
  */
 adapt.cssstyler.SlipMap.prototype.fixedBySlipped = function(slipped) {
-	var self = this;
+    var self = this;
     var index = adapt.base.binarySearch(this.map.length, function(index) {
         return slipped <= self.map[index].endSlipped;
     });
@@ -429,12 +429,12 @@ adapt.cssstyler.BoxStack.prototype.nearestBlockStartOffset = function(box) {
  * @implements {adapt.cssstyler.AbstractStyler}
  */
 adapt.cssstyler.Styler = function(xmldoc, cascade, scope, context, primaryFlows, validatorSet, counterListener, counterResolver) {
-	/** @const */ this.xmldoc = xmldoc;
-	/** @const */ this.root = xmldoc.root;
-	/** @const */ this.cascadeHolder = cascade;
-	/** @const */ this.scope = scope;
-	/** @const */ this.context = context;
-	/** @const */ this.validatorSet = validatorSet;
+    /** @const */ this.xmldoc = xmldoc;
+    /** @const */ this.root = xmldoc.root;
+    /** @const */ this.cascadeHolder = cascade;
+    /** @const */ this.scope = scope;
+    /** @const */ this.context = context;
+    /** @const */ this.validatorSet = validatorSet;
     /** @type {Node} */ this.last = this.root;
     /** @const */ this.rootStyle = /** @type {!adapt.csscasc.ElementStyle} */ ({});
     /** @type {Object.<string,adapt.csscasc.ElementStyle>} */ this.styleMap = {};
@@ -454,17 +454,17 @@ adapt.cssstyler.Styler = function(xmldoc, cascade, scope, context, primaryFlows,
     /** @type {number} */ this.lastOffset = rootOffset;
     /** @const */ this.breakBeforeValues = /** @type {!Object<number, ?string>} */ ({});
     /** @const */ this.boxStack = new adapt.cssstyler.BoxStack(context);
-    
+
     this.offsetMap.addStuckRange(rootOffset);
     var style = this.getAttrStyle(this.root);
     this.cascade.pushElement(this.root, style);
     this.postprocessTopStyle(style, false);
     /** @type {boolean} */ this.bodyReached = true;
     switch (this.root.namespaceURI) {
-    case adapt.base.NS.XHTML:
-    case adapt.base.NS.FB2:
-    	this.bodyReached = false;
-    	break;
+        case adapt.base.NS.XHTML:
+        case adapt.base.NS.FB2:
+            this.bodyReached = false;
+            break;
     }
     this.primaryStack.push(true);
     this.styleMap = {};
@@ -480,8 +480,8 @@ adapt.cssstyler.Styler = function(xmldoc, cascade, scope, context, primaryFlows,
  * @return {boolean}
  **/
 adapt.cssstyler.Styler.prototype.hasProp = function(style, map, name) {
-	var cascVal = style[name];
-	return cascVal && cascVal.evaluate(this.context) !== map[name];
+    var cascVal = style[name];
+    return cascVal && cascVal.evaluate(this.context) !== map[name];
 };
 
 /**
@@ -490,18 +490,18 @@ adapt.cssstyler.Styler.prototype.hasProp = function(style, map, name) {
  * @return {void}
  **/
 adapt.cssstyler.Styler.prototype.transferPropsToRoot = function(srcStyle, map) {
-	for (var pname in map) {
-		var cascval = srcStyle[pname];
-		if (cascval) {
-			this.rootStyle[pname] = cascval;
-			delete srcStyle[pname];
-		} else {
-			var val = map[pname];
-			if (val) {
-				this.rootStyle[pname] = new adapt.csscasc.CascadeValue(val, adapt.cssparse.SPECIFICITY_AUTHOR);
-			}
-		}
-	}
+    for (var pname in map) {
+        var cascval = srcStyle[pname];
+        if (cascval) {
+            this.rootStyle[pname] = cascval;
+            delete srcStyle[pname];
+        } else {
+            var val = map[pname];
+            if (val) {
+                this.rootStyle[pname] = new adapt.csscasc.CascadeValue(val, adapt.cssparse.SPECIFICITY_AUTHOR);
+            }
+        }
+    }
 };
 
 /**
@@ -518,35 +518,35 @@ adapt.cssstyler.columnProps = ["column-count", "column-width"];
  */
 adapt.cssstyler.Styler.prototype.postprocessTopStyle = function(elemStyle, isBody) {
     if (!isBody) {
-        ["writing-mode", "direction"].forEach(function (propName) {
+        ["writing-mode", "direction"].forEach(function(propName) {
             if (elemStyle[propName]) {
                 // Copy it over, but keep it at the root element as well.
                 this.rootStyle[propName] = elemStyle[propName];
             }
         }, this);
     }
-	if (!this.rootBackgroundAssigned) {
+    if (!this.rootBackgroundAssigned) {
         var backgroundColor = /** @type {adapt.css.Val} */
             (this.hasProp(elemStyle, this.validatorSet.backgroundProps, "background-color") ?
                 elemStyle["background-color"].evaluate(this.context) : null);
         var backgroundImage = /** @type {adapt.css.Val} */
             (this.hasProp(elemStyle, this.validatorSet.backgroundProps, "background-image") ?
                 elemStyle["background-image"].evaluate(this.context) : null);
-		if ((backgroundColor && backgroundColor !== adapt.css.ident.inherit) ||
+        if ((backgroundColor && backgroundColor !== adapt.css.ident.inherit) ||
             (backgroundImage && backgroundImage !== adapt.css.ident.inherit)) {
-			this.transferPropsToRoot(elemStyle, this.validatorSet.backgroundProps);
-			this.rootBackgroundAssigned = true;
-		}
-	}
-	if (!this.rootLayoutAssigned) {
-		for (var i = 0; i < adapt.cssstyler.columnProps.length; i++) {
-			if (this.hasProp(elemStyle, this.validatorSet.layoutProps, adapt.cssstyler.columnProps[i])) {
-				this.transferPropsToRoot(elemStyle, this.validatorSet.layoutProps);
-				this.rootLayoutAssigned = true;
-				break;
-			}
-		}
-	}
+            this.transferPropsToRoot(elemStyle, this.validatorSet.backgroundProps);
+            this.rootBackgroundAssigned = true;
+        }
+    }
+    if (!this.rootLayoutAssigned) {
+        for (var i = 0; i < adapt.cssstyler.columnProps.length; i++) {
+            if (this.hasProp(elemStyle, this.validatorSet.layoutProps, adapt.cssstyler.columnProps[i])) {
+                this.transferPropsToRoot(elemStyle, this.validatorSet.layoutProps);
+                this.rootLayoutAssigned = true;
+                break;
+            }
+        }
+    }
     if (!isBody) {
         var fontSize = elemStyle["font-size"];
         if (fontSize) {
@@ -601,14 +601,14 @@ adapt.cssstyler.Styler.prototype.getAttrStyle = function(elem) {
                 this.xmldoc.url, styleAttrValue);
         }
     }
-	return /** @type {adapt.csscasc.ElementStyle} */ ({});	
+    return /** @type {adapt.csscasc.ElementStyle} */ ({});
 };
 
 /**
  * @return {number} currently reached offset
  */
 adapt.cssstyler.Styler.prototype.getReachedOffset = function() {
-	return this.lastOffset;
+    return this.lastOffset;
 };
 
 /**
@@ -618,43 +618,43 @@ adapt.cssstyler.Styler.prototype.getReachedOffset = function() {
  */
 adapt.cssstyler.Styler.prototype.replayFlowElementsFromOffset = function(offset) {
     if (offset >= this.lastOffset)
-    	return;
+        return;
     var context = this.context;
     var rootOffset = this.xmldoc.getElementOffset(this.root);
-	if (offset < rootOffset) {
-		var rootStyle = this.getStyle(this.root, false);
+    if (offset < rootOffset) {
+        var rootStyle = this.getStyle(this.root, false);
         goog.asserts.assert(rootStyle);
-	    var flowName = adapt.csscasc.getProp(rootStyle, "flow-into");
-	    var flowNameStr = flowName ? flowName.evaluate(context, "flow-into").toString() : "body";
+        var flowName = adapt.csscasc.getProp(rootStyle, "flow-into");
+        var flowNameStr = flowName ? flowName.evaluate(context, "flow-into").toString() : "body";
         var newFlowChunk = this.encounteredFlowElement(flowNameStr, rootStyle, this.root, rootOffset);
         if (this.boxStack.empty()) {
             this.boxStack.push(rootStyle, rootOffset, true, newFlowChunk);
         }
-	}
-	var node = this.xmldoc.getNodeByOffset(offset);
-	var nodeOffset = this.xmldoc.getNodeOffset(node, 0, false);
+    }
+    var node = this.xmldoc.getNodeByOffset(offset);
+    var nodeOffset = this.xmldoc.getNodeOffset(node, 0, false);
     if (nodeOffset >= this.lastOffset)
-    	return;
+        return;
     while (true) {
         if (node.nodeType != 1) {
             nodeOffset += node.textContent.length;
         } else {
             var elem = /** @type {!Element} */ (node);
-        	if (goog.DEBUG) {
-        		if (nodeOffset != this.xmldoc.getElementOffset(elem)) {
-        			throw new Error("Inconsistent offset");
-        		}
-        	}
+            if (goog.DEBUG) {
+                if (nodeOffset != this.xmldoc.getElementOffset(elem)) {
+                    throw new Error("Inconsistent offset");
+                }
+            }
             var style = this.getStyle(elem, false);
             var flowName = style["flow-into"];
             if (flowName) {
-                var flowNameStr = flowName.evaluate(context,"flow-into").toString();
+                var flowNameStr = flowName.evaluate(context, "flow-into").toString();
                 this.encounteredFlowElement(flowNameStr, style, elem, nodeOffset);
             }
             nodeOffset++;
         }
         if (nodeOffset >= this.lastOffset)
-        	break;
+            break;
         var next = node.firstChild;
         if (next == null) {
             while (true) {
@@ -738,7 +738,7 @@ adapt.cssstyler.Styler.prototype.encounteredFlowElement = function(flowName, sty
     var lingerCV = style["flow-linger"];
     if (lingerCV) {
         linger = adapt.cssprop.toInt(lingerCV.evaluate(this.context, "flow-linger"),
-        		Number.POSITIVE_INFINITY);
+            Number.POSITIVE_INFINITY);
     }
     var priorityCV = style["flow-priority"];
     if (priorityCV) {
@@ -751,7 +751,7 @@ adapt.cssstyler.Styler.prototype.encounteredFlowElement = function(flowName, sty
         flow = this.flows[flowName] = new adapt.vtree.Flow(flowName, parentFlowName);
     }
     var flowChunk = new adapt.vtree.FlowChunk(flowName, elem,
-    		startOffset, priority, linger, exclusive, repeated, last, breakBefore);
+        startOffset, priority, linger, exclusive, repeated, last, breakBefore);
     this.flowChunks.push(flowChunk);
     if (this.flowToReach == flowName)
         this.flowToReach = null;
@@ -822,14 +822,14 @@ adapt.cssstyler.Styler.prototype.styleUntil = function(startOffset, lookup) {
                 if (this.last === this.root) {
                     this.last = null;
                     if (startOffset < this.lastOffset) {
-	                    if (targetSlippedOffset < 0) {
-	                        slippedOffset = this.offsetMap.slippedByFixed(startOffset);
-	                        targetSlippedOffset = slippedOffset + lookup;
-	                    }
-	                    if (targetSlippedOffset <= this.offsetMap.getMaxSlipped()) {
-	                        // got to the desired point
-	                        return this.offsetMap.fixedBySlipped(targetSlippedOffset);
-	                    }
+                        if (targetSlippedOffset < 0) {
+                            slippedOffset = this.offsetMap.slippedByFixed(startOffset);
+                            targetSlippedOffset = slippedOffset + lookup;
+                        }
+                        if (targetSlippedOffset <= this.offsetMap.getMaxSlipped()) {
+                            // got to the desired point
+                            return this.offsetMap.fixedBySlipped(targetSlippedOffset);
+                        }
                     }
                     return Number.POSITIVE_INFINITY;
                 }
@@ -852,14 +852,14 @@ adapt.cssstyler.Styler.prototype.styleUntil = function(startOffset, lookup) {
             if (id && id === this.idToReach) {
                 this.idToReach = null;
             }
-            if (!this.bodyReached && elem.localName == "body" && elem.parentNode == this.root) { 
-            	this.postprocessTopStyle(style, true);
-            	this.bodyReached = true;
+            if (!this.bodyReached && elem.localName == "body" && elem.parentNode == this.root) {
+                this.postprocessTopStyle(style, true);
+                this.bodyReached = true;
             }
             var box;
             var flowName = style["flow-into"];
             if (flowName) {
-                var flowNameStr = flowName.evaluate(context,"flow-into").toString();
+                var flowNameStr = flowName.evaluate(context, "flow-into").toString();
                 var newFlowChunk = this.encounteredFlowElement(flowNameStr, style, elem, this.lastOffset);
                 this.primary = !!this.primaryFlows[flowNameStr];
                 box = this.boxStack.push(style, this.lastOffset, elem === this.root, newFlowChunk);
@@ -881,9 +881,9 @@ adapt.cssstyler.Styler.prototype.styleUntil = function(startOffset, lookup) {
                 }
             }
             if (goog.DEBUG) {
-	            var offset = this.xmldoc.getElementOffset(/** @type {Element} */ (this.last));
-	            if (offset != this.lastOffset)
-	                throw new Error("Inconsistent offset");
+                var offset = this.xmldoc.getElementOffset(/** @type {Element} */ (this.last));
+                if (offset != this.lastOffset)
+                    throw new Error("Inconsistent offset");
             }
             this.styleMap["e"+this.lastOffset] = style;
             this.lastOffset++;
@@ -912,7 +912,7 @@ adapt.cssstyler.Styler.prototype.getStyle = function(element, deep) {
     var offset = this.xmldoc.getElementOffset(element);
     var key = "e" + offset;
     if (deep) {
-    	offset = this.xmldoc.getNodeOffset(element, 0, true);
+        offset = this.xmldoc.getNodeOffset(element, 0, true);
     }
     if (this.lastOffset <= offset) {
         this.styleUntil(offset, 0);

--- a/src/adapt/csstok.js
+++ b/src/adapt/csstok.js
@@ -44,8 +44,8 @@ adapt.csstok.escapeParseSingle = function(str) {
  * @return {string}
  */
 adapt.csstok.escapeParse = function(str) {
-    return str.replace( /\\([0-9a-fA-F]{0,6}(\r\n|[ \n\r\t\f])?|[^0-9a-fA-F\n\r])/g,
-    		adapt.csstok.escapeParseSingle );
+    return str.replace(/\\([0-9a-fA-F]{0,6}(\r\n|[ \n\r\t\f])?|[^0-9a-fA-F\n\r])/g,
+        adapt.csstok.escapeParseSingle);
 };
 
 /**
@@ -208,12 +208,12 @@ adapt.csstok.Action = {
 adapt.csstok.makeActions = function(def, spec) {
     /** @type {Array.<number>} */ var a = Array(128);
     /** @type {number} */ var i;
-    for (i = 0 ; i < 128 ; i++) {
+    for (i = 0; i < 128; i++) {
         a[i] = def;
     }
-    a[NaN] = def == adapt.csstok.Action.END ? 
-    		adapt.csstok.Action.END : adapt.csstok.Action.INVALID;
-    for (i = 0 ; i < spec.length ; i += 2) {
+    a[NaN] = def == adapt.csstok.Action.END ?
+        adapt.csstok.Action.END : adapt.csstok.Action.INVALID;
+    for (i = 0; i < spec.length; i += 2) {
         a[spec[i]] = spec[i + 1];
     }
     return a;
@@ -398,31 +398,31 @@ adapt.csstok.actionsNumber[NaN] = adapt.csstok.Action.ENDNUM;
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsCheckEq = adapt.csstok.makeActions( adapt.csstok.Action.END, [61/*=*/, adapt.csstok.Action.EQTAIL]);
+adapt.csstok.actionsCheckEq = adapt.csstok.makeActions(adapt.csstok.Action.END, [61/*=*/, adapt.csstok.Action.EQTAIL]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsColon = adapt.csstok.makeActions( adapt.csstok.Action.END, [58/*:*/, adapt.csstok.Action.COL_COL]);
+adapt.csstok.actionsColon = adapt.csstok.makeActions(adapt.csstok.Action.END, [58/*:*/, adapt.csstok.Action.COL_COL]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsBar = adapt.csstok.makeActions( adapt.csstok.Action.END, [61/*=*/, adapt.csstok.Action.EQTAIL, 124 /*|*/, adapt.csstok.Action.BAR_BAR]);
+adapt.csstok.actionsBar = adapt.csstok.makeActions(adapt.csstok.Action.END, [61/*=*/, adapt.csstok.Action.EQTAIL, 124 /*|*/, adapt.csstok.Action.BAR_BAR]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsAmp = adapt.csstok.makeActions( adapt.csstok.Action.END, [38 /*&*/, adapt.csstok.Action.AMP_AMP]);
+adapt.csstok.actionsAmp = adapt.csstok.makeActions(adapt.csstok.Action.END, [38 /*&*/, adapt.csstok.Action.AMP_AMP]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsSlash = adapt.csstok.makeActions( adapt.csstok.Action.END, [42/* * */, adapt.csstok.Action.COMMENT]);
+adapt.csstok.actionsSlash = adapt.csstok.makeActions(adapt.csstok.Action.END, [42/* * */, adapt.csstok.Action.COMMENT]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
@@ -446,49 +446,49 @@ adapt.csstok.actionsMinusMinus = adapt.csstok.makeActions(adapt.csstok.Action.KI
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsLt = adapt.csstok.makeActions( adapt.csstok.Action.END, [61/*=*/, adapt.csstok.Action.EQTAIL, 33 /*!*/, adapt.csstok.Action.LT_BG]);
+adapt.csstok.actionsLt = adapt.csstok.makeActions(adapt.csstok.Action.END, [61/*=*/, adapt.csstok.Action.EQTAIL, 33 /*!*/, adapt.csstok.Action.LT_BG]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsLtBang = adapt.csstok.makeActions( adapt.csstok.Action.KILL1, [45 /*-*/, adapt.csstok.Action.LT_BG_M]);
+adapt.csstok.actionsLtBang = adapt.csstok.makeActions(adapt.csstok.Action.KILL1, [45 /*-*/, adapt.csstok.Action.LT_BG_M]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsLtBangMinus = adapt.csstok.makeActions( adapt.csstok.Action.KILL2, [45 /*-*/, adapt.csstok.Action.ENDNOTK]);
+adapt.csstok.actionsLtBangMinus = adapt.csstok.makeActions(adapt.csstok.Action.KILL2, [45 /*-*/, adapt.csstok.Action.ENDNOTK]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsIdentEscChr = adapt.csstok.makeActions( adapt.csstok.Action.IDESCH, [9/*tab*/, adapt.csstok.Action.INVALID, 10/*LF*/, adapt.csstok.Action.INVALID, 13/*CR*/, adapt.csstok.Action.INVALID, 32/*sp*/, adapt.csstok.Action.INVALID] );
+adapt.csstok.actionsIdentEscChr = adapt.csstok.makeActions(adapt.csstok.Action.IDESCH, [9/*tab*/, adapt.csstok.Action.INVALID, 10/*LF*/, adapt.csstok.Action.INVALID, 13/*CR*/, adapt.csstok.Action.INVALID, 32/*sp*/, adapt.csstok.Action.INVALID]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsStr1 = adapt.csstok.makeActions( adapt.csstok.Action.CONT, [39/*'*/, adapt.csstok.Action.ENDSTR, 10/*LF*/, adapt.csstok.Action.INVALID, 13/*CR*/, adapt.csstok.Action.INVALID, 92/*\*/, adapt.csstok.Action.STR1ESC]);
+adapt.csstok.actionsStr1 = adapt.csstok.makeActions(adapt.csstok.Action.CONT, [39/*'*/, adapt.csstok.Action.ENDSTR, 10/*LF*/, adapt.csstok.Action.INVALID, 13/*CR*/, adapt.csstok.Action.INVALID, 92/*\*/, adapt.csstok.Action.STR1ESC]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsStr2 = adapt.csstok.makeActions( adapt.csstok.Action.CONT, [34/*"*/, adapt.csstok.Action.ENDSTR, 10/*LF*/, adapt.csstok.Action.INVALID, 13/*CR*/, adapt.csstok.Action.INVALID, 92/*\*/, adapt.csstok.Action.STR2ESC]);
+adapt.csstok.actionsStr2 = adapt.csstok.makeActions(adapt.csstok.Action.CONT, [34/*"*/, adapt.csstok.Action.ENDSTR, 10/*LF*/, adapt.csstok.Action.INVALID, 13/*CR*/, adapt.csstok.Action.INVALID, 92/*\*/, adapt.csstok.Action.STR2ESC]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsStr1Esc = adapt.csstok.makeActions( adapt.csstok.Action.CONT, [39/*'*/, adapt.csstok.Action.ENDESTR, 10/*LF*/, adapt.csstok.Action.CHKPOSN, 13/*CR*/, adapt.csstok.Action.CHKPOSN, 92/*\*/, adapt.csstok.Action.STR1ESC]);
+adapt.csstok.actionsStr1Esc = adapt.csstok.makeActions(adapt.csstok.Action.CONT, [39/*'*/, adapt.csstok.Action.ENDESTR, 10/*LF*/, adapt.csstok.Action.CHKPOSN, 13/*CR*/, adapt.csstok.Action.CHKPOSN, 92/*\*/, adapt.csstok.Action.STR1ESC]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
  * @const
  */
-adapt.csstok.actionsStr2Esc = adapt.csstok.makeActions( adapt.csstok.Action.CONT, [34/*"*/, adapt.csstok.Action.ENDESTR, 10/*LF*/, adapt.csstok.Action.CHKPOSN, 13/*CR*/, adapt.csstok.Action.CHKPOSN, 92/*\*/, adapt.csstok.Action.STR2ESC]);
+adapt.csstok.actionsStr2Esc = adapt.csstok.makeActions(adapt.csstok.Action.CONT, [34/*"*/, adapt.csstok.Action.ENDESTR, 10/*LF*/, adapt.csstok.Action.CHKPOSN, 13/*CR*/, adapt.csstok.Action.CHKPOSN, 92/*\*/, adapt.csstok.Action.STR2ESC]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
@@ -501,8 +501,8 @@ adapt.csstok.actionsURL = adapt.csstok.makeActions(adapt.csstok.Action.URL, [9/*
  * @const
  */
 adapt.csstok.actionsURLInside = adapt.csstok.makeActions(adapt.csstok.Action.CONT, [41/*)*/, adapt.csstok.Action.ENDURL, 9/*TAB*/, adapt.csstok.Action.CHKSP, 10/*LF*/, adapt.csstok.Action.CHKSP, 13/*CR*/, adapt.csstok.Action.CHKSP, 32/*sp*/, adapt.csstok.Action.CHKSP, 92/*\*/, adapt.csstok.Action.URLESC,
-                                                                                    40/*(*/, adapt.csstok.Action.INVALID, 91/*[*/, adapt.csstok.Action.INVALID,  93/*]*/, adapt.csstok.Action.INVALID, 123/*{*/, adapt.csstok.Action.INVALID, 125/*}*/, adapt.csstok.Action.INVALID,
-                                                                                    NaN, adapt.csstok.Action.ENDURL]);
+    40/*(*/, adapt.csstok.Action.INVALID, 91/*[*/, adapt.csstok.Action.INVALID,  93/*]*/, adapt.csstok.Action.INVALID, 123/*{*/, adapt.csstok.Action.INVALID, 125/*}*/, adapt.csstok.Action.INVALID,
+    NaN, adapt.csstok.Action.ENDURL]);
 
 /**
  * @type {Array.<adapt.csstok.Action>}
@@ -533,15 +533,15 @@ adapt.csstok.INITIAL_INDEX_MASK = 0xF;
  * @param {adapt.csstok.TokenizerHandler} handler
  */
 adapt.csstok.Tokenizer = function(input, handler) {
-	/** @const */ this.handler = handler;
+    /** @const */ this.handler = handler;
     /** @type {number} */ this.indexMask = adapt.csstok.INITIAL_INDEX_MASK;
-	/** @type {string} */ this.input = input;
+    /** @type {string} */ this.input = input;
     /** @type {Array.<adapt.csstok.Token>} */ this.buffer = Array(this.indexMask + 1);
     /** @type {number} */ this.head = -1; // saved, occupied if >= 0
     /** @type {number} */ this.tail = 0; // available, ready to write
     /** @type {number} */ this.curr = 0; // ready to read
     /** @type {number} */ this.position = 0;
-    for (var i = 0 ; i <= this.indexMask ; i++)
+    for (var i = 0; i <= this.indexMask; i++)
         this.buffer[i] = new adapt.csstok.Token();
 };
 
@@ -633,9 +633,9 @@ adapt.csstok.Tokenizer.prototype.reallocate = function() {
  * @private
  */
 adapt.csstok.Tokenizer.prototype.error = function(position, token, mnemonics) {
-	if (this.handler) {
-		this.handler.error(mnemonics, token);
-	}
+    if (this.handler) {
+        this.handler.error(mnemonics, token);
+    }
 };
 
 /**
@@ -674,12 +674,12 @@ adapt.csstok.Tokenizer.prototype.fillBuffer = function() {
         var charCode = input.charCodeAt(position);
         switch (actions[charCode] || actions[65/*A*/]) {
             case adapt.csstok.Action.INVALID:
-        		tokenType = adapt.csstok.TokenType.INVALID;
-        		if (isNaN(charCode)) {
-        			tokenText = "E_CSS_UNEXPECTED_EOF";        			
-        		} else {
-        			tokenText = "E_CSS_UNEXPECTED_CHAR";
-        		}
+                tokenType = adapt.csstok.TokenType.INVALID;
+                if (isNaN(charCode)) {
+                    tokenText = "E_CSS_UNEXPECTED_EOF";
+                } else {
+                    tokenText = "E_CSS_UNEXPECTED_CHAR";
+                }
                 actions = adapt.csstok.actionsNormal;
                 position++;
                 break;
@@ -713,7 +713,7 @@ adapt.csstok.Tokenizer.prototype.fillBuffer = function() {
                 continue;
             case adapt.csstok.Action.HASH:
                 tokenPosition = ++position; // after hash
-	            tokenType = adapt.csstok.TokenType.HASH;
+                tokenType = adapt.csstok.TokenType.HASH;
                 actions = adapt.csstok.actionsIdent;
                 continue;
             case adapt.csstok.Action.DOLLAR:
@@ -1027,8 +1027,8 @@ adapt.csstok.Tokenizer.prototype.fillBuffer = function() {
                         continue;
                     }
                 }
-                // end of url
-                // fall through
+            // end of url
+            // fall through
             case adapt.csstok.Action.TERMURL:
                 tokenType = adapt.csstok.TokenType.URL;
                 tokenText = adapt.csstok.escapeParse(input.substring(tokenPosition, position));
@@ -1046,8 +1046,8 @@ adapt.csstok.Tokenizer.prototype.fillBuffer = function() {
                     }
                 }
                 // invalid token
-        		tokenType = adapt.csstok.TokenType.INVALID;
-        		tokenText = "E_CSS_UNEXPECTED_NEWLINE";
+                tokenType = adapt.csstok.TokenType.INVALID;
+                tokenText = "E_CSS_UNEXPECTED_NEWLINE";
                 actions = adapt.csstok.actionsNormal;
                 break;
             case adapt.csstok.Action.CHKPOSS:
@@ -1075,9 +1075,9 @@ adapt.csstok.Tokenizer.prototype.fillBuffer = function() {
             default:
                 // EOF
                 if (actions !== adapt.csstok.actionsNormal) {
-            		tokenType = adapt.csstok.TokenType.INVALID;
-            		tokenText = "E_CSS_UNEXPECTED_STATE";
-            		break;
+                    tokenType = adapt.csstok.TokenType.INVALID;
+                    tokenText = "E_CSS_UNEXPECTED_STATE";
+                    break;
                 }
                 tokenPosition = position;
                 tokenType = adapt.csstok.TokenType.EOF;

--- a/src/adapt/cssvalid.js
+++ b/src/adapt/cssvalid.js
@@ -142,10 +142,10 @@ adapt.cssvalid.Connection = function(where, success) {
  * @enum {number}
  */
 adapt.cssvalid.Add = {
-	FOLLOW: 1,
-	OPTIONAL: 2,
-	REPEATED: 3,
-	ALTERNATE: 4
+    FOLLOW: 1,
+    OPTIONAL: 2,
+    REPEATED: 3,
+    ALTERNATE: 4
 };
 
 
@@ -154,12 +154,12 @@ adapt.cssvalid.Add = {
  * @constructor
  */
 adapt.cssvalid.ValidatingGroup = function() {
-	/** @type {Array.<adapt.cssvalid.Node>} */ this.nodes = [];
-	/** @type {Array.<adapt.cssvalid.Connection>} */ this.connections = [];
-	/** @type {Array.<number>} */ this.match = []; // connector indicies
-	/** @type {Array.<number>} */ this.nomatch = [];  // connector indicies
-	/** @type {Array.<number>} */ this.error = []; // connector indicies
-	/** @type {boolean} */ this.emptyHead = true;
+    /** @type {Array.<adapt.cssvalid.Node>} */ this.nodes = [];
+    /** @type {Array.<adapt.cssvalid.Connection>} */ this.connections = [];
+    /** @type {Array.<number>} */ this.match = []; // connector indicies
+    /** @type {Array.<number>} */ this.nomatch = [];  // connector indicies
+    /** @type {Array.<number>} */ this.error = []; // connector indicies
+    /** @type {boolean} */ this.emptyHead = true;
 };
 
 /**
@@ -322,10 +322,10 @@ adapt.cssvalid.ValidatingGroup.prototype.addGroup = function(group, how) {
     var index = this.nodes.length;
     // optimization for alternate primitive validators
     if (how == adapt.cssvalid.Add.ALTERNATE && index == 1 && group.isPrimitive() &&
-    		this.isPrimitive()) {
-        this.nodes[0].validator = 
-        	(/** @type {adapt.cssvalid.PrimitiveValidator} */ (this.nodes[0].validator)).combine(
-        			/** @type {adapt.cssvalid.PrimitiveValidator} */ (group.nodes[0].validator));
+        this.isPrimitive()) {
+        this.nodes[0].validator =
+            (/** @type {adapt.cssvalid.PrimitiveValidator} */ (this.nodes[0].validator)).combine(
+                /** @type {adapt.cssvalid.PrimitiveValidator} */ (group.nodes[0].validator));
         return;
     }
     for (var i = 0; i < group.nodes.length; i++) {
@@ -432,7 +432,7 @@ adapt.cssvalid.NO_IDENTS = {};
  * @extends {adapt.css.Visitor}
  */
 adapt.cssvalid.PropertyValidator = function() {
-	adapt.css.Visitor.call(this);
+    adapt.css.Visitor.call(this);
 };
 goog.inherits(adapt.cssvalid.PropertyValidator, adapt.css.Visitor);
 
@@ -460,10 +460,10 @@ adapt.cssvalid.PropertyValidator.prototype.validateForShorthand = function(value
  * @extends {adapt.cssvalid.PropertyValidator}
  */
 adapt.cssvalid.PrimitiveValidator = function(allowed, idents, units) {
-	adapt.cssvalid.PropertyValidator.call(this);
-	/** @const */ this.allowed = allowed;
-	/** @const */ this.idents = idents;
-	/** @const */ this.units = units;
+    adapt.cssvalid.PropertyValidator.call(this);
+    /** @const */ this.allowed = allowed;
+    /** @const */ this.idents = idents;
+    /** @const */ this.units = units;
 };
 goog.inherits(adapt.cssvalid.PrimitiveValidator, adapt.cssvalid.PropertyValidator);
 
@@ -484,7 +484,7 @@ adapt.cssvalid.PrimitiveValidator.prototype.visitSlash = function(slash) {
         return slash;
     return null;
 };
-    
+
 /**
  * @override
  */
@@ -511,8 +511,8 @@ adapt.cssvalid.PrimitiveValidator.prototype.visitIdent = function(ident) {
  */
 adapt.cssvalid.PrimitiveValidator.prototype.visitNumeric = function(numeric) {
     if (numeric.num == 0 && !(this.allowed & adapt.cssvalid.ALLOW_ZERO)) {
-    	if (numeric.unit == "%" && (this.allowed & adapt.cssvalid.ALLOW_ZERO_PERCENT))
-    		return numeric;
+        if (numeric.unit == "%" && (this.allowed & adapt.cssvalid.ALLOW_ZERO_PERCENT))
+            return numeric;
         return null;
     }
     if (numeric.num < 0 && !(this.allowed & adapt.cssvalid.ALLOW_NEGATIVE))
@@ -527,7 +527,7 @@ adapt.cssvalid.PrimitiveValidator.prototype.visitNumeric = function(numeric) {
  */
 adapt.cssvalid.PrimitiveValidator.prototype.visitNum = function(num) {
     if (num.num == 0) {
-    	return this.allowed & adapt.cssvalid.ALLOW_ZERO ? num : null;
+        return this.allowed & adapt.cssvalid.ALLOW_ZERO ? num : null;
     }
     if (num.num <= 0 && !(this.allowed & adapt.cssvalid.ALLOW_NEGATIVE))
         return null;
@@ -541,7 +541,7 @@ adapt.cssvalid.PrimitiveValidator.prototype.visitNum = function(num) {
  */
 adapt.cssvalid.PrimitiveValidator.prototype.visitInt = function(num) {
     if (num.num == 0) {
-    	return this.allowed & adapt.cssvalid.ALLOW_ZERO ? num : null;
+        return this.allowed & adapt.cssvalid.ALLOW_ZERO ? num : null;
     }
     if (num.num <= 0 && !(this.allowed & adapt.cssvalid.ALLOW_NEGATIVE))
         return null;
@@ -625,8 +625,8 @@ adapt.cssvalid.PrimitiveValidator.prototype.combine = function(other) {
 /**
  * @const
  */
-adapt.cssvalid.ALWAYS_FAIL = new adapt.cssvalid.PrimitiveValidator(0, 
-		adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS);
+adapt.cssvalid.ALWAYS_FAIL = new adapt.cssvalid.PrimitiveValidator(0,
+    adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS);
 
 
 /**
@@ -636,11 +636,11 @@ adapt.cssvalid.ALWAYS_FAIL = new adapt.cssvalid.PrimitiveValidator(0,
  * @extends {adapt.cssvalid.PropertyValidator}
  */
 adapt.cssvalid.ListValidator = function(group) {
-	adapt.cssvalid.PropertyValidator.call(this);
+    adapt.cssvalid.PropertyValidator.call(this);
     /** @type {adapt.cssvalid.Node} */ this.successTerminal = new adapt.cssvalid.Node(null);
     /** @type {adapt.cssvalid.Node} */ this.failureTerminal = new adapt.cssvalid.Node(null);
     /** @type {adapt.cssvalid.Node} */ this.first = group.finish(this.successTerminal,
-    		this.failureTerminal);
+        this.failureTerminal);
 };
 goog.inherits(adapt.cssvalid.ListValidator, adapt.cssvalid.PropertyValidator);
 
@@ -683,31 +683,31 @@ adapt.cssvalid.ListValidator.prototype.validateList = function(arr, slice, start
             } else {
                 success = alternatives[current.getAlternate()] == null;
             }
-            current = success ? current.success : current.failure; 
+            current = success ? current.success : current.failure;
         } else {
-        	if (index == 0 && !slice
-        			&& current.validator instanceof adapt.cssvalid.SpaceListValidator 
-        		&& this instanceof adapt.cssvalid.SpaceListValidator) {
-        	  // Special nesting case: validate the input space list as a whole.              
-        		outval = (new adapt.css.SpaceList(arr)).visit(current.validator);
-        		if (outval) {
-        			index = arr.length;
-        			current = current.success;
-        			continue;
-        		}
+            if (index == 0 && !slice
+                && current.validator instanceof adapt.cssvalid.SpaceListValidator
+                && this instanceof adapt.cssvalid.SpaceListValidator) {
+                // Special nesting case: validate the input space list as a whole.
+                outval = (new adapt.css.SpaceList(arr)).visit(current.validator);
+                if (outval) {
+                    index = arr.length;
+                    current = current.success;
+                    continue;
+                }
             } else 	if (index == 0 && !slice
-        			&& current.validator instanceof adapt.cssvalid.CommaListValidator 
-        			&& this instanceof adapt.cssvalid.SpaceListValidator) {
-        	  // Special nesting case: validate the input comma list as a whole.
-        	  outval = (new adapt.css.CommaList(arr)).visit(current.validator);
-        	  if (outval) {
-        			index = arr.length;
-        			current = current.success;
-        			continue;
-        		}
-        	} else {
-        		outval = inval.visit(current.validator);
-        	}
+                && current.validator instanceof adapt.cssvalid.CommaListValidator
+                && this instanceof adapt.cssvalid.SpaceListValidator) {
+                // Special nesting case: validate the input comma list as a whole.
+                outval = (new adapt.css.CommaList(arr)).visit(current.validator);
+                if (outval) {
+                    index = arr.length;
+                    current = current.success;
+                    continue;
+                }
+            } else {
+                outval = inval.visit(current.validator);
+            }
             if (!outval) {
                 current = current.failure;
                 continue;
@@ -753,13 +753,13 @@ adapt.cssvalid.ListValidator.prototype.validateSingle = function(inval) {
         outval = inval.visit(current.validator);
         if (!outval) {
             current = current.failure;
-            continue;            
+            continue;
         }
         inval = null;
         current = current.success;
     }
     if (current === this.successTerminal)
-    	return outval;
+        return outval;
     return null;
 };
 
@@ -823,7 +823,7 @@ adapt.cssvalid.ListValidator.prototype.visitColor = function(color) {
  * @override
  */
 adapt.cssvalid.ListValidator.prototype.visitURL = function(url) {
-	return this.validateSingle(url);
+    return this.validateSingle(url);
 };
 
 /**
@@ -837,7 +837,7 @@ adapt.cssvalid.ListValidator.prototype.visitSpaceList = function(list) {
  * @override
  */
 adapt.cssvalid.ListValidator.prototype.visitCommaList = function(list) {
-	return null;
+    return null;
 };
 
 /**
@@ -861,7 +861,7 @@ adapt.cssvalid.ListValidator.prototype.visitExpr = function(expr) {
  * @extends {adapt.cssvalid.ListValidator}
  */
 adapt.cssvalid.SpaceListValidator = function(group) {
-	adapt.cssvalid.ListValidator.call(this, group);
+    adapt.cssvalid.ListValidator.call(this, group);
 };
 goog.inherits(adapt.cssvalid.SpaceListValidator, adapt.cssvalid.ListValidator);
 
@@ -881,25 +881,25 @@ adapt.cssvalid.SpaceListValidator.prototype.visitSpaceList = function(list) {
  * @override
  */
 adapt.cssvalid.SpaceListValidator.prototype.visitCommaList = function(list) {
-  // Special Case : Issue #156
-  var node = this.first;
-  var hasCommaListValidator = false;
-  while (node) {
-    if (node.validator instanceof adapt.cssvalid.CommaListValidator) {
-      hasCommaListValidator = true;
-      break;
+    // Special Case : Issue #156
+    var node = this.first;
+    var hasCommaListValidator = false;
+    while (node) {
+        if (node.validator instanceof adapt.cssvalid.CommaListValidator) {
+            hasCommaListValidator = true;
+            break;
+        }
+        node = node.failure;
     }
-    node = node.failure;
-  }
-  if (hasCommaListValidator) {
-    var arr = this.validateList(list.values, false, 0);
-    if (arr === list.values)
-      return list;
-    if (!arr)
-      return null;
-    return new adapt.css.CommaList(arr);
-  } 
-  return null;
+    if (hasCommaListValidator) {
+        var arr = this.validateList(list.values, false, 0);
+        if (arr === list.values)
+            return list;
+        if (!arr)
+            return null;
+        return new adapt.css.CommaList(arr);
+    }
+    return null;
 };
 
 
@@ -917,7 +917,7 @@ adapt.cssvalid.SpaceListValidator.prototype.validateForShorthand = function(valu
  * @extends {adapt.cssvalid.ListValidator}
  */
 adapt.cssvalid.CommaListValidator = function(group) {
-	adapt.cssvalid.ListValidator.call(this, group);
+    adapt.cssvalid.ListValidator.call(this, group);
 };
 goog.inherits(adapt.cssvalid.CommaListValidator, adapt.cssvalid.ListValidator);
 
@@ -963,8 +963,8 @@ adapt.cssvalid.CommaListValidator.prototype.validateForShorthand = function(valu
  * @extends {adapt.cssvalid.ListValidator}
  */
 adapt.cssvalid.FuncValidator = function(name, group) {
-	adapt.cssvalid.ListValidator.call(this, group);
-	/** @const */ this.name = name;
+    adapt.cssvalid.ListValidator.call(this, group);
+    /** @const */ this.name = name;
 };
 goog.inherits(adapt.cssvalid.FuncValidator, adapt.cssvalid.ListValidator);
 
@@ -974,7 +974,7 @@ goog.inherits(adapt.cssvalid.FuncValidator, adapt.cssvalid.ListValidator);
 adapt.cssvalid.FuncValidator.prototype.validateSingle = function(inval) {
     return null;
 };
-    
+
 /**
  * @override
  */
@@ -1003,7 +1003,7 @@ adapt.cssvalid.ShorthandSyntaxNode = function() {};
  * @return {number} new index.
  */
 adapt.cssvalid.ShorthandSyntaxNode.prototype.tryParse = function(values, index, shorthandValidator) {
-	return index;
+    return index;
 };
 
 /**
@@ -1021,8 +1021,8 @@ adapt.cssvalid.ShorthandSyntaxNode.prototype.success = function(rval, shorthandV
  * @extends {adapt.cssvalid.ShorthandSyntaxNode}
  */
 adapt.cssvalid.ShorthandSyntaxProperty = function(validatorSet, name) {
-	adapt.cssvalid.ShorthandSyntaxNode.call(this);
-	/** @const */ this.name = name;
+    adapt.cssvalid.ShorthandSyntaxNode.call(this);
+    /** @const */ this.name = name;
     /** @type {adapt.cssvalid.PropertyValidator} */ this.validator = validatorSet.validators[this.name];
 };
 goog.inherits(adapt.cssvalid.ShorthandSyntaxProperty, adapt.cssvalid.ShorthandSyntaxNode);
@@ -1031,24 +1031,24 @@ goog.inherits(adapt.cssvalid.ShorthandSyntaxProperty, adapt.cssvalid.ShorthandSy
  * @override
  */
 adapt.cssvalid.ShorthandSyntaxProperty.prototype.tryParse = function(values, index, shorthandValidator) {
-     if (shorthandValidator.values[this.name]) {
-         return index;
-     }
-     var rvals = this.validator.validateForShorthand(values, index);
-     if (rvals) {
-         var len = rvals.length;
-         var rval = len > 1 ? new adapt.css.SpaceList(rvals) : rvals[0];
-         this.success(rval, shorthandValidator);
-         return index + len;
-     }
-     return index;
+    if (shorthandValidator.values[this.name]) {
+        return index;
+    }
+    var rvals = this.validator.validateForShorthand(values, index);
+    if (rvals) {
+        var len = rvals.length;
+        var rval = len > 1 ? new adapt.css.SpaceList(rvals) : rvals[0];
+        this.success(rval, shorthandValidator);
+        return index + len;
+    }
+    return index;
 };
 
 /**
  * @override
  */
 adapt.cssvalid.ShorthandSyntaxProperty.prototype.success = function(rval, shorthandValidator) {
-     shorthandValidator.values[this.name] = rval;
+    shorthandValidator.values[this.name] = rval;
 };
 
 
@@ -1059,8 +1059,8 @@ adapt.cssvalid.ShorthandSyntaxProperty.prototype.success = function(rval, shorth
  * @extends {adapt.cssvalid.ShorthandSyntaxProperty}
  */
 adapt.cssvalid.ShorthandSyntaxPropertyN = function(validatorSet, names) {
-	adapt.cssvalid.ShorthandSyntaxProperty.call(this, validatorSet, names[0]);
-	/** @const */ this.names = names;
+    adapt.cssvalid.ShorthandSyntaxProperty.call(this, validatorSet, names[0]);
+    /** @const */ this.names = names;
 };
 goog.inherits(adapt.cssvalid.ShorthandSyntaxPropertyN, adapt.cssvalid.ShorthandSyntaxProperty);
 
@@ -1081,9 +1081,9 @@ adapt.cssvalid.ShorthandSyntaxPropertyN.prototype.success = function(rval, short
  * @extends {adapt.cssvalid.ShorthandSyntaxNode}
  */
 adapt.cssvalid.ShorthandSyntaxCompound = function(nodes, slash) {
-	adapt.cssvalid.ShorthandSyntaxNode.call(this);
-	/** @const */ this.nodes = nodes;
-	/** @const */ this.slash = slash;
+    adapt.cssvalid.ShorthandSyntaxNode.call(this);
+    /** @const */ this.nodes = nodes;
+    /** @const */ this.slash = slash;
 };
 goog.inherits(adapt.cssvalid.ShorthandSyntaxCompound, adapt.cssvalid.ShorthandSyntaxNode);
 
@@ -1123,15 +1123,15 @@ adapt.cssvalid.ShorthandValidator = function() {
     /** @type {Array.<adapt.cssvalid.ShorthandSyntaxNode>} */ this.syntax = null;
     /** @type {Array.<string>} */ this.propList = null;
     /** @type {boolean} */ this.error = false;
-	/** @type {adapt.cssvalid.ValueMap} */ this.values = {};
-	/** @type {adapt.cssvalid.ValidatorSet} */ this.validatorSet = null;
+    /** @type {adapt.cssvalid.ValueMap} */ this.values = {};
+    /** @type {adapt.cssvalid.ValidatorSet} */ this.validatorSet = null;
 };
 
 /**
  * @param {adapt.cssvalid.ValidatorSet} validatorSet
  */
 adapt.cssvalid.ShorthandValidator.prototype.setOwner = function(validatorSet) {
-	this.validatorSet = validatorSet;
+    this.validatorSet = validatorSet;
 };
 
 /**
@@ -1243,7 +1243,7 @@ adapt.cssvalid.ShorthandValidator.prototype.visitNumeric = function(numeric) {
 adapt.cssvalid.ShorthandValidator.prototype.visitNum = function(num) {
     return this.validateSingle(num);
 };
- 
+
 /**
  * @override
  */
@@ -1264,7 +1264,7 @@ adapt.cssvalid.ShorthandValidator.prototype.visitColor = function(color) {
 adapt.cssvalid.ShorthandValidator.prototype.visitURL = function(url) {
     return this.validateSingle(url);
 };
- 
+
 /**
  * @override
  */
@@ -1272,7 +1272,7 @@ adapt.cssvalid.ShorthandValidator.prototype.visitSpaceList = function(list) {
     this.validateList(list.values);
     return null;
 };
- 
+
 /**
  * @override
  */
@@ -1302,7 +1302,7 @@ adapt.cssvalid.ShorthandValidator.prototype.visitExpr = function(expr) {
  * @extends {adapt.cssvalid.ShorthandValidator}
  */
 adapt.cssvalid.SimpleShorthandValidator = function() {
-	adapt.cssvalid.ShorthandValidator.call(this);
+    adapt.cssvalid.ShorthandValidator.call(this);
 };
 goog.inherits(adapt.cssvalid.SimpleShorthandValidator, adapt.cssvalid.ShorthandValidator);
 
@@ -1333,7 +1333,7 @@ adapt.cssvalid.SimpleShorthandValidator.prototype.validateList = function(list) 
  * @extends {adapt.cssvalid.ShorthandValidator}
  */
 adapt.cssvalid.InsetsShorthandValidator = function() {
-	adapt.cssvalid.ShorthandValidator.call(this);
+    adapt.cssvalid.ShorthandValidator.call(this);
 };
 goog.inherits(adapt.cssvalid.InsetsShorthandValidator, adapt.cssvalid.ShorthandValidator);
 
@@ -1371,7 +1371,7 @@ adapt.cssvalid.InsetsShorthandValidator.prototype.createSyntaxNode = function() 
  * @extends {adapt.cssvalid.ShorthandValidator}
  */
 adapt.cssvalid.InsetsSlashShorthandValidator = function() {
-	adapt.cssvalid.ShorthandValidator.call(this);
+    adapt.cssvalid.ShorthandValidator.call(this);
 };
 goog.inherits(adapt.cssvalid.InsetsSlashShorthandValidator, adapt.cssvalid.ShorthandValidator);
 
@@ -1419,7 +1419,7 @@ adapt.cssvalid.InsetsSlashShorthandValidator.prototype.validateList = function(l
  * @extends {adapt.cssvalid.SimpleShorthandValidator}
  */
 adapt.cssvalid.CommaShorthandValidator = function() {
-	adapt.cssvalid.SimpleShorthandValidator.call(this);
+    adapt.cssvalid.SimpleShorthandValidator.call(this);
 };
 goog.inherits(adapt.cssvalid.CommaShorthandValidator, adapt.cssvalid.SimpleShorthandValidator);
 
@@ -1476,7 +1476,7 @@ adapt.cssvalid.CommaShorthandValidator.prototype.visitCommaList = function(list)
  * @extends {adapt.cssvalid.SimpleShorthandValidator}
  */
 adapt.cssvalid.FontShorthandValidator = function() {
-	adapt.cssvalid.SimpleShorthandValidator.call(this);
+    adapt.cssvalid.SimpleShorthandValidator.call(this);
 };
 goog.inherits(adapt.cssvalid.FontShorthandValidator, adapt.cssvalid.SimpleShorthandValidator);
 
@@ -1484,7 +1484,7 @@ goog.inherits(adapt.cssvalid.FontShorthandValidator, adapt.cssvalid.SimpleShorth
  * @override
  */
 adapt.cssvalid.FontShorthandValidator.prototype.init = function(syntax, propList) {
-	adapt.cssvalid.SimpleShorthandValidator.prototype.init.call(this, syntax, propList);
+    adapt.cssvalid.SimpleShorthandValidator.prototype.init.call(this, syntax, propList);
     this.propList.push("font-family", "line-height", "font-size");
 };
 
@@ -1492,7 +1492,7 @@ adapt.cssvalid.FontShorthandValidator.prototype.init = function(syntax, propList
  * @override
  */
 adapt.cssvalid.FontShorthandValidator.prototype.validateList = function(list) {
-    var index = adapt.cssvalid.SimpleShorthandValidator.prototype.validateList.call(this,list);
+    var index = adapt.cssvalid.SimpleShorthandValidator.prototype.validateList.call(this, list);
     // must at least have font-size and font-family at the end
     if (index + 2 > list.length) {
         this.error = true;
@@ -1582,21 +1582,21 @@ adapt.cssvalid.shorthandValidators = {
  * @constructor
  */
 adapt.cssvalid.ValidatorSet = function() {
-	/** @type {Object.<string,adapt.cssvalid.PropertyValidator>} */ this.validators = {};
-	/** @type {Object.<string,Object.<string,boolean>>} */ this.prefixes = {};
-	/** @type {adapt.cssvalid.ValueMap} */ this.defaultValues = {};
-	/** @type {Object.<string,adapt.cssvalid.ValidatingGroup>} */ this.namedValidators = {};
-	/** @type {Object.<string,adapt.cssvalid.ValueMap>} */ this.systemFonts = {};
-	/** @type {Object.<string,adapt.cssvalid.ShorthandValidator>} */ this.shorthands = {};
-	/** @type {adapt.cssvalid.ValueMap} */ this.layoutProps = [];
-	/** @type {adapt.cssvalid.ValueMap} */ this.backgroundProps = [];
+    /** @type {Object.<string,adapt.cssvalid.PropertyValidator>} */ this.validators = {};
+    /** @type {Object.<string,Object.<string,boolean>>} */ this.prefixes = {};
+    /** @type {adapt.cssvalid.ValueMap} */ this.defaultValues = {};
+    /** @type {Object.<string,adapt.cssvalid.ValidatingGroup>} */ this.namedValidators = {};
+    /** @type {Object.<string,adapt.cssvalid.ValueMap>} */ this.systemFonts = {};
+    /** @type {Object.<string,adapt.cssvalid.ShorthandValidator>} */ this.shorthands = {};
+    /** @type {adapt.cssvalid.ValueMap} */ this.layoutProps = [];
+    /** @type {adapt.cssvalid.ValueMap} */ this.backgroundProps = [];
 };
 
 /**
  * @private
  * @param {adapt.cssvalid.ValidatingGroup} val
  * @param {adapt.csstok.Token} token
- * @return {adapt.cssvalid.ValidatingGroup} 
+ * @return {adapt.cssvalid.ValidatingGroup}
  */
 adapt.cssvalid.ValidatorSet.prototype.addReplacement = function(val, token) {
     /** @type {adapt.css.Val} */ var cssval;
@@ -1610,7 +1610,7 @@ adapt.cssvalid.ValidatorSet.prototype.addReplacement = function(val, token) {
         throw new Error("unexpected replacement");
     }
     if (val.isPrimitive()) {
-    	var validator = /** @type {adapt.cssvalid.PrimitiveValidator} */ (val.nodes[0].validator);
+        var validator = /** @type {adapt.cssvalid.PrimitiveValidator} */ (val.nodes[0].validator);
         var idents = validator.idents;
         for (var ident in idents) {
             idents[ident] = cssval;
@@ -1652,7 +1652,7 @@ adapt.cssvalid.ValidatorSet.prototype.newGroup = function(op, vals) {
                 how = adapt.cssvalid.Add.ALTERNATE;
                 break;
             default:
-            	throw new Error("unexpected op");
+                throw new Error("unexpected op");
         }
         for (var i = 0; i < vals.length; i++) {
             group.addGroup(vals[i], (i == 0 ? adapt.cssvalid.Add.FOLLOW : how));
@@ -1722,68 +1722,68 @@ adapt.cssvalid.ValidatorSet.prototype.newFunc = function(fn, val) {
  */
 adapt.cssvalid.ValidatorSet.prototype.initBuiltInValidators = function() {
     this.namedValidators["HASHCOLOR"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_COLOR, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_COLOR, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["POS_INT"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_INT, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_POS_INT, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["POS_NUM"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_NUM, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_POS_NUM, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["POS_PERCENTAGE"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
-		         "%": adapt.css.empty
-		    }));
+        adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
+            "%": adapt.css.empty
+        }));
     this.namedValidators["NEGATIVE"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_NEGATIVE, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_NEGATIVE, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["ZERO"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_ZERO, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_ZERO, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["ZERO_PERCENTAGE"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_ZERO_PERCENT, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_ZERO_PERCENT, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["POS_LENGTH"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
-		        "em": adapt.css.empty,
-		        "ex": adapt.css.empty,
-		        "ch": adapt.css.empty,
-		        "rem": adapt.css.empty,
-		        "vh": adapt.css.empty,
-		        "vw": adapt.css.empty,
-		        "vmin": adapt.css.empty,
-		        "vmax": adapt.css.empty,
-		        "cm": adapt.css.empty,
-		        "mm": adapt.css.empty,
-		        "in": adapt.css.empty,
-		        "px": adapt.css.empty,
-		        "pt": adapt.css.empty,
-		        "pc": adapt.css.empty,
-                "q": adapt.css.empty
-		    }));
+        adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
+            "em": adapt.css.empty,
+            "ex": adapt.css.empty,
+            "ch": adapt.css.empty,
+            "rem": adapt.css.empty,
+            "vh": adapt.css.empty,
+            "vw": adapt.css.empty,
+            "vmin": adapt.css.empty,
+            "vmax": adapt.css.empty,
+            "cm": adapt.css.empty,
+            "mm": adapt.css.empty,
+            "in": adapt.css.empty,
+            "px": adapt.css.empty,
+            "pt": adapt.css.empty,
+            "pc": adapt.css.empty,
+            "q": adapt.css.empty
+        }));
     this.namedValidators["POS_ANGLE"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
-		        "deg": adapt.css.empty,
-		        "grad": adapt.css.empty,
-		        "rad": adapt.css.empty,
-		        "turn": adapt.css.empty
-		    }));
+        adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
+            "deg": adapt.css.empty,
+            "grad": adapt.css.empty,
+            "rad": adapt.css.empty,
+            "turn": adapt.css.empty
+        }));
     this.namedValidators["POS_TIME"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
-		        "s": adapt.css.empty,
-		        "ms": adapt.css.empty
-		    }));
+        adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
+            "s": adapt.css.empty,
+            "ms": adapt.css.empty
+        }));
     this.namedValidators["FREQUENCY"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
-		        "Hz": adapt.css.empty,
-		        "kHz": adapt.css.empty
-		    }));
+        adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
+            "Hz": adapt.css.empty,
+            "kHz": adapt.css.empty
+        }));
     this.namedValidators["RESOLUTION"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
-		        "dpi": adapt.css.empty,
-		        "dpcm": adapt.css.empty,
-		        "dppx": adapt.css.empty
-		    }));
+        adapt.cssvalid.ALLOW_POS_NUMERIC, adapt.cssvalid.NO_IDENTS, {
+            "dpi": adapt.css.empty,
+            "dpcm": adapt.css.empty,
+            "dppx": adapt.css.empty
+        }));
     this.namedValidators["URI"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_URL, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_URL, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["IDENT"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_IDENT, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_IDENT, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
     this.namedValidators["STRING"] = this.primitive(new adapt.cssvalid.PrimitiveValidator(
-    		adapt.cssvalid.ALLOW_STR, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
+        adapt.cssvalid.ALLOW_STR, adapt.cssvalid.NO_IDENTS, adapt.cssvalid.NO_IDENTS));
 
     var stdfont = {
         "font-family": adapt.css.getName("sans-serif")
@@ -1874,11 +1874,11 @@ adapt.cssvalid.ValidatorSet.prototype.parseValidators = function(tok) {
         var val;
         var expectval = true;
         var self = this;
-        
+
         /**
          * @return {adapt.cssvalid.ValidatingGroup}
          */
-        var reduce = function () {
+        var reduce = function() {
             if (vals.length == 0)
                 throw new Error("No values");
             if (vals.length == 1)
@@ -2007,9 +2007,9 @@ adapt.cssvalid.ValidatorSet.prototype.parseValidators = function(tok) {
                         token = tok.token();
                     }
                     if (token.type != adapt.csstok.TokenType.C_BRC)
-                       throw new Error("'}' expected");
+                        throw new Error("'}' expected");
                     vals.push(this.addCounts(vals.pop(), min, max));
-                    break;                    
+                    break;
                 case adapt.csstok.TokenType.SEMICOL:
                     result = reduce();
                     if (stack.length > 0)
@@ -2087,7 +2087,7 @@ adapt.cssvalid.ValidatorSet.prototype.parseShorthands = function(tok) {
             shorthandValidator = new adapt.cssvalid.shorthandValidators[token.text]();
             tok.consume();
         } else {
-        	shorthandValidator = new adapt.cssvalid.SimpleShorthandValidator();
+            shorthandValidator = new adapt.cssvalid.SimpleShorthandValidator();
         }
         shorthandValidator.setOwner(this);
         var result = false;
@@ -2103,15 +2103,15 @@ adapt.cssvalid.ValidatorSet.prototype.parseShorthands = function(tok) {
                     if (this.validators[token.text]) {
                         syntax.push(shorthandValidator.syntaxNodeForProperty(token.text));
                         propList.push(token.text);
-                    } else if (this.shorthands[token.text] instanceof 
-                    		adapt.cssvalid.InsetsShorthandValidator) {
-                        var insetShorthand = /** @type {adapt.cssvalid.InsetsShorthandValidator} */ 
-                        	(this.shorthands[token.text]);
+                    } else if (this.shorthands[token.text] instanceof
+                        adapt.cssvalid.InsetsShorthandValidator) {
+                        var insetShorthand = /** @type {adapt.cssvalid.InsetsShorthandValidator} */
+                            (this.shorthands[token.text]);
                         syntax.push(insetShorthand.createSyntaxNode());
                         propList.push.apply(propList, insetShorthand.propList);
                     } else {
-                        throw new Error('\'' + token.text + 
-                        		'\' is neither a simple property nor an inset shorthand');
+                        throw new Error('\'' + token.text +
+                            '\' is neither a simple property nor an inset shorthand');
                     }
                     break;
                 case adapt.csstok.TokenType.SLASH :
@@ -2157,29 +2157,29 @@ adapt.cssvalid.ValidatorSet.prototype.parse = function(text) {
     this.parseShorthands(tok);
     this.backgroundProps = this.makePropSet(["background"]);
     this.layoutProps = this.makePropSet(["margin", "border", "padding",
-                                         "columns", "column-gap", "column-rule", "column-fill"]);
+        "columns", "column-gap", "column-rule", "column-fill"]);
 };
 
 /**
  * @param {Array.<string>} propList
  */
 adapt.cssvalid.ValidatorSet.prototype.makePropSet = function(propList) {
-	var map = {};
-	for (var i = 0; i < propList.length; i++) {
-		var prop = propList[i];
-		var shorthand = this.shorthands[prop];
-		var list = shorthand ? shorthand.propList : [prop];
-		for (var k = 0; k < list.length; k++) {
-			var pname = list[k];
-			var pval = this.defaultValues[pname];
-			if (!pval) {
+    var map = {};
+    for (var i = 0; i < propList.length; i++) {
+        var prop = propList[i];
+        var shorthand = this.shorthands[prop];
+        var list = shorthand ? shorthand.propList : [prop];
+        for (var k = 0; k < list.length; k++) {
+            var pname = list[k];
+            var pval = this.defaultValues[pname];
+            if (!pval) {
                 vivliostyle.logging.logger.warn("Unknown property in makePropSet:", pname);
-			} else {
-				map[pname] = pval;
-			}
-		}
-	}
-	return map;
+            } else {
+                map[pname] = pval;
+            }
+        }
+    }
+    return map;
 };
 
 /**
@@ -2189,66 +2189,66 @@ adapt.cssvalid.ValidatorSet.prototype.makePropSet = function(propList) {
  * @param {adapt.cssvalid.PropertyReceiver} receiver
  * @return {void}
  */
-adapt.cssvalid.ValidatorSet.prototype.validatePropertyAndHandleShorthand = 
-		function(name, value, important, receiver) {
-    var prefix = "";
-    var origName = name;
-    name = name.toLowerCase();
-    var r = name.match(/^-([a-z]+)-([-a-z0-9]+)$/);
-    if (r) {
-        prefix = r[1];
-        name = r[2];
-    }
-    var px = this.prefixes[name];
-    if (!px || !px[prefix]) {
-        receiver.unknownProperty(origName, value);
-        return;
-    }
-    var validator = this.validators[name];
-    if (validator) {
-        var rvalue = value === adapt.css.ident.inherit || value.isExpr() ? value : value.visit(validator);
-        if (rvalue) {
-            receiver.simpleProperty(name, rvalue, important);
-        } else {
-            receiver.invalidPropertyValue(origName, value);
+adapt.cssvalid.ValidatorSet.prototype.validatePropertyAndHandleShorthand =
+    function(name, value, important, receiver) {
+        var prefix = "";
+        var origName = name;
+        name = name.toLowerCase();
+        var r = name.match(/^-([a-z]+)-([-a-z0-9]+)$/);
+        if (r) {
+            prefix = r[1];
+            name = r[2];
         }
-    } else {
-        var shorthand = this.shorthands[name].clone();
-        if (value === adapt.css.ident.inherit) {
-            shorthand.propagateInherit(important, receiver);
-        } else {
-            value.visit(shorthand);
-            if (!shorthand.finish(important, receiver)) {
+        var px = this.prefixes[name];
+        if (!px || !px[prefix]) {
+            receiver.unknownProperty(origName, value);
+            return;
+        }
+        var validator = this.validators[name];
+        if (validator) {
+            var rvalue = value === adapt.css.ident.inherit || value.isExpr() ? value : value.visit(validator);
+            if (rvalue) {
+                receiver.simpleProperty(name, rvalue, important);
+            } else {
                 receiver.invalidPropertyValue(origName, value);
             }
+        } else {
+            var shorthand = this.shorthands[name].clone();
+            if (value === adapt.css.ident.inherit) {
+                shorthand.propagateInherit(important, receiver);
+            } else {
+                value.visit(shorthand);
+                if (!shorthand.finish(important, receiver)) {
+                    receiver.invalidPropertyValue(origName, value);
+                }
+            }
         }
-    }
-};
+    };
 
 
 /**
  * @type {adapt.taskutil.Fetcher.<adapt.cssvalid.ValidatorSet>}
  */
 adapt.cssvalid.validatorFetcher = new adapt.taskutil.Fetcher(function() {
-	/** @type {!adapt.task.Frame.<adapt.cssvalid.ValidatorSet>} */ var frame =
-		adapt.task.newFrame("loadValidatorSet.load");
+    /** @type {!adapt.task.Frame.<adapt.cssvalid.ValidatorSet>} */ var frame =
+        adapt.task.newFrame("loadValidatorSet.load");
     var url = adapt.base.resolveURL("validation.txt", adapt.base.resourceBaseURL);
     var result = adapt.net.ajax(url);
     var validatorSet = new adapt.cssvalid.ValidatorSet();
     validatorSet.initBuiltInValidators();
     result.then(function(xhr) {
         try {
-        	if (xhr.responseText) {
-        		validatorSet.parse(xhr.responseText);
-        	} else {
+            if (xhr.responseText) {
+                validatorSet.parse(xhr.responseText);
+            } else {
                 vivliostyle.logging.logger.error("Error: missing", url);
-        	}
+            }
         } catch (err) {
             vivliostyle.logging.logger.error(err, "Error:");
         }
         frame.finish(validatorSet);
     });
-    return frame.result();	
+    return frame.result();
 }, "validatorFetcher");
 
 /**

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -28,12 +28,12 @@ adapt.epub.Position;
  * @extends {adapt.ops.OPSDocStore}
  */
 adapt.epub.EPUBDocStore = function() {
-	adapt.ops.OPSDocStore.call(this, this.makeDeobfuscatorFactory());
-	/** @const */ this.plainXMLStore = adapt.xmldoc.newXMLDocStore();
-	/** @const */ this.jsonStore = adapt.net.newJSONStore();
-	/** @type {Object.<string,adapt.epub.OPFDoc>} */ this.opfByURL = {};
-	/** @type {Object.<string,adapt.epub.OPFDoc>} */ this.primaryOPFByEPubURL = {};
-	/** @type {Object.<string,function(Blob):adapt.task.Result.<Blob>>} */ this.deobfuscators = {};
+    adapt.ops.OPSDocStore.call(this, this.makeDeobfuscatorFactory());
+    /** @const */ this.plainXMLStore = adapt.xmldoc.newXMLDocStore();
+    /** @const */ this.jsonStore = adapt.net.newJSONStore();
+    /** @type {Object.<string,adapt.epub.OPFDoc>} */ this.opfByURL = {};
+    /** @type {Object.<string,adapt.epub.OPFDoc>} */ this.primaryOPFByEPubURL = {};
+    /** @type {Object.<string,function(Blob):adapt.task.Result.<Blob>>} */ this.deobfuscators = {};
     /** @type {Object.<string,!adapt.task.Result.<adapt.xmldoc.XMLDocHolder>>} */ this.documents = {};
 };
 goog.inherits(adapt.epub.EPUBDocStore, adapt.ops.OPSDocStore);
@@ -42,16 +42,16 @@ goog.inherits(adapt.epub.EPUBDocStore, adapt.ops.OPSDocStore);
  * @return {?function(string):?function(Blob):adapt.task.Result.<Blob>}
  */
 adapt.epub.EPUBDocStore.prototype.makeDeobfuscatorFactory = function() {
-	var self = this;
-	return (
-	/**
-	 * @param {string} url
-	 * @return {?function(Blob):adapt.task.Result.<Blob>}
-	 */
-	function(url) {
-		return self.deobfuscators[url];
-	}
-	);
+    var self = this;
+    return (
+        /**
+         * @param {string} url
+         * @return {?function(Blob):adapt.task.Result.<Blob>}
+         */
+        function(url) {
+            return self.deobfuscators[url];
+        }
+    );
 };
 
 /**
@@ -61,7 +61,7 @@ adapt.epub.EPUBDocStore.prototype.makeDeobfuscatorFactory = function() {
  * @return {!adapt.task.Result.<adapt.xmldoc.XMLDocHolder>}
  */
 adapt.epub.EPUBDocStore.prototype.loadAsPlainXML = function(url, opt_required, opt_message) {
-	return this.plainXMLStore.load(url, opt_required, opt_message);
+    return this.plainXMLStore.load(url, opt_required, opt_message);
 };
 
 /**
@@ -69,7 +69,7 @@ adapt.epub.EPUBDocStore.prototype.loadAsPlainXML = function(url, opt_required, o
  * @return {void}
  */
 adapt.epub.EPUBDocStore.prototype.startLoadingAsPlainXML = function(url) {
-	this.plainXMLStore.fetch(url);	
+    this.plainXMLStore.fetch(url);
 };
 
 /**
@@ -77,7 +77,7 @@ adapt.epub.EPUBDocStore.prototype.startLoadingAsPlainXML = function(url) {
  * @return {!adapt.task.Result.<adapt.base.JSON>}
  */
 adapt.epub.EPUBDocStore.prototype.loadAsJSON = function(url) {
-	return this.jsonStore.load(url);	
+    return this.jsonStore.load(url);
 };
 
 /**
@@ -85,7 +85,7 @@ adapt.epub.EPUBDocStore.prototype.loadAsJSON = function(url) {
  * @return {void}
  */
 adapt.epub.EPUBDocStore.prototype.startLoadingAsJSON = function(url) {
-	this.jsonStore.fetch(url);	
+    this.jsonStore.fetch(url);
 };
 
 /**
@@ -94,34 +94,34 @@ adapt.epub.EPUBDocStore.prototype.startLoadingAsJSON = function(url) {
  * @return {!adapt.task.Result.<adapt.epub.OPFDoc>}
  */
 adapt.epub.EPUBDocStore.prototype.loadEPUBDoc = function(url, haveZipMetadata) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.epub.OPFDoc>} */ var frame
-		= adapt.task.newFrame("loadEPUBDoc");
-	if (url.substring(url.length - 1) !== "/") {
-		url = url + "/";
-	}
-	if (haveZipMetadata) {
-		self.startLoadingAsJSON(url + "?r=list");
-	}
-	self.startLoadingAsPlainXML(url + "META-INF/encryption.xml");
-	var containerURL = url + "META-INF/container.xml";
-	self.loadAsPlainXML(containerURL, true, "Failed to fetch EPUB container.xml from " + containerURL).then(function(containerXML){
-		if (!containerXML) {
-			vivliostyle.logging.logger.error("Received an empty response for EPUB container.xml " + containerURL + ". This may be caused by the server not allowing cross origin requests.");
-		} else {
-			var roots = containerXML.doc().child("container").child("rootfiles")
-				.child("rootfile").attribute("full-path");
-			for (var i = 0; i < roots.length; i++) {
-				var root = roots[i];
-				if (root) {
-					self.loadOPF(url, root, haveZipMetadata).thenFinish(frame);
-					return;
-				}
-			}
-			frame.finish(null);
-		}
-	});
-	return frame.result();
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.epub.OPFDoc>} */ var frame
+        = adapt.task.newFrame("loadEPUBDoc");
+    if (url.substring(url.length - 1) !== "/") {
+        url = url + "/";
+    }
+    if (haveZipMetadata) {
+        self.startLoadingAsJSON(url + "?r=list");
+    }
+    self.startLoadingAsPlainXML(url + "META-INF/encryption.xml");
+    var containerURL = url + "META-INF/container.xml";
+    self.loadAsPlainXML(containerURL, true, "Failed to fetch EPUB container.xml from " + containerURL).then(function(containerXML) {
+        if (!containerXML) {
+            vivliostyle.logging.logger.error("Received an empty response for EPUB container.xml " + containerURL + ". This may be caused by the server not allowing cross origin requests.");
+        } else {
+            var roots = containerXML.doc().child("container").child("rootfiles")
+                .child("rootfile").attribute("full-path");
+            for (var i = 0; i < roots.length; i++) {
+                var root = roots[i];
+                if (root) {
+                    self.loadOPF(url, root, haveZipMetadata).thenFinish(frame);
+                    return;
+                }
+            }
+            frame.finish(null);
+        }
+    });
+    return frame.result();
 };
 
 /**
@@ -131,33 +131,33 @@ adapt.epub.EPUBDocStore.prototype.loadEPUBDoc = function(url, haveZipMetadata) {
  * @return {!adapt.task.Result.<adapt.epub.OPFDoc>}
  */
 adapt.epub.EPUBDocStore.prototype.loadOPF = function(epubURL, root, haveZipMetadata) {
-	var self = this;
-	var url = epubURL + root;
-	var opf = self.opfByURL[url];
-	if (opf) {
-		return adapt.task.newResult(opf);
-	}
-	/** @type {!adapt.task.Frame.<adapt.epub.OPFDoc>} */ var frame
-		= adapt.task.newFrame("loadOPF");
-	self.loadAsPlainXML(url).then(function(opfXML){
-		if (!opfXML) {
-			vivliostyle.logging.logger.error("Received an empty response for EPUB OPF " + url + ". This may be caused by the server not allowing cross origin requests.");
-		} else {
-			self.loadAsPlainXML(epubURL + "META-INF/encryption.xml").then(function (encXML) {
-				var zipMetadataResult = haveZipMetadata ?
-					self.loadAsJSON(epubURL + "?r=list") : adapt.task.newResult(null);
-				zipMetadataResult.then(function (zipMetadata) {
-					opf = new adapt.epub.OPFDoc(self, epubURL);
-					opf.initWithXMLDoc(opfXML, encXML, zipMetadata, epubURL + "?r=manifest").then(function () {
-						self.opfByURL[url] = opf;
-						self.primaryOPFByEPubURL[epubURL] = opf;
-						frame.finish(opf);
-					});
-				});
-			});
-		}
-	});
-	return frame.result();
+    var self = this;
+    var url = epubURL + root;
+    var opf = self.opfByURL[url];
+    if (opf) {
+        return adapt.task.newResult(opf);
+    }
+    /** @type {!adapt.task.Frame.<adapt.epub.OPFDoc>} */ var frame
+        = adapt.task.newFrame("loadOPF");
+    self.loadAsPlainXML(url).then(function(opfXML) {
+        if (!opfXML) {
+            vivliostyle.logging.logger.error("Received an empty response for EPUB OPF " + url + ". This may be caused by the server not allowing cross origin requests.");
+        } else {
+            self.loadAsPlainXML(epubURL + "META-INF/encryption.xml").then(function(encXML) {
+                var zipMetadataResult = haveZipMetadata ?
+                    self.loadAsJSON(epubURL + "?r=list") : adapt.task.newResult(null);
+                zipMetadataResult.then(function(zipMetadata) {
+                    opf = new adapt.epub.OPFDoc(self, epubURL);
+                    opf.initWithXMLDoc(opfXML, encXML, zipMetadata, epubURL + "?r=manifest").then(function() {
+                        self.opfByURL[url] = opf;
+                        self.primaryOPFByEPubURL[epubURL] = opf;
+                        frame.finish(opf);
+                    });
+                });
+            });
+        }
+    });
+    return frame.result();
 };
 
 /**
@@ -183,16 +183,16 @@ adapt.epub.EPUBDocStore.prototype.load = function(url) {
     if (r) {
         return r.isPending() ? r : adapt.task.newResult(r.get());
     } else {
-		var frame = adapt.task.newFrame("EPUBDocStore.load");
-		r = adapt.epub.EPUBDocStore.superClass_.load.call(this, docURL, true, "Failed to fetch a source document from " + docURL);
-		r.then(function(xmldoc) {
-			if (!xmldoc) {
-				vivliostyle.logging.logger.error("Received an empty response for " + docURL + ". This may be caused by the server not allowing cross origin requests.");
-			} else {
-				frame.finish(xmldoc);
-			}
-		});
-		return frame.result();
+        var frame = adapt.task.newFrame("EPUBDocStore.load");
+        r = adapt.epub.EPUBDocStore.superClass_.load.call(this, docURL, true, "Failed to fetch a source document from " + docURL);
+        r.then(function(xmldoc) {
+            if (!xmldoc) {
+                vivliostyle.logging.logger.error("Received an empty response for " + docURL + ". This may be caused by the server not allowing cross origin requests.");
+            } else {
+                frame.finish(xmldoc);
+            }
+        });
+        return frame.result();
     }
 };
 
@@ -210,18 +210,18 @@ adapt.epub.OPFItemParam;
  * @constructor
  */
 adapt.epub.OPFItem = function() {
-	/** @type {?string} */ this.id = null;
-	/** @type {string} */ this.src = "";
-	/** @type {?string} */ this.mediaType = null;
-	/** @type {Element} */ this.itemRefElement = null;
-	/** @type {number} */ this.spineIndex = -1;
-	/** @type {number} */ this.compressedSize = 0;
-	/** @type {?boolean} */ this.compressed = null;
-	/** @type {number} */ this.epage = 0;
-	/** @type {number} */ this.epageCount = 0;
-	/** @type {?number} */ this.startPage = null;
-	/** @type {?number} */ this.skipPagesBefore = null;
-	/** @type {Object.<string,boolean>} */ this.itemProperties = adapt.base.emptyObj;
+    /** @type {?string} */ this.id = null;
+    /** @type {string} */ this.src = "";
+    /** @type {?string} */ this.mediaType = null;
+    /** @type {Element} */ this.itemRefElement = null;
+    /** @type {number} */ this.spineIndex = -1;
+    /** @type {number} */ this.compressedSize = 0;
+    /** @type {?boolean} */ this.compressed = null;
+    /** @type {number} */ this.epage = 0;
+    /** @type {number} */ this.epageCount = 0;
+    /** @type {?number} */ this.startPage = null;
+    /** @type {?number} */ this.skipPagesBefore = null;
+    /** @type {Object.<string,boolean>} */ this.itemProperties = adapt.base.emptyObj;
 };
 
 /**
@@ -230,24 +230,24 @@ adapt.epub.OPFItem = function() {
  * @return {void}
  */
 adapt.epub.OPFItem.prototype.initWithElement = function(itemElem, opfURL) {
-	this.id = itemElem.getAttribute("id");
-	this.src = adapt.base.resolveURL(itemElem.getAttribute("href"), opfURL);
-	this.mediaType = itemElem.getAttribute("media-type");
-	var propStr = itemElem.getAttribute("properties");
-	if (propStr) {
-		this.itemProperties = adapt.base.arrayToSet(propStr.split(/\s+/));
-	}
+    this.id = itemElem.getAttribute("id");
+    this.src = adapt.base.resolveURL(itemElem.getAttribute("href"), opfURL);
+    this.mediaType = itemElem.getAttribute("media-type");
+    var propStr = itemElem.getAttribute("properties");
+    if (propStr) {
+        this.itemProperties = adapt.base.arrayToSet(propStr.split(/\s+/));
+    }
 };
 
 /**
  * @param {!adapt.epub.OPFItemParam} param
  */
 adapt.epub.OPFItem.prototype.initWithParam = function(param) {
-	this.spineIndex = param.index;
-	this.id = "item" + (param.index+1);
-	this.src = param.url;
-	this.startPage = param.startPage;
-	this.skipPagesBefore = param.skipPagesBefore;
+    this.spineIndex = param.index;
+    this.id = "item" + (param.index+1);
+    this.src = param.url;
+    this.startPage = param.startPage;
+    this.skipPagesBefore = param.skipPagesBefore;
 };
 
 /**
@@ -255,7 +255,7 @@ adapt.epub.OPFItem.prototype.initWithParam = function(param) {
  * @return {?string}
  */
 adapt.epub.getOPFItemId = function(item) {
-	return item.id;
+    return item.id;
 };
 
 /**
@@ -263,30 +263,30 @@ adapt.epub.getOPFItemId = function(item) {
  * @return {function(Blob):adapt.task.Result.<Blob>}
  */
 adapt.epub.makeDeobfuscator = function(uid) {
-	// TODO: use UTF8 of uid
-	var sha1 = adapt.sha1.bytesToSHA1Int8(uid);
-	return /** @param {Blob} blob */ function(blob) {
-		var frame = /** @type {adapt.task.Frame.<Blob>} */ (adapt.task.newFrame("deobfuscator"));
-		var head;
-		var tail;
-		if (blob.slice) {
-			head = blob.slice(0, 1040);
-			tail = blob.slice(1040, blob.size);
-		} else {
-			head = blob["webkitSlice"](0, 1040);
-			tail = blob["webkitSlice"](1040, blob.size - 1040);			
-		}
-		adapt.net.readBlob(head).then(function(buf) {
-			var dataView = new DataView(buf);
-			for (var k = 0; k < dataView.byteLength; k++) {
-				var b = dataView.getUint8(k);
-				b ^= sha1[k % 20];
-				dataView.setUint8(k, b);
-			}
-			frame.finish(adapt.net.makeBlob([dataView, tail]));
-		});
-		return frame.result();
-	};
+    // TODO: use UTF8 of uid
+    var sha1 = adapt.sha1.bytesToSHA1Int8(uid);
+    return /** @param {Blob} blob */ function(blob) {
+        var frame = /** @type {adapt.task.Frame.<Blob>} */ (adapt.task.newFrame("deobfuscator"));
+        var head;
+        var tail;
+        if (blob.slice) {
+            head = blob.slice(0, 1040);
+            tail = blob.slice(1040, blob.size);
+        } else {
+            head = blob["webkitSlice"](0, 1040);
+            tail = blob["webkitSlice"](1040, blob.size - 1040);
+        }
+        adapt.net.readBlob(head).then(function(buf) {
+            var dataView = new DataView(buf);
+            for (var k = 0; k < dataView.byteLength; k++) {
+                var b = dataView.getUint8(k);
+                b ^= sha1[k % 20];
+                dataView.setUint8(k, b);
+            }
+            frame.finish(adapt.net.makeBlob([dataView, tail]));
+        });
+        return frame.result();
+    };
 };
 
 /**
@@ -294,7 +294,7 @@ adapt.epub.makeDeobfuscator = function(uid) {
  * @return {string}
  */
 adapt.epub.makeObfuscationKey = function(uid) {
-	return "1040:" + adapt.sha1.bytesToSHA1Hex(uid);	
+    return "1040:" + adapt.sha1.bytesToSHA1Hex(uid);
 };
 
 /**
@@ -314,11 +314,11 @@ adapt.epub.RawMetaItem;
  * @const
  */
 adapt.epub.predefinedPrefixes = {
-	"dcterms": "http://purl.org/dc/terms/",
-	"marc": "http://id.loc.gov/vocabulary/",
-	"media": "http://www.idpf.org/epub/vocab/overlays/#",
-	"onix":	"http://www.editeur.org/ONIX/book/codelists/current.html#",
-	"xsd": "http://www.w3.org/2001/XMLSchema#"
+    "dcterms": "http://purl.org/dc/terms/",
+    "marc": "http://id.loc.gov/vocabulary/",
+    "media": "http://www.idpf.org/epub/vocab/overlays/#",
+    "onix":	"http://www.editeur.org/ONIX/book/codelists/current.html#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
 };
 
 /**
@@ -331,12 +331,12 @@ adapt.epub.defaultIRI = "http://idpf.org/epub/vocab/package/#";
  * @const
  */
 adapt.epub.metaTerms = {
-	language: adapt.epub.predefinedPrefixes["dcterms"] + "language",
-	title: adapt.epub.predefinedPrefixes["dcterms"] + "title",
-	creator: adapt.epub.predefinedPrefixes["dcterms"] + "creator",
-	titleType: adapt.epub.defaultIRI + "title-type",
-	displaySeq: adapt.epub.defaultIRI + "display-seq",
-	alternateScript: adapt.epub.defaultIRI + "alternate-script"
+    language: adapt.epub.predefinedPrefixes["dcterms"] + "language",
+    title: adapt.epub.predefinedPrefixes["dcterms"] + "title",
+    creator: adapt.epub.predefinedPrefixes["dcterms"] + "creator",
+    titleType: adapt.epub.defaultIRI + "title-type",
+    displaySeq: adapt.epub.defaultIRI + "display-seq",
+    alternateScript: adapt.epub.defaultIRI + "alternate-script"
 };
 
 /**
@@ -345,38 +345,38 @@ adapt.epub.metaTerms = {
  * @return {function(adapt.base.JSON,adapt.base.JSON):number}
  */
 adapt.epub.getMetadataComparator = function(term, lang) {
-	var empty = {};
-	return function(item1, item2) {
-		var m1, m2;
-		var r1 = item1["r"] || empty;
-		var r2 = item2["r"] || empty;
-		if (term == adapt.epub.metaTerms.title) {
-			m1 = r1[adapt.epub.metaTerms.titleType] == "main";
-			m2 = r2[adapt.epub.metaTerms.titleType] == "main";			
-			if (m1 != m2) {
-				return m1 ? -1 : 1;
-			}
-		}
-		var i1 = parseInt(r1[adapt.epub.metaTerms.displaySeq], 10);
-		if (isNaN(i1)) {
-			i1 = Number.MAX_VALUE;
-		}
-		var i2 = parseInt(r2[adapt.epub.metaTerms.displaySeq], 10);			
-		if (isNaN(i2)) {
-			i2 = Number.MAX_VALUE;
-		}
-		if (i1 != i2) {
-			return i1 - i2;
-		}
-		if (term != adapt.epub.metaTerms.language && lang) {
-			m1 = (r1[adapt.epub.metaTerms.language] || r1[adapt.epub.metaTerms.alternateScript]) == lang;
-			m2 = (r2[adapt.epub.metaTerms.language] || r2[adapt.epub.metaTerms.alternateScript]) == lang;
-			if (m1 != m2) {
-				return m1 ? -1 : 1;
-			}
-		}
-		return item1["o"] - item2["o"];
-	};
+    var empty = {};
+    return function(item1, item2) {
+        var m1, m2;
+        var r1 = item1["r"] || empty;
+        var r2 = item2["r"] || empty;
+        if (term == adapt.epub.metaTerms.title) {
+            m1 = r1[adapt.epub.metaTerms.titleType] == "main";
+            m2 = r2[adapt.epub.metaTerms.titleType] == "main";
+            if (m1 != m2) {
+                return m1 ? -1 : 1;
+            }
+        }
+        var i1 = parseInt(r1[adapt.epub.metaTerms.displaySeq], 10);
+        if (isNaN(i1)) {
+            i1 = Number.MAX_VALUE;
+        }
+        var i2 = parseInt(r2[adapt.epub.metaTerms.displaySeq], 10);
+        if (isNaN(i2)) {
+            i2 = Number.MAX_VALUE;
+        }
+        if (i1 != i2) {
+            return i1 - i2;
+        }
+        if (term != adapt.epub.metaTerms.language && lang) {
+            m1 = (r1[adapt.epub.metaTerms.language] || r1[adapt.epub.metaTerms.alternateScript]) == lang;
+            m2 = (r2[adapt.epub.metaTerms.language] || r2[adapt.epub.metaTerms.alternateScript]) == lang;
+            if (m1 != m2) {
+                return m1 ? -1 : 1;
+            }
+        }
+        return item1["o"] - item2["o"];
+    };
 };
 
 
@@ -386,139 +386,139 @@ adapt.epub.getMetadataComparator = function(term, lang) {
  * @return {adapt.base.JSON}
  */
 adapt.epub.readMetadata = function(mroot, prefixes) {
-	// Parse prefix map (if any)
-	var prefixMap;
-	if (!prefixes) {
-		prefixMap = adapt.epub.predefinedPrefixes;
-	} else {
-		prefixMap = {};
-		for (var pn in adapt.epub.predefinedPrefixes) {
-			prefixMap[pn] = adapt.epub.predefinedPrefixes[pn];
-		}
-		var r;
-		// This code permits any non-ASCII characters in the name to avoid bloating the pattern.
-		while ((r = prefixes.match(/(^\s*[A-Z_a-z\u007F-\uFFFF][-.A-Z_a-z0-9\u007F-\uFFFF]*):\s*(\S+)/)) != null) {
-			prefixes = prefixes.substr(r[0].length);
-			prefixMap[r[1]] = r[2];
-		}
-	}
-	/**
-	 * @param {?string} val 
-	 * @return {?string}
-	 */
-	var resolveProperty = function(val) {
-		if (val) {
-			var r = val.match(/^\s*(([^:]*):)?(\S+)\s*$/);
-			if (r) {
-				var iri = r[1] ? prefixMap[r[1]] : adapt.epub.defaultIRI;
-				if (iri) {
-					return iri + r[3];
-				}
-			}
-		}
-		return null;
-	};
-	var order = 1;
-	// List of metadata items.
-	var rawItems = mroot.childElements().forEachNonNull(/** @return {?adapt.epub.RawMetaItem} */ function(node) {
-		if (node.localName == "meta") {
-			var p = resolveProperty(node.getAttribute("property"));
-			if (p) {
-				return {name: p,
-					value: node.textContent, id: node.getAttribute("id"), order: order++,
-					refines: node.getAttribute("refines"), lang:null,
-					scheme: resolveProperty(node.getAttribute("scheme"))};
-			}
-		} else if (node.namespaceURI == adapt.base.NS.DC) {
-			return {name: adapt.epub.predefinedPrefixes["dcterms"] + node.localName, order: order++,
-				lang: node.getAttribute("xml:lang"),
-				value: node.textContent, id: node.getAttribute("id"), refines:null, scheme:null};
-		}
-		return null;
-	});
-	// Items grouped by their target id.
-	var rawItemsByTarget = adapt.base.multiIndexArray(rawItems,
-			function(rawItem) { return rawItem.refines; });
-	var makeMetadata = function(map) {
-		return adapt.base.mapObj(map, /** @return {Array} */ function(rawItemArr, itemName) {
-			var result = adapt.base.map(rawItemArr, function(rawItem) {
-				var entry = {"v": rawItem.value, "o": rawItem.order};
-				if (rawItem.schema) {
-					entry["s"] = rawItem.scheme;
-				}
-				if (rawItem.id || rawItem.lang) {
-					var refs = rawItemsByTarget[rawItem.id];
-					if (refs || rawItem.lang) {
-						if (rawItem.lang) {
-							// Special handling for xml:lang
-							var langItem = {name:adapt.epub.metaTerms.language, value:rawItem.lang,
-									lang:null, id:null, refines:rawItem.id, scheme:null,
-									order: rawItem.order};
-							if (refs) {
-								refs.push(langItem);
-							} else {
-								refs = [langItem];
-							}
-						}
-						var entryMap = adapt.base.multiIndexArray(refs, function(rawItem) { return rawItem.name; });
-						entry["r"] = makeMetadata(entryMap);
-					}
-				}
-				return entry;
-			});
-			return result;
-		});
-	};
-	var metadata = makeMetadata(adapt.base.multiIndexArray(rawItems,
-			function(rawItem) { return rawItem.refines ? null : rawItem.name; }));
-	var lang = null;
-	if (metadata[adapt.epub.metaTerms.language]) {
-		lang = metadata[adapt.epub.metaTerms.language][0]["v"];
-	}
-	var sortMetadata = function(metadata) {
-		for (var term in metadata) {
-			var arr = /** @type {Array} */ (metadata[term]);
-			arr.sort(adapt.epub.getMetadataComparator(term, lang));
-			for (var i = 0; i < arr.length; i++) {
-				var r = arr[i]["r"];
-				if (r) {
-					sortMetadata(r);
-				}
-			}
-		}
-	};
-	sortMetadata(metadata);
-	return metadata;
+    // Parse prefix map (if any)
+    var prefixMap;
+    if (!prefixes) {
+        prefixMap = adapt.epub.predefinedPrefixes;
+    } else {
+        prefixMap = {};
+        for (var pn in adapt.epub.predefinedPrefixes) {
+            prefixMap[pn] = adapt.epub.predefinedPrefixes[pn];
+        }
+        var r;
+        // This code permits any non-ASCII characters in the name to avoid bloating the pattern.
+        while ((r = prefixes.match(/(^\s*[A-Z_a-z\u007F-\uFFFF][-.A-Z_a-z0-9\u007F-\uFFFF]*):\s*(\S+)/)) != null) {
+            prefixes = prefixes.substr(r[0].length);
+            prefixMap[r[1]] = r[2];
+        }
+    }
+    /**
+     * @param {?string} val
+     * @return {?string}
+     */
+    var resolveProperty = function(val) {
+        if (val) {
+            var r = val.match(/^\s*(([^:]*):)?(\S+)\s*$/);
+            if (r) {
+                var iri = r[1] ? prefixMap[r[1]] : adapt.epub.defaultIRI;
+                if (iri) {
+                    return iri + r[3];
+                }
+            }
+        }
+        return null;
+    };
+    var order = 1;
+    // List of metadata items.
+    var rawItems = mroot.childElements().forEachNonNull(/** @return {?adapt.epub.RawMetaItem} */ function(node) {
+        if (node.localName == "meta") {
+            var p = resolveProperty(node.getAttribute("property"));
+            if (p) {
+                return {name: p,
+                    value: node.textContent, id: node.getAttribute("id"), order: order++,
+                    refines: node.getAttribute("refines"), lang:null,
+                    scheme: resolveProperty(node.getAttribute("scheme"))};
+            }
+        } else if (node.namespaceURI == adapt.base.NS.DC) {
+            return {name: adapt.epub.predefinedPrefixes["dcterms"] + node.localName, order: order++,
+                lang: node.getAttribute("xml:lang"),
+                value: node.textContent, id: node.getAttribute("id"), refines:null, scheme:null};
+        }
+        return null;
+    });
+    // Items grouped by their target id.
+    var rawItemsByTarget = adapt.base.multiIndexArray(rawItems,
+        function(rawItem) { return rawItem.refines; });
+    var makeMetadata = function(map) {
+        return adapt.base.mapObj(map, /** @return {Array} */ function(rawItemArr, itemName) {
+            var result = adapt.base.map(rawItemArr, function(rawItem) {
+                var entry = {"v": rawItem.value, "o": rawItem.order};
+                if (rawItem.schema) {
+                    entry["s"] = rawItem.scheme;
+                }
+                if (rawItem.id || rawItem.lang) {
+                    var refs = rawItemsByTarget[rawItem.id];
+                    if (refs || rawItem.lang) {
+                        if (rawItem.lang) {
+                            // Special handling for xml:lang
+                            var langItem = {name:adapt.epub.metaTerms.language, value:rawItem.lang,
+                                lang:null, id:null, refines:rawItem.id, scheme:null,
+                                order: rawItem.order};
+                            if (refs) {
+                                refs.push(langItem);
+                            } else {
+                                refs = [langItem];
+                            }
+                        }
+                        var entryMap = adapt.base.multiIndexArray(refs, function(rawItem) { return rawItem.name; });
+                        entry["r"] = makeMetadata(entryMap);
+                    }
+                }
+                return entry;
+            });
+            return result;
+        });
+    };
+    var metadata = makeMetadata(adapt.base.multiIndexArray(rawItems,
+        function(rawItem) { return rawItem.refines ? null : rawItem.name; }));
+    var lang = null;
+    if (metadata[adapt.epub.metaTerms.language]) {
+        lang = metadata[adapt.epub.metaTerms.language][0]["v"];
+    }
+    var sortMetadata = function(metadata) {
+        for (var term in metadata) {
+            var arr = /** @type {Array} */ (metadata[term]);
+            arr.sort(adapt.epub.getMetadataComparator(term, lang));
+            for (var i = 0; i < arr.length; i++) {
+                var r = arr[i]["r"];
+                if (r) {
+                    sortMetadata(r);
+                }
+            }
+        }
+    };
+    sortMetadata(metadata);
+    return metadata;
 };
 
 /**
  * @return {Object}
  */
 adapt.epub.getMathJaxHub = function() {
-	var math = window["MathJax"];
-	if (math) {
-		return math["Hub"];
-	}
-	return null;
+    var math = window["MathJax"];
+    if (math) {
+        return math["Hub"];
+    }
+    return null;
 };
 
 /**
  * @return {void}
  */
 adapt.epub.checkMathJax = function() {
-	if (adapt.epub.getMathJaxHub()) {
-		adapt.csscasc.supportedNamespaces[adapt.base.NS.MATHML] = true;
-	}
+    if (adapt.epub.getMathJaxHub()) {
+        adapt.csscasc.supportedNamespaces[adapt.base.NS.MATHML] = true;
+    }
 };
 
 /** @const */
 adapt.epub.supportedMediaTypes = {
-	"appliaction/xhtml+xml": true,
-	"image/jpeg": true,
-	"image/png": true,
-	"image/svg+xml": true,
-	"image/gif": true,
-	"audio/mp3": true
+    "appliaction/xhtml+xml": true,
+    "image/jpeg": true,
+    "image/png": true,
+    "image/svg+xml": true,
+    "image/gif": true,
+    "audio/mp3": true
 };
 
 /**
@@ -527,72 +527,72 @@ adapt.epub.supportedMediaTypes = {
  * @param {string} epubURL
  */
 adapt.epub.OPFDoc = function(store, epubURL) {
-	/** @const */ this.store = store;
-	/** @type {adapt.xmldoc.XMLDocHolder} */ this.opfXML = null;
-	/** @type {adapt.xmldoc.XMLDocHolder} */ this.encXML = null;
-	/** @type {Array.<adapt.epub.OPFItem>} */ this.items = null;
-	/** @type {Array.<adapt.epub.OPFItem>} */ this.spine = null;
-	/** @type {Object.<string,adapt.epub.OPFItem>} */ this.itemMap = null;
-	/** @type {Object.<string,adapt.epub.OPFItem>} */ this.itemMapByPath = null;
-	/** @const */ this.epubURL = epubURL;
-	/** @type {?string} */ this.uid = null;
-	/** @type {Object.<string,string>} */ this.bindings = {};
-	/** @type {?string} */ this.lang = null;
-	/** @type {number} */ this.epageCount = 0;
-	/** @type {adapt.base.JSON} */ this.metadata = {};
-	/** @type {adapt.epub.OPFItem} */ this.ncxToc = null;
-	/** @type {adapt.epub.OPFItem} */ this.xhtmlToc = null;
-	/** @type {adapt.epub.OPFItem} */ this.cover = null;
-	/** @type {Object.<string,string>} */ this.fallbackMap = {};
-	/** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
-	/** @const */ this.documentURLTransformer = this.createDocumentURLTransformer();
-	adapt.epub.checkMathJax();
+    /** @const */ this.store = store;
+    /** @type {adapt.xmldoc.XMLDocHolder} */ this.opfXML = null;
+    /** @type {adapt.xmldoc.XMLDocHolder} */ this.encXML = null;
+    /** @type {Array.<adapt.epub.OPFItem>} */ this.items = null;
+    /** @type {Array.<adapt.epub.OPFItem>} */ this.spine = null;
+    /** @type {Object.<string,adapt.epub.OPFItem>} */ this.itemMap = null;
+    /** @type {Object.<string,adapt.epub.OPFItem>} */ this.itemMapByPath = null;
+    /** @const */ this.epubURL = epubURL;
+    /** @type {?string} */ this.uid = null;
+    /** @type {Object.<string,string>} */ this.bindings = {};
+    /** @type {?string} */ this.lang = null;
+    /** @type {number} */ this.epageCount = 0;
+    /** @type {adapt.base.JSON} */ this.metadata = {};
+    /** @type {adapt.epub.OPFItem} */ this.ncxToc = null;
+    /** @type {adapt.epub.OPFItem} */ this.xhtmlToc = null;
+    /** @type {adapt.epub.OPFItem} */ this.cover = null;
+    /** @type {Object.<string,string>} */ this.fallbackMap = {};
+    /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
+    /** @const */ this.documentURLTransformer = this.createDocumentURLTransformer();
+    adapt.epub.checkMathJax();
 };
 
 adapt.epub.OPFDoc.prototype.createDocumentURLTransformer = function() {
-	var self = this;
+    var self = this;
 
-	/**
-	 * @constructor
-	 * @implements {adapt.base.DocumentURLTransformer}
+    /**
+     * @constructor
+     * @implements {adapt.base.DocumentURLTransformer}
      */
-	function OPFDocumentURLTransformer() {}
-	/**
-	 * @override
+    function OPFDocumentURLTransformer() {}
+    /**
+     * @override
      */
-	OPFDocumentURLTransformer.prototype.transformFragment = function(fragment, baseURL) {
-		var url = baseURL + (fragment ? "#" + fragment : "");
-		return encodeURIComponent(url);
-	};
-	/**
-	 * @override
+    OPFDocumentURLTransformer.prototype.transformFragment = function(fragment, baseURL) {
+        var url = baseURL + (fragment ? "#" + fragment : "");
+        return encodeURIComponent(url);
+    };
+    /**
+     * @override
      */
-	OPFDocumentURLTransformer.prototype.transformURL = function(url, baseURL) {
-		var r = url.match(/^([^#]*)#?(.*)$/);
-		if (r) {
-			var path = r[1] || baseURL;
-			var fragment = r[2];
-			if (path) {
-				if (self.items.some(function(item) { return item.src === path; })) {
-					return "#" + this.transformFragment(fragment, path);
-				}
-			}
-		}
-		return url;
-	};
-	/**
-	 * @override
-	 */
-	OPFDocumentURLTransformer.prototype.restoreURL = function(encoded) {
-		if (encoded.charAt(0) === "#") {
-			encoded = encoded.substring(1);
-		}
-		var decoded = decodeURIComponent(encoded);
-		var r = decoded.match(/^([^#]*)#?(.*)$/);
-		return r ? [r[1], r[2]] : [];
-	};
+    OPFDocumentURLTransformer.prototype.transformURL = function(url, baseURL) {
+        var r = url.match(/^([^#]*)#?(.*)$/);
+        if (r) {
+            var path = r[1] || baseURL;
+            var fragment = r[2];
+            if (path) {
+                if (self.items.some(function(item) { return item.src === path; })) {
+                    return "#" + this.transformFragment(fragment, path);
+                }
+            }
+        }
+        return url;
+    };
+    /**
+     * @override
+     */
+    OPFDocumentURLTransformer.prototype.restoreURL = function(encoded) {
+        if (encoded.charAt(0) === "#") {
+            encoded = encoded.substring(1);
+        }
+        var decoded = decodeURIComponent(encoded);
+        var r = decoded.match(/^([^#]*)#?(.*)$/);
+        return r ? [r[1], r[2]] : [];
+    };
 
-	return new OPFDocumentURLTransformer();
+    return new OPFDocumentURLTransformer();
 };
 
 /**
@@ -607,7 +607,7 @@ adapt.epub.OPFDoc.prototype.createDocumentURLTransformer = function() {
  * @return {adapt.base.JSON}
  */
 adapt.epub.OPFDoc.prototype.getMetadata = function() {
-	return this.metadata;
+    return this.metadata;
 };
 
 /**
@@ -615,12 +615,12 @@ adapt.epub.OPFDoc.prototype.getMetadata = function() {
  * @return {?string}
  */
 adapt.epub.OPFDoc.prototype.getPathFromURL = function(url) {
-	if (this.epubURL) {
-		return url.substr(0, this.epubURL.length) == this.epubURL ?
-				decodeURI(url.substr(this.epubURL.length)) : null;
-	} else {
-		return url;
-	}
+    if (this.epubURL) {
+        return url.substr(0, this.epubURL.length) == this.epubURL ?
+            decodeURI(url.substr(this.epubURL.length)) : null;
+    } else {
+        return url;
+    }
 };
 
 /**
@@ -631,153 +631,153 @@ adapt.epub.OPFDoc.prototype.getPathFromURL = function(url) {
  * @return {adapt.task.Result}
  */
 adapt.epub.OPFDoc.prototype.initWithXMLDoc = function(opfXML, encXML, zipMetadata, manifestURL) {
-	var self = this;
-	this.opfXML = opfXML;
-	this.encXML = encXML;
-	var pkg = opfXML.doc().child("package");
-	var uidref = pkg.attribute("unique-identifier")[0];
-	if (uidref) {
-		var uidElem = opfXML.getElement(opfXML.url + "#" + uidref);
-		if (uidElem) {
-			this.uid = uidElem.textContent.replace(/[ \n\r\t]/g, '');
-		}
-	}
-	var srcToFallbackId = {};
-	this.items = adapt.base.map(pkg.child("manifest").child("item").asArray(), 
-		function(node) {
-			var item = new adapt.epub.OPFItem();
-			var elem = /** @type {Element} */ (node);
-			item.initWithElement(elem, opfXML.url);
-			var fallback = elem.getAttribute("fallback");
-			if (fallback && !adapt.epub.supportedMediaTypes[item.mediaType]) {
-				srcToFallbackId[item.src] = fallback;
-			}
-			if (!self.xhtmlToc && item.itemProperties["nav"]) {
-				self.xhtmlToc = item;
-			}
-			if (!self.cover && item.itemProperties["cover-image"]) {
-				self.cover = item;
-			}
-			return item;
-		});
-	this.itemMap = adapt.base.indexArray(this.items,
-			/** @type {function(adapt.epub.OPFItem):?string} */ (adapt.epub.getOPFItemId));
-	this.itemMapByPath = adapt.base.indexArray(this.items, function(item) {
-				return self.getPathFromURL(item.src);
-			});
-	for (var src in srcToFallbackId) {
-		var fallbackSrc = src;
-		while(true) {
-			var item = this.itemMap[srcToFallbackId[fallbackSrc]];
-			if (!item) {
-				break;
-			}
-			if (adapt.epub.supportedMediaTypes[item.mediaType]) {
-				this.fallbackMap[src] = item.src;
-				break;
-			}
-			fallbackSrc = item.src;
-		}
-	}
-	this.spine = adapt.base.map(pkg.child("spine").child("itemref").asArray(),
-			function(node, index) {
-				var elem = /** @type {Element} */ (node);
-				var id = elem.getAttribute("idref");
-				var item = self.itemMap[/** @type {string} */ (id)];
-				if (item) {
-					item.itemRefElement = elem;
-					item.spineIndex = index;
-				}
-				return item;
-			});
-	var tocAttr = pkg.child("spine").attribute("toc")[0];
-	if (tocAttr) {
-		this.ncxToc = this.itemMap[tocAttr];
-	}
-	var pageProgressionAttr = pkg.child("spine").attribute("page-progression-direction")[0];
-	if (pageProgressionAttr) {
-		this.pageProgression = vivliostyle.constants.PageProgression.of(pageProgressionAttr);
-	}
-	var idpfObfURLs = !encXML ? [] : encXML.doc().child("encryption").child("EncryptedData")
-		.predicate(adapt.xmldoc.predicate.withChild("EncryptionMethod",
-				adapt.xmldoc.predicate.withAttribute("Algorithm",
-						"http://www.idpf.org/2008/embedding")))
-		.child("CipherData").child("CipherReference").attribute("URI");
-	var mediaTypeElems = pkg.child("bindings").child("mediaType").asArray();
-	for (var i = 0; i < mediaTypeElems.length; i++) {
-		var handlerId = mediaTypeElems[i].getAttribute("handler");
+    var self = this;
+    this.opfXML = opfXML;
+    this.encXML = encXML;
+    var pkg = opfXML.doc().child("package");
+    var uidref = pkg.attribute("unique-identifier")[0];
+    if (uidref) {
+        var uidElem = opfXML.getElement(opfXML.url + "#" + uidref);
+        if (uidElem) {
+            this.uid = uidElem.textContent.replace(/[ \n\r\t]/g, '');
+        }
+    }
+    var srcToFallbackId = {};
+    this.items = adapt.base.map(pkg.child("manifest").child("item").asArray(),
+        function(node) {
+            var item = new adapt.epub.OPFItem();
+            var elem = /** @type {Element} */ (node);
+            item.initWithElement(elem, opfXML.url);
+            var fallback = elem.getAttribute("fallback");
+            if (fallback && !adapt.epub.supportedMediaTypes[item.mediaType]) {
+                srcToFallbackId[item.src] = fallback;
+            }
+            if (!self.xhtmlToc && item.itemProperties["nav"]) {
+                self.xhtmlToc = item;
+            }
+            if (!self.cover && item.itemProperties["cover-image"]) {
+                self.cover = item;
+            }
+            return item;
+        });
+    this.itemMap = adapt.base.indexArray(this.items,
+        /** @type {function(adapt.epub.OPFItem):?string} */ (adapt.epub.getOPFItemId));
+    this.itemMapByPath = adapt.base.indexArray(this.items, function(item) {
+        return self.getPathFromURL(item.src);
+    });
+    for (var src in srcToFallbackId) {
+        var fallbackSrc = src;
+        while (true) {
+            var item = this.itemMap[srcToFallbackId[fallbackSrc]];
+            if (!item) {
+                break;
+            }
+            if (adapt.epub.supportedMediaTypes[item.mediaType]) {
+                this.fallbackMap[src] = item.src;
+                break;
+            }
+            fallbackSrc = item.src;
+        }
+    }
+    this.spine = adapt.base.map(pkg.child("spine").child("itemref").asArray(),
+        function(node, index) {
+            var elem = /** @type {Element} */ (node);
+            var id = elem.getAttribute("idref");
+            var item = self.itemMap[/** @type {string} */ (id)];
+            if (item) {
+                item.itemRefElement = elem;
+                item.spineIndex = index;
+            }
+            return item;
+        });
+    var tocAttr = pkg.child("spine").attribute("toc")[0];
+    if (tocAttr) {
+        this.ncxToc = this.itemMap[tocAttr];
+    }
+    var pageProgressionAttr = pkg.child("spine").attribute("page-progression-direction")[0];
+    if (pageProgressionAttr) {
+        this.pageProgression = vivliostyle.constants.PageProgression.of(pageProgressionAttr);
+    }
+    var idpfObfURLs = !encXML ? [] : encXML.doc().child("encryption").child("EncryptedData")
+        .predicate(adapt.xmldoc.predicate.withChild("EncryptionMethod",
+            adapt.xmldoc.predicate.withAttribute("Algorithm",
+                "http://www.idpf.org/2008/embedding")))
+        .child("CipherData").child("CipherReference").attribute("URI");
+    var mediaTypeElems = pkg.child("bindings").child("mediaType").asArray();
+    for (var i = 0; i < mediaTypeElems.length; i++) {
+        var handlerId = mediaTypeElems[i].getAttribute("handler");
         var mediaType = mediaTypeElems[i].getAttribute("media-type");
         if (mediaType && handlerId && this.itemMap[handlerId]) {
-        	this.bindings[mediaType] = this.itemMap[handlerId].src;
+            this.bindings[mediaType] = this.itemMap[handlerId].src;
         }
-	}
-	this.metadata = adapt.epub.readMetadata(pkg.child("metadata"), pkg.attribute("prefix")[0]);
-	if (this.metadata[adapt.epub.metaTerms.language]) {
-		this.lang = this.metadata[adapt.epub.metaTerms.language][0]["v"];
-	}
-	if (!zipMetadata) {
-		if (idpfObfURLs.length > 0 && this.uid) {
-			// Have to deobfuscate in JavaScript
-			var deobfuscator = adapt.epub.makeDeobfuscator(this.uid);
-			for (var i = 0; i < idpfObfURLs.length; i++) {
-				this.store.deobfuscators[this.epubURL + idpfObfURLs[i]] = deobfuscator;
-			}
-		}
-		return adapt.task.newResult(true);
-	}
-	var manifestText = new adapt.base.StringBuffer();
-	var obfuscations = {};
-	if (idpfObfURLs.length > 0 && this.uid) {
-		// Deobfuscate in the server.
-		var obfuscationKey = adapt.epub.makeObfuscationKey(this.uid);
-		for (var i = 0; i < idpfObfURLs.length; i++) {
-			obfuscations[idpfObfURLs[i]] = obfuscationKey;
-		}
-	}
-	for (var i = 0; i < zipMetadata.length; i++) {
-		var entry = zipMetadata[i];
-		var encodedPath = entry["n"];
-		if (encodedPath) {
-			var path = decodeURI(encodedPath);
-			var item = this.itemMapByPath[path];
-			var mediaType = null;
-			if (item) {
-				item.compressed = entry["m"] != 0;
-				item.compressedSize = entry["c"];
-				if (item.mediaType) {
-					mediaType = item.mediaType.replace(/\s+/g, "");
-				}
-			}
-			var obfuscation = obfuscations[path];
-			if (mediaType || obfuscation) {
-				manifestText.append(encodedPath);
-				manifestText.append(' ');
-				manifestText.append(mediaType || "application/octet-stream");
-				if (obfuscation) {
-					manifestText.append(' ');
-					manifestText.append(obfuscation);				
-				}
-				manifestText.append('\n');
-			}
-		}
-	}
-	self.assignAutoPages();
-	return adapt.net.ajax(manifestURL, adapt.net.XMLHttpRequestResponseType.DEFAULT, "POST", manifestText.toString(), "text/plain");
+    }
+    this.metadata = adapt.epub.readMetadata(pkg.child("metadata"), pkg.attribute("prefix")[0]);
+    if (this.metadata[adapt.epub.metaTerms.language]) {
+        this.lang = this.metadata[adapt.epub.metaTerms.language][0]["v"];
+    }
+    if (!zipMetadata) {
+        if (idpfObfURLs.length > 0 && this.uid) {
+            // Have to deobfuscate in JavaScript
+            var deobfuscator = adapt.epub.makeDeobfuscator(this.uid);
+            for (var i = 0; i < idpfObfURLs.length; i++) {
+                this.store.deobfuscators[this.epubURL + idpfObfURLs[i]] = deobfuscator;
+            }
+        }
+        return adapt.task.newResult(true);
+    }
+    var manifestText = new adapt.base.StringBuffer();
+    var obfuscations = {};
+    if (idpfObfURLs.length > 0 && this.uid) {
+        // Deobfuscate in the server.
+        var obfuscationKey = adapt.epub.makeObfuscationKey(this.uid);
+        for (var i = 0; i < idpfObfURLs.length; i++) {
+            obfuscations[idpfObfURLs[i]] = obfuscationKey;
+        }
+    }
+    for (var i = 0; i < zipMetadata.length; i++) {
+        var entry = zipMetadata[i];
+        var encodedPath = entry["n"];
+        if (encodedPath) {
+            var path = decodeURI(encodedPath);
+            var item = this.itemMapByPath[path];
+            var mediaType = null;
+            if (item) {
+                item.compressed = entry["m"] != 0;
+                item.compressedSize = entry["c"];
+                if (item.mediaType) {
+                    mediaType = item.mediaType.replace(/\s+/g, "");
+                }
+            }
+            var obfuscation = obfuscations[path];
+            if (mediaType || obfuscation) {
+                manifestText.append(encodedPath);
+                manifestText.append(' ');
+                manifestText.append(mediaType || "application/octet-stream");
+                if (obfuscation) {
+                    manifestText.append(' ');
+                    manifestText.append(obfuscation);
+                }
+                manifestText.append('\n');
+            }
+        }
+    }
+    self.assignAutoPages();
+    return adapt.net.ajax(manifestURL, adapt.net.XMLHttpRequestResponseType.DEFAULT, "POST", manifestText.toString(), "text/plain");
 };
 
 /**
  * @return {void}
  */
 adapt.epub.OPFDoc.prototype.assignAutoPages = function() {
-	var epage = 0;
-	for (var i = 0; i < this.spine.length; i++) {
-		var item = this.spine[i];
-		var epageCount = Math.ceil(item.compressedSize / 1024);
-		item.epage = epage;
-		item.epageCount = epageCount;
-		epage += epageCount;
-	}
-	this.epageCount = epage;
+    var epage = 0;
+    for (var i = 0; i < this.spine.length; i++) {
+        var item = this.spine[i];
+        var epageCount = Math.ceil(item.compressedSize / 1024);
+        item.epage = epage;
+        item.epageCount = epageCount;
+        epage += epageCount;
+    }
+    this.epageCount = epage;
 };
 
 /**
@@ -786,27 +786,27 @@ adapt.epub.OPFDoc.prototype.assignAutoPages = function() {
  * @param {?Document} doc
  */
 adapt.epub.OPFDoc.prototype.initWithChapters = function(params, doc) {
-	this.itemMap = {};
-	this.itemMapByPath = {};
-	this.items = [];
-	this.spine = this.items;
-	// create a minimum fake OPF XML for navigation with EPUB CFI
-	var opfXML = this.opfXML = new adapt.xmldoc.XMLDocHolder(null, "", new DOMParser().parseFromString("<spine></spine>", "text/xml"));
+    this.itemMap = {};
+    this.itemMapByPath = {};
+    this.items = [];
+    this.spine = this.items;
+    // create a minimum fake OPF XML for navigation with EPUB CFI
+    var opfXML = this.opfXML = new adapt.xmldoc.XMLDocHolder(null, "", new DOMParser().parseFromString("<spine></spine>", "text/xml"));
 
-	params.forEach(function(param) {
-		var item = new adapt.epub.OPFItem();
-		item.initWithParam(param);
-		goog.asserts.assert(item.id);
+    params.forEach(function(param) {
+        var item = new adapt.epub.OPFItem();
+        item.initWithParam(param);
+        goog.asserts.assert(item.id);
 
-		var itemref = opfXML.document.createElement("itemref");
-		itemref.setAttribute("idref", item.id);
-		opfXML.root.appendChild(itemref);
-		item.itemRefElement = itemref;
+        var itemref = opfXML.document.createElement("itemref");
+        itemref.setAttribute("idref", item.id);
+        opfXML.root.appendChild(itemref);
+        item.itemRefElement = itemref;
 
-		this.itemMap[item.id] = item;
-		this.itemMapByPath[param.url] = item;
-		this.items.push(item);
-	}, this);
+        this.itemMap[item.id] = item;
+        this.itemMapByPath[param.url] = item;
+        this.items.push(item);
+    }, this);
 
     if (doc) {
         return this.store.addDocument(params[0].url, doc);
@@ -821,24 +821,24 @@ adapt.epub.OPFDoc.prototype.initWithChapters = function(params, doc) {
  * @return {!adapt.task.Result.<?string>} cfi
  */
 adapt.epub.OPFDoc.prototype.getCFI = function(spineIndex, offsetInItem) {
-	var item = this.spine[spineIndex];
-	/** @type {!adapt.task.Frame.<?string>} */ var frame = adapt.task.newFrame("getCFI");
-	this.store.load(item.src).then(function (xmldoc) {
-		var node = xmldoc.getNodeByOffset(offsetInItem);
-		var cfi = null;
-		if (node) {
-			var startOffset = xmldoc.getNodeOffset(node, 0, false);
-			var offsetInNode = offsetInItem - startOffset;
-			var fragment = new adapt.cfi.Fragment();
-			fragment.prependPathFromNode(node, offsetInNode, false, null);
-			if (item.itemRefElement) {
-				fragment.prependPathFromNode(item.itemRefElement, 0, false, null);
-			}
-			cfi = fragment.toString();
-		}
-		frame.finish(cfi);
-	});
-	return frame.result();
+    var item = this.spine[spineIndex];
+    /** @type {!adapt.task.Frame.<?string>} */ var frame = adapt.task.newFrame("getCFI");
+    this.store.load(item.src).then(function(xmldoc) {
+        var node = xmldoc.getNodeByOffset(offsetInItem);
+        var cfi = null;
+        if (node) {
+            var startOffset = xmldoc.getNodeOffset(node, 0, false);
+            var offsetInNode = offsetInItem - startOffset;
+            var fragment = new adapt.cfi.Fragment();
+            fragment.prependPathFromNode(node, offsetInNode, false, null);
+            if (item.itemRefElement) {
+                fragment.prependPathFromNode(item.itemRefElement, 0, false, null);
+            }
+            cfi = fragment.toString();
+        }
+        frame.finish(cfi);
+    });
+    return frame.result();
 };
 
 /**
@@ -846,52 +846,52 @@ adapt.epub.OPFDoc.prototype.getCFI = function(spineIndex, offsetInItem) {
  * @return {!adapt.task.Result.<?adapt.epub.Position>}
  */
 adapt.epub.OPFDoc.prototype.resolveFragment = function(fragstr) {
-	var self = this;
-	return adapt.task.handle("resolveFragment",
-    	/**
-    	 * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
-    	 * @return {void}
-    	 */			
-		function(frame) {
-			if (!fragstr) {
-				frame.finish(null);
-				return;
-			}
-			var fragment = new adapt.cfi.Fragment();
-			fragment.fromString(fragstr);
-			var item;
-			if (self.opfXML) {
-				var opfNav = fragment.navigate(self.opfXML.document);
-				if (opfNav.node.nodeType != 1 || opfNav.after || !opfNav.ref) {
-					frame.finish(null);
-					return;
-				}
-				var elem = /** @type {Element} */ (opfNav.node);
-				var idref = elem.getAttribute("idref");
-				if (elem.localName != "itemref" || !idref || !self.itemMap[idref]) {
-					frame.finish(null);
-					return;					
-				}
-				item = self.itemMap[idref];
-				fragment = opfNav.ref;
-			} else {
-				item = self.spine[0];
-			}
-			self.store.load(item.src).then(function (xmldoc) {
-				var nodeNav = fragment.navigate(xmldoc.document);
-				var offset = xmldoc.getNodeOffset(nodeNav.node, nodeNav.offset, nodeNav.after);
-				frame.finish({spineIndex: item.spineIndex, offsetInItem: offset, pageIndex: -1});
-			});
-		},
-    	/**
-    	 * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
-    	 * @param {Error} err
-    	 * @return {void}
-    	 */					
-		function(frame, err) {
-			vivliostyle.logging.logger.warn(err, "Cannot resolve fragment:", fragstr);
-			frame.finish(null);
-		});
+    var self = this;
+    return adapt.task.handle("resolveFragment",
+        /**
+         * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
+         * @return {void}
+         */
+        function(frame) {
+            if (!fragstr) {
+                frame.finish(null);
+                return;
+            }
+            var fragment = new adapt.cfi.Fragment();
+            fragment.fromString(fragstr);
+            var item;
+            if (self.opfXML) {
+                var opfNav = fragment.navigate(self.opfXML.document);
+                if (opfNav.node.nodeType != 1 || opfNav.after || !opfNav.ref) {
+                    frame.finish(null);
+                    return;
+                }
+                var elem = /** @type {Element} */ (opfNav.node);
+                var idref = elem.getAttribute("idref");
+                if (elem.localName != "itemref" || !idref || !self.itemMap[idref]) {
+                    frame.finish(null);
+                    return;
+                }
+                item = self.itemMap[idref];
+                fragment = opfNav.ref;
+            } else {
+                item = self.spine[0];
+            }
+            self.store.load(item.src).then(function(xmldoc) {
+                var nodeNav = fragment.navigate(xmldoc.document);
+                var offset = xmldoc.getNodeOffset(nodeNav.node, nodeNav.offset, nodeNav.after);
+                frame.finish({spineIndex: item.spineIndex, offsetInItem: offset, pageIndex: -1});
+            });
+        },
+        /**
+         * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
+         * @param {Error} err
+         * @return {void}
+         */
+        function(frame, err) {
+            vivliostyle.logging.logger.warn(err, "Cannot resolve fragment:", fragstr);
+            frame.finish(null);
+        });
 };
 
 /**
@@ -899,47 +899,47 @@ adapt.epub.OPFDoc.prototype.resolveFragment = function(fragstr) {
  * @return {!adapt.task.Result.<?adapt.epub.Position>}
  */
 adapt.epub.OPFDoc.prototype.resolveEPage = function(epage) {
-	var self = this;
-	return adapt.task.handle("resolveEPage",
-    	/**
-    	 * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
-    	 * @return {void}
-    	 */			
-		function(frame) {
-			if (epage <= 0) {
-				frame.finish({spineIndex: 0, offsetInItem: 0, pageIndex: -1});
-				return;
-			}
-			var spineIndex = adapt.base.binarySearch(self.spine.length, function(index) {
-				var item = self.spine[index];
-				return item.epage + item.epageCount > epage;
-			});
-			var item = self.spine[spineIndex];
-			self.store.load(item.src).then(function (xmldoc) {
-				epage -= item.epage;
-				if (epage > item.epageCount) {
-					epage = item.epageCount;
-				}
-				var offset = 0;
-				if (epage > 0) {
-					var totalOffset = xmldoc.getTotalOffset();
-					offset = Math.round(totalOffset * epage / item.epageCount);
-					if (offset == totalOffset) {
-						offset--;
-					}
-				}
-				frame.finish({spineIndex: spineIndex, offsetInItem: offset, pageIndex: -1});
-			});
-		},
-    	/**
-    	 * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
-    	 * @param {Error} err
-    	 * @return {void}
-    	 */					
-		function(frame, err) {
-			vivliostyle.logging.logger.warn(err, "Cannot resolve epage:", epage);
-			frame.finish(null);
-		});
+    var self = this;
+    return adapt.task.handle("resolveEPage",
+        /**
+         * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
+         * @return {void}
+         */
+        function(frame) {
+            if (epage <= 0) {
+                frame.finish({spineIndex: 0, offsetInItem: 0, pageIndex: -1});
+                return;
+            }
+            var spineIndex = adapt.base.binarySearch(self.spine.length, function(index) {
+                var item = self.spine[index];
+                return item.epage + item.epageCount > epage;
+            });
+            var item = self.spine[spineIndex];
+            self.store.load(item.src).then(function(xmldoc) {
+                epage -= item.epage;
+                if (epage > item.epageCount) {
+                    epage = item.epageCount;
+                }
+                var offset = 0;
+                if (epage > 0) {
+                    var totalOffset = xmldoc.getTotalOffset();
+                    offset = Math.round(totalOffset * epage / item.epageCount);
+                    if (offset == totalOffset) {
+                        offset--;
+                    }
+                }
+                frame.finish({spineIndex: spineIndex, offsetInItem: offset, pageIndex: -1});
+            });
+        },
+        /**
+         * @param {!adapt.task.Frame.<?adapt.epub.Position>} frame
+         * @param {Error} err
+         * @return {void}
+         */
+        function(frame, err) {
+            vivliostyle.logging.logger.warn(err, "Cannot resolve epage:", epage);
+            frame.finish(null);
+        });
 };
 
 /**
@@ -947,17 +947,17 @@ adapt.epub.OPFDoc.prototype.resolveEPage = function(epage) {
  * @return {!adapt.task.Result.<number>}
  */
 adapt.epub.OPFDoc.prototype.getEPageFromPosition = function(position) {
-	var item = this.spine[position.spineIndex];
-	if (position.offsetInItem <= 0) {
-		return adapt.task.newResult(item.epage);
-	}
-	/** @type {!adapt.task.Frame.<number>} */ var frame = adapt.task.newFrame("getEPage");
-	this.store.load(item.src).then(function (xmldoc) {
-		var totalOffset = xmldoc.getTotalOffset();
-		var offset = Math.min(totalOffset, position.offsetInItem);
-		frame.finish(item.epage + offset * item.epageCount / totalOffset);
-	});
-	return frame.result();
+    var item = this.spine[position.spineIndex];
+    if (position.offsetInItem <= 0) {
+        return adapt.task.newResult(item.epage);
+    }
+    /** @type {!adapt.task.Frame.<number>} */ var frame = adapt.task.newFrame("getEPage");
+    this.store.load(item.src).then(function(xmldoc) {
+        var totalOffset = xmldoc.getTotalOffset();
+        var offset = Math.min(totalOffset, position.offsetInItem);
+        frame.finish(item.epage + offset * item.epageCount / totalOffset);
+    });
+    return frame.result();
 };
 
 /**
@@ -982,35 +982,35 @@ adapt.epub.OPFViewItem;
  * @implements {adapt.vgen.CustomRendererFactory}
  */
 adapt.epub.OPFView = function(opf, viewport, fontMapper, pref, pageSheetSizeReporter) {
-	/** @const */ this.opf = opf;
-	/** @const */ this.viewport = viewport;
-	/** @const */ this.fontMapper = fontMapper;
-	/** @const */ this.pageSheetSizeReporter = pageSheetSizeReporter;
-	/** @type {Array.<adapt.epub.OPFViewItem>} */ this.spineItems = [];
-	/** @type {number} */ this.spineIndex = 0;
-	/** @type {number} */ this.pageIndex = 0;
-	/** @type {number} */ this.offsetInItem = 0;
-	/** @const */ this.pref = adapt.expr.clonePreferences(pref);
-	/** @const */ this.clientLayout = new adapt.vgen.DefaultClientLayout(viewport.window);
-	/** @const */ this.counterStore = new vivliostyle.counters.CounterStore(opf.documentURLTransformer);
+    /** @const */ this.opf = opf;
+    /** @const */ this.viewport = viewport;
+    /** @const */ this.fontMapper = fontMapper;
+    /** @const */ this.pageSheetSizeReporter = pageSheetSizeReporter;
+    /** @type {Array.<adapt.epub.OPFViewItem>} */ this.spineItems = [];
+    /** @type {number} */ this.spineIndex = 0;
+    /** @type {number} */ this.pageIndex = 0;
+    /** @type {number} */ this.offsetInItem = 0;
+    /** @const */ this.pref = adapt.expr.clonePreferences(pref);
+    /** @const */ this.clientLayout = new adapt.vgen.DefaultClientLayout(viewport.window);
+    /** @const */ this.counterStore = new vivliostyle.counters.CounterStore(opf.documentURLTransformer);
 };
 
 /**
  * @return {boolean}
  */
 adapt.epub.OPFView.prototype.isAtTheFirstPage = function() {
-	return this.spineIndex == 0 && this.pageIndex == 0;
+    return this.spineIndex == 0 && this.pageIndex == 0;
 };
 
 /**
  * @return {boolean}
  */
 adapt.epub.OPFView.prototype.isAtTheLastPage = function() {
-	if (this.spineIndex != this.opf.spine.length - 1) {
-		return false;
-	}
-	var viewItem = this.spineItems[this.spineIndex];
-	return viewItem && !viewItem.complete && this.pageIndex == viewItem.layoutPositions.length - 1;	
+    if (this.spineIndex != this.opf.spine.length - 1) {
+        return false;
+    }
+    var viewItem = this.spineItems[this.spineIndex];
+    return viewItem && !viewItem.complete && this.pageIndex == viewItem.layoutPositions.length - 1;
 };
 
 /**
@@ -1026,12 +1026,12 @@ adapt.epub.OPFView.prototype.getCurrentPage = function() {
  * @returns {?vivliostyle.constants.PageProgression}
  */
 adapt.epub.OPFView.prototype.getCurrentPageProgression = function() {
-	if (this.opf.pageProgression) {
-		return this.opf.pageProgression;
-	} else {
-		var viewItem = this.spineItems[this.spineIndex];
-		return viewItem ? viewItem.instance.pageProgression : null;
-	}
+    if (this.opf.pageProgression) {
+        return this.opf.pageProgression;
+    } else {
+        var viewItem = this.spineItems[this.spineIndex];
+        return viewItem ? viewItem.instance.pageProgression : null;
+    }
 };
 
 /**
@@ -1041,27 +1041,27 @@ adapt.epub.OPFView.prototype.getCurrentPageProgression = function() {
  * @param {number} pageIndex
  */
 adapt.epub.OPFView.prototype.finishPageContainer = function(viewItem, page, pageIndex) {
-	page.container.style.display = "none";
-	page.container.style.visibility = "visible";
-	page.container.style.position = "";
-	page.container.style.top = "";
-	page.container.style.left = "";
-	page.container.setAttribute("data-vivliostyle-page-side", /** @type {string} */ (page.side));
-	var oldPage = viewItem.pages[pageIndex];
-	page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
-	viewItem.pages[pageIndex] = page;
-	if (oldPage) {
-		viewItem.instance.viewport.contentContainer.replaceChild(page.container, oldPage.container);
-		oldPage.dispatchEvent({
-			type: "replaced",
-			target: null,
-			currentTarget: null,
-			newPage: page
-		});
-	} else {
-		viewItem.instance.viewport.contentContainer.appendChild(page.container);
-	}
-	this.pageSheetSizeReporter(viewItem.instance.pageSheetSize, viewItem.item.spineIndex, pageIndex);
+    page.container.style.display = "none";
+    page.container.style.visibility = "visible";
+    page.container.style.position = "";
+    page.container.style.top = "";
+    page.container.style.left = "";
+    page.container.setAttribute("data-vivliostyle-page-side", /** @type {string} */ (page.side));
+    var oldPage = viewItem.pages[pageIndex];
+    page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
+    viewItem.pages[pageIndex] = page;
+    if (oldPage) {
+        viewItem.instance.viewport.contentContainer.replaceChild(page.container, oldPage.container);
+        oldPage.dispatchEvent({
+            type: "replaced",
+            target: null,
+            currentTarget: null,
+            newPage: page
+        });
+    } else {
+        viewItem.instance.viewport.contentContainer.appendChild(page.container);
+    }
+    this.pageSheetSizeReporter(viewItem.instance.pageSheetSize, viewItem.item.spineIndex, pageIndex);
 };
 
 /**
@@ -1082,85 +1082,85 @@ adapt.epub.OPFView.RenderSinglePageResult;
  * @returns {!adapt.task.Result<!adapt.epub.OPFView.RenderSinglePageResult>}
  */
 adapt.epub.OPFView.prototype.renderSinglePage = function(viewItem, pos) {
-	/** @type {!adapt.task.Frame<!adapt.epub.OPFView.RenderSinglePageResult>} */ var frame
-		= adapt.task.newFrame("renderSinglePage");
-	var page = this.makePage(viewItem, pos);
-	var self = this;
-	viewItem.instance.layoutNextPage(page, pos).then(function(posParam) {
-		pos = /** @type {adapt.vtree.LayoutPosition} */ (posParam);
-		var pageIndex = pos ? pos.page - 1 : viewItem.layoutPositions.length - 1;
-		self.finishPageContainer(viewItem, page, pageIndex);
+    /** @type {!adapt.task.Frame<!adapt.epub.OPFView.RenderSinglePageResult>} */ var frame
+        = adapt.task.newFrame("renderSinglePage");
+    var page = this.makePage(viewItem, pos);
+    var self = this;
+    viewItem.instance.layoutNextPage(page, pos).then(function(posParam) {
+        pos = /** @type {adapt.vtree.LayoutPosition} */ (posParam);
+        var pageIndex = pos ? pos.page - 1 : viewItem.layoutPositions.length - 1;
+        self.finishPageContainer(viewItem, page, pageIndex);
 
-		self.counterStore.finishPage(self.spineIndex, pageIndex);
+        self.counterStore.finishPage(self.spineIndex, pageIndex);
 
-		// backup original values
-		var origSpineIndex = self.spineIndex;
-		var origPageIndex = self.pageIndex;
-		var origOffsetInItem = self.offsetInItem;
+        // backup original values
+        var origSpineIndex = self.spineIndex;
+        var origPageIndex = self.pageIndex;
+        var origOffsetInItem = self.offsetInItem;
 
-		// If the position of the page break change, we should re-layout the next page too.
-		var cont = null;
-		if (pos) {
-			var prevPos = viewItem.layoutPositions[pos.page];
-			viewItem.layoutPositions[pos.page] = pos;
-			if (prevPos && viewItem.pages[pos.page]) {
-				if (!pos.isSamePosition(prevPos)) {
-					self.pageIndex = pos.page;
-					cont = self.renderSinglePage(viewItem, pos);
-				}
-			}
-		}
-		if (!cont) {
-			cont = adapt.task.newResult(true);
-		}
+        // If the position of the page break change, we should re-layout the next page too.
+        var cont = null;
+        if (pos) {
+            var prevPos = viewItem.layoutPositions[pos.page];
+            viewItem.layoutPositions[pos.page] = pos;
+            if (prevPos && viewItem.pages[pos.page]) {
+                if (!pos.isSamePosition(prevPos)) {
+                    self.pageIndex = pos.page;
+                    cont = self.renderSinglePage(viewItem, pos);
+                }
+            }
+        }
+        if (!cont) {
+            cont = adapt.task.newResult(true);
+        }
 
-		cont.then(function() {
-			var unresolvedRefs = self.counterStore.getUnresolvedRefsToPage(page);
-			var index = 0;
-			frame.loopWithFrame(function(loopFrame) {
-				index++;
-				if (index > unresolvedRefs.length) {
-					loopFrame.breakLoop();
-					return;
-				}
-				var refs = unresolvedRefs[index - 1];
-				refs.refs = refs.refs.filter(function(ref) { return !ref.isResolved(); });
-				if (refs.refs.length === 0) {
-					loopFrame.continueLoop();
-					return;
-				}
+        cont.then(function() {
+            var unresolvedRefs = self.counterStore.getUnresolvedRefsToPage(page);
+            var index = 0;
+            frame.loopWithFrame(function(loopFrame) {
+                index++;
+                if (index > unresolvedRefs.length) {
+                    loopFrame.breakLoop();
+                    return;
+                }
+                var refs = unresolvedRefs[index - 1];
+                refs.refs = refs.refs.filter(function(ref) { return !ref.isResolved(); });
+                if (refs.refs.length === 0) {
+                    loopFrame.continueLoop();
+                    return;
+                }
 
-				self.spineIndex = refs.spineIndex;
-				self.pageIndex = refs.pageIndex;
-				self.getPageViewItem().then(function(viewItem) {
-					if (!viewItem) {
-						loopFrame.continueLoop();
-						return;
-					}
-					self.counterStore.pushPageCounters(refs.pageCounters);
-					self.counterStore.pushReferencesToSolve(refs.refs);
-					var pos = viewItem.layoutPositions[self.pageIndex];
-					self.renderSinglePage(viewItem, pos).then(function() {
-						self.counterStore.popPageCounters();
-						self.counterStore.popReferencesToSolve();
-						loopFrame.continueLoop();
-					});
-				});
-			}).then(function() {
-				// restore original values
-				self.spineIndex = origSpineIndex;
-				self.pageIndex = origPageIndex;
-				self.offsetInItem = origOffsetInItem;
-				frame.finish({
-					page: page,
-					position: pos,
-					pageIndex: pageIndex
-				});
-			});
-		});
+                self.spineIndex = refs.spineIndex;
+                self.pageIndex = refs.pageIndex;
+                self.getPageViewItem().then(function(viewItem) {
+                    if (!viewItem) {
+                        loopFrame.continueLoop();
+                        return;
+                    }
+                    self.counterStore.pushPageCounters(refs.pageCounters);
+                    self.counterStore.pushReferencesToSolve(refs.refs);
+                    var pos = viewItem.layoutPositions[self.pageIndex];
+                    self.renderSinglePage(viewItem, pos).then(function() {
+                        self.counterStore.popPageCounters();
+                        self.counterStore.popReferencesToSolve();
+                        loopFrame.continueLoop();
+                    });
+                });
+            }).then(function() {
+                // restore original values
+                self.spineIndex = origSpineIndex;
+                self.pageIndex = origPageIndex;
+                self.offsetInItem = origOffsetInItem;
+                frame.finish({
+                    page: page,
+                    position: pos,
+                    pageIndex: pageIndex
+                });
+            });
+        });
 
-	});
-	return frame.result();
+    });
+    return frame.result();
 };
 
 /**
@@ -1168,104 +1168,104 @@ adapt.epub.OPFView.prototype.renderSinglePage = function(viewItem, pos) {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.renderPage = function() {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
-		= adapt.task.newFrame("renderPage");
-	self.getPageViewItem().then(function(viewItem) {
-		if (!viewItem) {
-			frame.finish(null);
-			return;
-		}
-		var seekOffset = -1;
-		if (self.pageIndex < 0) {
-			seekOffset = self.offsetInItem;
-			// page with offset higher than seekOffset
-			var pageIndex = adapt.base.binarySearch(viewItem.layoutPositions.length,
-				function(pageIndex) {
-					var offset = viewItem.instance.getPosition(viewItem.layoutPositions[pageIndex]);
-					return offset > seekOffset;
-				});
-			if (pageIndex == viewItem.layoutPositions.length) {
-				// need to search through pages that are not yet produced
-				self.pageIndex = Number.POSITIVE_INFINITY;
-			} else {
-				// page that contains seekOffset
-				self.pageIndex = pageIndex - 1;
-			}
-		}
-		var resultPage = viewItem.pages[self.pageIndex];
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
+        = adapt.task.newFrame("renderPage");
+    self.getPageViewItem().then(function(viewItem) {
+        if (!viewItem) {
+            frame.finish(null);
+            return;
+        }
+        var seekOffset = -1;
+        if (self.pageIndex < 0) {
+            seekOffset = self.offsetInItem;
+            // page with offset higher than seekOffset
+            var pageIndex = adapt.base.binarySearch(viewItem.layoutPositions.length,
+                function(pageIndex) {
+                    var offset = viewItem.instance.getPosition(viewItem.layoutPositions[pageIndex]);
+                    return offset > seekOffset;
+                });
+            if (pageIndex == viewItem.layoutPositions.length) {
+                // need to search through pages that are not yet produced
+                self.pageIndex = Number.POSITIVE_INFINITY;
+            } else {
+                // page that contains seekOffset
+                self.pageIndex = pageIndex - 1;
+            }
+        }
+        var resultPage = viewItem.pages[self.pageIndex];
         if (resultPage) {
             self.offsetInItem = resultPage.offset;
             frame.finish(resultPage);
             return;
         }
-		frame.loopWithFrame(function(loopFrame) {
-			if (self.pageIndex < viewItem.layoutPositions.length) {
-				loopFrame.breakLoop();
-				return;
-			}
-			if (viewItem.complete) {
-				self.pageIndex = viewItem.layoutPositions.length - 1;
-				loopFrame.breakLoop();
-				return;
-			}
-			var pos = viewItem.layoutPositions[viewItem.layoutPositions.length - 1];
-			self.renderSinglePage(viewItem, pos).then(function(result) {
-				var page = result.page;
-				pos = result.position;
-				var pageIndex = result.pageIndex;
-				if (pos) {
-					if (seekOffset >= 0) {
-						// Searching for offset, don't know the page number.
-						var offset = viewItem.instance.getPosition(pos);
-						if (offset > seekOffset) {
-							resultPage = page;
-							self.pageIndex = viewItem.layoutPositions.length - 2;
-							loopFrame.breakLoop();
-							return;
-						}
-					}
-					loopFrame.continueLoop();
-				} else {
-					resultPage = page;
-					self.pageIndex = pageIndex;
-					if (seekOffset < 0) {
-						self.offsetInItem = page.offset;
-					}
-					viewItem.complete = true;
-					page.isLastPage = viewItem.item.spineIndex == self.opf.spine.length - 1;
-					loopFrame.breakLoop();
-				}
-			});
-		}).then(function() {
-			resultPage = resultPage || viewItem.pages[self.pageIndex];
-			var pos = viewItem.layoutPositions[self.pageIndex];
-	    	if (seekOffset < 0) {
-	    		self.offsetInItem = viewItem.instance.getPosition(pos);
-	    	}
-			if (resultPage) {
-				frame.finish(resultPage);
-				return;
-			}
-			self.renderSinglePage(viewItem, pos).then(function(result) {
-				var page = result.page;
-				pos = result.position;
-				if (!pos) {
-					viewItem.complete = true;
-					page.isLastPage = viewItem.item.spineIndex == self.opf.spine.length - 1;
-				}
-				frame.finish(page);
-			});
-		});
-	});
-	return frame.result();
+        frame.loopWithFrame(function(loopFrame) {
+            if (self.pageIndex < viewItem.layoutPositions.length) {
+                loopFrame.breakLoop();
+                return;
+            }
+            if (viewItem.complete) {
+                self.pageIndex = viewItem.layoutPositions.length - 1;
+                loopFrame.breakLoop();
+                return;
+            }
+            var pos = viewItem.layoutPositions[viewItem.layoutPositions.length - 1];
+            self.renderSinglePage(viewItem, pos).then(function(result) {
+                var page = result.page;
+                pos = result.position;
+                var pageIndex = result.pageIndex;
+                if (pos) {
+                    if (seekOffset >= 0) {
+                        // Searching for offset, don't know the page number.
+                        var offset = viewItem.instance.getPosition(pos);
+                        if (offset > seekOffset) {
+                            resultPage = page;
+                            self.pageIndex = viewItem.layoutPositions.length - 2;
+                            loopFrame.breakLoop();
+                            return;
+                        }
+                    }
+                    loopFrame.continueLoop();
+                } else {
+                    resultPage = page;
+                    self.pageIndex = pageIndex;
+                    if (seekOffset < 0) {
+                        self.offsetInItem = page.offset;
+                    }
+                    viewItem.complete = true;
+                    page.isLastPage = viewItem.item.spineIndex == self.opf.spine.length - 1;
+                    loopFrame.breakLoop();
+                }
+            });
+        }).then(function() {
+            resultPage = resultPage || viewItem.pages[self.pageIndex];
+            var pos = viewItem.layoutPositions[self.pageIndex];
+            if (seekOffset < 0) {
+                self.offsetInItem = viewItem.instance.getPosition(pos);
+            }
+            if (resultPage) {
+                frame.finish(resultPage);
+                return;
+            }
+            self.renderSinglePage(viewItem, pos).then(function(result) {
+                var page = result.page;
+                pos = result.position;
+                if (!pos) {
+                    viewItem.complete = true;
+                    page.isLastPage = viewItem.item.spineIndex == self.opf.spine.length - 1;
+                }
+                frame.finish(page);
+            });
+        });
+    });
+    return frame.result();
 };
 
 /**
  * @returns {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.renderAllPages = function() {
-	return this.renderPagesUpto(this.opf.spine.length - 1, Number.POSITIVE_INFINITY);
+    return this.renderPagesUpto(this.opf.spine.length - 1, Number.POSITIVE_INFINITY);
 };
 
 /**
@@ -1306,9 +1306,9 @@ adapt.epub.OPFView.prototype.renderPagesUpto = function(spineIndex, pageIndex) {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.firstPage = function() {
-	this.spineIndex = 0;
-	this.pageIndex = 0;
-	return this.renderPage();
+    this.spineIndex = 0;
+    this.pageIndex = 0;
+    return this.renderPage();
 };
 
 /**
@@ -1316,9 +1316,9 @@ adapt.epub.OPFView.prototype.firstPage = function() {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.lastPage = function() {
-	this.spineIndex = this.opf.spine.length - 1;
-	this.pageIndex = Number.POSITIVE_INFINITY;
-	return this.renderPage();
+    this.spineIndex = this.opf.spine.length - 1;
+    this.pageIndex = Number.POSITIVE_INFINITY;
+    return this.renderPage();
 };
 
 /**
@@ -1326,27 +1326,27 @@ adapt.epub.OPFView.prototype.lastPage = function() {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.nextPage = function() {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
-		= adapt.task.newFrame("nextPage");
-	self.getPageViewItem().then(function(viewItem) {
-		if (!viewItem) {
-			frame.finish(null);
-			return;
-		}
-		if (viewItem.complete && self.pageIndex == viewItem.layoutPositions.length - 1) {
-			if (self.spineIndex >= self.opf.spine.length - 1) {
-				frame.finish(null);
-				return;
-			}
-			self.spineIndex++;
-			self.pageIndex = 0;
-		} else {
-			self.pageIndex++;
-		}
-		self.renderPage().thenFinish(frame);
-	});
-	return frame.result();
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
+        = adapt.task.newFrame("nextPage");
+    self.getPageViewItem().then(function(viewItem) {
+        if (!viewItem) {
+            frame.finish(null);
+            return;
+        }
+        if (viewItem.complete && self.pageIndex == viewItem.layoutPositions.length - 1) {
+            if (self.spineIndex >= self.opf.spine.length - 1) {
+                frame.finish(null);
+                return;
+            }
+            self.spineIndex++;
+            self.pageIndex = 0;
+        } else {
+            self.pageIndex++;
+        }
+        self.renderPage().thenFinish(frame);
+    });
+    return frame.result();
 };
 
 /**
@@ -1354,16 +1354,16 @@ adapt.epub.OPFView.prototype.nextPage = function() {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.previousPage = function() {
-	if (this.pageIndex == 0) {
-		if (this.spineIndex == 0) {
-			return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));
-		}
-		this.spineIndex--;
-		this.pageIndex = Number.POSITIVE_INFINITY;
-	} else {
-		this.pageIndex--;
-	}
-	return this.renderPage();
+    if (this.pageIndex == 0) {
+        if (this.spineIndex == 0) {
+            return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));
+        }
+        this.spineIndex--;
+        this.pageIndex = Number.POSITIVE_INFINITY;
+    } else {
+        this.pageIndex--;
+    }
+    return this.renderPage();
 };
 
 /**
@@ -1466,18 +1466,18 @@ adapt.epub.OPFView.prototype.previousSpread = function() {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.navigateToEPage = function(epage) {
-	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
-		= adapt.task.newFrame("navigateToEPage");
-	var self = this;
-	this.opf.resolveEPage(epage).then(function(position) {
-		if (position) {
-			self.spineIndex = position.spineIndex;
-			self.pageIndex = position.pageIndex;
-			self.offsetInItem = position.offsetInItem;
-		}
-		self.renderPage().thenFinish(frame);
-	});
-	return frame.result();
+    /** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
+        = adapt.task.newFrame("navigateToEPage");
+    var self = this;
+    this.opf.resolveEPage(epage).then(function(position) {
+        if (position) {
+            self.spineIndex = position.spineIndex;
+            self.pageIndex = position.pageIndex;
+            self.offsetInItem = position.offsetInItem;
+        }
+        self.renderPage().thenFinish(frame);
+    });
+    return frame.result();
 };
 
 /**
@@ -1486,18 +1486,18 @@ adapt.epub.OPFView.prototype.navigateToEPage = function(epage) {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.navigateToFragment = function(fragment) {
-	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
-		= adapt.task.newFrame("navigateToCFI");
-	var self = this;
-	self.opf.resolveFragment(fragment).then(function(position) {
-		if (position) {
-			self.spineIndex = position.spineIndex;
-			self.pageIndex = position.pageIndex;
-			self.offsetInItem = position.offsetInItem;
-		}
-		self.renderPage().thenFinish(frame);		
-	});
-	return frame.result();
+    /** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
+        = adapt.task.newFrame("navigateToCFI");
+    var self = this;
+    self.opf.resolveFragment(fragment).then(function(position) {
+        if (position) {
+            self.spineIndex = position.spineIndex;
+            self.pageIndex = position.pageIndex;
+            self.offsetInItem = position.offsetInItem;
+        }
+        self.renderPage().thenFinish(frame);
+    });
+    return frame.result();
 };
 
 
@@ -1507,54 +1507,54 @@ adapt.epub.OPFView.prototype.navigateToFragment = function(fragment) {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.navigateTo = function(href) {
-	vivliostyle.logging.logger.debug("Navigate to", href);
-	var path = this.opf.getPathFromURL(adapt.base.stripFragment(href));
-	if (!path) {
-		if (this.opf.opfXML && href.match(/^#epubcfi\(/)) {
-			// CFI fragment is "relative" to OPF.
-			path = this.opf.getPathFromURL(this.opf.opfXML.url);
-		} else if (href.charAt(0) === "#") {
-			var restored = this.opf.documentURLTransformer.restoreURL(href);
-			if (this.opf.opfXML) {
-				path = this.opf.getPathFromURL(restored[0]);
-			} else {
-				path = restored[0];
-			}
-			href = path + (restored[1] ? "#" + restored[1] : "");
-		}
-		if (path == null) {
-			return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));		
-		}
-	}
-	var item = this.opf.itemMapByPath[path];
-	if (!item) {
-		if (this.opf.opfXML && path == this.opf.getPathFromURL(this.opf.opfXML.url)) {
-			// CFI link?
-			var fragmentIndex = href.indexOf("#");
-			if (fragmentIndex >= 0) {
-				return this.navigateToFragment(href.substr(fragmentIndex + 1));
-			}
-		}
-		return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));
-	}
-	// Committed to navigate. If not moving to a different item, current
-	// page is good enough.
-	if (item.spineIndex != this.spineIndex) {
-		this.spineIndex = item.spineIndex;
-		this.pageIndex = 0;
-	}
-	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
-		= adapt.task.newFrame("navigateTo");
-	var self = this;
-	self.getPageViewItem().then(function(viewItem) {
-		var target = viewItem.xmldoc.getElement(href);
-		if (target) {
-			self.offsetInItem = viewItem.xmldoc.getElementOffset(target);
-			self.pageIndex = -1;
-		}
-		self.renderPage().thenFinish(frame);
-	});
-	return frame.result();
+    vivliostyle.logging.logger.debug("Navigate to", href);
+    var path = this.opf.getPathFromURL(adapt.base.stripFragment(href));
+    if (!path) {
+        if (this.opf.opfXML && href.match(/^#epubcfi\(/)) {
+            // CFI fragment is "relative" to OPF.
+            path = this.opf.getPathFromURL(this.opf.opfXML.url);
+        } else if (href.charAt(0) === "#") {
+            var restored = this.opf.documentURLTransformer.restoreURL(href);
+            if (this.opf.opfXML) {
+                path = this.opf.getPathFromURL(restored[0]);
+            } else {
+                path = restored[0];
+            }
+            href = path + (restored[1] ? "#" + restored[1] : "");
+        }
+        if (path == null) {
+            return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));
+        }
+    }
+    var item = this.opf.itemMapByPath[path];
+    if (!item) {
+        if (this.opf.opfXML && path == this.opf.getPathFromURL(this.opf.opfXML.url)) {
+            // CFI link?
+            var fragmentIndex = href.indexOf("#");
+            if (fragmentIndex >= 0) {
+                return this.navigateToFragment(href.substr(fragmentIndex + 1));
+            }
+        }
+        return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));
+    }
+    // Committed to navigate. If not moving to a different item, current
+    // page is good enough.
+    if (item.spineIndex != this.spineIndex) {
+        this.spineIndex = item.spineIndex;
+        this.pageIndex = 0;
+    }
+    /** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
+        = adapt.task.newFrame("navigateTo");
+    var self = this;
+    self.getPageViewItem().then(function(viewItem) {
+        var target = viewItem.xmldoc.getElement(href);
+        if (target) {
+            self.offsetInItem = viewItem.xmldoc.getElementOffset(target);
+            self.pageIndex = -1;
+        }
+        self.renderPage().thenFinish(frame);
+    });
+    return frame.result();
 };
 
 /**
@@ -1563,36 +1563,36 @@ adapt.epub.OPFView.prototype.navigateTo = function(href) {
  * @return {!adapt.vtree.Page}
  */
 adapt.epub.OPFView.prototype.makePage = function(viewItem, pos) {
-	var viewport = viewItem.instance.viewport;
+    var viewport = viewItem.instance.viewport;
 
     var pageCont = /** @type {HTMLElement} */ (viewport.document.createElement("div"));
-	pageCont.setAttribute("data-vivliostyle-page-container", true);
-	pageCont.style.position = "absolute";
-	pageCont.style.top = "0";
-	pageCont.style.left = "0";
-	if (!vivliostyle.constants.isDebug) {
-		pageCont.style.visibility = "hidden";
-	}
-	viewport.root.appendChild(pageCont);
+    pageCont.setAttribute("data-vivliostyle-page-container", true);
+    pageCont.style.position = "absolute";
+    pageCont.style.top = "0";
+    pageCont.style.left = "0";
+    if (!vivliostyle.constants.isDebug) {
+        pageCont.style.visibility = "hidden";
+    }
+    viewport.root.appendChild(pageCont);
 
-	var bleedBox = /** @type {HTMLElement} */ (viewport.document.createElement("div"));
-	bleedBox.setAttribute("data-vivliostyle-bleed-box", true);
-	pageCont.appendChild(bleedBox);
+    var bleedBox = /** @type {HTMLElement} */ (viewport.document.createElement("div"));
+    bleedBox.setAttribute("data-vivliostyle-bleed-box", true);
+    pageCont.appendChild(bleedBox);
 
     var page = new adapt.vtree.Page(pageCont, bleedBox);
     page.spineIndex = viewItem.item.spineIndex;
     page.position = pos;
     page.offset = viewItem.instance.getPosition(pos);
-	if (page.offset === 0) {
-		var id = this.opf.documentURLTransformer.transformFragment("", viewItem.item.src);
-		bleedBox.setAttribute("id", id);
-		page.registerElementWithId(bleedBox, id);
-	}
+    if (page.offset === 0) {
+        var id = this.opf.documentURLTransformer.transformFragment("", viewItem.item.src);
+        bleedBox.setAttribute("id", id);
+        page.registerElementWithId(bleedBox, id);
+    }
     if (viewport !== this.viewport) {
-    	var matrix = adapt.expr.letterbox(this.viewport.width, this.viewport.height,
-    			viewport.width, viewport.height);
-    	var cssMatrix = adapt.cssparse.parseValue(null, new adapt.csstok.Tokenizer(matrix, null), "");
-    	page.delayedItems.push(new adapt.vtree.DelayedItem(pageCont, "transform", cssMatrix));
+        var matrix = adapt.expr.letterbox(this.viewport.width, this.viewport.height,
+            viewport.width, viewport.height);
+        var cssMatrix = adapt.cssparse.parseValue(null, new adapt.csstok.Tokenizer(matrix, null), "");
+        page.delayedItems.push(new adapt.vtree.DelayedItem(pageCont, "transform", cssMatrix));
     }
     return page;
 };
@@ -1604,66 +1604,66 @@ adapt.epub.OPFView.prototype.makePage = function(viewItem, pos) {
  * @return {!adapt.task.Result.<Element>}
  */
 adapt.epub.OPFView.prototype.makeObjectView = function(xmldoc, srcElem, viewParent, computedStyle) {
-	var data = srcElem.getAttribute("data");
-	/** @type {Element} */ var result = null;
-	if (data) {
-		data = adapt.base.resolveURL(data, xmldoc.url);
-		var mediaType = srcElem.getAttribute("media-type");
-		if (!mediaType) {
-			var path = this.opf.getPathFromURL(data);
-			if (path) {
-				var item = this.opf.itemMapByPath[path];
-				if (item) {
-					mediaType = item.mediaType;
-				}
-			}
-		}
-		if (mediaType) {
-			var handlerSrc = this.opf.bindings[mediaType];
-			if (handlerSrc) {
-				result = this.viewport.document.createElement("iframe");
-				result.style.border = "none";
-				var srcParam = adapt.base.lightURLEncode(data);
-				var typeParam = adapt.base.lightURLEncode(mediaType);
-				var sb = new adapt.base.StringBuffer();
-				sb.append(handlerSrc);
-				sb.append("?src=");
-				sb.append(srcParam);
-				sb.append("&type=");
-				sb.append(typeParam);
-				for (var c = srcElem.firstChild; c; c = c.nextSibling) {
-					if (c.nodeType == 1) {
-						var ce = /** @type {Element} */ (c);
-						if (ce.localName == "param" && ce.namespaceURI == adapt.base.NS.XHTML) {
-							var pname = ce.getAttribute("name");
-							var pvalue = ce.getAttribute("value");
-							if (pname && pvalue) {
-								sb.append("&");
-								sb.append(encodeURIComponent(pname));
-								sb.append("=");
-								sb.append(encodeURIComponent(pvalue));
-							}
-						}
-					}
-				}
-				result.setAttribute("src", sb.toString());
-				var width = srcElem.getAttribute("width");
-				if (width) {
-					result.setAttribute("width", width);
-				}
-				var height = srcElem.getAttribute("height");
-				if (height) {
-					result.setAttribute("height", height);
-				}
-			}
-		}
-	}
-	if (!result) {
-		result = this.viewport.document.createElement("span");
-		result.setAttribute("data-adapt-process-children", "true");
-	}
-	// Need to cast because we need {Element}, not {!Element}
-	return adapt.task.newResult(/** @type {Element} */ (result));
+    var data = srcElem.getAttribute("data");
+    /** @type {Element} */ var result = null;
+    if (data) {
+        data = adapt.base.resolveURL(data, xmldoc.url);
+        var mediaType = srcElem.getAttribute("media-type");
+        if (!mediaType) {
+            var path = this.opf.getPathFromURL(data);
+            if (path) {
+                var item = this.opf.itemMapByPath[path];
+                if (item) {
+                    mediaType = item.mediaType;
+                }
+            }
+        }
+        if (mediaType) {
+            var handlerSrc = this.opf.bindings[mediaType];
+            if (handlerSrc) {
+                result = this.viewport.document.createElement("iframe");
+                result.style.border = "none";
+                var srcParam = adapt.base.lightURLEncode(data);
+                var typeParam = adapt.base.lightURLEncode(mediaType);
+                var sb = new adapt.base.StringBuffer();
+                sb.append(handlerSrc);
+                sb.append("?src=");
+                sb.append(srcParam);
+                sb.append("&type=");
+                sb.append(typeParam);
+                for (var c = srcElem.firstChild; c; c = c.nextSibling) {
+                    if (c.nodeType == 1) {
+                        var ce = /** @type {Element} */ (c);
+                        if (ce.localName == "param" && ce.namespaceURI == adapt.base.NS.XHTML) {
+                            var pname = ce.getAttribute("name");
+                            var pvalue = ce.getAttribute("value");
+                            if (pname && pvalue) {
+                                sb.append("&");
+                                sb.append(encodeURIComponent(pname));
+                                sb.append("=");
+                                sb.append(encodeURIComponent(pvalue));
+                            }
+                        }
+                    }
+                }
+                result.setAttribute("src", sb.toString());
+                var width = srcElem.getAttribute("width");
+                if (width) {
+                    result.setAttribute("width", width);
+                }
+                var height = srcElem.getAttribute("height");
+                if (height) {
+                    result.setAttribute("height", height);
+                }
+            }
+        }
+    }
+    if (!result) {
+        result = this.viewport.document.createElement("span");
+        result.setAttribute("data-adapt-process-children", "true");
+    }
+    // Need to cast because we need {Element}, not {!Element}
+    return adapt.task.newResult(/** @type {Element} */ (result));
 };
 
 
@@ -1674,25 +1674,25 @@ adapt.epub.OPFView.prototype.makeObjectView = function(xmldoc, srcElem, viewPare
  * @return {!adapt.task.Result.<Element>}
  */
 adapt.epub.OPFView.prototype.makeMathJaxView = function(xmldoc, srcElem, viewParent, computedStyle) {
-	// See if MathJax installed, use it if it is.
-	var hub = adapt.epub.getMathJaxHub();
-	if (hub) {
-		var doc = viewParent.ownerDocument;
-		var span = doc.createElement("span");
-		viewParent.appendChild(span);
-		var clonedMath = doc.importNode(srcElem, true);
-		span.appendChild(clonedMath);
-		var queue = hub["queue"];
-		queue["Push"](["Typeset", hub, span]);
-		/** @type {!adapt.task.Frame.<Element>} */ var frame
-					= adapt.task.newFrame("navigateToEPage");
-		var continuation = frame.suspend();
-		queue["Push"](function() {
-			continuation.schedule(span);
-		});
-		return frame.result();
-	}
-	return adapt.task.newResult(/** @type {Element} */ (null));
+    // See if MathJax installed, use it if it is.
+    var hub = adapt.epub.getMathJaxHub();
+    if (hub) {
+        var doc = viewParent.ownerDocument;
+        var span = doc.createElement("span");
+        viewParent.appendChild(span);
+        var clonedMath = doc.importNode(srcElem, true);
+        span.appendChild(clonedMath);
+        var queue = hub["queue"];
+        queue["Push"](["Typeset", hub, span]);
+        /** @type {!adapt.task.Frame.<Element>} */ var frame
+            = adapt.task.newFrame("navigateToEPage");
+        var continuation = frame.suspend();
+        queue["Push"](function() {
+            continuation.schedule(span);
+        });
+        return frame.result();
+    }
+    return adapt.task.newResult(/** @type {Element} */ (null));
 };
 
 // TODO move makeSSEView to a more appropriate class (SSE XML content is not allowed in EPUB)
@@ -1737,82 +1737,82 @@ adapt.epub.OPFView.prototype.makeSSEView = function(xmldoc, srcElem, viewParent,
  * @override
  */
 adapt.epub.OPFView.prototype.makeCustomRenderer = function(xmldoc) {
-	var self = this;
-	return (
-	/**
-	 * @param {Element} srcElem
-	 * @param {Element} viewParent
-	 * @return {!adapt.task.Result.<Element>}
-	 */
-	function(srcElem, viewParent, computedStyle) {
-		if (srcElem.localName == "object" && srcElem.namespaceURI == adapt.base.NS.XHTML) {
-			return self.makeObjectView(xmldoc, srcElem, viewParent, computedStyle);
-		} else if (srcElem.namespaceURI == adapt.base.NS.MATHML) {
-			return self.makeMathJaxView(xmldoc, srcElem, viewParent, computedStyle);
-		} else if (srcElem.namespaceURI == adapt.base.NS.SSE) {
-            return self.makeSSEView(xmldoc, srcElem, viewParent, computedStyle);
-        } else if (srcElem.dataset && srcElem.dataset["mathTypeset"] == "true") {
-			return self.makeMathJaxView(xmldoc, srcElem, viewParent, computedStyle);
+    var self = this;
+    return (
+        /**
+         * @param {Element} srcElem
+         * @param {Element} viewParent
+         * @return {!adapt.task.Result.<Element>}
+         */
+        function(srcElem, viewParent, computedStyle) {
+            if (srcElem.localName == "object" && srcElem.namespaceURI == adapt.base.NS.XHTML) {
+                return self.makeObjectView(xmldoc, srcElem, viewParent, computedStyle);
+            } else if (srcElem.namespaceURI == adapt.base.NS.MATHML) {
+                return self.makeMathJaxView(xmldoc, srcElem, viewParent, computedStyle);
+            } else if (srcElem.namespaceURI == adapt.base.NS.SSE) {
+                return self.makeSSEView(xmldoc, srcElem, viewParent, computedStyle);
+            } else if (srcElem.dataset && srcElem.dataset["mathTypeset"] == "true") {
+                return self.makeMathJaxView(xmldoc, srcElem, viewParent, computedStyle);
+            }
+            return adapt.task.newResult(/** @type {Element} */ (null));
         }
-		return adapt.task.newResult(/** @type {Element} */ (null));
-	}
-	);
+    );
 };
 
 /**
  * @return {!adapt.task.Result.<adapt.epub.OPFViewItem>}
  */
 adapt.epub.OPFView.prototype.getPageViewItem = function() {
-	var self = this;
-	if (self.spineIndex >= self.opf.spine.length) {
-		return adapt.task.newResult(/** @type {adapt.epub.OPFViewItem} */ (null));
-	}
-	var viewItem = self.spineItems[self.spineIndex];
-	if (viewItem) {
-		return adapt.task.newResult(viewItem);		
-	}
-	var item = self.opf.spine[self.spineIndex];
-	var store = self.opf.store;
-	/** @type {!adapt.task.Frame.<adapt.epub.OPFViewItem>} */ var frame
-		= adapt.task.newFrame("getPageViewItem");
-    store.load(item.src).then(function (xmldoc) {
-    	if (item.epageCount == 0 && self.opf.spine.length == 1) {
-    		// Single-chapter doc without epages (e.g. FB2).
-    		// Estimate that offset=2700 roughly corresponds to 1024 bytes of compressed size. 
-    		item.epageCount = Math.ceil(xmldoc.getTotalOffset() / 2700);
-    		self.opf.epageCount = item.epageCount;
-    	}
-    	var style = store.getStyleForDoc(xmldoc);
-    	var customRenderer = self.makeCustomRenderer(xmldoc);
-    	var viewport = self.viewport;
-    	var viewportSize = style.sizeViewport(viewport.width, viewport.height, viewport.fontSize);
-    	if (viewportSize.width != viewport.width || viewportSize.height != viewport.height ||
-    			viewportSize.fontSize != viewport.fontSize) {
-    		viewport = new adapt.vgen.Viewport(viewport.window, viewportSize.fontSize, viewport.root,
-    				viewportSize.width, viewportSize.height);
-    	}
-		var previousViewItem = self.spineItems[self.spineIndex - 1];
-		var pageNumberOffset;
-		if (item.startPage !== null) {
-			pageNumberOffset = item.startPage - 1;
-		} else {
-			pageNumberOffset = previousViewItem ? previousViewItem.instance.pageNumberOffset + previousViewItem.pages.length : 0;
-			if (item.skipPagesBefore !== null) {
-				pageNumberOffset += item.skipPagesBefore;
-			}
-		}
-		self.counterStore.forceSetPageCounter(pageNumberOffset);
+    var self = this;
+    if (self.spineIndex >= self.opf.spine.length) {
+        return adapt.task.newResult(/** @type {adapt.epub.OPFViewItem} */ (null));
+    }
+    var viewItem = self.spineItems[self.spineIndex];
+    if (viewItem) {
+        return adapt.task.newResult(viewItem);
+    }
+    var item = self.opf.spine[self.spineIndex];
+    var store = self.opf.store;
+    /** @type {!adapt.task.Frame.<adapt.epub.OPFViewItem>} */ var frame
+        = adapt.task.newFrame("getPageViewItem");
+    store.load(item.src).then(function(xmldoc) {
+        if (item.epageCount == 0 && self.opf.spine.length == 1) {
+            // Single-chapter doc without epages (e.g. FB2).
+            // Estimate that offset=2700 roughly corresponds to 1024 bytes of compressed size.
+            item.epageCount = Math.ceil(xmldoc.getTotalOffset() / 2700);
+            self.opf.epageCount = item.epageCount;
+        }
+        var style = store.getStyleForDoc(xmldoc);
+        var customRenderer = self.makeCustomRenderer(xmldoc);
+        var viewport = self.viewport;
+        var viewportSize = style.sizeViewport(viewport.width, viewport.height, viewport.fontSize);
+        if (viewportSize.width != viewport.width || viewportSize.height != viewport.height ||
+            viewportSize.fontSize != viewport.fontSize) {
+            viewport = new adapt.vgen.Viewport(viewport.window, viewportSize.fontSize, viewport.root,
+                viewportSize.width, viewportSize.height);
+        }
+        var previousViewItem = self.spineItems[self.spineIndex - 1];
+        var pageNumberOffset;
+        if (item.startPage !== null) {
+            pageNumberOffset = item.startPage - 1;
+        } else {
+            pageNumberOffset = previousViewItem ? previousViewItem.instance.pageNumberOffset + previousViewItem.pages.length : 0;
+            if (item.skipPagesBefore !== null) {
+                pageNumberOffset += item.skipPagesBefore;
+            }
+        }
+        self.counterStore.forceSetPageCounter(pageNumberOffset);
 
         var instance = new adapt.ops.StyleInstance(style, xmldoc, self.opf.lang,
-			viewport, self.clientLayout, self.fontMapper, customRenderer, self.opf.fallbackMap, pageNumberOffset,
-			self.opf.documentURLTransformer, self.counterStore);
+            viewport, self.clientLayout, self.fontMapper, customRenderer, self.opf.fallbackMap, pageNumberOffset,
+            self.opf.documentURLTransformer, self.counterStore);
 
         instance.pref = self.pref;
         instance.init().then(function() {
-			viewItem = {item: item, xmldoc: xmldoc, instance: instance,
-					layoutPositions: [null], pages: [], complete: false};
-			self.spineItems[self.spineIndex] = viewItem;
-			frame.finish(viewItem);
+            viewItem = {item: item, xmldoc: xmldoc, instance: instance,
+                layoutPositions: [null], pages: [], complete: false};
+            self.spineItems[self.spineIndex] = viewItem;
+            frame.finish(viewItem);
         });
     });
     return frame.result();
@@ -1822,7 +1822,7 @@ adapt.epub.OPFView.prototype.getPageViewItem = function() {
  * @return {adapt.epub.Position}
  */
 adapt.epub.OPFView.prototype.getPagePosition = function() {
-	return {spineIndex: this.spineIndex, pageIndex: this.pageIndex, offsetInItem: this.offsetInItem};
+    return {spineIndex: this.spineIndex, pageIndex: this.pageIndex, offsetInItem: this.offsetInItem};
 };
 
 /**
@@ -1830,16 +1830,16 @@ adapt.epub.OPFView.prototype.getPagePosition = function() {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.setPagePosition = function(pos) {
-	if (pos) {
-		this.spineIndex = pos.spineIndex;
-		this.pageIndex = -1;
-		this.offsetInItem = pos.offsetInItem;
-	} else {
-		this.spineIndex = 0;
-		this.pageIndex = 0;
-		this.offsetInItem = 0;		
-	}
-	return this.renderPagesUpto(this.spineIndex, this.pageIndex);
+    if (pos) {
+        this.spineIndex = pos.spineIndex;
+        this.pageIndex = -1;
+        this.offsetInItem = pos.offsetInItem;
+    } else {
+        this.spineIndex = 0;
+        this.pageIndex = 0;
+        this.offsetInItem = 0;
+    }
+    return this.renderPagesUpto(this.spineIndex, this.pageIndex);
 };
 
 adapt.epub.OPFView.prototype.removeRenderedPages = function() {
@@ -1862,20 +1862,20 @@ adapt.epub.OPFView.prototype.removeRenderedPages = function() {
  * @returns {boolean}
  */
 adapt.epub.OPFView.prototype.hasAutoSizedPages = function() {
-	var items = this.spineItems;
-	for (var i = 0; i < items.length; i++) {
-		var item = items[i];
-		if (item) {
-			var pages = item.pages;
-			for (var j = 0; j < pages.length; j++) {
-				var page = pages[j];
-				if (page.isAutoPageWidth && page.isAutoPageHeight) {
-					return true;
-				}
-			}
-		}
-	}
-	return false;
+    var items = this.spineItems;
+    for (var i = 0; i < items.length; i++) {
+        var item = items[i];
+        if (item) {
+            var pages = item.pages;
+            for (var j = 0; j < pages.length; j++) {
+                var page = pages[j];
+                if (page.isAutoPageWidth && page.isAutoPageHeight) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
 };
 
 /**
@@ -1883,21 +1883,21 @@ adapt.epub.OPFView.prototype.hasAutoSizedPages = function() {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.epub.OPFView.prototype.showTOC = function(autohide) {
-	var opf = this.opf;
-	var toc = opf.xhtmlToc || opf.ncxToc;
-	if (!toc) {
-		return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));
-	}
-	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
-			= adapt.task.newFrame("showTOC");
-	if (!this.tocView) {
-		this.tocView = new adapt.toc.TOCView(opf.store, toc.src, opf.lang, 
-				this.clientLayout, this.fontMapper, this.pref, this, opf.fallbackMap, opf.documentURLTransformer,
-				this.counterStore);
-	}
-	var viewport = this.viewport;
-	var tocWidth = Math.min(350, Math.round(0.67 * viewport.width) - 16);
-	var tocHeight = viewport.height - 6;
+    var opf = this.opf;
+    var toc = opf.xhtmlToc || opf.ncxToc;
+    if (!toc) {
+        return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (null));
+    }
+    /** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame
+        = adapt.task.newFrame("showTOC");
+    if (!this.tocView) {
+        this.tocView = new adapt.toc.TOCView(opf.store, toc.src, opf.lang,
+            this.clientLayout, this.fontMapper, this.pref, this, opf.fallbackMap, opf.documentURLTransformer,
+            this.counterStore);
+    }
+    var viewport = this.viewport;
+    var tocWidth = Math.min(350, Math.round(0.67 * viewport.width) - 16);
+    var tocHeight = viewport.height - 6;
     var pageCont = /** @type {HTMLElement} */ (viewport.document.createElement("div"));
     viewport.root.appendChild(pageCont);
     pageCont.style.position = "absolute";
@@ -1912,26 +1912,26 @@ adapt.epub.OPFView.prototype.showTOC = function(autohide) {
     pageCont.style.border = "1px outset #999";
     pageCont.style["borderRadius"] = "2px";
     pageCont.style["boxShadow"] = " 5px 5px rgba(128,128,128,0.3)";
-	this.tocView.showTOC(pageCont, viewport, tocWidth, tocHeight, this.viewport.fontSize).then(function(page) {
-	    pageCont.style.visibility = "visible";
-	    frame.finish(page);
-	});
-	return frame.result();
+    this.tocView.showTOC(pageCont, viewport, tocWidth, tocHeight, this.viewport.fontSize).then(function(page) {
+        pageCont.style.visibility = "visible";
+        frame.finish(page);
+    });
+    return frame.result();
 };
 
 /**
  * @return {void}
  */
 adapt.epub.OPFView.prototype.hideTOC = function() {
-	if (this.tocView) {
-		this.tocView.hideTOC();
-	}
+    if (this.tocView) {
+        this.tocView.hideTOC();
+    }
 };
 
 /**
  * @return {boolean}
  */
 adapt.epub.OPFView.prototype.isTOCVisible = function(autohide) {
-	return this.tocView && this.tocView.isTOCVisible();
+    return this.tocView && this.tocView.isTOCVisible();
 };
 

--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -18,9 +18,9 @@ adapt.expr.Preferences;
  * @return {adapt.expr.Preferences}
  */
 adapt.expr.defaultPreferences = function() {
-	return {fontFamily:"serif", lineHeight:1.25, margin:8, hyphenate:true, columnWidth:25,
-				horizontal:false, nightMode:false, spreadView:false, pageBorder:1,
-                enabledMediaTypes:{"print": true}};
+    return {fontFamily:"serif", lineHeight:1.25, margin:8, hyphenate:true, columnWidth:25,
+        horizontal:false, nightMode:false, spreadView:false, pageBorder:1,
+        enabledMediaTypes:{"print": true}};
 };
 
 /**
@@ -28,9 +28,9 @@ adapt.expr.defaultPreferences = function() {
  * @return {adapt.expr.Preferences}
  */
 adapt.expr.clonePreferences = function(pref) {
-	return {fontFamily:pref.fontFamily, lineHeight:pref.lineHeight, margin:pref.margin,
-		hyphenate:pref.hyphenate, columnWidth:pref.columnWidth, horizontal:pref.horizontal,
-		nightMode:pref.nightMode, spreadView:pref.spreadView, pageBorder:pref.pageBorder,
+    return {fontFamily:pref.fontFamily, lineHeight:pref.lineHeight, margin:pref.margin,
+        hyphenate:pref.hyphenate, columnWidth:pref.columnWidth, horizontal:pref.horizontal,
+        nightMode:pref.nightMode, spreadView:pref.spreadView, pageBorder:pref.pageBorder,
         enabledMediaTypes:Object.assign({}, pref.enabledMediaTypes)};
 };
 
@@ -45,7 +45,7 @@ adapt.expr.defaultPreferencesInstance = adapt.expr.defaultPreferences();
  * @enum {!Object}
  */
 adapt.expr.Special = {
-	PENDING: {}
+    PENDING: {}
 };
 
 /**
@@ -94,8 +94,8 @@ adapt.expr.cssIdent = function(name) {
  */
 adapt.expr.makeQualifiedName = function(objName, memberName) {
     if (objName) {
-        return adapt.base.escapeCSSIdent(objName) + "." + 
-        	adapt.base.escapeCSSIdent(memberName);
+        return adapt.base.escapeCSSIdent(objName) + "." +
+            adapt.base.escapeCSSIdent(memberName);
     }
     return adapt.base.escapeCSSIdent(memberName);
 };
@@ -113,7 +113,7 @@ adapt.expr.nextKeyIndex = 0;
  * @constructor
  */
 adapt.expr.LexicalScope = function(parent, resolver) {
-	this.parent = parent;
+    this.parent = parent;
     /** @type {string} */ this.scopeKey = "S" + (adapt.expr.nextKeyIndex++);
     /** @type {Array.<adapt.expr.LexicalScope>} */ this.children = [];
     /** @type {adapt.expr.Const} */ this.zero = new adapt.expr.Const(this, 0);
@@ -128,7 +128,7 @@ adapt.expr.LexicalScope = function(parent, resolver) {
     this.builtIns = {};
     /** @const */ this.resolver = resolver;
     if (!parent) {
-    	// root scope
+        // root scope
         var builtIns = this.builtIns;
         builtIns["floor"] = Math.floor;
         builtIns["ceil"] = Math.ceil;
@@ -139,7 +139,7 @@ adapt.expr.LexicalScope = function(parent, resolver) {
         builtIns["letterbox"] = adapt.expr.letterbox;
         builtIns["css-string"] = adapt.expr.cssString;
         builtIns["css-name"] = adapt.expr.cssIdent;
-        builtIns["typeof"] = function(x) { return typeof(x); };
+        builtIns["typeof"] = function(x) { return typeof x; };
         this.defineBuiltInName("page-width", function() { return this.pageWidth(); });
         this.defineBuiltInName("page-height", function() { return this.pageHeight(); });
         this.defineBuiltInName("pref-font-family", function() { return this.pref.fontFamily; });
@@ -149,7 +149,7 @@ adapt.expr.LexicalScope = function(parent, resolver) {
         this.defineBuiltInName("pref-line-height", function() { return this.pref.lineHeight; });
         this.defineBuiltInName("pref-column-width", function() { return this.pref.columnWidth * this.fontSize; });
         this.defineBuiltInName("pref-horizontal", function() {
-        	return this.pref.horizontal;
+            return this.pref.horizontal;
         });
         this.defineBuiltInName("pref-spread-view", function() { return this.pref.spreadView; });
     }
@@ -160,7 +160,7 @@ adapt.expr.LexicalScope = function(parent, resolver) {
  * @param {function(this:adapt.expr.Context):adapt.expr.Result} fn
  */
 adapt.expr.LexicalScope.prototype.defineBuiltInName = function(name, fn) {
-	this.values[name] = new adapt.expr.Native(this, fn, name);
+    this.values[name] = new adapt.expr.Native(this, fn, name);
 };
 
 /**
@@ -261,7 +261,7 @@ adapt.expr.ScopeContext;
  * @constructor
  */
 adapt.expr.Context = function(rootScope, viewportWidth, viewportHeight, fontSize) {
-	/** @const */ this.rootScope = rootScope;
+    /** @const */ this.rootScope = rootScope;
     /** @const */ this.viewportWidth = viewportWidth;
     /** @const */ this.viewportHeight = viewportHeight;
     /** @protected @type {?number} */ this.actualPageWidth = null;
@@ -282,14 +282,14 @@ adapt.expr.Context = function(rootScope, viewportWidth, viewportHeight, fontSize
     };
     /** @const */ this.initialFontSize = fontSize;
     /** @type {?number} */ this.rootFontSize = null;
-	this.fontSize = function() {
+    this.fontSize = function() {
         if (this.rootFontSize)
             return this.rootFontSize;
         else
             return fontSize;
     };
-	this.pref = adapt.expr.defaultPreferencesInstance;
-	/** @type {Object.<string,adapt.expr.ScopeContext>} */ this.scopes = {};
+    this.pref = adapt.expr.defaultPreferencesInstance;
+    /** @type {Object.<string,adapt.expr.ScopeContext>} */ this.scopes = {};
 };
 
 /**
@@ -347,9 +347,9 @@ adapt.expr.Context.prototype.evalName = function(scope, qualifiedName) {
         if (val)
             return val;
         if (scope.resolver) {
-        	val = scope.resolver.call(this, qualifiedName, false);
-        	if (val)
-        		return val;
+            val = scope.resolver.call(this, qualifiedName, false);
+            if (val)
+                return val;
         }
         scope = scope.parent;
     } while (scope);
@@ -369,14 +369,14 @@ adapt.expr.Context.prototype.evalCall = function(scope, qualifiedName, params, n
         if (body)
             return body; // will be expanded by callee
         if (scope.resolver) {
-        	body = scope.resolver.call(this, qualifiedName, true);
-        	if (body)
-        		return body;
-        }        
+            body = scope.resolver.call(this, qualifiedName, true);
+            if (body)
+                return body;
+        }
         var fn = scope.builtIns[qualifiedName];
         if (fn) {
-        	if (noBuiltInEval)
-        		return scope.zero;
+            if (noBuiltInEval)
+                return scope.zero;
             var args = Array(params.length);
             for (var i = 0; i < params.length; i++) {
                 args[i] = params[i].evaluate(this);
@@ -486,7 +486,7 @@ adapt.expr.DependencyCache;
  * @constructor
  */
 adapt.expr.Val = function(scope) {
-	this.scope = scope;
+    this.scope = scope;
     this.key = "_" + adapt.expr.nextKeyIndex++;
 };
 
@@ -596,8 +596,8 @@ adapt.expr.Val.prototype.isMediaName = function() {
  * @extends {adapt.expr.Val}
  */
 adapt.expr.Prefix = function(scope, val) {
-	adapt.expr.Val.call(this, scope);
-	/** @type {adapt.expr.Val} */ this.val = val;
+    adapt.expr.Val.call(this, scope);
+    /** @type {adapt.expr.Val} */ this.val = val;
 };
 goog.inherits(adapt.expr.Prefix, adapt.expr.Val);
 
@@ -606,7 +606,7 @@ goog.inherits(adapt.expr.Prefix, adapt.expr.Val);
  * @return {string}
  */
 adapt.expr.Prefix.prototype.getOp = function() {
-    throw new Error("F_ABSTRACT");        
+    throw new Error("F_ABSTRACT");
 };
 
 /**
@@ -614,7 +614,7 @@ adapt.expr.Prefix.prototype.getOp = function() {
  * @return {adapt.expr.Result}
  */
 adapt.expr.Prefix.prototype.evalPrefix = function(val) {
-	throw new Error("F_ABSTRACT");        
+    throw new Error("F_ABSTRACT");
 };
 
 /**
@@ -649,7 +649,7 @@ adapt.expr.Prefix.prototype.appendTo = function(buf, priority) {
  */
 adapt.expr.Prefix.prototype.expand = function(context, params) {
     var val = this.val.expand(context, params);
-    if( val === this.val )
+    if (val === this.val)
         return this;
     var r = new this.constructor(this.scope, val);
     return r;
@@ -681,7 +681,7 @@ adapt.expr.Infix.prototype.getPriority = function() {
  * @return {string}
  */
 adapt.expr.Infix.prototype.getOp = function() {
-    throw new Error("F_ABSTRACT");        
+    throw new Error("F_ABSTRACT");
 };
 
 /**
@@ -690,7 +690,7 @@ adapt.expr.Infix.prototype.getOp = function() {
  * @return {adapt.expr.Result}
  */
 adapt.expr.Infix.prototype.evalInfix = function(lhs, rhs) {
-    throw new Error("F_ABSTRACT");        
+    throw new Error("F_ABSTRACT");
 };
 
 /**
@@ -707,7 +707,7 @@ adapt.expr.Infix.prototype.evaluateCore = function(context) {
  */
 adapt.expr.Infix.prototype.dependCore = function(other, context, dependencyCache) {
     return other === this || this.lhs.dependOuter(other, context, dependencyCache) ||
-         this.rhs.dependOuter(other, context, dependencyCache);
+        this.rhs.dependOuter(other, context, dependencyCache);
 };
 
 /**
@@ -730,7 +730,7 @@ adapt.expr.Infix.prototype.appendTo = function(buf, priority) {
 adapt.expr.Infix.prototype.expand = function(context, params) {
     var lhs = this.lhs.expand(context, params);
     var rhs = this.rhs.expand(context, params);
-    if( lhs === this.lhs && rhs === this.rhs )
+    if (lhs === this.lhs && rhs === this.rhs)
         return this;
     var r = new this.constructor(this.scope, lhs, rhs);
     return r;
@@ -745,7 +745,7 @@ adapt.expr.Infix.prototype.expand = function(context, params) {
  * @param {adapt.expr.Val} rhs
  */
 adapt.expr.Logical = function(scope, lhs, rhs) {
-	adapt.expr.Infix.call(this, scope, lhs, rhs);
+    adapt.expr.Infix.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Logical, adapt.expr.Infix);
 
@@ -765,7 +765,7 @@ adapt.expr.Logical.prototype.getPriority = function() {
  * @param {adapt.expr.Val} rhs
  */
 adapt.expr.Comparison = function(scope, lhs, rhs) {
-	adapt.expr.Infix.call(this, scope, lhs, rhs);
+    adapt.expr.Infix.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Comparison, adapt.expr.Infix);
 
@@ -785,7 +785,7 @@ adapt.expr.Comparison.prototype.getPriority = function() {
  * @param {adapt.expr.Val} rhs
  */
 adapt.expr.Additive = function(scope, lhs, rhs) {
-	adapt.expr.Infix.call(this, scope, lhs, rhs);
+    adapt.expr.Infix.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Additive, adapt.expr.Infix);
 
@@ -805,7 +805,7 @@ adapt.expr.Additive.prototype.getPriority = function() {
  * @param {adapt.expr.Val} rhs
  */
 adapt.expr.Multiplicative = function(scope, lhs, rhs) {
-	adapt.expr.Infix.call(this, scope, lhs, rhs);
+    adapt.expr.Infix.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Multiplicative, adapt.expr.Infix);
 
@@ -824,7 +824,7 @@ adapt.expr.Multiplicative.prototype.getPriority = function() {
  * @extends {adapt.expr.Prefix}
  */
 adapt.expr.Not = function(scope, val) {
-	adapt.expr.Prefix.call(this, scope, val);
+    adapt.expr.Prefix.call(this, scope, val);
 };
 goog.inherits(adapt.expr.Not, adapt.expr.Prefix);
 
@@ -850,7 +850,7 @@ adapt.expr.Not.prototype.evalPrefix = function(val) {
  * @extends {adapt.expr.Prefix}
  */
 adapt.expr.Negate = function(scope, val) {
-	adapt.expr.Prefix.call(this, scope, val);
+    adapt.expr.Prefix.call(this, scope, val);
 };
 goog.inherits(adapt.expr.Negate, adapt.expr.Prefix);
 
@@ -877,7 +877,7 @@ adapt.expr.Negate.prototype.evalPrefix = function(val) {
  * @extends {adapt.expr.Logical}
  */
 adapt.expr.And = function(scope, lhs, rhs) {
-	adapt.expr.Logical.call(this, scope, lhs, rhs);
+    adapt.expr.Logical.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.And, adapt.expr.Logical);
 
@@ -894,7 +894,7 @@ adapt.expr.And.prototype.getOp = function() {
 adapt.expr.And.prototype.evaluateCore = function(context) {
     return this.lhs.evaluate(context) && this.rhs.evaluate(context);
 };
-    
+
 
 /**
  * @constructor
@@ -904,7 +904,7 @@ adapt.expr.And.prototype.evaluateCore = function(context) {
  * @extends {adapt.expr.And}
  */
 adapt.expr.AndMedia = function(scope, lhs, rhs) {
-	adapt.expr.And.call(this, scope, lhs, rhs);
+    adapt.expr.And.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.AndMedia, adapt.expr.And);
 
@@ -924,7 +924,7 @@ adapt.expr.AndMedia.prototype.getOp = function() {
  * @extends {adapt.expr.Logical}
  */
 adapt.expr.Or = function(scope, lhs, rhs) {
-	adapt.expr.Logical.call(this, scope, lhs, rhs);
+    adapt.expr.Logical.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Or, adapt.expr.Logical);
 
@@ -951,7 +951,7 @@ adapt.expr.Or.prototype.evaluateCore = function(context) {
  * @extends {adapt.expr.Or}
  */
 adapt.expr.OrMedia = function(scope, lhs, rhs) {
-	adapt.expr.Or.call(this, scope, lhs, rhs);
+    adapt.expr.Or.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.OrMedia, adapt.expr.Or);
 
@@ -971,7 +971,7 @@ adapt.expr.OrMedia.prototype.getOp = function() {
  * @extends {adapt.expr.Comparison}
  */
 adapt.expr.Lt = function(scope, lhs, rhs) {
-	adapt.expr.Comparison.call(this, scope, lhs, rhs);
+    adapt.expr.Comparison.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Lt, adapt.expr.Comparison);
 
@@ -998,7 +998,7 @@ adapt.expr.Lt.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Comparison}
  */
 adapt.expr.Le = function(scope, lhs, rhs) {
-	adapt.expr.Comparison.call(this, scope, lhs, rhs);
+    adapt.expr.Comparison.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Le, adapt.expr.Comparison);
 
@@ -1025,7 +1025,7 @@ adapt.expr.Le.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Comparison}
  */
 adapt.expr.Gt = function(scope, lhs, rhs) {
-	adapt.expr.Comparison.call(this, scope, lhs, rhs);
+    adapt.expr.Comparison.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Gt, adapt.expr.Comparison);
 
@@ -1052,7 +1052,7 @@ adapt.expr.Gt.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Comparison}
  */
 adapt.expr.Ge = function(scope, lhs, rhs) {
-	adapt.expr.Comparison.call(this, scope, lhs, rhs);
+    adapt.expr.Comparison.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Ge, adapt.expr.Comparison);
 
@@ -1079,7 +1079,7 @@ adapt.expr.Ge.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Comparison}
  */
 adapt.expr.Eq = function(scope, lhs, rhs) {
-	adapt.expr.Comparison.call(this, scope, lhs, rhs);
+    adapt.expr.Comparison.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Eq, adapt.expr.Comparison);
 
@@ -1106,7 +1106,7 @@ adapt.expr.Eq.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Comparison}
  */
 adapt.expr.Ne = function(scope, lhs, rhs) {
-	adapt.expr.Comparison.call(this, scope, lhs, rhs);
+    adapt.expr.Comparison.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Ne, adapt.expr.Comparison);
 
@@ -1133,7 +1133,7 @@ adapt.expr.Ne.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Additive}
  */
 adapt.expr.Add = function(scope, lhs, rhs) {
-	adapt.expr.Additive.call(this, scope, lhs, rhs);
+    adapt.expr.Additive.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Add, adapt.expr.Additive);
 
@@ -1160,7 +1160,7 @@ adapt.expr.Add.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Additive}
  */
 adapt.expr.Subtract = function(scope, lhs, rhs) {
-	adapt.expr.Additive.call(this, scope, lhs, rhs);
+    adapt.expr.Additive.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Subtract, adapt.expr.Additive);
 
@@ -1187,7 +1187,7 @@ adapt.expr.Subtract.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Multiplicative}
  */
 adapt.expr.Multiply = function(scope, lhs, rhs) {
-	adapt.expr.Multiplicative.call(this, scope, lhs, rhs);
+    adapt.expr.Multiplicative.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Multiply, adapt.expr.Multiplicative);
 
@@ -1214,7 +1214,7 @@ adapt.expr.Multiply.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Multiplicative}
  */
 adapt.expr.Divide = function(scope, lhs, rhs) {
-	adapt.expr.Multiplicative.call(this, scope, lhs, rhs);
+    adapt.expr.Multiplicative.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Divide, adapt.expr.Multiplicative);
 
@@ -1241,7 +1241,7 @@ adapt.expr.Divide.prototype.evalInfix = function(lhs, rhs) {
  * @extends {adapt.expr.Multiplicative}
  */
 adapt.expr.Modulo = function(scope, lhs, rhs) {
-	adapt.expr.Multiplicative.call(this, scope, lhs, rhs);
+    adapt.expr.Multiplicative.call(this, scope, lhs, rhs);
 };
 goog.inherits(adapt.expr.Modulo, adapt.expr.Multiplicative);
 
@@ -1295,7 +1295,7 @@ adapt.expr.Numeric.prototype.evaluateCore = function(context) {
  * Named value.
  * @constructor
  * @param {adapt.expr.LexicalScope} scope
- * @param {string} qualifiedName CSS-escaped name sequence separated by dots. 
+ * @param {string} qualifiedName CSS-escaped name sequence separated by dots.
  * @extends {adapt.expr.Val}
  */
 adapt.expr.Named = function(scope, qualifiedName) {
@@ -1310,7 +1310,7 @@ goog.inherits(adapt.expr.Named, adapt.expr.Val);
 adapt.expr.Named.prototype.appendTo = function(buf, priority) {
     buf.append(this.qualifiedName);
 };
-    
+
 /**
  * @override
  */
@@ -1322,7 +1322,7 @@ adapt.expr.Named.prototype.evaluateCore = function(context) {
  * @override
  */
 adapt.expr.Named.prototype.dependCore = function(other, context, dependencyCache) {
-    return other === this || 
+    return other === this ||
         context.evalName(this.scope, this.qualifiedName).dependOuter(other, context, dependencyCache);
 };
 
@@ -1336,7 +1336,7 @@ adapt.expr.Named.prototype.dependCore = function(other, context, dependencyCache
  * @extends {adapt.expr.Val}
  */
 adapt.expr.MediaName = function(scope, not, name) {
-	adapt.expr.Val.call(this, scope);
+    adapt.expr.Val.call(this, scope);
     /** @type {boolean} */ this.not = not;
     /** @type {string} */ this.name = name;
 };
@@ -1350,7 +1350,7 @@ adapt.expr.MediaName.prototype.appendTo = function(buf, priority) {
         buf.append('not ');
     buf.append(adapt.base.escapeCSSIdent(this.name));
 };
-    
+
 /**
  * @override
  */
@@ -1414,8 +1414,8 @@ adapt.expr.Native.prototype.evaluateCore = function(context) {
  */
 adapt.expr.appendValArray = function(buf, arr) {
     buf.append("(");
-    for (var i = 0 ; i < arr.length ; i++) {
-        if (i) 
+    for (var i = 0; i < arr.length; i++) {
+        if (i)
             buf.append(",");
         arr[i].appendTo(buf, 0);
     }
@@ -1433,13 +1433,13 @@ adapt.expr.expandValArray = function(context, arr, params) {
     for (var i = 0; i < arr.length; i++) {
         var p = arr[i].expand(context, params);
         if (arr !== expanded) {
-        	expanded[i] = p;
+            expanded[i] = p;
         } else if (p !== arr[i]) {
-        	expanded = Array(arr.length);
-        	for (var j = 0; j < i; j++) {
-        		expanded[j] = arr[j];
-        	}
-        	expanded[i] = p;
+            expanded = Array(arr.length);
+            for (var j = 0; j < i; j++) {
+                expanded[j] = arr[j];
+            }
+            expanded[i] = p;
         }
     }
     return expanded;
@@ -1523,10 +1523,10 @@ adapt.expr.Call.prototype.expand = function(context, params) {
  * @extends {adapt.expr.Val}
  */
 adapt.expr.Cond = function(scope, cond, ifTrue, ifFalse) {
-	adapt.expr.Val.call(this, scope);
-	/** @type {adapt.expr.Val} */ this.cond = cond;
-	/** @type {adapt.expr.Val} */ this.ifTrue = ifTrue;
-	/** @type {adapt.expr.Val} */ this.ifFalse = ifFalse;
+    adapt.expr.Val.call(this, scope);
+    /** @type {adapt.expr.Val} */ this.cond = cond;
+    /** @type {adapt.expr.Val} */ this.ifTrue = ifTrue;
+    /** @type {adapt.expr.Val} */ this.ifFalse = ifFalse;
 };
 goog.inherits(adapt.expr.Cond, adapt.expr.Val);
 
@@ -1534,14 +1534,14 @@ goog.inherits(adapt.expr.Cond, adapt.expr.Val);
  * @override
  */
 adapt.expr.Cond.prototype.appendTo = function(buf, priority) {
-    if( priority > 0 )
+    if (priority > 0)
         buf.append("(");
     this.cond.appendTo(buf, 0);
     buf.append("?");
     this.ifTrue.appendTo(buf, 0);
     buf.append(":");
     this.ifFalse.appendTo(buf, 0);
-    if( priority > 0 )
+    if (priority > 0)
         buf.append(")");
 };
 
@@ -1584,7 +1584,7 @@ adapt.expr.Cond.prototype.expand = function(context, params) {
  * @extends {adapt.expr.Val}
  */
 adapt.expr.Const = function(scope, val) {
-	adapt.expr.Val.call(this, scope);
+    adapt.expr.Val.call(this, scope);
     this.val = val;
 };
 goog.inherits(adapt.expr.Const, adapt.expr.Val);
@@ -1594,17 +1594,17 @@ goog.inherits(adapt.expr.Const, adapt.expr.Val);
  */
 adapt.expr.Const.prototype.appendTo = function(buf, priority) {
     switch (typeof this.val) {
-    case "number":
-    case "boolean":
-        buf.append(this.val.toString());
-        break;
-    case "string":
-        buf.append('"');
-        buf.append(adapt.base.escapeCSSStr(this.val));
-        buf.append('"');
-        break;
-    default:
-        throw new Error("F_UNEXPECTED_STATE");
+        case "number":
+        case "boolean":
+            buf.append(this.val.toString());
+            break;
+        case "string":
+            buf.append('"');
+            buf.append(adapt.base.escapeCSSStr(this.val));
+            buf.append('"');
+            break;
+        default:
+            throw new Error("F_UNEXPECTED_STATE");
     }
 };
 
@@ -1624,7 +1624,7 @@ adapt.expr.Const.prototype.evaluateCore = function(context) {
  * @extends {adapt.expr.Val}
  */
 adapt.expr.MediaTest = function(scope, name, value) {
-	adapt.expr.Val.call(this, scope);
+    adapt.expr.Val.call(this, scope);
     this.name = name;
     this.value = value;
 };
@@ -1673,7 +1673,7 @@ adapt.expr.MediaTest.prototype.expand = function(context, params) {
  * @extends {adapt.expr.Val}
  */
 adapt.expr.Param = function(scope, index) {
-	adapt.expr.Val.call(this, scope);
+    adapt.expr.Val.call(this, scope);
     this.index = index;
 };
 goog.inherits(adapt.expr.Param, adapt.expr.Val);

--- a/src/adapt/font.js
+++ b/src/adapt/font.js
@@ -17,9 +17,9 @@ goog.require('adapt.cssparse');
 
 /** @type {Object.<string,adapt.css.Val>} */
 adapt.font.traitProps = {
-	"font-style": adapt.css.ident.normal,
-	"font-variant": adapt.css.ident.normal,
-	"font-weight": adapt.css.ident.normal
+    "font-style": adapt.css.ident.normal,
+    "font-variant": adapt.css.ident.normal,
+    "font-weight": adapt.css.ident.normal
 };
 
 /**
@@ -37,22 +37,22 @@ adapt.font.bogusFontCounter = 1;
  * @return {string}
  */
 adapt.font.makeFontTraitKey = function(properties) {
-	var sb = new adapt.base.StringBuffer();
-	for (var prop in adapt.font.traitProps) {
-		sb.append(" ");
-		sb.append(properties[prop].toString());
-	}
-	return sb.toString();
+    var sb = new adapt.base.StringBuffer();
+    for (var prop in adapt.font.traitProps) {
+        sb.append(" ");
+        sb.append(properties[prop].toString());
+    }
+    return sb.toString();
 };
 
 /**
  * @param {Object.<string,adapt.css.Val>} properties
  */
 adapt.font.fillDefaults = function(properties) {
-	for (var prop in adapt.font.traitProps) {
-		if (!properties[prop])
-			properties[prop] = adapt.font.traitProps[prop];
-	}
+    for (var prop in adapt.font.traitProps) {
+        if (!properties[prop])
+            properties[prop] = adapt.font.traitProps[prop];
+    }
 };
 
 
@@ -62,12 +62,12 @@ adapt.font.fillDefaults = function(properties) {
  * @return {Object.<string,adapt.css.Val>}
  */
 adapt.font.prepareProperties = function(properties, context) {
-	var result = /** @type {Object.<string,adapt.css.Val>} */ ({});
-	for (var prop in properties) {
-		result[prop] = adapt.csscasc.getProp(properties, prop).evaluate(context, prop);
-	}
-	adapt.font.fillDefaults(result);
-	return result;
+    var result = /** @type {Object.<string,adapt.css.Val>} */ ({});
+    for (var prop in properties) {
+        result[prop] = adapt.csscasc.getProp(properties, prop).evaluate(context, prop);
+    }
+    adapt.font.fillDefaults(result);
+    return result;
 };
 
 /**
@@ -76,13 +76,13 @@ adapt.font.prepareProperties = function(properties, context) {
  * @constructor
  */
 adapt.font.Face = function(properties) {
-	/** @const */ this.properties = properties;
-	/** @const */ this.fontTraitKey = adapt.font.makeFontTraitKey(this.properties);
-	/** @const */ this.src = this.properties["src"] ? this.properties["src"].toString() : null;
-	/** @type {Array.<string>} */ this.blobURLs = [];
-	/** @type {Array.<Blob>} */ this.blobs = [];
-	var family = this.properties["font-family"];
-	/** @const */ this.family = family ? family.stringValue() : null;
+    /** @const */ this.properties = properties;
+    /** @const */ this.fontTraitKey = adapt.font.makeFontTraitKey(this.properties);
+    /** @const */ this.src = this.properties["src"] ? this.properties["src"].toString() : null;
+    /** @type {Array.<string>} */ this.blobURLs = [];
+    /** @type {Array.<Blob>} */ this.blobs = [];
+    var family = this.properties["font-family"];
+    /** @const */ this.family = family ? family.stringValue() : null;
 };
 
 /**
@@ -91,7 +91,7 @@ adapt.font.Face = function(properties) {
  * @return {boolean}
  */
 adapt.font.Face.prototype.traitsEqual = function(other) {
-	return this.fontTraitKey == other.fontTraitKey;
+    return this.fontTraitKey == other.fontTraitKey;
 };
 
 /**
@@ -101,29 +101,29 @@ adapt.font.Face.prototype.traitsEqual = function(other) {
  * @return {string}
  */
 adapt.font.Face.prototype.makeAtRule = function(src, fontBytes) {
-	var sb = new adapt.base.StringBuffer();
-	sb.append('@font-face {\n  font-family: ');
-	sb.append(/** @type {string} */ (this.family));
-	sb.append(';\n  ');
-	for (var prop in adapt.font.traitProps) {
-		sb.append(prop);
-		sb.append(': ');
-		this.properties[prop].appendTo(sb, true);
-		sb.append(';\n  ');
-	}
-	if (fontBytes) {
-		sb.append('src: url("');
-		var blobURL = adapt.net.createObjectURL(fontBytes);
-		sb.append(blobURL);
-		this.blobURLs.push(blobURL);
-		this.blobs.push(fontBytes);
-		sb.append('")');
-	} else {
-		sb.append('src: ');
-		sb.append(src);
-	}
-	sb.append(';\n}\n');
-	return sb.toString();
+    var sb = new adapt.base.StringBuffer();
+    sb.append('@font-face {\n  font-family: ');
+    sb.append(/** @type {string} */ (this.family));
+    sb.append(';\n  ');
+    for (var prop in adapt.font.traitProps) {
+        sb.append(prop);
+        sb.append(': ');
+        this.properties[prop].appendTo(sb, true);
+        sb.append(';\n  ');
+    }
+    if (fontBytes) {
+        sb.append('src: url("');
+        var blobURL = adapt.net.createObjectURL(fontBytes);
+        sb.append(blobURL);
+        this.blobURLs.push(blobURL);
+        this.blobs.push(fontBytes);
+        sb.append('")');
+    } else {
+        sb.append('src: ');
+        sb.append(src);
+    }
+    sb.append(';\n}\n');
+    return sb.toString();
 };
 
 /**
@@ -133,12 +133,12 @@ adapt.font.Face.prototype.makeAtRule = function(src, fontBytes) {
  * @constructor
  */
 adapt.font.DocumentFaces = function(deobfuscator) {
-	/** @const */ this.deobfuscator = deobfuscator;
-	/**
-	 * Maps source font family names to the family names used in the HTML view.
-	 * @const
-	 */
-	this.familyMap = /** @type {Object.<string,string>} */ ({});
+    /** @const */ this.deobfuscator = deobfuscator;
+    /**
+     * Maps source font family names to the family names used in the HTML view.
+     * @const
+     */
+    this.familyMap = /** @type {Object.<string,string>} */ ({});
 };
 
 /**
@@ -147,15 +147,15 @@ adapt.font.DocumentFaces = function(deobfuscator) {
  * @return {void}
  */
 adapt.font.DocumentFaces.prototype.registerFamily = function(srcFace, viewFace) {
-	var srcFamily = /** @type {string} */ (srcFace.family);
-	var viewFamilyFromSrc = this.familyMap[srcFamily];
-	var viewFamilyFromView = viewFace.family;
-	if (viewFamilyFromSrc) {
-		if (viewFamilyFromSrc != viewFamilyFromView)
-			throw new Error("E_FONT_FAMILY_INCONSISTENT " + srcFace.family);
-	} else {
-		this.familyMap[srcFamily] = /** @type {string} */ (viewFamilyFromView);
-	}
+    var srcFamily = /** @type {string} */ (srcFace.family);
+    var viewFamilyFromSrc = this.familyMap[srcFamily];
+    var viewFamilyFromView = viewFace.family;
+    if (viewFamilyFromSrc) {
+        if (viewFamilyFromSrc != viewFamilyFromView)
+            throw new Error("E_FONT_FAMILY_INCONSISTENT " + srcFace.family);
+    } else {
+        this.familyMap[srcFamily] = /** @type {string} */ (viewFamilyFromView);
+    }
 };
 
 /**
@@ -163,29 +163,29 @@ adapt.font.DocumentFaces.prototype.registerFamily = function(srcFace, viewFace) 
  * @return {adapt.css.Val}
  */
 adapt.font.DocumentFaces.prototype.filterFontFamily = function(val) {
-	if (val instanceof adapt.css.CommaList) {
-		var list = (/** @type {adapt.css.CommaList} */ (val)).values;
-		var newValues = /** @type {Array.<adapt.css.Val>} */ ([]);
-		for (var i = 0; i < list.length; i++) {
-			var v = list[i];
-			var r = this.familyMap[v.stringValue()];
-			if (r) {
-				newValues.push(adapt.css.getName(r));
-			}
-			newValues.push(v);
-		}
-		return new adapt.css.CommaList(newValues);
-	} else {
-		var rf = this.familyMap[val.stringValue()];
-		if (rf) {
-			return new adapt.css.CommaList([adapt.css.getName(rf), val]);
-		}
-		return val;
-	}
+    if (val instanceof adapt.css.CommaList) {
+        var list = (/** @type {adapt.css.CommaList} */ (val)).values;
+        var newValues = /** @type {Array.<adapt.css.Val>} */ ([]);
+        for (var i = 0; i < list.length; i++) {
+            var v = list[i];
+            var r = this.familyMap[v.stringValue()];
+            if (r) {
+                newValues.push(adapt.css.getName(r));
+            }
+            newValues.push(v);
+        }
+        return new adapt.css.CommaList(newValues);
+    } else {
+        var rf = this.familyMap[val.stringValue()];
+        if (rf) {
+            return new adapt.css.CommaList([adapt.css.getName(rf), val]);
+        }
+        return val;
+    }
 };
 
 
-/** 
+/**
  * Object that loads fonts in a document and allocates font families for them
  * in the view document
  * @param {Element} head where to add styles in the view document (normally head element)
@@ -194,15 +194,15 @@ adapt.font.DocumentFaces.prototype.filterFontFamily = function(val) {
  * @constructor
  */
 adapt.font.Mapper = function(head, body, opt_familyPrefix) {
-	/** @const */ this.head = head;
-	/** @const */ this.body = body;
-	/**
-	 * Maps Face.src to an entry for an already-loaded font.
-	 * @const {Object.<string,adapt.taskutil.Fetcher.<adapt.font.Face>>}
-	 */
-	this.srcURLMap = {};
-	/** @const */ this.familyPrefix = opt_familyPrefix || "Fnt_";
-	/** @type {number} */ this.familyCounter = 0;
+    /** @const */ this.head = head;
+    /** @const */ this.body = body;
+    /**
+     * Maps Face.src to an entry for an already-loaded font.
+     * @const {Object.<string,adapt.taskutil.Fetcher.<adapt.font.Face>>}
+     */
+    this.srcURLMap = {};
+    /** @const */ this.familyPrefix = opt_familyPrefix || "Fnt_";
+    /** @type {number} */ this.familyCounter = 0;
 };
 
 /**
@@ -211,14 +211,14 @@ adapt.font.Mapper = function(head, body, opt_familyPrefix) {
  * @return {string}
  */
 adapt.font.Mapper.prototype.getViewFontFamily = function(srcFace, documentFaces) {
-	var srcFamily = /** @type {string} */ (srcFace.family);
-	var viewFamily = documentFaces.familyMap[srcFamily];
-	if (viewFamily) {
-		return viewFamily;
-	}
-	viewFamily = this.familyPrefix + (++this.familyCounter);
-	documentFaces.familyMap[srcFamily] = viewFamily;
-	return viewFamily;
+    var srcFamily = /** @type {string} */ (srcFace.family);
+    var viewFamily = documentFaces.familyMap[srcFamily];
+    if (viewFamily) {
+        return viewFamily;
+    }
+    viewFamily = this.familyPrefix + (++this.familyCounter);
+    documentFaces.familyMap[srcFamily] = viewFamily;
+    return viewFamily;
 };
 
 /**
@@ -229,59 +229,59 @@ adapt.font.Mapper.prototype.getViewFontFamily = function(srcFace, documentFaces)
  * @return {!adapt.task.Result.<adapt.font.Face>}
  */
 adapt.font.Mapper.prototype.initFont = function(srcFace, fontBytes, documentFaces) {
-	/** @type {adapt.task.Frame.<adapt.font.Face>} */ var frame =
-		adapt.task.newFrame("initFont");
-	var self = this;
-	var src = /** @type {string} */ (srcFace.src);
-	var props = /** @type {Object.<string,adapt.css.Val>} */ ({});
-	for (var prop in adapt.font.traitProps) {
-		props[prop] = srcFace.properties[prop];
-	}
-	var fontFamily = self.getViewFontFamily(srcFace, documentFaces);
-	props["font-family"] = adapt.css.getName(fontFamily);
-	var viewFontFace = new adapt.font.Face(props);
-	var probe = /** @type {HTMLElement} */ (self.body.ownerDocument.createElement("span"));
-	probe.textContent = "M";
-	var killTime = (new Date()).valueOf() + 1000;
-	var style = self.head.ownerDocument.createElement("style");
-	var bogusData = adapt.font.bogusFontData + (adapt.font.bogusFontCounter++);
-	style.textContent = viewFontFace.makeAtRule("", adapt.net.makeBlob([bogusData]));
-	self.head.appendChild(style);
-	self.body.appendChild(probe);
-	probe.style.visibility = "hidden";
-	probe.style.fontFamily = fontFamily;
-	for (var pname in adapt.font.traitProps) {
-		adapt.base.setCSSProperty(probe, pname, props[pname].toString());
-	}
-	var rect = probe.getBoundingClientRect();
-	var initWidth = rect.right - rect.left;
-	var initHeight = rect.bottom - rect.top;
-	style.textContent = viewFontFace.makeAtRule(src, fontBytes);
-	vivliostyle.logging.logger.info("Starting to load font:", src);
-	var loaded = false;
-	frame.loop(function() {
-		var rect = probe.getBoundingClientRect();
-		var currWidth = rect.right - rect.left;
-		var currHeight = rect.bottom - rect.top;
-		if (initWidth != currWidth || initHeight != currHeight) {
-			loaded = true;
-			return adapt.task.newResult(false);
-		}
-		var currTime = (new Date()).valueOf();
-		if (currTime > killTime) {
-			return adapt.task.newResult(false);						
-		}
-		return frame.sleep(10);
-	}).then(function() {
-		if (loaded) {
-			vivliostyle.logging.logger.info("Loaded font:", src);
-		} else {
-			vivliostyle.logging.logger.warn("Failed to load font:", src);
-		}
-		self.body.removeChild(probe);
-		frame.finish(viewFontFace);
-	});
-	return frame.result();
+    /** @type {adapt.task.Frame.<adapt.font.Face>} */ var frame =
+        adapt.task.newFrame("initFont");
+    var self = this;
+    var src = /** @type {string} */ (srcFace.src);
+    var props = /** @type {Object.<string,adapt.css.Val>} */ ({});
+    for (var prop in adapt.font.traitProps) {
+        props[prop] = srcFace.properties[prop];
+    }
+    var fontFamily = self.getViewFontFamily(srcFace, documentFaces);
+    props["font-family"] = adapt.css.getName(fontFamily);
+    var viewFontFace = new adapt.font.Face(props);
+    var probe = /** @type {HTMLElement} */ (self.body.ownerDocument.createElement("span"));
+    probe.textContent = "M";
+    var killTime = (new Date()).valueOf() + 1000;
+    var style = self.head.ownerDocument.createElement("style");
+    var bogusData = adapt.font.bogusFontData + (adapt.font.bogusFontCounter++);
+    style.textContent = viewFontFace.makeAtRule("", adapt.net.makeBlob([bogusData]));
+    self.head.appendChild(style);
+    self.body.appendChild(probe);
+    probe.style.visibility = "hidden";
+    probe.style.fontFamily = fontFamily;
+    for (var pname in adapt.font.traitProps) {
+        adapt.base.setCSSProperty(probe, pname, props[pname].toString());
+    }
+    var rect = probe.getBoundingClientRect();
+    var initWidth = rect.right - rect.left;
+    var initHeight = rect.bottom - rect.top;
+    style.textContent = viewFontFace.makeAtRule(src, fontBytes);
+    vivliostyle.logging.logger.info("Starting to load font:", src);
+    var loaded = false;
+    frame.loop(function() {
+        var rect = probe.getBoundingClientRect();
+        var currWidth = rect.right - rect.left;
+        var currHeight = rect.bottom - rect.top;
+        if (initWidth != currWidth || initHeight != currHeight) {
+            loaded = true;
+            return adapt.task.newResult(false);
+        }
+        var currTime = (new Date()).valueOf();
+        if (currTime > killTime) {
+            return adapt.task.newResult(false);
+        }
+        return frame.sleep(10);
+    }).then(function() {
+        if (loaded) {
+            vivliostyle.logging.logger.info("Loaded font:", src);
+        } else {
+            vivliostyle.logging.logger.warn("Failed to load font:", src);
+        }
+        self.body.removeChild(probe);
+        frame.finish(viewFontFace);
+    });
+    return frame.result();
 };
 
 /**
@@ -290,43 +290,43 @@ adapt.font.Mapper.prototype.initFont = function(srcFace, fontBytes, documentFace
  * @return {!adapt.taskutil.Fetcher.<adapt.font.Face>}
  */
 adapt.font.Mapper.prototype.loadFont = function(srcFace, documentFaces) {
-	var src = /** @type {string} */ (srcFace.src);
-	var fetcher = this.srcURLMap[src];
-	var self = this;
-	if (fetcher) {
-		fetcher.piggyback(function(viewFaceParam) {
-			var viewFace = /** @type {adapt.font.Face} */ (viewFaceParam);
-			if (!viewFace.traitsEqual(srcFace)) {
-				vivliostyle.logging.logger.warn("E_FONT_FACE_INCOMPATIBLE", srcFace.src);
-			} else {
-				documentFaces.registerFamily(srcFace, viewFace);
-				vivliostyle.logging.logger.warn("Found already-loaded font:", src);
-			}			
-		});
-	} else {
-		fetcher = new adapt.taskutil.Fetcher( function() {
-			/** @type {!adapt.task.Frame.<adapt.font.Face>} */ var frame =
-				adapt.task.newFrame("loadFont");
-			var deobfuscator = documentFaces.deobfuscator ? documentFaces.deobfuscator(src) : null;
-			if (deobfuscator) {
-				adapt.net.ajax(src, adapt.net.XMLHttpRequestResponseType.BLOB).then(function(xhr) {
-					if (!xhr.responseBlob) {
-						frame.finish(null);
-						return;
-					}
-					deobfuscator(xhr.responseBlob).then(function(fontBytes) {
-						self.initFont(srcFace, fontBytes, documentFaces).thenFinish(frame);
-					});
-				});
-			} else {
-				self.initFont(srcFace, null, documentFaces).thenFinish(frame);
-			}
-			return frame.result();
-		}, "loadFont " + src);
-		this.srcURLMap[src] = fetcher;
-		fetcher.start();
-	}
-	return fetcher;
+    var src = /** @type {string} */ (srcFace.src);
+    var fetcher = this.srcURLMap[src];
+    var self = this;
+    if (fetcher) {
+        fetcher.piggyback(function(viewFaceParam) {
+            var viewFace = /** @type {adapt.font.Face} */ (viewFaceParam);
+            if (!viewFace.traitsEqual(srcFace)) {
+                vivliostyle.logging.logger.warn("E_FONT_FACE_INCOMPATIBLE", srcFace.src);
+            } else {
+                documentFaces.registerFamily(srcFace, viewFace);
+                vivliostyle.logging.logger.warn("Found already-loaded font:", src);
+            }
+        });
+    } else {
+        fetcher = new adapt.taskutil.Fetcher(function() {
+            /** @type {!adapt.task.Frame.<adapt.font.Face>} */ var frame =
+                adapt.task.newFrame("loadFont");
+            var deobfuscator = documentFaces.deobfuscator ? documentFaces.deobfuscator(src) : null;
+            if (deobfuscator) {
+                adapt.net.ajax(src, adapt.net.XMLHttpRequestResponseType.BLOB).then(function(xhr) {
+                    if (!xhr.responseBlob) {
+                        frame.finish(null);
+                        return;
+                    }
+                    deobfuscator(xhr.responseBlob).then(function(fontBytes) {
+                        self.initFont(srcFace, fontBytes, documentFaces).thenFinish(frame);
+                    });
+                });
+            } else {
+                self.initFont(srcFace, null, documentFaces).thenFinish(frame);
+            }
+            return frame.result();
+        }, "loadFont " + src);
+        this.srcURLMap[src] = fetcher;
+        fetcher.start();
+    }
+    return fetcher;
 };
 
 /**
@@ -335,14 +335,14 @@ adapt.font.Mapper.prototype.loadFont = function(srcFace, documentFaces) {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.font.Mapper.prototype.findOrLoadFonts = function(srcFaces, documentFaces) {
-	var fetchers = /** @type {Array.<adapt.taskutil.Fetcher.<adapt.font.Face>>} */ ([]);
-	for (var i = 0; i < srcFaces.length; i++) {
-		var srcFace = srcFaces[i];
-		if (!srcFace.src || !srcFace.family) {
-			vivliostyle.logging.logger.warn("E_FONT_FACE_INVALID");
-			continue;
-		}
-		fetchers.push(this.loadFont(srcFace, documentFaces));
-	}
-	return adapt.taskutil.waitForFetchers(fetchers);
+    var fetchers = /** @type {Array.<adapt.taskutil.Fetcher.<adapt.font.Face>>} */ ([]);
+    for (var i = 0; i < srcFaces.length; i++) {
+        var srcFace = srcFaces[i];
+        if (!srcFace.src || !srcFace.family) {
+            vivliostyle.logging.logger.warn("E_FONT_FACE_INVALID");
+            continue;
+        }
+        fetchers.push(this.loadFont(srcFace, documentFaces));
+    }
+    return adapt.taskutil.waitForFetchers(fetchers);
 };

--- a/src/adapt/geom.js
+++ b/src/adapt/geom.js
@@ -15,10 +15,10 @@ goog.require('vivliostyle.logging');
  * @constructor
  */
 adapt.geom.Rect = function(x1, y1, x2, y2) {
-	/** @type {number} */ this.x1 = x1;
-	/** @type {number} */ this.y1 = y1;
-	/** @type {number} */ this.x2 = x2;
-	/** @type {number} */ this.y2 = y2;
+    /** @type {number} */ this.x1 = x1;
+    /** @type {number} */ this.y1 = y1;
+    /** @type {number} */ this.x2 = x2;
+    /** @type {number} */ this.y2 = y2;
 };
 
 /**
@@ -39,10 +39,10 @@ adapt.geom.Point = function(x, y) {
  * @constructor
  */
 adapt.geom.Insets = function(left, top, right, bottom) {
-	/** @type {number} */ this.left = left;
-	/** @type {number} */ this.top = top;
-	/** @type {number} */ this.right = right;
-	/** @type {number} */ this.bottom = bottom;
+    /** @type {number} */ this.left = left;
+    /** @type {number} */ this.top = top;
+    /** @type {number} */ this.right = right;
+    /** @type {number} */ this.bottom = bottom;
 };
 
 /**
@@ -53,10 +53,10 @@ adapt.geom.Insets = function(left, top, right, bottom) {
  * @constructor
  */
 adapt.geom.Segment = function(low, high, winding, shapeId) {
-	/** @type {adapt.geom.Point} */ this.low = low;
-	/** @type {adapt.geom.Point} */ this.high = high;
-	/** @type {number} */ this.winding = winding;
-	/** @type {number} */ this.shapeId = shapeId;
+    /** @type {adapt.geom.Point} */ this.low = low;
+    /** @type {adapt.geom.Point} */ this.high = high;
+    /** @type {number} */ this.winding = winding;
+    /** @type {number} */ this.shapeId = shapeId;
 };
 
 /**
@@ -105,25 +105,25 @@ adapt.geom.Shape.prototype.addSegments = function(arr, id) {
     var points = this.points;
     var length = points.length;
     var prev = points[length - 1];
-    for (var i = 0 ; i < length ; i++) {
+    for (var i = 0; i < length; i++) {
         var curr = points[i];
         /** @type {adapt.geom.Segment} */ var s;
-        if( prev.y < curr.y )
+        if (prev.y < curr.y)
             s = new adapt.geom.Segment(prev, curr, 1, id);
         else
-        	s = new adapt.geom.Segment(curr, prev, -1, id);
+            s = new adapt.geom.Segment(curr, prev, -1, id);
         arr.push(s);
         prev = curr;
     }
 };
 
 adapt.geom.Shape.prototype.withOffset = function(offsetX, offsetY) {
-	var points = [];
-	for (var i = 0; i < this.points.length; i++) {
-		var p = this.points[i];
-		points.push(new adapt.geom.Point(p.x + offsetX, p.y + offsetY));
-	}
-	return new adapt.geom.Shape(points);
+    var points = [];
+    for (var i = 0; i < this.points.length; i++) {
+        var p = this.points[i];
+        points.push(new adapt.geom.Point(p.x + offsetX, p.y + offsetY));
+    }
+    return new adapt.geom.Shape(points);
 };
 
 /**
@@ -139,7 +139,7 @@ adapt.geom.shapeForEllipse = function(cx, cy, rx, ry) {
     for (var i = 0; i < count; i++) {
         var a = i * 2 * Math.PI / count;
         points.push(new adapt.geom.Point(cx + rx * Math.sin(a),
-        		cy + ry * Math.cos(a)));
+            cy + ry * Math.cos(a)));
     }
     return new adapt.geom.Shape(points);
 };
@@ -175,10 +175,10 @@ adapt.geom.shapeForRectObj = function(r) {
  * @constructor
  */
 adapt.geom.BandIntersection = function(x, winding, shapeId, lowOrHigh) {
-	/** @type {number} */ this.x = x;
-	/** @type {number} */ this.winding = winding;
-	/** @type {number} */ this.shapeId = shapeId;
-	/** @type {number} */ this.lowOrHigh = lowOrHigh;
+    /** @type {number} */ this.x = x;
+    /** @type {number} */ this.winding = winding;
+    /** @type {number} */ this.shapeId = shapeId;
+    /** @type {number} */ this.lowOrHigh = lowOrHigh;
 };
 
 /**
@@ -207,7 +207,7 @@ adapt.geom.addBandIntersections = function(intersections, s, y1, y2) {
     /** @type {number} */ var x2;
     /** @type {number} */ var w2;
     if (s.high.y < y1) {
-    	vivliostyle.logging.logger.warn("Error: inconsistent segment (1)");
+        vivliostyle.logging.logger.warn("Error: inconsistent segment (1)");
     }
     if (s.low.y <= y1) {
         // outside
@@ -232,9 +232,9 @@ adapt.geom.addBandIntersections = function(intersections, s, y1, y2) {
             new adapt.geom.BandIntersection(x2, w2, s.shapeId, 1));
     } else {
         intersections.push(
-                new adapt.geom.BandIntersection(x2, w2, s.shapeId, -1));
+            new adapt.geom.BandIntersection(x2, w2, s.shapeId, -1));
         intersections.push(
-                new adapt.geom.BandIntersection(x1, w1, s.shapeId, 1));
+            new adapt.geom.BandIntersection(x1, w1, s.shapeId, 1));
     }
 };
 
@@ -245,30 +245,30 @@ adapt.geom.addBandIntersections = function(intersections, s, y1, y2) {
  * @return {Array.<number>}
  */
 adapt.geom.mergeIntersections = function(intersections, includeCount,
-		excludeCount) {
+                                         excludeCount) {
     var shapeCount = includeCount + excludeCount;
     /** @type {Array.<number>} */ var windings1 = Array(shapeCount);
     /** @type {Array.<number>} */ var windings2 = Array(shapeCount);
-    for (var i = 0 ; i <= shapeCount ; i++) {
+    for (var i = 0; i <= shapeCount; i++) {
         windings1[i] = 0;
         windings2[i] = 0;
     }
     /** @type {Array.<number>} */ var xranges = [];
     /** @type {boolean} */ var inside = false;
     var intersectionCount = intersections.length;
-    for (var k = 0 ; k < intersectionCount ; k++) {
+    for (var k = 0; k < intersectionCount; k++) {
         var intersection = intersections[k];
         windings1[intersection.shapeId] += intersection.winding;
         windings2[intersection.shapeId] += intersection.lowOrHigh;
         var stillInside = false;
-        for (i = 0 ; i < includeCount ; i++) {
+        for (i = 0; i < includeCount; i++) {
             if (windings1[i] && !windings2[i]) {
                 stillInside = true;
                 break;
             }
         }
         if (stillInside) {
-            for (i = includeCount ; i <= shapeCount ; i++) {
+            for (i = includeCount; i <= shapeCount; i++) {
                 if (windings1[i] || windings2[i]) {
                     stillInside = false;
                     break;
@@ -290,7 +290,7 @@ adapt.geom.mergeIntersections = function(intersections, includeCount,
  * @return {number}
  */
 adapt.geom.ceil = function(v, unit) {
-	return unit ? Math.ceil(v/unit)*unit : v;
+    return unit ? Math.ceil(v/unit)*unit : v;
 };
 
 /**
@@ -300,7 +300,7 @@ adapt.geom.ceil = function(v, unit) {
  * @return {number}
  */
 adapt.geom.floor = function(v, unit) {
-	return unit ? Math.floor(v/unit)*unit : v;
+    return unit ? Math.floor(v/unit)*unit : v;
 };
 
 /**
@@ -308,7 +308,7 @@ adapt.geom.floor = function(v, unit) {
  * @return {adapt.geom.Point}
  */
 adapt.geom.rotatePoint = function(point) {
-	return new adapt.geom.Point(point.y, -point.x);
+    return new adapt.geom.Point(point.y, -point.x);
 };
 
 /**
@@ -317,7 +317,7 @@ adapt.geom.rotatePoint = function(point) {
  * @return {adapt.geom.Rect}
  */
 adapt.geom.rotateBox = function(box) {
-	return new adapt.geom.Rect(box.y1, -box.x2, box.y2, -box.x1);
+    return new adapt.geom.Rect(box.y1, -box.x2, box.y2, -box.x1);
 };
 
 /**
@@ -326,7 +326,7 @@ adapt.geom.rotateBox = function(box) {
  * @return {adapt.geom.Rect}
  */
 adapt.geom.unrotateBox = function(box) {
-	return new adapt.geom.Rect(-box.y2, box.x1, -box.y1, box.x2);
+    return new adapt.geom.Rect(-box.y2, box.x1, -box.y1, box.x2);
 };
 
 /**
@@ -334,7 +334,7 @@ adapt.geom.unrotateBox = function(box) {
  * @return {adapt.geom.Shape}
  */
 adapt.geom.rotateShape = function(shape) {
-	return new adapt.geom.Shape(adapt.base.map(shape.points, adapt.geom.rotatePoint));
+    return new adapt.geom.Shape(adapt.base.map(shape.points, adapt.geom.rotatePoint));
 };
 
 /**
@@ -347,12 +347,12 @@ adapt.geom.rotateShape = function(shape) {
  * @return {Array.<adapt.geom.Band>}
  */
 adapt.geom.shapesToBands = function(box, include, exclude,
-        granularity, snapHeight, vertical) {
-	if (vertical) {
-		box = adapt.geom.rotateBox(box);
-		include = adapt.base.map(include, adapt.geom.rotateShape);
-		exclude = adapt.base.map(exclude, adapt.geom.rotateShape);
-	}
+                                    granularity, snapHeight, vertical) {
+    if (vertical) {
+        box = adapt.geom.rotateBox(box);
+        include = adapt.base.map(include, adapt.geom.rotateShape);
+        exclude = adapt.base.map(exclude, adapt.geom.rotateShape);
+    }
     var includeCount = include.length;
     var excludeCount = exclude ? exclude.length : 0;
     /** @type {!Array.<adapt.geom.Band>} */ var result = [];
@@ -360,9 +360,9 @@ adapt.geom.shapesToBands = function(box, include, exclude,
     /** @type {number} */ var i;
     /** @type {number} */ var k;
     /** @type {adapt.geom.Segment} */ var segment;
-    for (i = 0 ; i < includeCount ; i++ )
-        include[i].addSegments(segments,i);
-    for (i = 0 ; i < excludeCount ; i++)
+    for (i = 0; i < includeCount; i++)
+        include[i].addSegments(segments, i);
+    for (i = 0; i < excludeCount; i++)
         exclude[i].addSegments(segments, i + includeCount);
     var segmentCount = segments.length;
     segments.sort(adapt.geom.segmentCompare);
@@ -377,17 +377,17 @@ adapt.geom.shapesToBands = function(box, include, exclude,
     var segmentIndex = 0;
     /** @type {!Array.<adapt.geom.Segment>} */ var activeSegments = [];
     while (segmentIndex < segmentCount && (segment = segments[segmentIndex]).low.y < y) {
-        if( segment.high.y > y )
+        if (segment.high.y > y)
             activeSegments.push(segment);
         segmentIndex++;
     }
     // process the segments from low to high y values
-    while (segmentIndex < segmentCount || activeSegments.length > 0 ) {
+    while (segmentIndex < segmentCount || activeSegments.length > 0) {
         // calculate the height of the band to work with
         var y2 = box.y2;  // band bottom
         // min possible y2
         var y2min = adapt.geom.ceil(Math.ceil(y + granularity), snapHeight);
-        for (k = 0 ; k < activeSegments.length && y2 > y2min ; k++) {
+        for (k = 0; k < activeSegments.length && y2 > y2min; k++) {
             segment = activeSegments[k];
             if (segment.low.x == segment.high.x) {
                 // vertical
@@ -399,13 +399,13 @@ adapt.geom.shapesToBands = function(box, include, exclude,
             }
         }
         if (y2 > box.y2) {
-        	y2 = box.y2;
+            y2 = box.y2;
         }
         // include new segments, decreasing y2 if needed
         while (segmentIndex < segmentCount && (segment = segments[segmentIndex]).low.y < y2) {
             if (segment.high.y < y) {
-            	segmentIndex++;
-            	continue;
+                segmentIndex++;
+                continue;
             }
             if (segment.low.y < y2min) {
                 if (segment.low.y == segment.high.y && segment.low.y == y) {
@@ -417,11 +417,11 @@ adapt.geom.shapesToBands = function(box, include, exclude,
                 segmentIndex++;
             } else {
                 // Do not consume it, consider bottom edge "outside"
-            	var yn = adapt.geom.floor(segment.low.y, snapHeight);
-            	if (yn < y2) {
-	                y2 = yn;
-            	}
-	            break;
+                var yn = adapt.geom.floor(segment.low.y, snapHeight);
+                if (yn < y2) {
+                    y2 = yn;
+                }
+                break;
             }
         }
         // now look at the band with top at y and bottom at y2
@@ -432,19 +432,19 @@ adapt.geom.shapesToBands = function(box, include, exclude,
          * @type {!Array.<adapt.geom.BandIntersection>}
          */
         var bandIntersections = [];
-        for (k = 0 ; k < activeSegments.length ; k++) {
+        for (k = 0; k < activeSegments.length; k++) {
             adapt.geom.addBandIntersections(bandIntersections,
-            		activeSegments[k], y, y2);
+                activeSegments[k], y, y2);
         }
         bandIntersections.sort(
-        	/**
-        	 * @param {adapt.geom.BandIntersection} bi1
-        	 * @param {adapt.geom.BandIntersection} bi2
-        	 * @return {number}
-        	 */
-    		function(bi1, bi2) {
-    			return bi1.x - bi2.x || bi1.lowOrHigh - bi2.lowOrHigh;
-    		});
+            /**
+             * @param {adapt.geom.BandIntersection} bi1
+             * @param {adapt.geom.BandIntersection} bi2
+             * @return {number}
+             */
+            function(bi1, bi2) {
+                return bi1.x - bi2.x || bi1.lowOrHigh - bi2.lowOrHigh;
+            });
         var xranges = adapt.geom.mergeIntersections(bandIntersections,
             includeCount, excludeCount);
         if (xranges.length == 0) {
@@ -453,7 +453,7 @@ adapt.geom.shapesToBands = function(box, include, exclude,
             // get the widest
             var width = 0;
             var x = box.x1;
-            for (k = 0 ; k < xranges.length ; k += 2) {
+            for (k = 0; k < xranges.length; k += 2) {
                 var rx = Math.max(box.x1, xranges[k]);
                 var rw = Math.min(box.x2, xranges[k + 1]) - rx;
                 if (rw > width) {
@@ -465,14 +465,14 @@ adapt.geom.shapesToBands = function(box, include, exclude,
                 // no space left
                 result.push(new adapt.geom.Band(y, y2, box.x2, box.x2));
             } else {
-                result.push(new adapt.geom.Band(y, y2, 
+                result.push(new adapt.geom.Band(y, y2,
                     Math.max(x, box.x1), Math.min(x + width, box.x2)));
             }
         }
         if (y2 == box.y2)
             break;
         y = y2;
-        for (k = activeSegments.length - 1 ; k >= 0 ; k--) {
+        for (k = activeSegments.length - 1; k >= 0; k--) {
             if (activeSegments[k].high.y <= y2) {
                 activeSegments.splice(k, 1);
             }
@@ -605,15 +605,15 @@ adapt.geom.addFloatToBands = function(box, bands, floatBox, floatBands, side) {
             band = bands[index];
             index++;
             bands.splice(index, 0,
-            	new adapt.geom.Band(floatBand.y1, band.y2, band.x1, band.x2));
+                new adapt.geom.Band(floatBand.y1, band.y2, band.x1, band.x2));
             band.y2 = floatBand.y1;
         }
         while (index < bands.length) {
             band = bands[index++];
             if (band.y2 > floatBand.y2) {
                 // split it
-                bands.splice(index, 0, 
-                	new adapt.geom.Band(floatBand.y2, band.y2, band.x1, band.x2));
+                bands.splice(index, 0,
+                    new adapt.geom.Band(floatBand.y2, band.y2, band.x1, band.x2));
                 band.y2 = floatBand.y2;
             }
             if (floatBand.x1 != floatBand.x2) {

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -17,10 +17,10 @@ goog.provide('adapt.layout');
 
 /** @const */
 adapt.layout.mediaTags = {
-	"img": true,
-	"svg": true,
-	"audio": true,
-	"video": true
+    "img": true,
+    "svg": true,
+    "audio": true,
+    "video": true
 };
 
 /**
@@ -33,29 +33,29 @@ adapt.layout.mediaTags = {
  * @param {Array.<adapt.vtree.ClientRect>} boxes
  * @return {Array.<adapt.vtree.ClientRect>}
  */
-adapt.layout.fixBoxesForNode = function(clientLayout, boxes, node) {console.info("trying to fix");
-	var fullRange = node.ownerDocument.createRange();
-	fullRange.setStart(node, 0);
-	fullRange.setEnd(node, node.textContent.length);
-	var fullBoxes = clientLayout.getRangeClientRects(fullRange);
-	var result = [];
-	for (var i = 0; i < boxes.length; i++) {
-		var box = boxes[i];
-		var k;
-		for (k = 0; k < fullBoxes.length; k++) {
-			var fullBox = fullBoxes[k];
-			if (box.top >= fullBox.top && box.bottom <= fullBox.bottom &&
-					Math.abs(box.left - fullBox.left) < 1) {
-				result.push({top:box.top, left:fullBox.left, bottom:box.bottom, right: fullBox.right});
-				break;
-			}
-		}
-		if (k == fullBoxes.length) {
-			vivliostyle.logging.logger.warn("Could not fix character box");
-			result.push(box);
-		}
-	}
-	return result;
+adapt.layout.fixBoxesForNode = function(clientLayout, boxes, node) {
+    var fullRange = node.ownerDocument.createRange();
+    fullRange.setStart(node, 0);
+    fullRange.setEnd(node, node.textContent.length);
+    var fullBoxes = clientLayout.getRangeClientRects(fullRange);
+    var result = [];
+    for (var i = 0; i < boxes.length; i++) {
+        var box = boxes[i];
+        var k;
+        for (k = 0; k < fullBoxes.length; k++) {
+            var fullBox = fullBoxes[k];
+            if (box.top >= fullBox.top && box.bottom <= fullBox.bottom &&
+                Math.abs(box.left - fullBox.left) < 1) {
+                result.push({top:box.top, left:fullBox.left, bottom:box.bottom, right: fullBox.right});
+                break;
+            }
+        }
+        if (k == fullBoxes.length) {
+            vivliostyle.logging.logger.warn("Could not fix character box");
+            result.push(box);
+        }
+    }
+    return result;
 };
 
 /**
@@ -70,14 +70,14 @@ adapt.layout.fixBoxesForNode = function(clientLayout, boxes, node) {console.info
  * @return {number}
  */
 adapt.layout.calculateEdge = function(nodeContext, clientLayout,
-		extraOffset, vertical) {
+                                      extraOffset, vertical) {
     var node = nodeContext.viewNode;
     if (!node)
         return NaN;
     if (node.nodeType == 1) {
         if (nodeContext.after) {
             var cbox = clientLayout.getElementClientRect(
-            		/** @type {Element} */ (node));
+                /** @type {Element} */ (node));
             if (cbox.right >= cbox.left && cbox.bottom >= cbox.top) {
                 return vertical ? cbox.left : cbox.bottom;
             }
@@ -88,9 +88,9 @@ adapt.layout.calculateEdge = function(nodeContext, clientLayout,
         var range = node.ownerDocument.createRange();
         var length = node.textContent.length;
         if (!length)
-        	return NaN;
+            return NaN;
         if (nodeContext.after)
-        	extraOffset += length;
+            extraOffset += length;
         if (extraOffset >= length) {
             extraOffset = length - 1;
         }
@@ -98,15 +98,15 @@ adapt.layout.calculateEdge = function(nodeContext, clientLayout,
         range.setEnd(node, extraOffset + 1);
         var boxes = clientLayout.getRangeClientRects(range);
         if (vertical && adapt.base.checkVerticalBBoxBug(document.body)) {
-        	boxes = adapt.layout.fixBoxesForNode(clientLayout, boxes, node);
+            boxes = adapt.layout.fixBoxesForNode(clientLayout, boxes, node);
         }
         var maxSize = 0;
-        // Get first of the widest boxes (works around Chrome results for soft hyphens). 
+        // Get first of the widest boxes (works around Chrome results for soft hyphens).
         for (var i = 0; i < boxes.length; i++) {
             var box = boxes[i];
             var boxSize = vertical ? box.bottom - box.top : box.right - box.left;
             if (box.right > box.left && box.bottom > box.top &&
-                   (isNaN(edge) || boxSize > maxSize)) {
+                (isNaN(edge) || boxSize > maxSize)) {
                 edge = vertical ? box.left : box.bottom;
                 maxSize = boxSize;
             }
@@ -155,24 +155,24 @@ adapt.layout.BreakPosition.prototype.getMinBreakPenalty = function() {};
  * @implements {adapt.layout.BreakPosition}
  */
 adapt.layout.BoxBreakPosition = function(checkPoints, penalty) {
-	/** @const */ this.checkPoints = checkPoints;
-	/** @const */ this.penalty = penalty;
+    /** @const */ this.checkPoints = checkPoints;
+    /** @const */ this.penalty = penalty;
 };
 
 /**
  * @override
  */
 adapt.layout.BoxBreakPosition.prototype.findAcceptableBreak = function(column, penalty) {
-	if (penalty < this.penalty)
-		return null;
-	return column.findBoxBreakPosition(this, penalty > 0);
+    if (penalty < this.penalty)
+        return null;
+    return column.findBoxBreakPosition(this, penalty > 0);
 };
 
 /**
  * @override
  */
 adapt.layout.BoxBreakPosition.prototype.getMinBreakPenalty = function() {
-	return this.penalty;
+    return this.penalty;
 };
 
 /**
@@ -185,28 +185,28 @@ adapt.layout.BoxBreakPosition.prototype.getMinBreakPenalty = function() {
  * @implements {adapt.layout.BreakPosition}
  */
 adapt.layout.EdgeBreakPosition = function(position, breakOnEdge, overflows, computedBlockSize) {
-	/** @const */ this.position = position;
-	/** @const */ this.breakOnEdge = breakOnEdge;
-	/** @const */ this.overflows = overflows;
-	/** @const */ this.computedBlockSize = computedBlockSize;
+    /** @const */ this.position = position;
+    /** @const */ this.breakOnEdge = breakOnEdge;
+    /** @const */ this.overflows = overflows;
+    /** @const */ this.computedBlockSize = computedBlockSize;
 };
 
 /**
  * @override
  */
 adapt.layout.EdgeBreakPosition.prototype.findAcceptableBreak = function(column, penalty) {
-	if (penalty < this.getMinBreakPenalty())
-		return null;
-	return column.findEdgeBreakPosition(this);
+    if (penalty < this.getMinBreakPenalty())
+        return null;
+    return column.findEdgeBreakPosition(this);
 };
 
 /**
  * @override
  */
 adapt.layout.EdgeBreakPosition.prototype.getMinBreakPenalty = function() {
-	return (vivliostyle.break.isAvoidBreakValue(this.breakOnEdge) ? 1 : 0)
-		+ (this.overflows ? 3 : 0)
-		+ (this.position.parent ? this.position.parent.breakPenalty : 0);
+    return (vivliostyle.break.isAvoidBreakValue(this.breakOnEdge) ? 1 : 0)
+        + (this.overflows ? 3 : 0)
+        + (this.position.parent ? this.position.parent.breakPenalty : 0);
 };
 
 
@@ -218,38 +218,38 @@ adapt.layout.EdgeBreakPosition.prototype.getMinBreakPenalty = function() {
  * @param {?adapt.vtree.NodePosition} overflowPosition
  */
 adapt.layout.FootnoteItem = function(boxOffset, startPosition, overflowPosition) {
-	/** @const */ this.boxOffset = boxOffset;
-	/** @const */ this.startPosition = startPosition;
-	/** @const */ this.overflowPosition = overflowPosition;
+    /** @const */ this.boxOffset = boxOffset;
+    /** @const */ this.startPosition = startPosition;
+    /** @const */ this.overflowPosition = overflowPosition;
 };
 
 /**
- * @param {Array.<adapt.vtree.NodeContext>} checkPoints 
+ * @param {Array.<adapt.vtree.NodeContext>} checkPoints
  */
 adapt.layout.validateCheckPoints = function(checkPoints) {
-	for (var i = 1; i < checkPoints.length; i++) {
-		var cp0 = checkPoints[i-1];
-		var cp1 = checkPoints[i];
-		if (cp0 === cp1) {
-			vivliostyle.logging.logger.warn("validateCheckPoints: duplicate entry");
-		} else if (cp0.boxOffset >= cp1.boxOffset) {
-			vivliostyle.logging.logger.warn("validateCheckPoints: incorrect boxOffset");
-		} else if (cp0.sourceNode == cp1.sourceNode) {
-			if (cp1.after) {
-				if (cp0.after) {
-					vivliostyle.logging.logger.warn("validateCheckPoints: duplicate after points");
-				}
-			} else {
-				if (cp0.after) {
-					vivliostyle.logging.logger.warn("validateCheckPoints: inconsistent after point");
-				} else {
-					if (cp1.boxOffset - cp0.boxOffset != cp1.offsetInNode - cp0.offsetInNode) {
-						vivliostyle.logging.logger.warn("validateCheckPoints: boxOffset inconsistent with offsetInNode");
-					}
-				}
-			}
-		}
-	}
+    for (var i = 1; i < checkPoints.length; i++) {
+        var cp0 = checkPoints[i-1];
+        var cp1 = checkPoints[i];
+        if (cp0 === cp1) {
+            vivliostyle.logging.logger.warn("validateCheckPoints: duplicate entry");
+        } else if (cp0.boxOffset >= cp1.boxOffset) {
+            vivliostyle.logging.logger.warn("validateCheckPoints: incorrect boxOffset");
+        } else if (cp0.sourceNode == cp1.sourceNode) {
+            if (cp1.after) {
+                if (cp0.after) {
+                    vivliostyle.logging.logger.warn("validateCheckPoints: duplicate after points");
+                }
+            } else {
+                if (cp0.after) {
+                    vivliostyle.logging.logger.warn("validateCheckPoints: inconsistent after point");
+                } else {
+                    if (cp1.boxOffset - cp0.boxOffset != cp1.offsetInNode - cp0.offsetInNode) {
+                        vivliostyle.logging.logger.warn("validateCheckPoints: boxOffset inconsistent with offsetInNode");
+                    }
+                }
+            }
+        }
+    }
 };
 
 /**
@@ -261,30 +261,30 @@ adapt.layout.validateCheckPoints = function(checkPoints) {
  * @extends {adapt.vtree.Container}
  */
 adapt.layout.Column = function(element, layoutContext, clientLayout, layoutConstraint) {
-	adapt.vtree.Container.call(this, element);
-	/** @type {Node} */ this.last = element.lastChild;
-	/** @type {adapt.vtree.LayoutContext} */ this.layoutContext = layoutContext;
-	/** @type {adapt.vtree.ClientLayout} */ this.clientLayout = clientLayout;
-	/** @const */ this.layoutConstraint = layoutConstraint;
-	/** @type {Document} */ this.viewDocument = element.ownerDocument;
+    adapt.vtree.Container.call(this, element);
+    /** @type {Node} */ this.last = element.lastChild;
+    /** @type {adapt.vtree.LayoutContext} */ this.layoutContext = layoutContext;
+    /** @type {adapt.vtree.ClientLayout} */ this.clientLayout = clientLayout;
+    /** @const */ this.layoutConstraint = layoutConstraint;
+    /** @type {Document} */ this.viewDocument = element.ownerDocument;
     /** @type {boolean} */ this.isFootnote = false;
-	/** @type {number} */ this.startEdge = 0;
-	/** @type {number} */ this.endEdge = 0;
-	/** @type {number} */ this.beforeEdge = 0;
-	/** @type {number} */ this.afterEdge = 0;
-	/** @type {number} */ this.footnoteEdge = 0;
-	/** @type {adapt.geom.Rect} */ this.box = null;
-	/** @type {adapt.layout.Column} */ this.footnoteArea = null;
-	/** @type {Array.<adapt.vtree.ChunkPosition>} */ this.chunkPositions = null;
-	/** @type {Array.<adapt.geom.Band>} */ this.bands = null;
-	/** @type {boolean} */ this.overflown = false;
-	/** @type {Array.<adapt.layout.BreakPosition>} */ this.breakPositions = null;
-	/** @type {Array.<adapt.layout.FootnoteItem>} */ this.footnoteItems = null;
-	/** @type {?string} */ this.pageBreakType = null;
-	/** @type {boolean} */ this.forceNonfitting = true;
-	/** @type {number} */ this.leftFloatEdge = 0;  // bottom of the bottommost left float
-	/** @type {number} */ this.rightFloatEdge = 0;  // bottom of the bottommost right float
-	/** @type {number} */ this.bottommostFloatTop = 0;  // Top of the bottommost float
+    /** @type {number} */ this.startEdge = 0;
+    /** @type {number} */ this.endEdge = 0;
+    /** @type {number} */ this.beforeEdge = 0;
+    /** @type {number} */ this.afterEdge = 0;
+    /** @type {number} */ this.footnoteEdge = 0;
+    /** @type {adapt.geom.Rect} */ this.box = null;
+    /** @type {adapt.layout.Column} */ this.footnoteArea = null;
+    /** @type {Array.<adapt.vtree.ChunkPosition>} */ this.chunkPositions = null;
+    /** @type {Array.<adapt.geom.Band>} */ this.bands = null;
+    /** @type {boolean} */ this.overflown = false;
+    /** @type {Array.<adapt.layout.BreakPosition>} */ this.breakPositions = null;
+    /** @type {Array.<adapt.layout.FootnoteItem>} */ this.footnoteItems = null;
+    /** @type {?string} */ this.pageBreakType = null;
+    /** @type {boolean} */ this.forceNonfitting = true;
+    /** @type {number} */ this.leftFloatEdge = 0;  // bottom of the bottommost left float
+    /** @type {number} */ this.rightFloatEdge = 0;  // bottom of the bottommost right float
+    /** @type {number} */ this.bottommostFloatTop = 0;  // Top of the bottommost float
 };
 goog.inherits(adapt.layout.Column, adapt.vtree.Container);
 
@@ -293,48 +293,48 @@ goog.inherits(adapt.layout.Column, adapt.vtree.Container);
  * @return {adapt.layout.Column}
  */
 adapt.layout.Column.prototype.clone = function() {
-	var copy = new adapt.layout.Column(this.element, this.layoutContext, this.clientLayout, this.layoutConstraint);
-	copy.copyFrom(this);
-	copy.last = this.last;
+    var copy = new adapt.layout.Column(this.element, this.layoutContext, this.clientLayout, this.layoutConstraint);
+    copy.copyFrom(this);
+    copy.last = this.last;
     copy.isFootnote = this.isFootnote;
-	copy.footnoteArea = (this.footnoteArea ? this.footnoteArea.clone() : null);
-	copy.chunkPositions = this.chunkPositions.concat();  // Make a copy
-	return copy;
+    copy.footnoteArea = (this.footnoteArea ? this.footnoteArea.clone() : null);
+    copy.chunkPositions = this.chunkPositions.concat();  // Make a copy
+    return copy;
 };
 
 /**
  * @returns {number}
  */
 adapt.layout.Column.prototype.getTopEdge = function() {
-	return this.vertical ? this.startEdge : this.beforeEdge;
+    return this.vertical ? this.startEdge : this.beforeEdge;
 };
 
 /**
  * @returns {number}
  */
 adapt.layout.Column.prototype.getBottomEdge = function() {
-	return this.vertical ? this.endEdge : this.afterEdge;
+    return this.vertical ? this.endEdge : this.afterEdge;
 };
 
 /**
  * @returns {number}
  */
 adapt.layout.Column.prototype.getLeftEdge = function() {
-	return this.vertical ? this.afterEdge : this.startEdge;
+    return this.vertical ? this.afterEdge : this.startEdge;
 };
 
 /**
  * @returns {number}
  */
 adapt.layout.Column.prototype.getRightEdge = function() {
-	return this.vertical ? this.beforeEdge : this.endEdge;
+    return this.vertical ? this.beforeEdge : this.endEdge;
 };
 
 /**
  * @returns {boolean}
  */
 adapt.layout.Column.prototype.hasNewlyAddedPageFloats = function() {
-	return this.layoutContext.getPageFloatHolder().hasNewlyAddedFloats();
+    return this.layoutContext.getPageFloatHolder().hasNewlyAddedFloats();
 };
 
 /**
@@ -342,11 +342,11 @@ adapt.layout.Column.prototype.hasNewlyAddedPageFloats = function() {
  * @return {boolean}
  */
 adapt.layout.Column.prototype.isOverflown = function(edge) {
-	if (this.vertical) {
-		return edge < this.footnoteEdge;		
-	} else {
-		return edge > this.footnoteEdge;
-	}
+    if (this.vertical) {
+        return edge < this.footnoteEdge;
+    } else {
+        return edge > this.footnoteEdge;
+    }
 };
 
 /**
@@ -369,13 +369,13 @@ adapt.layout.Column.prototype.removeFollowingSiblings = function(parentNode, vie
  * @private
  */
 adapt.layout.Column.prototype.makeNodeContext = function(step, parent) {
-	var nodeContext = new adapt.vtree.NodeContext(step.node, parent, 0);
-	nodeContext.shadowType = step.shadowType;
-	nodeContext.shadowContext = step.shadowContext,
-	nodeContext.nodeShadow = step.nodeShadow;
-	nodeContext.shadowSibling = step.shadowSibling ?
-			this.makeNodeContext(step.shadowSibling, parent.copy()) : null;
-	return nodeContext;
+    var nodeContext = new adapt.vtree.NodeContext(step.node, parent, 0);
+    nodeContext.shadowType = step.shadowType;
+    nodeContext.shadowContext = step.shadowContext,
+        nodeContext.nodeShadow = step.nodeShadow;
+    nodeContext.shadowSibling = step.shadowSibling ?
+        this.makeNodeContext(step.shadowSibling, parent.copy()) : null;
+    return nodeContext;
 };
 
 /**
@@ -383,39 +383,39 @@ adapt.layout.Column.prototype.makeNodeContext = function(step, parent) {
  * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.openAllViews = function(position) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame =
-		adapt.task.newFrame("openAllViews");
-	var steps = position.steps;
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame =
+        adapt.task.newFrame("openAllViews");
+    var steps = position.steps;
     self.layoutContext.setViewRoot(self.element, self.isFootnote);
     var stepIndex = steps.length - 1;
     var nodeContext = null;
     frame.loop(function() {
-	    while (stepIndex >= 0) {
-	    	var prevContext = nodeContext;
-			var step = steps[stepIndex];
-			nodeContext = self.makeNodeContext(step, prevContext);
-			if (stepIndex == 0) {
-				nodeContext.offsetInNode = position.offsetInNode;
-				nodeContext.after = position.after;
-		    	if (nodeContext.after) {
-		    		break;
-		    	}
-			}
-	    	var r = self.layoutContext.setCurrent(nodeContext, stepIndex == 0 && nodeContext.offsetInNode == 0);
-	    	stepIndex--;
-	    	if (r.isPending())
-	    		return r;
-	    }
-	    return adapt.task.newResult(false);
+        while (stepIndex >= 0) {
+            var prevContext = nodeContext;
+            var step = steps[stepIndex];
+            nodeContext = self.makeNodeContext(step, prevContext);
+            if (stepIndex == 0) {
+                nodeContext.offsetInNode = position.offsetInNode;
+                nodeContext.after = position.after;
+                if (nodeContext.after) {
+                    break;
+                }
+            }
+            var r = self.layoutContext.setCurrent(nodeContext, stepIndex == 0 && nodeContext.offsetInNode == 0);
+            stepIndex--;
+            if (r.isPending())
+                return r;
+        }
+        return adapt.task.newResult(false);
     }).then(function() {
-	    frame.finish(nodeContext);
+        frame.finish(nodeContext);
     });
     return frame.result();
 };
 
-adapt.layout.firstCharPattern = 
-	/^[^A-Za-z0-9_\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]*([A-Za-z0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527][^A-Za-z0-9_\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]*)?/;
+adapt.layout.firstCharPattern =
+    /^[^A-Za-z0-9_\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]*([A-Za-z0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527][^A-Za-z0-9_\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]*)?/;
 
 /**
  * @param {adapt.vtree.NodeContext} position
@@ -424,12 +424,12 @@ adapt.layout.firstCharPattern =
  */
 adapt.layout.Column.prototype.maybePeelOff = function(position, count) {
     if (position.firstPseudo && position.inline && !position.after && position.firstPseudo.count == 0) {
-    	// first char
-    	if (position.viewNode.nodeType != 1) {
-    		var text = position.viewNode.textContent;
-    		var r = text.match(adapt.layout.firstCharPattern);
-    		return this.layoutContext.peelOff(position, r[0].length);
-    	}
+        // first char
+        if (position.viewNode.nodeType != 1) {
+            var text = position.viewNode.textContent;
+            var r = text.match(adapt.layout.firstCharPattern);
+            return this.layoutContext.peelOff(position, r[0].length);
+        }
     }
     return /** @type {!adapt.task.Result.<adapt.vtree.NodeContext>} */ (adapt.task.newResult(position));
 };
@@ -443,53 +443,53 @@ adapt.layout.Column.prototype.maybePeelOff = function(position, count) {
  *                      or null if the source is exhausted.
  */
 adapt.layout.Column.prototype.buildViewToNextBlockEdge = function(position, checkPoints) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("buildViewToNextBlockEdge");
-	frame.loopWithFrame(function(bodyFrame) {
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("buildViewToNextBlockEdge");
+    frame.loopWithFrame(function(bodyFrame) {
         if (position.viewNode)
             checkPoints.push(position.copy());
         self.maybePeelOff(position, 0).then(function(position1Param) {
-        	var position1 = /** @type {adapt.vtree.NodeContext} */ (position1Param);
-	        if (position1 !== position) {
-	        	position = position1;
-	            checkPoints.push(position.copy());
-	        }
-	        self.layoutContext.nextInTree(position).then(function(positionParam) {
-	        	position = /** @type {adapt.vtree.NodeContext} */ (positionParam);
-		        if (!position) {
-		        	// Exit the loop
-		        	bodyFrame.breakLoop();
-		            return;
-		        }
-				if (!self.layoutConstraint.allowLayout(position)) {
-					position = position.modify();
-					position.overflow = true;
-					bodyFrame.breakLoop();
-					return;
-				}
-		        if (position.floatSide && !self.vertical) {
-		        	// TODO: implement floats and footnotes properly
-		        	self.layoutFloatOrFootnote(position).then(function(positionParam) {
-			        	position = /** @type {adapt.vtree.NodeContext} */ (positionParam);
-			        	if (!position || position.overflow || self.hasNewlyAddedPageFloats()) {
-				        	bodyFrame.breakLoop();
-				            return;
-			        	}
-			        	bodyFrame.continueLoop();			        	
-		        	});
-		        } else if (!position.inline) {
-		        	// Exit the loop
-		        	bodyFrame.breakLoop();
-		        } else {
-		        	// Continue the loop
-		        	bodyFrame.continueLoop();
-		        }
-	        });
+            var position1 = /** @type {adapt.vtree.NodeContext} */ (position1Param);
+            if (position1 !== position) {
+                position = position1;
+                checkPoints.push(position.copy());
+            }
+            self.layoutContext.nextInTree(position).then(function(positionParam) {
+                position = /** @type {adapt.vtree.NodeContext} */ (positionParam);
+                if (!position) {
+                    // Exit the loop
+                    bodyFrame.breakLoop();
+                    return;
+                }
+                if (!self.layoutConstraint.allowLayout(position)) {
+                    position = position.modify();
+                    position.overflow = true;
+                    bodyFrame.breakLoop();
+                    return;
+                }
+                if (position.floatSide && !self.vertical) {
+                    // TODO: implement floats and footnotes properly
+                    self.layoutFloatOrFootnote(position).then(function(positionParam) {
+                        position = /** @type {adapt.vtree.NodeContext} */ (positionParam);
+                        if (!position || position.overflow || self.hasNewlyAddedPageFloats()) {
+                            bodyFrame.breakLoop();
+                            return;
+                        }
+                        bodyFrame.continueLoop();
+                    });
+                } else if (!position.inline) {
+                    // Exit the loop
+                    bodyFrame.breakLoop();
+                } else {
+                    // Continue the loop
+                    bodyFrame.continueLoop();
+                }
+            });
         });
-	}).then(function() {
-		frame.finish(position);
-	});
+    }).then(function() {
+        frame.finish(position);
+    });
     return frame.result();
 };
 
@@ -506,40 +506,40 @@ adapt.layout.Column.prototype.buildDeepElementView = function(position) {
     var sourceNode = position.sourceNode;
     var self = this;
     /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame =
-    	adapt.task.newFrame("buildDeepElementView");
+        adapt.task.newFrame("buildDeepElementView");
     // TODO: end the loop based on depth, not sourceNode comparison
-	frame.loopWithFrame(function(bodyFrame) {
+    frame.loopWithFrame(function(bodyFrame) {
         self.maybePeelOff(position, 0).then(function(position1Param) {
-        	var position1 = /** @type {adapt.vtree.NodeContext} */ (position1Param);
-	        if (position1 !== position) {
-	        	var p = position1;
-	        	while (p && p.sourceNode != sourceNode) {
-	        		p = p.parent;
-	        	}
-	        	if (p == null) {
-	        		// outside of the subtree
-	        		position = position1;
-	        		bodyFrame.breakLoop();
-	        		return;
-	        	}
-	        }
-	        self.layoutContext.nextInTree(position1).then(function(positionParam) {
-	        	position = /** @type {adapt.vtree.NodeContext} */ (positionParam);
-		        if (!position || position.sourceNode == sourceNode) {
-					bodyFrame.breakLoop();
-				} else if (!self.layoutConstraint.allowLayout(position)) {
-					position = position.modify();
-					position.overflow = true;
-					bodyFrame.breakLoop();
-		        } else {
-		        	bodyFrame.continueLoop();
-		        }
-	        });
+            var position1 = /** @type {adapt.vtree.NodeContext} */ (position1Param);
+            if (position1 !== position) {
+                var p = position1;
+                while (p && p.sourceNode != sourceNode) {
+                    p = p.parent;
+                }
+                if (p == null) {
+                    // outside of the subtree
+                    position = position1;
+                    bodyFrame.breakLoop();
+                    return;
+                }
+            }
+            self.layoutContext.nextInTree(position1).then(function(positionParam) {
+                position = /** @type {adapt.vtree.NodeContext} */ (positionParam);
+                if (!position || position.sourceNode == sourceNode) {
+                    bodyFrame.breakLoop();
+                } else if (!self.layoutConstraint.allowLayout(position)) {
+                    position = position.modify();
+                    position.overflow = true;
+                    bodyFrame.breakLoop();
+                } else {
+                    bodyFrame.continueLoop();
+                }
+            });
         });
     }).then(function() {
-    	frame.finish(position);
+        frame.finish(position);
     });
-	return frame.result();
+    return frame.result();
 };
 
 /**
@@ -551,14 +551,14 @@ adapt.layout.Column.prototype.buildDeepElementView = function(position) {
  * @return {Element} newly created float element.
  */
 adapt.layout.Column.prototype.createFloat = function(ref, side, width,
-		height) {
+                                                     height) {
     var div = this.viewDocument.createElement("div");
     if (this.vertical) {
-	    adapt.base.setCSSProperty(div, "height", width + "px");
-	    adapt.base.setCSSProperty(div, "width", height + "px");    	
+        adapt.base.setCSSProperty(div, "height", width + "px");
+        adapt.base.setCSSProperty(div, "width", height + "px");
     } else {
-	    adapt.base.setCSSProperty(div, "width", width + "px");
-	    adapt.base.setCSSProperty(div, "height", height + "px");
+        adapt.base.setCSSProperty(div, "width", width + "px");
+        adapt.base.setCSSProperty(div, "height", height + "px");
     }
     adapt.base.setCSSProperty(div, "float", side);
     adapt.base.setCSSProperty(div, "clear", side);
@@ -573,20 +573,20 @@ adapt.layout.Column.prototype.createFloat = function(ref, side, width,
  * @return {void}
  */
 adapt.layout.Column.prototype.killFloats = function() {
-	var c = this.element.firstChild;
-	while (c) {
-		var nc = c.nextSibling;
-		if (c.nodeType == 1) {
-			var e = /** @type {HTMLElement} */ (c);
-			var f = e.style.cssFloat;
-			if (f == "left" || f == "right") {
-				this.element.removeChild(e);
-			} else {
-				break;
-			}
-		}
-		c = nc;
-	}
+    var c = this.element.firstChild;
+    while (c) {
+        var nc = c.nextSibling;
+        if (c.nodeType == 1) {
+            var e = /** @type {HTMLElement} */ (c);
+            var f = e.style.cssFloat;
+            if (f == "left" || f == "right") {
+                this.element.removeChild(e);
+            } else {
+                break;
+            }
+        }
+        c = nc;
+    }
 };
 
 /**
@@ -598,13 +598,13 @@ adapt.layout.Column.prototype.createFloats = function() {
     var bands = this.bands;
     var x1 = this.vertical ? this.getTopEdge() : this.getLeftEdge();
     var x2 = this.vertical ? this.getBottomEdge() : this.getRightEdge();
-    for (var ri = 0 ; ri < bands.length ; ri++) {
+    for (var ri = 0; ri < bands.length; ri++) {
         var band = bands[ri];
         var height = band.y2 - band.y1;
         band.left = this.createFloat(
-        		ref, "left", band.x1 - x1, height);        
+            ref, "left", band.x1 - x1, height);
         band.right = this.createFloat(
-        		ref, "right", x2 - band.x2, height);        
+            ref, "right", x2 - band.x2, height);
     }
 };
 
@@ -616,15 +616,15 @@ adapt.layout.Column.prototype.createFloats = function() {
  * @return {number} edge position
  */
 adapt.layout.Column.prototype.calculateEdge = function(nodeContext, checkPoints, index, boxOffset) {
-	var edge;
-	if (nodeContext && nodeContext.after && !nodeContext.inline) {
-		edge = adapt.layout.calculateEdge(nodeContext, this.clientLayout, 0, this.vertical);
-		if (!isNaN(edge))
-			return edge;
-	}
+    var edge;
+    if (nodeContext && nodeContext.after && !nodeContext.inline) {
+        edge = adapt.layout.calculateEdge(nodeContext, this.clientLayout, 0, this.vertical);
+        if (!isNaN(edge))
+            return edge;
+    }
     nodeContext = checkPoints[index];
     var offset = boxOffset - nodeContext.boxOffset;
-    while(true) {
+    while (true) {
         edge = adapt.layout.calculateEdge(nodeContext, this.clientLayout, offset, this.vertical);
         if (!isNaN(edge))
             return edge;
@@ -647,9 +647,9 @@ adapt.layout.Column.prototype.calculateEdge = function(nodeContext, checkPoints,
  * @return {number} value in pixels or 0 if not parsable
  */
 adapt.layout.Column.prototype.parseComputedLength = function(val) {
-	if (typeof val == "number") {
-		return val;
-	}
+    if (typeof val == "number") {
+        return val;
+    }
     var r = val.match(/^(-?[0-9]*(\.[0-9]*)?)px$/);
     if (r)
         return parseFloat(r[0]);
@@ -679,23 +679,23 @@ adapt.layout.Column.prototype.getComputedMargin = function(element) {
  * @returns {adapt.geom.Insets}
  */
 adapt.layout.Column.prototype.getComputedPaddingBorder = function(element) {
-	var style = this.clientLayout.getElementComputedStyle(element);
-	var insets = new adapt.geom.Insets(0, 0, 0, 0);
-	if (style) {
-		insets.left =
-			this.parseComputedLength(style.borderLeftWidth) +
-			this.parseComputedLength(style.paddingLeft);
-		insets.top =
-			this.parseComputedLength(style.borderTopWidth) +
-			this.parseComputedLength(style.paddingTop);
-		insets.right =
-			this.parseComputedLength(style.borderRightWidth) +
-			this.parseComputedLength(style.paddingRight);
-		insets.bottom =
-			this.parseComputedLength(style.borderBottomWidth) +
-			this.parseComputedLength(style.paddingBottom);
-	}
-	return insets;
+    var style = this.clientLayout.getElementComputedStyle(element);
+    var insets = new adapt.geom.Insets(0, 0, 0, 0);
+    if (style) {
+        insets.left =
+            this.parseComputedLength(style.borderLeftWidth) +
+            this.parseComputedLength(style.paddingLeft);
+        insets.top =
+            this.parseComputedLength(style.borderTopWidth) +
+            this.parseComputedLength(style.paddingTop);
+        insets.right =
+            this.parseComputedLength(style.borderRightWidth) +
+            this.parseComputedLength(style.paddingRight);
+        insets.bottom =
+            this.parseComputedLength(style.borderBottomWidth) +
+            this.parseComputedLength(style.paddingBottom);
+    }
+    return insets;
 };
 
 /**
@@ -709,20 +709,20 @@ adapt.layout.Column.prototype.getComputedInsets = function(element) {
     if (style) {
         if (style.boxSizing == "border-box")
             return this.getComputedMargin(element);
-        
-        insets.left = 
+
+        insets.left =
             this.parseComputedLength(style.marginLeft) +
             this.parseComputedLength(style.borderLeftWidth) +
             this.parseComputedLength(style.paddingLeft);
-        insets.top = 
+        insets.top =
             this.parseComputedLength(style.marginTop) +
             this.parseComputedLength(style.borderTopWidth) +
             this.parseComputedLength(style.paddingTop);
-        insets.right = 
+        insets.right =
             this.parseComputedLength(style.marginRight) +
             this.parseComputedLength(style.borderRightWidth) +
             this.parseComputedLength(style.paddingRight);
-        insets.bottom = 
+        insets.bottom =
             this.parseComputedLength(style.marginBottom) +
             this.parseComputedLength(style.borderBottomWidth) +
             this.parseComputedLength(style.paddingBottom);
@@ -768,14 +768,14 @@ adapt.layout.Column.prototype.layoutUnbreakable = function(nodeContextIn) {
  * @param {adapt.vtree.NodePosition} footnoteNodePosition
  */
 adapt.layout.Column.prototype.processFullyOverflownFootnote = function(boxOffset, footnoteNodePosition) {
-	// already have overflowing footnotes, just add to the list
-	var footnoteItem = new adapt.layout.FootnoteItem(boxOffset, footnoteNodePosition,
-			footnoteNodePosition);
-	if (this.footnoteItems) {
-		this.footnoteItems.push(footnoteItem);
-	} else {
-		this.footnoteItems = [footnoteItem];
-	}
+    // already have overflowing footnotes, just add to the list
+    var footnoteItem = new adapt.layout.FootnoteItem(boxOffset, footnoteNodePosition,
+        footnoteNodePosition);
+    if (this.footnoteItems) {
+        this.footnoteItems.push(footnoteItem);
+    } else {
+        this.footnoteItems = [footnoteItem];
+    }
 };
 
 /**
@@ -785,125 +785,125 @@ adapt.layout.Column.prototype.processFullyOverflownFootnote = function(boxOffset
  * @return {!adapt.task.Result.<boolean>} holding true
  */
 adapt.layout.Column.prototype.layoutFootnoteInner = function(boxOffset, footnoteNodePosition, boundingEdge) {
-	var self = this;
-	if (self.footnoteItems) {
-		var lastItem = self.footnoteItems[self.footnoteItems.length - 1];
-		if (lastItem.overflowPosition) {
-			self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
-			return adapt.task.newResult(true);
-		}
-	}
-	boundingEdge += self.getBoxDir() * 40; // Leave some space
-	var footnoteArea = self.footnoteArea;
-	var firstFootnoteInColumn = !footnoteArea;
+    var self = this;
+    if (self.footnoteItems) {
+        var lastItem = self.footnoteItems[self.footnoteItems.length - 1];
+        if (lastItem.overflowPosition) {
+            self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
+            return adapt.task.newResult(true);
+        }
+    }
+    boundingEdge += self.getBoxDir() * 40; // Leave some space
+    var footnoteArea = self.footnoteArea;
+    var firstFootnoteInColumn = !footnoteArea;
     if (firstFootnoteInColumn) {
-    	var footnoteContainer = self.element.ownerDocument.createElement("div");
+        var footnoteContainer = self.element.ownerDocument.createElement("div");
         adapt.base.setCSSProperty(footnoteContainer, "position", "absolute");
         var layoutContext = self.layoutContext.clone();
-    	footnoteArea = new adapt.layout.Column(footnoteContainer,
-    			layoutContext, self.clientLayout, self.layoutConstraint);
-    	self.footnoteArea = footnoteArea;
-    	footnoteArea.vertical = self.layoutContext.applyFootnoteStyle(self.vertical, footnoteContainer);
-    	footnoteArea.isFootnote = true;
-    	if (self.vertical) {
-	    	footnoteArea.left = 0;    		
-	    	adapt.base.setCSSProperty(footnoteArea.element, "width", "2em");
-    	} else {
-	    	footnoteArea.top = self.afterEdge;
-	    	adapt.base.setCSSProperty(footnoteArea.element, "height", "2em");
-    	}
+        footnoteArea = new adapt.layout.Column(footnoteContainer,
+            layoutContext, self.clientLayout, self.layoutConstraint);
+        self.footnoteArea = footnoteArea;
+        footnoteArea.vertical = self.layoutContext.applyFootnoteStyle(self.vertical, footnoteContainer);
+        footnoteArea.isFootnote = true;
+        if (self.vertical) {
+            footnoteArea.left = 0;
+            adapt.base.setCSSProperty(footnoteArea.element, "width", "2em");
+        } else {
+            footnoteArea.top = self.afterEdge;
+            adapt.base.setCSSProperty(footnoteArea.element, "height", "2em");
+        }
     }
-	self.element.appendChild(footnoteArea.element);
-	self.setComputedInsets(footnoteArea.element, footnoteArea);
-	var before = self.getBoxDir() * (boundingEdge - self.beforeEdge);
-	if (self.vertical) {
-		footnoteArea.height = self.box.y2 - self.box.y1
-			- footnoteArea.getInsetTop() - footnoteArea.getInsetBottom();		
-	} else {
-		footnoteArea.width = self.box.x2 - self.box.x1
-			- footnoteArea.getInsetLeft() - footnoteArea.getInsetRight();
-	}
-	var blockDirInsets = self.vertical ? 
-			footnoteArea.getInsetLeft() - footnoteArea.getInsetRight() :
-			footnoteArea.getInsetTop() + footnoteArea.getInsetBottom();
-	var extent = self.getBoxDir() * (self.afterEdge - boundingEdge) - blockDirInsets;
-	if (firstFootnoteInColumn && extent < 18) {
-		self.element.removeChild(footnoteArea.element);
-		self.footnoteArea = null;
-		self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
-		return adapt.task.newResult(true);
-	}
-	if (!self.vertical && footnoteArea.top < before) {  // Can be removed???
-		self.element.removeChild(footnoteArea.element);
-		self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
-		return adapt.task.newResult(true);
-	}
-	
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame
-		= adapt.task.newFrame("layoutFootnoteInner");
-	if (self.vertical) {
-		footnoteArea.setHorizontalPosition(0, extent);		
-	} else {
-		footnoteArea.setVerticalPosition(before, extent);
-	}
+    self.element.appendChild(footnoteArea.element);
+    self.setComputedInsets(footnoteArea.element, footnoteArea);
+    var before = self.getBoxDir() * (boundingEdge - self.beforeEdge);
+    if (self.vertical) {
+        footnoteArea.height = self.box.y2 - self.box.y1
+            - footnoteArea.getInsetTop() - footnoteArea.getInsetBottom();
+    } else {
+        footnoteArea.width = self.box.x2 - self.box.x1
+            - footnoteArea.getInsetLeft() - footnoteArea.getInsetRight();
+    }
+    var blockDirInsets = self.vertical ?
+    footnoteArea.getInsetLeft() - footnoteArea.getInsetRight() :
+    footnoteArea.getInsetTop() + footnoteArea.getInsetBottom();
+    var extent = self.getBoxDir() * (self.afterEdge - boundingEdge) - blockDirInsets;
+    if (firstFootnoteInColumn && extent < 18) {
+        self.element.removeChild(footnoteArea.element);
+        self.footnoteArea = null;
+        self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
+        return adapt.task.newResult(true);
+    }
+    if (!self.vertical && footnoteArea.top < before) {  // Can be removed???
+        self.element.removeChild(footnoteArea.element);
+        self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
+        return adapt.task.newResult(true);
+    }
+
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame
+        = adapt.task.newFrame("layoutFootnoteInner");
+    if (self.vertical) {
+        footnoteArea.setHorizontalPosition(0, extent);
+    } else {
+        footnoteArea.setVerticalPosition(before, extent);
+    }
     footnoteArea.originX = self.originX + self.left + self.getInsetLeft();
-    footnoteArea.originY = self.originY + self.top + self.getInsetTop();    
+    footnoteArea.originY = self.originY + self.top + self.getInsetTop();
     footnoteArea.exclusions = self.exclusions;
     var footnotePosition = new adapt.vtree.ChunkPosition(footnoteNodePosition);
     var initResult;
     if (firstFootnoteInColumn) {
-    	footnoteArea.init();
-    	initResult = adapt.task.newResult(true);
+        footnoteArea.init();
+        initResult = adapt.task.newResult(true);
     } else if (footnoteArea.exclusions.length == 0) {
-    	// No need to redo, just reset the geometry
-    	footnoteArea.initGeom();
-    	initResult = adapt.task.newResult(true);
+        // No need to redo, just reset the geometry
+        footnoteArea.initGeom();
+        initResult = adapt.task.newResult(true);
     } else {
-    	// Don't expect overflow, as we gave it more space
-    	initResult = footnoteArea.redoLayout();
+        // Don't expect overflow, as we gave it more space
+        initResult = footnoteArea.redoLayout();
     }
     initResult.then(function() {
-		footnoteArea.layout(footnotePosition).then(function(footnoteOverflowParam) {
-			var footnoteOverflow = /** @type {adapt.vtree.ChunkPosition} */ (footnoteOverflowParam);
-			// If the footnote overflows, defer it to the next column entirely.
-			// TODO: Possibility of infinite loops?
-			if (firstFootnoteInColumn && footnoteOverflow) {
-				self.element.removeChild(footnoteArea.element);
-				self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
-				self.footnoteArea = null;
-				frame.finish(true);
-				return;
-			}
-			if (self.vertical) {
-				self.footnoteEdge = self.afterEdge + (footnoteArea.computedBlockSize
-						+ footnoteArea.getInsetLeft() + footnoteArea.getInsetRight());
-				footnoteArea.setHorizontalPosition(0, footnoteArea.computedBlockSize);				
-			} else {
-				self.footnoteEdge = self.afterEdge - (footnoteArea.computedBlockSize
-						+ footnoteArea.getInsetTop() + footnoteArea.getInsetBottom());
-				var footnoteTop = self.footnoteEdge - self.beforeEdge;
-				footnoteArea.setVerticalPosition(footnoteTop, footnoteArea.computedBlockSize);
-			}
-			var redoResult;
-			if (!self.vertical && footnoteArea.exclusions.length > 0) {
-				redoResult = footnoteArea.redoLayout();
-			} else {
-				redoResult = adapt.task.newResult(footnoteOverflow);
-			}
-			redoResult.then(function(footnoteOverflow) {
-				var overflowPosition = footnoteOverflow ? footnoteOverflow.primary : null;
-				var footnoteItem = new adapt.layout.FootnoteItem(boxOffset, footnoteNodePosition,
-						overflowPosition);
-				if (self.footnoteItems) {
-					self.footnoteItems.push(footnoteItem);
-				} else {
-					self.footnoteItems = [footnoteItem];
-				}
-				frame.finish(true);
-			});
-		});
+        footnoteArea.layout(footnotePosition).then(function(footnoteOverflowParam) {
+            var footnoteOverflow = /** @type {adapt.vtree.ChunkPosition} */ (footnoteOverflowParam);
+            // If the footnote overflows, defer it to the next column entirely.
+            // TODO: Possibility of infinite loops?
+            if (firstFootnoteInColumn && footnoteOverflow) {
+                self.element.removeChild(footnoteArea.element);
+                self.processFullyOverflownFootnote(boxOffset, footnoteNodePosition);
+                self.footnoteArea = null;
+                frame.finish(true);
+                return;
+            }
+            if (self.vertical) {
+                self.footnoteEdge = self.afterEdge + (footnoteArea.computedBlockSize
+                    + footnoteArea.getInsetLeft() + footnoteArea.getInsetRight());
+                footnoteArea.setHorizontalPosition(0, footnoteArea.computedBlockSize);
+            } else {
+                self.footnoteEdge = self.afterEdge - (footnoteArea.computedBlockSize
+                    + footnoteArea.getInsetTop() + footnoteArea.getInsetBottom());
+                var footnoteTop = self.footnoteEdge - self.beforeEdge;
+                footnoteArea.setVerticalPosition(footnoteTop, footnoteArea.computedBlockSize);
+            }
+            var redoResult;
+            if (!self.vertical && footnoteArea.exclusions.length > 0) {
+                redoResult = footnoteArea.redoLayout();
+            } else {
+                redoResult = adapt.task.newResult(footnoteOverflow);
+            }
+            redoResult.then(function(footnoteOverflow) {
+                var overflowPosition = footnoteOverflow ? footnoteOverflow.primary : null;
+                var footnoteItem = new adapt.layout.FootnoteItem(boxOffset, footnoteNodePosition,
+                    overflowPosition);
+                if (self.footnoteItems) {
+                    self.footnoteItems.push(footnoteItem);
+                } else {
+                    self.footnoteItems = [footnoteItem];
+                }
+                frame.finish(true);
+            });
+        });
     });
-	return frame.result();
+    return frame.result();
 };
 
 /**
@@ -912,9 +912,9 @@ adapt.layout.Column.prototype.layoutFootnoteInner = function(boxOffset, footnote
  * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.layoutFootnote = function(nodeContext) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("layoutFootnote");
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("layoutFootnote");
     var element = /** @type {Element} */ (nodeContext.viewNode);
     element.setAttribute("style", ""); // clear styling
     // Default footnote call style
@@ -926,20 +926,20 @@ adapt.layout.Column.prototype.layoutFootnote = function(nodeContext) {
     // Defaults for footnote-call, can be overriden by the stylesheet.
     self.layoutContext.applyPseudoelementStyle(nodeContext, "footnote-call", element);
     if (!element.textContent) {
-    	element.parentNode.removeChild(element);
+        element.parentNode.removeChild(element);
     }
     var footnoteNodePosition = adapt.vtree.newNodePositionFromNodeContext(nodeContext);
     var boxOffset = nodeContext.boxOffset;
     nodeContext = nodeContext.modify();
     nodeContext.after = true;
     self.layoutFootnoteInner(boxOffset, footnoteNodePosition, callBoxAfter).then(function() {
-	    if (self.footnoteArea && self.footnoteArea.element.parentNode) {
-	    	self.element.removeChild(self.footnoteArea.element);
-	    }
-	    if (self.isOverflown(callBoxAfter) && self.breakPositions.length != 0) {
-	    	nodeContext.overflow = true;
-	    }
-    	frame.finish(nodeContext);
+        if (self.footnoteArea && self.footnoteArea.element.parentNode) {
+            self.element.removeChild(self.footnoteArea.element);
+        }
+        if (self.isOverflown(callBoxAfter) && self.breakPositions.length != 0) {
+            nodeContext.overflow = true;
+        }
+        frame.finish(nodeContext);
     });
     return frame.result();
 };
@@ -950,179 +950,179 @@ adapt.layout.Column.prototype.layoutFootnote = function(nodeContext) {
  * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.layoutFloat = function(nodeContext) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("layoutFloat");
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("layoutFloat");
     var element = /** @type {!Element} */ (nodeContext.viewNode);
-	var floatSide = /** @type {string} */ (nodeContext.floatSide);
-	var floatReference = /** @type {string} */ (nodeContext.floatReference);
-	var direction = nodeContext.parent ? nodeContext.parent.direction : "ltr";
-	var floatHolder = self.layoutContext.getPageFloatHolder();
+    var floatSide = /** @type {string} */ (nodeContext.floatSide);
+    var floatReference = /** @type {string} */ (nodeContext.floatReference);
+    var direction = nodeContext.parent ? nodeContext.parent.direction : "ltr";
+    var floatHolder = self.layoutContext.getPageFloatHolder();
 
-	var originalViewNodeParent = nodeContext.viewNode.parentNode;
+    var originalViewNodeParent = nodeContext.viewNode.parentNode;
 
-	if (floatReference === "page") {
-		floatHolder.prepareFloatElement(element, floatSide);
-	} else {
-		adapt.base.setCSSProperty(element, "float", "none");
-		adapt.base.setCSSProperty(element, "display", "inline-block");
-		adapt.base.setCSSProperty(element, "vertical-align", "top");                
-	}
+    if (floatReference === "page") {
+        floatHolder.prepareFloatElement(element, floatSide);
+    } else {
+        adapt.base.setCSSProperty(element, "float", "none");
+        adapt.base.setCSSProperty(element, "display", "inline-block");
+        adapt.base.setCSSProperty(element, "vertical-align", "top");
+    }
     self.buildDeepElementView(nodeContext).then(function(nodeContextAfter) {
-		var floatBBox = self.clientLayout.getElementClientRect(element);
-	    var margin = self.getComputedMargin(element);
-	    var floatBox = new adapt.geom.Rect(floatBBox.left - margin.left,
-	    		floatBBox.top - margin.top, floatBBox.right + margin.right,
-	    		floatBBox.bottom + margin.bottom);
+        var floatBBox = self.clientLayout.getElementClientRect(element);
+        var margin = self.getComputedMargin(element);
+        var floatBox = new adapt.geom.Rect(floatBBox.left - margin.left,
+            floatBBox.top - margin.top, floatBBox.right + margin.right,
+            floatBBox.bottom + margin.bottom);
 
-		// page floats
-		if (floatReference === "page") {
-			goog.asserts.assert(self.layoutContext);
-			var pageFloat = floatHolder.getFloat(nodeContext, self.layoutContext);
-			if (pageFloat) {
-				// Replace nodeContextAfter.viewNode with a dummy span.
-				// Since the actual viewNode is moved and attached to a parent node
-				// which is different from that of subsequent content nodes,
-				// clearOverflownViewNodes method does not work correctly without this replacement.
-				var dummy = originalViewNodeParent.ownerDocument.createElement("span");
-				adapt.base.setCSSProperty(dummy, "width", "0");
-				adapt.base.setCSSProperty(dummy, "height", "0");
-				originalViewNodeParent.appendChild(dummy);
-				nodeContextAfter.viewNode = dummy;
-				frame.finish(nodeContextAfter);
-			} else {
-				floatHolder.tryToAddFloat(nodeContext, element, floatBox, floatSide).then(function() {
-					frame.finish(null);
-				});
-			}
-			return;
-		}
+        // page floats
+        if (floatReference === "page") {
+            goog.asserts.assert(self.layoutContext);
+            var pageFloat = floatHolder.getFloat(nodeContext, self.layoutContext);
+            if (pageFloat) {
+                // Replace nodeContextAfter.viewNode with a dummy span.
+                // Since the actual viewNode is moved and attached to a parent node
+                // which is different from that of subsequent content nodes,
+                // clearOverflownViewNodes method does not work correctly without this replacement.
+                var dummy = originalViewNodeParent.ownerDocument.createElement("span");
+                adapt.base.setCSSProperty(dummy, "width", "0");
+                adapt.base.setCSSProperty(dummy, "height", "0");
+                originalViewNodeParent.appendChild(dummy);
+                nodeContextAfter.viewNode = dummy;
+                frame.finish(nodeContextAfter);
+            } else {
+                floatHolder.tryToAddFloat(nodeContext, element, floatBox, floatSide).then(function() {
+                    frame.finish(null);
+                });
+            }
+            return;
+        }
 
-		floatSide = vivliostyle.pagefloat.resolveInlineFloatDirection(floatSide, self.vertical, direction);
-		var x1 = self.startEdge;
-		var x2 = self.endEdge;
-	    var parent = nodeContext.parent;
-	    while (parent && parent.inline) {
-	    	parent = parent.parent;
-	    }
-	    if (parent) {
-	        // Position it at the parent element's edge.
-	    	// We need to get the edge of the parent's content area, calling getElementClientRect will
-	    	// also give us borders. Avoid it by creating a temporary element and using it for measurment.
-	    	var probe = parent.viewNode.ownerDocument.createElement("div");
-	    	probe.style.left = "0px";
-	    	probe.style.top = "0px";
-	    	if (self.vertical) {
-		    	probe.style.bottom = "0px";
-		    	probe.style.width = "1px";	    		
-	    	} else {
-		    	probe.style.right = "0px";
-		    	probe.style.height = "1px";
-	    	}
-	    	parent.viewNode.appendChild(probe);
-	        var parentBox = self.clientLayout.getElementClientRect(probe);
-	    	x1 = Math.max(self.getStartEdge(parentBox), x1);
-	    	x2 = Math.min(self.getEndEdge(parentBox), x2);	    	
-	    	parent.viewNode.removeChild(probe);
-	    	var floatBoxMeasure = self.vertical ? floatBox.y2 - floatBox.y1 : floatBox.x2 - floatBox.x1;
-	    	if (floatSide == "left")
-	    		x2 = Math.max(x2, x1 + floatBoxMeasure);
-	    	else
-	    		x1 = Math.min(x1, x2 - floatBoxMeasure);
+        floatSide = vivliostyle.pagefloat.resolveInlineFloatDirection(floatSide, self.vertical, direction);
+        var x1 = self.startEdge;
+        var x2 = self.endEdge;
+        var parent = nodeContext.parent;
+        while (parent && parent.inline) {
+            parent = parent.parent;
+        }
+        if (parent) {
+            // Position it at the parent element's edge.
+            // We need to get the edge of the parent's content area, calling getElementClientRect will
+            // also give us borders. Avoid it by creating a temporary element and using it for measurment.
+            var probe = parent.viewNode.ownerDocument.createElement("div");
+            probe.style.left = "0px";
+            probe.style.top = "0px";
+            if (self.vertical) {
+                probe.style.bottom = "0px";
+                probe.style.width = "1px";
+            } else {
+                probe.style.right = "0px";
+                probe.style.height = "1px";
+            }
+            parent.viewNode.appendChild(probe);
+            var parentBox = self.clientLayout.getElementClientRect(probe);
+            x1 = Math.max(self.getStartEdge(parentBox), x1);
+            x2 = Math.min(self.getEndEdge(parentBox), x2);
+            parent.viewNode.removeChild(probe);
+            var floatBoxMeasure = self.vertical ? floatBox.y2 - floatBox.y1 : floatBox.x2 - floatBox.x1;
+            if (floatSide == "left")
+                x2 = Math.max(x2, x1 + floatBoxMeasure);
+            else
+                x1 = Math.min(x1, x2 - floatBoxMeasure);
 
-			// Move the float below the block parent.
-			// Otherwise, if the float is attached to an inline box with 'position: relative',
-			// the absolute positioning of the float gets broken,
-			// since the inline parent can be pushed horizontally by exclusion floats
-			// after the layout of the float is done.
-			parent.viewNode.appendChild(nodeContext.viewNode);
-	    }
-	    // box is rotated for vertical orientation
-		var box = new adapt.geom.Rect(x1, self.getBoxDir() * self.beforeEdge, x2, self.getBoxDir() * self.afterEdge);
-	    var floatHorBox = floatBox;
-	    if (self.vertical) {
-	    	floatHorBox = adapt.geom.rotateBox(floatBox);
-	    }
+            // Move the float below the block parent.
+            // Otherwise, if the float is attached to an inline box with 'position: relative',
+            // the absolute positioning of the float gets broken,
+            // since the inline parent can be pushed horizontally by exclusion floats
+            // after the layout of the float is done.
+            parent.viewNode.appendChild(nodeContext.viewNode);
+        }
+        // box is rotated for vertical orientation
+        var box = new adapt.geom.Rect(x1, self.getBoxDir() * self.beforeEdge, x2, self.getBoxDir() * self.afterEdge);
+        var floatHorBox = floatBox;
+        if (self.vertical) {
+            floatHorBox = adapt.geom.rotateBox(floatBox);
+        }
         var dir = self.getBoxDir();
         if (floatHorBox.y1 < self.bottommostFloatTop * dir) {
             var boxExtent = floatHorBox.y2 - floatHorBox.y1;
             floatHorBox.y1 = self.bottommostFloatTop * dir;
             floatHorBox.y2 = floatHorBox.y1 + boxExtent;
         }
-	    adapt.geom.positionFloat(box, self.bands, floatHorBox, floatSide);
-	    if (self.vertical) {
-	    	floatBox = adapt.geom.unrotateBox(floatHorBox);
-	    }
+        adapt.geom.positionFloat(box, self.bands, floatHorBox, floatSide);
+        if (self.vertical) {
+            floatBox = adapt.geom.unrotateBox(floatHorBox);
+        }
         var insets = self.getComputedInsets(element);
         adapt.base.setCSSProperty(element, "width", floatBox.x2 - floatBox.x1 - insets.left - insets.right + "px");
-        adapt.base.setCSSProperty(element, "height", floatBox.y2 - floatBox.y1 - insets.top - insets.bottom + "px");        
-		adapt.base.setCSSProperty(element, "position", "absolute");
-		goog.asserts.assert(nodeContext.display);
-		adapt.base.setCSSProperty(element, "display", nodeContext.display);
+        adapt.base.setCSSProperty(element, "height", floatBox.y2 - floatBox.y1 - insets.top - insets.bottom + "px");
+        adapt.base.setCSSProperty(element, "position", "absolute");
+        goog.asserts.assert(nodeContext.display);
+        adapt.base.setCSSProperty(element, "display", nodeContext.display);
 
-		var offsets;
-		var containingBlockForAbsolute = null;
-		if (parent) {
-			if (parent.containingBlockForAbsolute) {
-				containingBlockForAbsolute = parent;
-			} else {
-				containingBlockForAbsolute = parent.getContainingBlockForAbsolute();
-			}
-		}
-		if (containingBlockForAbsolute) {
-			var probe = containingBlockForAbsolute.viewNode.ownerDocument.createElement("div");
-			probe.style.position = "absolute";
-			if (containingBlockForAbsolute.vertical) {
-				probe.style.right = "0";
-			} else {
-				probe.style.left = "0";
-			}
-			probe.style.top = "0";
-			containingBlockForAbsolute.viewNode.appendChild(probe);
-			offsets = self.clientLayout.getElementClientRect(probe);
-			containingBlockForAbsolute.viewNode.removeChild(probe);
-		} else {
-			offsets = {left: self.getLeftEdge(), right: self.getRightEdge(), top: self.getTopEdge()};
-		}
+        var offsets;
+        var containingBlockForAbsolute = null;
+        if (parent) {
+            if (parent.containingBlockForAbsolute) {
+                containingBlockForAbsolute = parent;
+            } else {
+                containingBlockForAbsolute = parent.getContainingBlockForAbsolute();
+            }
+        }
+        if (containingBlockForAbsolute) {
+            var probe = containingBlockForAbsolute.viewNode.ownerDocument.createElement("div");
+            probe.style.position = "absolute";
+            if (containingBlockForAbsolute.vertical) {
+                probe.style.right = "0";
+            } else {
+                probe.style.left = "0";
+            }
+            probe.style.top = "0";
+            containingBlockForAbsolute.viewNode.appendChild(probe);
+            offsets = self.clientLayout.getElementClientRect(probe);
+            containingBlockForAbsolute.viewNode.removeChild(probe);
+        } else {
+            offsets = {left: self.getLeftEdge(), right: self.getRightEdge(), top: self.getTopEdge()};
+        }
 
-		if (containingBlockForAbsolute ? containingBlockForAbsolute.vertical : self.vertical) {
-			adapt.base.setCSSProperty(element, "right",
-				(offsets.right - floatBox.x2 + self.paddingRight) + "px");
-		} else {
-			adapt.base.setCSSProperty(element, "left",
-				(floatBox.x1 - offsets.left + self.paddingLeft) + "px");
-		}
-	    adapt.base.setCSSProperty(element, "top",
-	    		(floatBox.y1 - offsets.top + self.paddingTop) + "px");
+        if (containingBlockForAbsolute ? containingBlockForAbsolute.vertical : self.vertical) {
+            adapt.base.setCSSProperty(element, "right",
+                (offsets.right - floatBox.x2 + self.paddingRight) + "px");
+        } else {
+            adapt.base.setCSSProperty(element, "left",
+                (floatBox.x1 - offsets.left + self.paddingLeft) + "px");
+        }
+        adapt.base.setCSSProperty(element, "top",
+            (floatBox.y1 - offsets.top + self.paddingTop) + "px");
         if (nodeContext.clearSpacer) {
             nodeContext.clearSpacer.parentNode.removeChild(nodeContext.clearSpacer);
             nodeContext.clearSpacer = null;
         }
-	    var floatBoxEdge = self.vertical ? floatBox.x1 : floatBox.y2;
+        var floatBoxEdge = self.vertical ? floatBox.x1 : floatBox.y2;
         var floatBoxTop = self.vertical? floatBox.x2 : floatBox.y1;
-	    // TODO: subtract after margin when determining overflow.
-	    if (!self.isOverflown(floatBoxEdge) || self.breakPositions.length == 0) {
-	        // no overflow
-	    	self.killFloats();
-			box = new adapt.geom.Rect(self.getLeftEdge(), self.getTopEdge(), self.getRightEdge(), self.getBottomEdge());
-			if (self.vertical) {
-				box = adapt.geom.rotateBox(box);
-			}
-	        adapt.geom.addFloatToBands(box, self.bands, floatHorBox, null, floatSide);
-	        self.createFloats();
-	        if (floatSide == "left") {
-	        	self.leftFloatEdge = floatBoxEdge;
-	        } else {
-	        	self.rightFloatEdge = floatBoxEdge;	        	
-	        }
+        // TODO: subtract after margin when determining overflow.
+        if (!self.isOverflown(floatBoxEdge) || self.breakPositions.length == 0) {
+            // no overflow
+            self.killFloats();
+            box = new adapt.geom.Rect(self.getLeftEdge(), self.getTopEdge(), self.getRightEdge(), self.getBottomEdge());
+            if (self.vertical) {
+                box = adapt.geom.rotateBox(box);
+            }
+            adapt.geom.addFloatToBands(box, self.bands, floatHorBox, null, floatSide);
+            self.createFloats();
+            if (floatSide == "left") {
+                self.leftFloatEdge = floatBoxEdge;
+            } else {
+                self.rightFloatEdge = floatBoxEdge;
+            }
             self.bottommostFloatTop = floatBoxTop;
-	    	self.updateMaxReachedAfterEdge(floatBoxEdge);
-	        frame.finish(nodeContextAfter);
-	    } else {
-	    	nodeContext = nodeContext.modify();
-	    	nodeContext.overflow = true;
-	        frame.finish(nodeContext);	    	
-	    }
+            self.updateMaxReachedAfterEdge(floatBoxEdge);
+            frame.finish(nodeContextAfter);
+        } else {
+            nodeContext = nodeContext.modify();
+            nodeContext.overflow = true;
+            frame.finish(nodeContext);
+        }
     });
     return frame.result();
 };
@@ -1135,19 +1135,19 @@ adapt.layout.Column.prototype.layoutFloat = function(nodeContext) {
  * @return {void}
  */
 adapt.layout.Column.prototype.fixJustificationIfNeeded = function(nodeContext, endOfRegion) {
-	var node = nodeContext.viewNode;
-	var textAlign = "";
+    var node = nodeContext.viewNode;
+    var textAlign = "";
     for (; node && endOfRegion && !textAlign; node = node.parentNode) {
-    	if (node.nodeType != 1)
-    		continue;
-    	textAlign = (/** @type {HTMLElement} */ (node)).style.textAlign;
-    	if (!endOfRegion)
-    		break;
+        if (node.nodeType != 1)
+            continue;
+        textAlign = (/** @type {HTMLElement} */ (node)).style.textAlign;
+        if (!endOfRegion)
+            break;
     }
     if (endOfRegion && textAlign != "justify")
-    	return;
+        return;
     node = nodeContext.viewNode;
-	var doc = node.ownerDocument;
+    var doc = node.ownerDocument;
     var span = /** @type {HTMLElement} */ (doc.createElement("span"));
     span.style.visibility = "hidden";
     span.textContent = " ########################";
@@ -1155,17 +1155,17 @@ adapt.layout.Column.prototype.fixJustificationIfNeeded = function(nodeContext, e
     var insertionPoint = endOfRegion && (nodeContext.after || node.nodeType != 1) ? node.nextSibling : node;
     var parent = node.parentNode;
     if (!parent) {
-    	// Possible if nothing was added to the column
-    	return;
+        // Possible if nothing was added to the column
+        return;
     }
     parent.insertBefore(span, insertionPoint);
     if (!endOfRegion) {
-    	var br = /** @type {HTMLElement} */ (doc.createElement("div"));
+        var br = /** @type {HTMLElement} */ (doc.createElement("div"));
         parent.insertBefore(br, insertionPoint);
         // TODO: see if it can be reduced
         span.style.lineHeight = "80px";
         br.style.marginTop = "-80px";
-    	br.style.height = "0px";
+        br.style.height = "0px";
         br.setAttribute(adapt.vtree.SPECIAL_ATTR, "1");
     }
 };
@@ -1177,55 +1177,55 @@ adapt.layout.Column.prototype.fixJustificationIfNeeded = function(nodeContext, e
  * @return {adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.processLineStyling = function(nodeContext, resNodeContext, checkPoints) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("processLineStyling");
-	if (goog.DEBUG) {
-		adapt.layout.validateCheckPoints(checkPoints);
-	}
-	var lastCheckPoints = checkPoints.concat([]);  // make a copy
-	checkPoints.splice(0, checkPoints.length);  // make empty
-	var totalLineCount = 0;
-	var firstPseudo = nodeContext.firstPseudo;
-	if (firstPseudo.count == 0)  // :first-letter is not processed here
-		firstPseudo = firstPseudo.outer;  // move to line pseudoelement (if any)
-	frame.loopWithFrame(function(loopFrame) {
-		if (!firstPseudo) {
-			loopFrame.breakLoop();
-			return;
-		}
-		var linePositions = self.findLinePositions(lastCheckPoints);
-		var count = firstPseudo.count - totalLineCount;
-		if (linePositions.length <= count) {
-			loopFrame.breakLoop();
-			return;
-		}
-		var lineBreak = self.findAcceptableBreakInside(lastCheckPoints, linePositions[count-1]);
-		self.finishBreak(lineBreak, false, false).then(function() {
-			totalLineCount += count;
-			self.layoutContext.peelOff(lineBreak, 0).then(function(resNodeContextParam) {
-				nodeContext = resNodeContextParam;
-		    	self.fixJustificationIfNeeded(nodeContext, false);		
-				firstPseudo = nodeContext.firstPseudo;
-				lastCheckPoints = [];  // Wipe out line breaks inside pseudoelements
-				self.buildViewToNextBlockEdge(nodeContext, lastCheckPoints).then(function(resNodeContextParam) {
-					resNodeContext = resNodeContextParam;
-					if (self.hasNewlyAddedPageFloats()) {
-						loopFrame.breakLoop();
-					} else {
-						loopFrame.continueLoop();
-					}
-				});
-			});
-		});
-	}).then(function() {
-		Array.prototype.push.apply(checkPoints, lastCheckPoints);
-		if (goog.DEBUG) {
-			adapt.layout.validateCheckPoints(checkPoints);
-		}
-		frame.finish(resNodeContext);
-	});
-	return frame.result();
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("processLineStyling");
+    if (goog.DEBUG) {
+        adapt.layout.validateCheckPoints(checkPoints);
+    }
+    var lastCheckPoints = checkPoints.concat([]);  // make a copy
+    checkPoints.splice(0, checkPoints.length);  // make empty
+    var totalLineCount = 0;
+    var firstPseudo = nodeContext.firstPseudo;
+    if (firstPseudo.count == 0)  // :first-letter is not processed here
+        firstPseudo = firstPseudo.outer;  // move to line pseudoelement (if any)
+    frame.loopWithFrame(function(loopFrame) {
+        if (!firstPseudo) {
+            loopFrame.breakLoop();
+            return;
+        }
+        var linePositions = self.findLinePositions(lastCheckPoints);
+        var count = firstPseudo.count - totalLineCount;
+        if (linePositions.length <= count) {
+            loopFrame.breakLoop();
+            return;
+        }
+        var lineBreak = self.findAcceptableBreakInside(lastCheckPoints, linePositions[count-1]);
+        self.finishBreak(lineBreak, false, false).then(function() {
+            totalLineCount += count;
+            self.layoutContext.peelOff(lineBreak, 0).then(function(resNodeContextParam) {
+                nodeContext = resNodeContextParam;
+                self.fixJustificationIfNeeded(nodeContext, false);
+                firstPseudo = nodeContext.firstPseudo;
+                lastCheckPoints = [];  // Wipe out line breaks inside pseudoelements
+                self.buildViewToNextBlockEdge(nodeContext, lastCheckPoints).then(function(resNodeContextParam) {
+                    resNodeContext = resNodeContextParam;
+                    if (self.hasNewlyAddedPageFloats()) {
+                        loopFrame.breakLoop();
+                    } else {
+                        loopFrame.continueLoop();
+                    }
+                });
+            });
+        });
+    }).then(function() {
+        Array.prototype.push.apply(checkPoints, lastCheckPoints);
+        if (goog.DEBUG) {
+            adapt.layout.validateCheckPoints(checkPoints);
+        }
+        frame.finish(resNodeContext);
+    });
+    return frame.result();
 };
 
 /**
@@ -1233,11 +1233,11 @@ adapt.layout.Column.prototype.processLineStyling = function(nodeContext, resNode
  * @return {boolean}
  */
 adapt.layout.Column.prototype.isLoneImage = function(checkPoints) {
-	if (checkPoints.length != 2 && this.breakPositions.length > 0) {
-		return false;
-	}
-	return checkPoints[0].sourceNode == checkPoints[1].sourceNode
-		&& adapt.layout.mediaTags[/** @type {Element} */(checkPoints[0].sourceNode).localName];
+    if (checkPoints.length != 2 && this.breakPositions.length > 0) {
+        return false;
+    }
+    return checkPoints[0].sourceNode == checkPoints[1].sourceNode
+        && adapt.layout.mediaTags[/** @type {Element} */(checkPoints[0].sourceNode).localName];
 };
 
 /**
@@ -1245,24 +1245,24 @@ adapt.layout.Column.prototype.isLoneImage = function(checkPoints) {
  * @return {number}
  */
 adapt.layout.Column.prototype.getTrailingMarginEdgeAdjustment = function(trailingEdgeContexts) {
-	// Margins push the computed height, but are not counted as overflow. We need to find
-	// the overall collapsed margin from all enclosed blocks.
-	var maxPos = 0;
-	var minNeg = 0;
-	for (var i = trailingEdgeContexts.length - 1; i >= 0; i--) {
-		var nodeContext = trailingEdgeContexts[i];
-		if (!nodeContext.after || !nodeContext.viewNode || nodeContext.viewNode.nodeType != 1) {
-			break;
-		}
-		var margin = this.getComputedMargin(/** @type {Element} */ (nodeContext.viewNode));
-		var m = this.vertical ? -margin.left : margin.bottom;
-		if (m > 0) {
-			maxPos = Math.max(maxPos, m);
-		} else {
-			minNeg = Math.min(minNeg, m);		
-		}
-	}
-	return maxPos - minNeg;
+    // Margins push the computed height, but are not counted as overflow. We need to find
+    // the overall collapsed margin from all enclosed blocks.
+    var maxPos = 0;
+    var minNeg = 0;
+    for (var i = trailingEdgeContexts.length - 1; i >= 0; i--) {
+        var nodeContext = trailingEdgeContexts[i];
+        if (!nodeContext.after || !nodeContext.viewNode || nodeContext.viewNode.nodeType != 1) {
+            break;
+        }
+        var margin = this.getComputedMargin(/** @type {Element} */ (nodeContext.viewNode));
+        var m = this.vertical ? -margin.left : margin.bottom;
+        if (m > 0) {
+            maxPos = Math.max(maxPos, m);
+        } else {
+            minNeg = Math.min(minNeg, m);
+        }
+    }
+    return maxPos - minNeg;
 };
 
 /**
@@ -1271,54 +1271,54 @@ adapt.layout.Column.prototype.getTrailingMarginEdgeAdjustment = function(trailin
  * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.layoutBreakableBlock = function(nodeContext) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("layoutBreakableBlock");
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("layoutBreakableBlock");
     /** @type {Array.<adapt.vtree.NodeContext>} */ var checkPoints = [];
     self.buildViewToNextBlockEdge(nodeContext, checkPoints).then(function(resNodeContext) {
-		if (self.hasNewlyAddedPageFloats()) {
-			frame.finish(resNodeContext);
-			return;
-		}
+        if (self.hasNewlyAddedPageFloats()) {
+            frame.finish(resNodeContext);
+            return;
+        }
 
-	    // at this point a single block was appended to the column
-	    // flowPosition is either null or 
-	    //  - if !after: contains view for the next block element
-	    //  - if after: contains view for the enclosing block element
-	    var checkPointIndex = checkPoints.length - 1;
-	    if (checkPointIndex < 0) {
-	    	frame.finish(resNodeContext);
-	    	return;
-	    }
-	    // Record the height
-	    // TODO: should this be done after first-line calculation?
-	    var edge = self.calculateEdge(resNodeContext, checkPoints, checkPointIndex,
-                checkPoints[checkPointIndex].boxOffset);
-	    var overflown = self.isOverflown(edge);
-	    if (resNodeContext == null) {
-	    	edge += self.getTrailingMarginEdgeAdjustment(checkPoints);
-	    }
-	    self.updateMaxReachedAfterEdge(edge);
-	    var lineCont;
-	    if (nodeContext.firstPseudo) {
-	    	// possibly need to deal with :first-line and friends
-	    	lineCont = self.processLineStyling(nodeContext, resNodeContext, checkPoints);
-	    } else {
-	    	lineCont = adapt.task.newResult(resNodeContext);
-	    }
-	    lineCont.then(function(nodeContext) {
-		    if (checkPoints.length > 0) {
-		    	self.saveBoxBreakPosition(checkPoints);
-		    	// TODO: how to signal overflow in the last pagargaph???
-		    	if (overflown && !self.isLoneImage(checkPoints) && nodeContext) {
-		    		nodeContext = nodeContext.modify();
-		    		nodeContext.overflow = true;
-		    	}
-		    }
-		    frame.finish(nodeContext);
-	    });
+        // at this point a single block was appended to the column
+        // flowPosition is either null or
+        //  - if !after: contains view for the next block element
+        //  - if after: contains view for the enclosing block element
+        var checkPointIndex = checkPoints.length - 1;
+        if (checkPointIndex < 0) {
+            frame.finish(resNodeContext);
+            return;
+        }
+        // Record the height
+        // TODO: should this be done after first-line calculation?
+        var edge = self.calculateEdge(resNodeContext, checkPoints, checkPointIndex,
+            checkPoints[checkPointIndex].boxOffset);
+        var overflown = self.isOverflown(edge);
+        if (resNodeContext == null) {
+            edge += self.getTrailingMarginEdgeAdjustment(checkPoints);
+        }
+        self.updateMaxReachedAfterEdge(edge);
+        var lineCont;
+        if (nodeContext.firstPseudo) {
+            // possibly need to deal with :first-line and friends
+            lineCont = self.processLineStyling(nodeContext, resNodeContext, checkPoints);
+        } else {
+            lineCont = adapt.task.newResult(resNodeContext);
+        }
+        lineCont.then(function(nodeContext) {
+            if (checkPoints.length > 0) {
+                self.saveBoxBreakPosition(checkPoints);
+                // TODO: how to signal overflow in the last pagargaph???
+                if (overflown && !self.isLoneImage(checkPoints) && nodeContext) {
+                    nodeContext = nodeContext.modify();
+                    nodeContext.overflow = true;
+                }
+            }
+            frame.finish(nodeContext);
+        });
     });
-	return frame.result();
+    return frame.result();
 };
 
 /**
@@ -1327,9 +1327,9 @@ adapt.layout.Column.prototype.layoutBreakableBlock = function(nodeContext) {
  * @return {adapt.vtree.NodeContext}
  */
 adapt.layout.Column.prototype.findAcceptableBreakInside = function(checkPoints, edgePosition) {
-	if (goog.DEBUG) {
-		adapt.layout.validateCheckPoints(checkPoints);
-	}
+    if (goog.DEBUG) {
+        adapt.layout.validateCheckPoints(checkPoints);
+    }
     // find the first character which is out
     var lowCP = 0;
     var low = checkPoints[0].boxOffset;
@@ -1354,10 +1354,10 @@ adapt.layout.Column.prototype.findAcceptableBreakInside = function(checkPoints, 
         if (this.vertical ? edge < edgePosition : edge > edgePosition) {
             high = mid - 1;
             while (checkPoints[low1].boxOffset == mid)
-            	low1--;
+                low1--;
             highCP = low1;
         } else {
-        	this.updateMaxReachedAfterEdge(edge);
+            this.updateMaxReachedAfterEdge(edge);
             low = mid;
             lowCP = low1;
         }
@@ -1367,31 +1367,31 @@ adapt.layout.Column.prototype.findAcceptableBreakInside = function(checkPoints, 
     var viewNode = nodeContext.viewNode;
     if (viewNode.nodeType != 1) {
         var textNode = /** @type {Text} */ (viewNode);
-    	if (nodeContext.after) {    	
-    		nodeContext.offsetInNode = textNode.length;
-	    } else {
-	    	// Character with index low is the last one that fits.
-	        viewIndex = low - nodeContext.boxOffset;
-	        var text = textNode.data;
-	        if (text.charCodeAt(viewIndex) == 0xAD) {
-	        	// convert trailing soft hyphen to a real hyphen
-		        textNode.replaceData(viewIndex, text.length - viewIndex, "-");
-		        viewIndex++;
-	        } else {
-	        	// keep the trailing character (it may be a space or not)
-	        	var ch0 = text.charAt(viewIndex);
-	        	viewIndex++;
-	        	var ch1 = text.charAt(viewIndex);
-	        	// If automatic hyphen was inserted here, add a real hyphen.
-		        textNode.replaceData(viewIndex, text.length - viewIndex, 
-		        		adapt.base.isLetter(ch0) && adapt.base.isLetter(ch1) ? "-" : "");	        	
-	        }
-	        if (viewIndex > 0) {
-		        nodeContext = nodeContext.modify();
-		        nodeContext.offsetInNode += viewIndex;
-		        nodeContext.breakBefore = null;
-	        }
-	    }
+        if (nodeContext.after) {
+            nodeContext.offsetInNode = textNode.length;
+        } else {
+            // Character with index low is the last one that fits.
+            viewIndex = low - nodeContext.boxOffset;
+            var text = textNode.data;
+            if (text.charCodeAt(viewIndex) == 0xAD) {
+                // convert trailing soft hyphen to a real hyphen
+                textNode.replaceData(viewIndex, text.length - viewIndex, "-");
+                viewIndex++;
+            } else {
+                // keep the trailing character (it may be a space or not)
+                var ch0 = text.charAt(viewIndex);
+                viewIndex++;
+                var ch1 = text.charAt(viewIndex);
+                // If automatic hyphen was inserted here, add a real hyphen.
+                textNode.replaceData(viewIndex, text.length - viewIndex,
+                    adapt.base.isLetter(ch0) && adapt.base.isLetter(ch1) ? "-" : "");
+            }
+            if (viewIndex > 0) {
+                nodeContext = nodeContext.modify();
+                nodeContext.offsetInNode += viewIndex;
+                nodeContext.breakBefore = null;
+            }
+        }
     }
     return nodeContext;
 };
@@ -1401,7 +1401,7 @@ adapt.layout.Column.prototype.findAcceptableBreakInside = function(checkPoints, 
  * @return {boolean}
  */
 adapt.layout.isSpecial = function(e) {
-	return !!e.getAttribute(adapt.vtree.SPECIAL_ATTR);
+    return !!e.getAttribute(adapt.vtree.SPECIAL_ATTR);
 };
 
 /**
@@ -1411,7 +1411,7 @@ adapt.layout.isSpecial = function(e) {
  * @return {Array.<adapt.vtree.ClientRect>}
  */
 adapt.layout.Column.prototype.getRangeBoxes = function(start, end) {
-	var arr = [];
+    var arr = [];
     var range = start.ownerDocument.createRange();
     var wentUp = false;
     var node = start;
@@ -1419,43 +1419,43 @@ adapt.layout.Column.prototype.getRangeBoxes = function(start, end) {
     var haveStart = false;
     var endNotReached = true;
     while (endNotReached) {
-    	var seekRange = true;
-    	do {
-	    	var next = null;
-	    	if (node == end) {
-	    		endNotReached = false;
-	    	}
-	    	if (node.nodeType != 1) {
-	    		if (!haveStart) {
-	    			range.setStartBefore(node);
-	    			haveStart = true;
-	    		}
-	    		lastGood = node;
-	    	} else if (wentUp) {
-    			wentUp = false;
-    		} else if (adapt.layout.isSpecial(/** @type {Element} */ (node))) {
-    			// Skip special
-    			seekRange = !haveStart;
-    		} else {
-    			next = node.firstChild;
-    		}
-	    	if (!next) {
-	    		next = node.nextSibling;
-	    		if (!next) {
-	    			wentUp = true;
-	    			next = node.parentNode;
-	    		}
-	    	}
-	    	node = next;
-    	} while(seekRange && endNotReached)
-    	if (haveStart) {
-    		range.setEndAfter(lastGood);
-	        var boxList = this.clientLayout.getRangeClientRects(range);
-	        for (var i = 0; i < boxList.length; i++) {
-	        	arr.push(boxList[i]);
-	        }
-	        haveStart = false;
-    	}
+        var seekRange = true;
+        do {
+            var next = null;
+            if (node == end) {
+                endNotReached = false;
+            }
+            if (node.nodeType != 1) {
+                if (!haveStart) {
+                    range.setStartBefore(node);
+                    haveStart = true;
+                }
+                lastGood = node;
+            } else if (wentUp) {
+                wentUp = false;
+            } else if (adapt.layout.isSpecial(/** @type {Element} */ (node))) {
+                // Skip special
+                seekRange = !haveStart;
+            } else {
+                next = node.firstChild;
+            }
+            if (!next) {
+                next = node.nextSibling;
+                if (!next) {
+                    wentUp = true;
+                    next = node.parentNode;
+                }
+            }
+            node = next;
+        } while (seekRange && endNotReached);
+        if (haveStart) {
+            range.setEndAfter(lastGood);
+            var boxList = this.clientLayout.getRangeClientRects(range);
+            for (var i = 0; i < boxList.length; i++) {
+                arr.push(boxList[i]);
+            }
+            haveStart = false;
+        }
     }
     return arr;
 };
@@ -1467,12 +1467,12 @@ adapt.layout.Column.prototype.getRangeBoxes = function(start, end) {
  * @return {Array.<number>} position of line breaks
  */
 adapt.layout.Column.prototype.findLinePositions = function(checkPoints) {
-	var LOW_OVERLAP = 0.2;
-	var MID_OVERLAP = 0.6;
-	var positions = [];
-	var boxes = this.getRangeBoxes(checkPoints[0].viewNode, checkPoints[checkPoints.length - 1].viewNode);
-    boxes.sort(this.vertical ? 
-    		adapt.vtree.clientrectDecreasingRight : adapt.vtree.clientrectIncreasingTop);
+    var LOW_OVERLAP = 0.2;
+    var MID_OVERLAP = 0.6;
+    var positions = [];
+    var boxes = this.getRangeBoxes(checkPoints[0].viewNode, checkPoints[checkPoints.length - 1].viewNode);
+    boxes.sort(this.vertical ?
+        adapt.vtree.clientrectDecreasingRight : adapt.vtree.clientrectIncreasingTop);
     var lineBefore = 0;
     var lineAfter = 0;
     var lineEnd = 0;
@@ -1480,45 +1480,45 @@ adapt.layout.Column.prototype.findLinePositions = function(checkPoints) {
     var i = 0;
     var dir = this.getBoxDir();
     while (true) {
-    	if (i < boxes.length) {
-	        var box = boxes[i];
-	        var overlap = 1;
-	        if (lineLength > 0) {
-	        	var boxSize = Math.max(this.getBoxSize(box), 1);
-	        	if (dir * this.getBeforeEdge(box) < dir * lineBefore) {
-	        		overlap = dir * (this.getAfterEdge(box) - lineBefore) / boxSize;
-	        	} else if (dir * this.getAfterEdge(box) > dir * lineAfter) {
-	        		overlap = dir * (lineAfter - this.getBeforeEdge(box)) / boxSize;
-	        	} else {
-	        		overlap = 1;
-	        	}
-	        }
-        	if (lineLength == 0 || overlap >= MID_OVERLAP || 
-        			(overlap >= LOW_OVERLAP && this.getStartEdge(box) >= lineEnd-1)) {
-            	lineEnd = this.getEndEdge(box);
-            	if (this.vertical) {
-		        	lineBefore = lineLength == 0 ? box.right : Math.max(lineBefore, box.right);
-		        	lineAfter = lineLength == 0 ? box.left : Math.min(lineAfter, box.left);
-            	} else {
-		        	lineBefore = lineLength == 0 ? box.top : Math.min(lineBefore, box.top);
-		        	lineAfter = lineLength == 0 ? box.bottom : Math.max(lineAfter, box.bottom);            		
-            	}
-	        	lineLength++;
-	        	i++;
-	        	continue;
-        	}
-    	}
-    	// Add line
-    	if (lineLength > 0) {
-    		positions.push(lineAfter);
-    		lineLength = 0;
-    	}
-		if (i >= boxes.length)
-			break;
+        if (i < boxes.length) {
+            var box = boxes[i];
+            var overlap = 1;
+            if (lineLength > 0) {
+                var boxSize = Math.max(this.getBoxSize(box), 1);
+                if (dir * this.getBeforeEdge(box) < dir * lineBefore) {
+                    overlap = dir * (this.getAfterEdge(box) - lineBefore) / boxSize;
+                } else if (dir * this.getAfterEdge(box) > dir * lineAfter) {
+                    overlap = dir * (lineAfter - this.getBeforeEdge(box)) / boxSize;
+                } else {
+                    overlap = 1;
+                }
+            }
+            if (lineLength == 0 || overlap >= MID_OVERLAP ||
+                (overlap >= LOW_OVERLAP && this.getStartEdge(box) >= lineEnd-1)) {
+                lineEnd = this.getEndEdge(box);
+                if (this.vertical) {
+                    lineBefore = lineLength == 0 ? box.right : Math.max(lineBefore, box.right);
+                    lineAfter = lineLength == 0 ? box.left : Math.min(lineAfter, box.left);
+                } else {
+                    lineBefore = lineLength == 0 ? box.top : Math.min(lineBefore, box.top);
+                    lineAfter = lineLength == 0 ? box.bottom : Math.max(lineAfter, box.bottom);
+                }
+                lineLength++;
+                i++;
+                continue;
+            }
+        }
+        // Add line
+        if (lineLength > 0) {
+            positions.push(lineAfter);
+            lineLength = 0;
+        }
+        if (i >= boxes.length)
+            break;
     }
     positions.sort(adapt.base.numberCompare);
     if (this.vertical) {
-    	positions.reverse();
+        positions.reverse();
     }
     return positions;
 };
@@ -1529,42 +1529,42 @@ adapt.layout.Column.prototype.findLinePositions = function(checkPoints) {
  * @return {!adapt.task.Result.<boolean>} holding true
  */
 adapt.layout.Column.prototype.clearFootnotes = function(boxOffset) {
-	var self = this;
-	if (!self.footnoteItems) {
-		return adapt.task.newResult(true);
-	}
-	var redo = false;
-	for (var i = self.footnoteItems.length - 1; i >= 0; --i) {
-		var item = self.footnoteItems[i];
-		if (item.boxOffset <= boxOffset) {
-			break;
-		}
-		self.footnoteItems.pop();
-		if (item.overflowPosition !== item.startPosition) {
-			redo = true;
-		}
-	}
-	if (!redo) {
-		return adapt.task.newResult(true);
-	}
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("clearFootnotes");
-	var maxY = self.computedBlockSize + self.beforeEdge;
-	var items = self.footnoteItems;
-	self.footnoteArea = null;
-	self.footnoteItems = null;
-	var k = 0;
-	frame.loop(function() {
-		while (k < items.length) {
-			var item = items[k++];
-			var r = self.layoutFootnoteInner(item.boxOffset, item.startPosition, maxY);
-			if (r.isPending())
-				return r;
-		}
-		return adapt.task.newResult(false);
-	}).then(function() {
-		frame.finish(true);
-	});
-	return frame.result();
+    var self = this;
+    if (!self.footnoteItems) {
+        return adapt.task.newResult(true);
+    }
+    var redo = false;
+    for (var i = self.footnoteItems.length - 1; i >= 0; --i) {
+        var item = self.footnoteItems[i];
+        if (item.boxOffset <= boxOffset) {
+            break;
+        }
+        self.footnoteItems.pop();
+        if (item.overflowPosition !== item.startPosition) {
+            redo = true;
+        }
+    }
+    if (!redo) {
+        return adapt.task.newResult(true);
+    }
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("clearFootnotes");
+    var maxY = self.computedBlockSize + self.beforeEdge;
+    var items = self.footnoteItems;
+    self.footnoteArea = null;
+    self.footnoteItems = null;
+    var k = 0;
+    frame.loop(function() {
+        while (k < items.length) {
+            var item = items[k++];
+            var r = self.layoutFootnoteInner(item.boxOffset, item.startPosition, maxY);
+            if (r.isPending())
+                return r;
+        }
+        return adapt.task.newResult(false);
+    }).then(function() {
+        frame.finish(true);
+    });
+    return frame.result();
 };
 
 /**
@@ -1573,54 +1573,54 @@ adapt.layout.Column.prototype.clearFootnotes = function(boxOffset) {
  * @return {adapt.vtree.NodeContext}
  */
 adapt.layout.Column.prototype.findBoxBreakPosition = function(bp, force) {
-	var self = this;
-	var checkPoints = bp.checkPoints;
+    var self = this;
+    var checkPoints = bp.checkPoints;
 
-	var block = checkPoints[0];
-	while (block.parent && block.inline) {
-		block = block.parent;
-	}
+    var block = checkPoints[0];
+    while (block.parent && block.inline) {
+        block = block.parent;
+    }
 
-	var widows;
-	var orphans;
-	if (force) {
-		// Last resort, ignore widows/orphans
-		widows = 1;
-		orphans = 1;
-	} else {
-		// Get widows/orphans settings from the block element
-		widows = Math.max((block.inheritedProps["widows"] || 2) - 0, 1);
-		orphans = Math.max((block.inheritedProps["orphans"] || 2) - 0, 1);
-	}
+    var widows;
+    var orphans;
+    if (force) {
+        // Last resort, ignore widows/orphans
+        widows = 1;
+        orphans = 1;
+    } else {
+        // Get widows/orphans settings from the block element
+        widows = Math.max((block.inheritedProps["widows"] || 2) - 0, 1);
+        orphans = Math.max((block.inheritedProps["orphans"] || 2) - 0, 1);
+    }
 
-	// In case of box-decoration-break: clone, width (or height in vertical writing mode) of cloned paddings and borders should be taken into account.
-	var clonedPaddingBorder = 0;
-	block.walkBlocksUpToBFC(function(block) {
-		if (block.inheritedProps["box-decoration-break"] === "clone") {
-			goog.asserts.assert(block.viewNode instanceof Element);
-			var paddingBorders = self.getComputedPaddingBorder(block.viewNode);
-			clonedPaddingBorder += block.vertical ? -paddingBorders.left : paddingBorders.bottom;
-		}
-	});
+    // In case of box-decoration-break: clone, width (or height in vertical writing mode) of cloned paddings and borders should be taken into account.
+    var clonedPaddingBorder = 0;
+    block.walkBlocksUpToBFC(function(block) {
+        if (block.inheritedProps["box-decoration-break"] === "clone") {
+            goog.asserts.assert(block.viewNode instanceof Element);
+            var paddingBorders = self.getComputedPaddingBorder(block.viewNode);
+            clonedPaddingBorder += block.vertical ? -paddingBorders.left : paddingBorders.bottom;
+        }
+    });
 
-	// Select the first overflowing line break position
-	var linePositions = this.findLinePositions(checkPoints);
-	var edge = this.footnoteEdge - clonedPaddingBorder;
-	var lineIndex = adapt.base.binarySearch(linePositions.length, function(i) {
-		return self.vertical ? linePositions[i] < edge : linePositions[i] > edge;
-	});
-	// First edge after the one that both fits and satisfies widows constraint.
-	lineIndex = Math.min(linePositions.length - widows, lineIndex);
-	if (lineIndex < orphans) {
-	    // Not enough lines to satisfy orphans constraint, cannot break here.
-		return null;
-	}
-	edge = linePositions[lineIndex-1];
-	var nodeContext = this.findAcceptableBreakInside(bp.checkPoints, edge);	
-	if (nodeContext) {
-		this.computedBlockSize = this.getBoxDir() * (edge - this.beforeEdge);		
-	}
-	return nodeContext;
+    // Select the first overflowing line break position
+    var linePositions = this.findLinePositions(checkPoints);
+    var edge = this.footnoteEdge - clonedPaddingBorder;
+    var lineIndex = adapt.base.binarySearch(linePositions.length, function(i) {
+        return self.vertical ? linePositions[i] < edge : linePositions[i] > edge;
+    });
+    // First edge after the one that both fits and satisfies widows constraint.
+    lineIndex = Math.min(linePositions.length - widows, lineIndex);
+    if (lineIndex < orphans) {
+        // Not enough lines to satisfy orphans constraint, cannot break here.
+        return null;
+    }
+    edge = linePositions[lineIndex-1];
+    var nodeContext = this.findAcceptableBreakInside(bp.checkPoints, edge);
+    if (nodeContext) {
+        this.computedBlockSize = this.getBoxDir() * (edge - this.beforeEdge);
+    }
+    return nodeContext;
 };
 
 /**
@@ -1628,8 +1628,8 @@ adapt.layout.Column.prototype.findBoxBreakPosition = function(bp, force) {
  * @return {adapt.vtree.NodeContext}
  */
 adapt.layout.Column.prototype.findEdgeBreakPosition = function(bp) {
-	this.computedBlockSize = bp.computedBlockSize;
-	return bp.position;
+    this.computedBlockSize = bp.computedBlockSize;
+    return bp.position;
 };
 
 /**
@@ -1640,13 +1640,13 @@ adapt.layout.Column.prototype.findEdgeBreakPosition = function(bp) {
  * @return {!adapt.task.Result.<boolean>} holing true
  */
 adapt.layout.Column.prototype.finishBreak = function(nodeContext, forceRemoveSelf, endOfRegion) {
-	var removeSelf = forceRemoveSelf || (nodeContext.viewNode != null && nodeContext.viewNode.nodeType == 1 && !nodeContext.after);
+    var removeSelf = forceRemoveSelf || (nodeContext.viewNode != null && nodeContext.viewNode.nodeType == 1 && !nodeContext.after);
     this.clearOverflownViewNodes(nodeContext, removeSelf);
     if (endOfRegion) {
-		this.fixJustificationIfNeeded(nodeContext, true);
-		this.layoutContext.processFragmentedBlockEdge(removeSelf ? nodeContext : nodeContext.parent);
-	}
-    return this.clearFootnotes(nodeContext.boxOffset);	
+        this.fixJustificationIfNeeded(nodeContext, true);
+        this.layoutContext.processFragmentedBlockEdge(removeSelf ? nodeContext : nodeContext.parent);
+    }
+    return this.clearFootnotes(nodeContext.boxOffset);
 };
 
 /**
@@ -1655,49 +1655,49 @@ adapt.layout.Column.prototype.finishBreak = function(nodeContext, forceRemoveSel
  * @return {adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.findAcceptableBreak = function(overflownNodeContext, initialNodeContext) {
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame =
-		adapt.task.newFrame("findAcceptableBreak");
-	var self = this;
-	var nodeContext = null;
-	var penalty = 0;
-	var nextPenalty = 0;
-	do {
-		penalty = nextPenalty;
-		nextPenalty = Number.MAX_VALUE;
-		for (var i = this.breakPositions.length - 1; i >= 0 && !nodeContext; --i) {
-			nodeContext = this.breakPositions[i].findAcceptableBreak(this, penalty);
-			var minPenalty = this.breakPositions[i].getMinBreakPenalty();
-			if (minPenalty > penalty) {
-				nextPenalty = Math.min(nextPenalty, minPenalty);
-			}
-		}
-	} while(nextPenalty > penalty && !nodeContext)
-	var forceRemoveSelf = false;
-	if (!nodeContext) {
-		vivliostyle.logging.logger.warn("Could not find any page breaks?!!");
-		// Last resort
-		if (this.forceNonfitting) {
-			self.skipTailEdges(overflownNodeContext).then(function(nodeContext) {
-				if (nodeContext) {
-					nodeContext = nodeContext.modify();
-					nodeContext.overflow = false;
-					self.finishBreak(nodeContext, forceRemoveSelf, true).then(function() {
-						frame.finish(nodeContext);
-					});
-				} else {
-					frame.finish(nodeContext);					
-				}
-			});
-			return frame.result();
-		} else {
-			nodeContext = initialNodeContext;
-			forceRemoveSelf = true;
-		}
-	}
-	this.finishBreak(nodeContext, forceRemoveSelf, true).then(function() {
-	    frame.finish(nodeContext);
-	});
-	return frame.result();
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame =
+        adapt.task.newFrame("findAcceptableBreak");
+    var self = this;
+    var nodeContext = null;
+    var penalty = 0;
+    var nextPenalty = 0;
+    do {
+        penalty = nextPenalty;
+        nextPenalty = Number.MAX_VALUE;
+        for (var i = this.breakPositions.length - 1; i >= 0 && !nodeContext; --i) {
+            nodeContext = this.breakPositions[i].findAcceptableBreak(this, penalty);
+            var minPenalty = this.breakPositions[i].getMinBreakPenalty();
+            if (minPenalty > penalty) {
+                nextPenalty = Math.min(nextPenalty, minPenalty);
+            }
+        }
+    } while (nextPenalty > penalty && !nodeContext);
+    var forceRemoveSelf = false;
+    if (!nodeContext) {
+        vivliostyle.logging.logger.warn("Could not find any page breaks?!!");
+        // Last resort
+        if (this.forceNonfitting) {
+            self.skipTailEdges(overflownNodeContext).then(function(nodeContext) {
+                if (nodeContext) {
+                    nodeContext = nodeContext.modify();
+                    nodeContext.overflow = false;
+                    self.finishBreak(nodeContext, forceRemoveSelf, true).then(function() {
+                        frame.finish(nodeContext);
+                    });
+                } else {
+                    frame.finish(nodeContext);
+                }
+            });
+            return frame.result();
+        } else {
+            nodeContext = initialNodeContext;
+            forceRemoveSelf = true;
+        }
+    }
+    this.finishBreak(nodeContext, forceRemoveSelf, true).then(function() {
+        frame.finish(nodeContext);
+    });
+    return frame.result();
 };
 
 /**
@@ -1706,13 +1706,13 @@ adapt.layout.Column.prototype.findAcceptableBreak = function(overflownNodeContex
  * @return {boolean}
  */
 adapt.layout.Column.prototype.isBreakable = function(flowPosition) {
-	if (flowPosition.after)
-		return true; // may be an empty block
-	switch (flowPosition.sourceNode.namespaceURI) {
-	case adapt.base.NS.SVG:
-		return false;
-	}
-	return !flowPosition.flexContainer;
+    if (flowPosition.after)
+        return true; // may be an empty block
+    switch (flowPosition.sourceNode.namespaceURI) {
+        case adapt.base.NS.SVG:
+            return false;
+    }
+    return !flowPosition.flexContainer;
 };
 
 /**
@@ -1721,8 +1721,8 @@ adapt.layout.Column.prototype.isBreakable = function(flowPosition) {
  * @return {boolean}
  */
 adapt.layout.Column.prototype.zeroIndent = function(val) {
-	var s = val.toString();
-	return s == "" || s == "auto" || !!s.match(/^0+(.0*)?[^0-9]/);
+    var s = val.toString();
+    return s == "" || s == "auto" || !!s.match(/^0+(.0*)?[^0-9]/);
 };
 
 /**
@@ -1734,19 +1734,19 @@ adapt.layout.Column.prototype.zeroIndent = function(val) {
  * @return {boolean} true if overflows
  */
 adapt.layout.Column.prototype.saveEdgeAndCheckForOverflow = function(nodeContext,
-		trailingEdgeContexts, saveEvenOverflown, breakAtTheEdge) {
-	if (!nodeContext) {
-		return false;
-	}
+                                                                     trailingEdgeContexts, saveEvenOverflown, breakAtTheEdge) {
+    if (!nodeContext) {
+        return false;
+    }
     var edge = adapt.layout.calculateEdge(nodeContext, this.clientLayout, 0, this.vertical);
-	var overflown = this.isOverflown(edge);
-	if (trailingEdgeContexts) {
-		edge += this.getTrailingMarginEdgeAdjustment(trailingEdgeContexts);
-	}
-	this.updateMaxReachedAfterEdge(edge);
-	if (saveEvenOverflown || !overflown) {
-		this.saveEdgeBreakPosition(nodeContext, breakAtTheEdge, overflown);
-	}
+    var overflown = this.isOverflown(edge);
+    if (trailingEdgeContexts) {
+        edge += this.getTrailingMarginEdgeAdjustment(trailingEdgeContexts);
+    }
+    this.updateMaxReachedAfterEdge(edge);
+    if (saveEvenOverflown || !overflown) {
+        this.saveEdgeBreakPosition(nodeContext, breakAtTheEdge, overflown);
+    }
     return overflown;
 };
 
@@ -1754,251 +1754,251 @@ adapt.layout.Column.prototype.saveEdgeAndCheckForOverflow = function(nodeContext
  * @param {adapt.vtree.NodeContext} nodeContext
  */
 adapt.layout.Column.prototype.applyClearance = function(nodeContext) {
-	if (!nodeContext.viewNode.parentNode) {
-		// Cannot do ceralance for nodes without parents
-		return;
-	}
-	// measure where the edge of the element would be without clearance
-	var margin = this.getComputedMargin(/** @type {Element} */ (nodeContext.viewNode));
-	var spacer = nodeContext.viewNode.ownerDocument.createElement("div");
-	if (this.vertical) {
-    	spacer.style.bottom = "0px";
-    	spacer.style.width = "1px";	    		
-    	spacer.style.marginRight = margin.right + "px";	    		
-	} else {
-    	spacer.style.right = "0px";
-    	spacer.style.height = "1px";
-    	spacer.style.marginTop = margin.top + "px";	    		
-	}
-	nodeContext.viewNode.parentNode.insertBefore(spacer, nodeContext.viewNode);
+    if (!nodeContext.viewNode.parentNode) {
+        // Cannot do ceralance for nodes without parents
+        return;
+    }
+    // measure where the edge of the element would be without clearance
+    var margin = this.getComputedMargin(/** @type {Element} */ (nodeContext.viewNode));
+    var spacer = nodeContext.viewNode.ownerDocument.createElement("div");
+    if (this.vertical) {
+        spacer.style.bottom = "0px";
+        spacer.style.width = "1px";
+        spacer.style.marginRight = margin.right + "px";
+    } else {
+        spacer.style.right = "0px";
+        spacer.style.height = "1px";
+        spacer.style.marginTop = margin.top + "px";
+    }
+    nodeContext.viewNode.parentNode.insertBefore(spacer, nodeContext.viewNode);
     var spacerBox = this.clientLayout.getElementClientRect(spacer);
-	var edge = this.getBeforeEdge(spacerBox);
-	var dir = this.getBoxDir();
-	var clearEdge;
-	switch (nodeContext.clearSide) {
-	case "left" :
-		clearEdge = this.leftFloatEdge;
-		break;
-	case "right" :
-		clearEdge = this.rightFloatEdge;
-		break;
-	default :
-		clearEdge = dir * Math.max(this.rightFloatEdge*dir, this.leftFloatEdge*dir);
-	}
-	// edge holds the position where element border "before" edge will be without clearance.
-	// clearEdge is the "after" edge of the float to clear.
-	if (edge * dir >= clearEdge * dir) {
-		// No need for clearance
-		nodeContext.viewNode.parentNode.removeChild(spacer);
-	} else {
-		// Need some clearance, determine how much. Add the clearance node, measure its after
-		// edge and adjust after margin (required due to possible margin collapse before
-		// clearance was introduced).
-		var height = Math.max(1, (clearEdge - edge) * dir);
-		if (this.vertical) {
-			spacer.style.width = height + "px";
-		} else {
-			spacer.style.height = height + "px";			
-		}
-		spacerBox = this.clientLayout.getElementClientRect(spacer);
-		var afterEdge = this.getAfterEdge(spacerBox);
-		if (this.vertical) {
-			var wAdj = (afterEdge + margin.right) - clearEdge;
-			if ((wAdj > 0) == (margin.right >= 0)) {
-				// In addition to collapsed portion
-				wAdj += margin.right;
-			}
-			spacer.style.marginLeft = wAdj + "px";			
-		} else {
-			var hAdj = clearEdge - (afterEdge + margin.top);
-			if ((hAdj > 0) == (margin.top >= 0)) {
-				// In addition to collapsed portion
-				hAdj += margin.top;
-			}
-			spacer.style.marginBottom = hAdj + "px";			
-		}
-        nodeContext.clearSpacer = spacer;            
-	}
+    var edge = this.getBeforeEdge(spacerBox);
+    var dir = this.getBoxDir();
+    var clearEdge;
+    switch (nodeContext.clearSide) {
+        case "left" :
+            clearEdge = this.leftFloatEdge;
+            break;
+        case "right" :
+            clearEdge = this.rightFloatEdge;
+            break;
+        default :
+            clearEdge = dir * Math.max(this.rightFloatEdge*dir, this.leftFloatEdge*dir);
+    }
+    // edge holds the position where element border "before" edge will be without clearance.
+    // clearEdge is the "after" edge of the float to clear.
+    if (edge * dir >= clearEdge * dir) {
+        // No need for clearance
+        nodeContext.viewNode.parentNode.removeChild(spacer);
+    } else {
+        // Need some clearance, determine how much. Add the clearance node, measure its after
+        // edge and adjust after margin (required due to possible margin collapse before
+        // clearance was introduced).
+        var height = Math.max(1, (clearEdge - edge) * dir);
+        if (this.vertical) {
+            spacer.style.width = height + "px";
+        } else {
+            spacer.style.height = height + "px";
+        }
+        spacerBox = this.clientLayout.getElementClientRect(spacer);
+        var afterEdge = this.getAfterEdge(spacerBox);
+        if (this.vertical) {
+            var wAdj = (afterEdge + margin.right) - clearEdge;
+            if ((wAdj > 0) == (margin.right >= 0)) {
+                // In addition to collapsed portion
+                wAdj += margin.right;
+            }
+            spacer.style.marginLeft = wAdj + "px";
+        } else {
+            var hAdj = clearEdge - (afterEdge + margin.top);
+            if ((hAdj > 0) == (margin.top >= 0)) {
+                // In addition to collapsed portion
+                hAdj += margin.top;
+            }
+            spacer.style.marginBottom = hAdj + "px";
+        }
+        nodeContext.clearSpacer = spacer;
+    }
 };
 
 /**
  * Skips positions until either the start of unbreakable block or inline content.
  * Also sets breakBefore on the result combining break-before and break-after
- * properties from all elements that meet at the edge. 
+ * properties from all elements that meet at the edge.
  * @param {adapt.vtree.NodeContext} nodeContext
  * @param {boolean} leadingEdge
  * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("skipEdges");
-	// If a forced break occurred at the end of the previous column, nodeContext.after should be false.
-	var atUnforcedBreak = leadingEdge && (nodeContext && nodeContext.after);
-	var breakAtTheEdge = null;
-	var lastAfterNodeContext = null;
-	var leadingEdgeContexts = [];
-	var trailingEdgeContexts = [];
-	var onStartEdges = false;
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("skipEdges");
+    // If a forced break occurred at the end of the previous column, nodeContext.after should be false.
+    var atUnforcedBreak = leadingEdge && (nodeContext && nodeContext.after);
+    var breakAtTheEdge = null;
+    var lastAfterNodeContext = null;
+    var leadingEdgeContexts = [];
+    var trailingEdgeContexts = [];
+    var onStartEdges = false;
 
-	function needForcedBreak() {
-		// leadingEdge=true means that we are at the beginning of the new column and hence must avoid a break
-		// (Otherwise leading to an infinite loop)
-		return !leadingEdge && vivliostyle.break.isForcedBreakValue(breakAtTheEdge);
-	}
+    function needForcedBreak() {
+        // leadingEdge=true means that we are at the beginning of the new column and hence must avoid a break
+        // (Otherwise leading to an infinite loop)
+        return !leadingEdge && vivliostyle.break.isForcedBreakValue(breakAtTheEdge);
+    }
 
-	function processForcedBreak() {
-		nodeContext = leadingEdgeContexts[0] || nodeContext;
-		nodeContext.viewNode.parentNode.removeChild(nodeContext.viewNode);
-		self.pageBreakType = breakAtTheEdge;
-	}
+    function processForcedBreak() {
+        nodeContext = leadingEdgeContexts[0] || nodeContext;
+        nodeContext.viewNode.parentNode.removeChild(nodeContext.viewNode);
+        self.pageBreakType = breakAtTheEdge;
+    }
 
-	frame.loopWithFrame(function(loopFrame) {
-		while (nodeContext) {
-			// A code block to be able to use break. Break moves to the next node position.
-			do {
-				if (!nodeContext.viewNode) {
-					// Non-displayable content, skip
-					break;
-				}
-				if (nodeContext.inline && nodeContext.viewNode.nodeType != 1) {
-					if (adapt.vtree.canIgnore(nodeContext.viewNode, nodeContext.whitespace)) {
-						// Ignorable text content, skip
-						break;
-					}
-					if (!nodeContext.after) {
-						// Leading edge of non-empty block -> finished going through all starting edges of the box
-						if (needForcedBreak()) {
-							processForcedBreak();
-						} else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge)) {
-							nodeContext = (lastAfterNodeContext || nodeContext).modify();
-					    	nodeContext.overflow = true;
-						} else {
-							nodeContext = nodeContext.modify();
-							nodeContext.breakBefore = breakAtTheEdge;
-						}
-						loopFrame.breakLoop();
-						return;
-					}
-				}
-				if (!nodeContext.after) {
-					if (nodeContext.clearSide) {
-						// clear
-						self.applyClearance(nodeContext);
-					}
-					if (nodeContext.floatSide || nodeContext.flexContainer) {
-						// float or flex container (unbreakable)
-						leadingEdgeContexts.push(nodeContext.copy());
-						breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
-						// check if a forced break must occur before the block.
-						if (needForcedBreak()) {
-							processForcedBreak();
-						} else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge) || !self.layoutConstraint.allowLayout(nodeContext)) {
-							// overflow
-					    	nodeContext = (lastAfterNodeContext || nodeContext).modify();
-					    	nodeContext.overflow = true;
-						}
-						loopFrame.breakLoop();
-						return;
-					}
-				}
-				if (nodeContext.viewNode.nodeType != 1) {
-					// not an element
-					break;
-				}
-				var style = (/** @type {HTMLElement} */ (nodeContext.viewNode)).style;
-				if (nodeContext.after) {
-					// Trailing edge
-					if (onStartEdges) {
-						// finished going through all starting edges of the box.
-						// check if a forced break must occur before the block.
-						if (needForcedBreak()) {
-							processForcedBreak();
-							loopFrame.breakLoop();
-							return;
-						}
-						// since a break did not occur, move to the next edge. this edge is no longer the leading edge.
-						leadingEdgeContexts = [];
-						leadingEdge = false;
-						atUnforcedBreak = false;
-						breakAtTheEdge = null;
-					}
-					onStartEdges = false; // we are now on end edges.
-					lastAfterNodeContext = nodeContext.copy();
-					trailingEdgeContexts.push(lastAfterNodeContext);
-					breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakAfter);
-					if (style && !(self.zeroIndent(style.paddingBottom) && self.zeroIndent(style.borderBottomWidth))) {
-						// Non-zero trailing inset.
-						if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge)) {
-							// overflow
-					    	nodeContext = (lastAfterNodeContext || nodeContext).modify();
-					    	nodeContext.overflow = true;
-							loopFrame.breakLoop();
-							return;
-						}
-						// Margins don't collapse across non-zero borders and paddings.
-						trailingEdgeContexts = [lastAfterNodeContext];
-						lastAfterNodeContext = null;
-					}
-				} else {
-					// Leading edge
-					leadingEdgeContexts.push(nodeContext.copy());
-					breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
-					if (!self.layoutConstraint.allowLayout(nodeContext)) {
-						self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, false, breakAtTheEdge);
-						nodeContext = nodeContext.modify();
-						nodeContext.overflow = true;
-						loopFrame.breakLoop();
-						return;
-					}
-					var viewTag = nodeContext.viewNode.localName;
-					if (adapt.layout.mediaTags[viewTag]) {
-						// elements that have inherent content
-						// check if a forced break must occur before the block.
-						if (needForcedBreak()) {
-							processForcedBreak();
-						} else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge)) {
-							// overflow
-					    	nodeContext = (lastAfterNodeContext || nodeContext).modify();
-					    	nodeContext.overflow = true;
-						}
-						loopFrame.breakLoop();
-						return;
-					}
-					if (style && !(self.zeroIndent(style.paddingTop) && self.zeroIndent(style.borderTopWidth))) {
-						// Non-zero leading inset
-						atUnforcedBreak = false;
-						trailingEdgeContexts = [];
-					}
-					onStartEdges = true; // we are now on starting edges.
-				}
-			} while(false);  // End of block of code to use break
-			var nextResult = self.layoutContext.nextInTree(nodeContext, atUnforcedBreak);
-			if (nextResult.isPending()) {
-				nextResult.then(function(nodeContextParam) {
-					nodeContext = nodeContextParam;
-					loopFrame.continueLoop();
-				});
-				return;
-			} else {
-				nodeContext = nextResult.get();
-			}
-		}
-		if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, trailingEdgeContexts, false, breakAtTheEdge)) {
-			if (lastAfterNodeContext) {
-		    	nodeContext = lastAfterNodeContext.modify();
-		    	nodeContext.overflow = true;
-			} else {
-				// TODO: what to return here??
-			}
-		} else if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
-			self.pageBreakType = breakAtTheEdge;
-		}
-		loopFrame.breakLoop();
-	}).then(function() {
-		frame.finish(nodeContext);
-	});
-	return frame.result();
+    frame.loopWithFrame(function(loopFrame) {
+        while (nodeContext) {
+            // A code block to be able to use break. Break moves to the next node position.
+            do {
+                if (!nodeContext.viewNode) {
+                    // Non-displayable content, skip
+                    break;
+                }
+                if (nodeContext.inline && nodeContext.viewNode.nodeType != 1) {
+                    if (adapt.vtree.canIgnore(nodeContext.viewNode, nodeContext.whitespace)) {
+                        // Ignorable text content, skip
+                        break;
+                    }
+                    if (!nodeContext.after) {
+                        // Leading edge of non-empty block -> finished going through all starting edges of the box
+                        if (needForcedBreak()) {
+                            processForcedBreak();
+                        } else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge)) {
+                            nodeContext = (lastAfterNodeContext || nodeContext).modify();
+                            nodeContext.overflow = true;
+                        } else {
+                            nodeContext = nodeContext.modify();
+                            nodeContext.breakBefore = breakAtTheEdge;
+                        }
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                }
+                if (!nodeContext.after) {
+                    if (nodeContext.clearSide) {
+                        // clear
+                        self.applyClearance(nodeContext);
+                    }
+                    if (nodeContext.floatSide || nodeContext.flexContainer) {
+                        // float or flex container (unbreakable)
+                        leadingEdgeContexts.push(nodeContext.copy());
+                        breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
+                        // check if a forced break must occur before the block.
+                        if (needForcedBreak()) {
+                            processForcedBreak();
+                        } else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge) || !self.layoutConstraint.allowLayout(nodeContext)) {
+                            // overflow
+                            nodeContext = (lastAfterNodeContext || nodeContext).modify();
+                            nodeContext.overflow = true;
+                        }
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                }
+                if (nodeContext.viewNode.nodeType != 1) {
+                    // not an element
+                    break;
+                }
+                var style = (/** @type {HTMLElement} */ (nodeContext.viewNode)).style;
+                if (nodeContext.after) {
+                    // Trailing edge
+                    if (onStartEdges) {
+                        // finished going through all starting edges of the box.
+                        // check if a forced break must occur before the block.
+                        if (needForcedBreak()) {
+                            processForcedBreak();
+                            loopFrame.breakLoop();
+                            return;
+                        }
+                        // since a break did not occur, move to the next edge. this edge is no longer the leading edge.
+                        leadingEdgeContexts = [];
+                        leadingEdge = false;
+                        atUnforcedBreak = false;
+                        breakAtTheEdge = null;
+                    }
+                    onStartEdges = false; // we are now on end edges.
+                    lastAfterNodeContext = nodeContext.copy();
+                    trailingEdgeContexts.push(lastAfterNodeContext);
+                    breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakAfter);
+                    if (style && !(self.zeroIndent(style.paddingBottom) && self.zeroIndent(style.borderBottomWidth))) {
+                        // Non-zero trailing inset.
+                        if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge)) {
+                            // overflow
+                            nodeContext = (lastAfterNodeContext || nodeContext).modify();
+                            nodeContext.overflow = true;
+                            loopFrame.breakLoop();
+                            return;
+                        }
+                        // Margins don't collapse across non-zero borders and paddings.
+                        trailingEdgeContexts = [lastAfterNodeContext];
+                        lastAfterNodeContext = null;
+                    }
+                } else {
+                    // Leading edge
+                    leadingEdgeContexts.push(nodeContext.copy());
+                    breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
+                    if (!self.layoutConstraint.allowLayout(nodeContext)) {
+                        self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, false, breakAtTheEdge);
+                        nodeContext = nodeContext.modify();
+                        nodeContext.overflow = true;
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                    var viewTag = nodeContext.viewNode.localName;
+                    if (adapt.layout.mediaTags[viewTag]) {
+                        // elements that have inherent content
+                        // check if a forced break must occur before the block.
+                        if (needForcedBreak()) {
+                            processForcedBreak();
+                        } else if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, null, true, breakAtTheEdge)) {
+                            // overflow
+                            nodeContext = (lastAfterNodeContext || nodeContext).modify();
+                            nodeContext.overflow = true;
+                        }
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                    if (style && !(self.zeroIndent(style.paddingTop) && self.zeroIndent(style.borderTopWidth))) {
+                        // Non-zero leading inset
+                        atUnforcedBreak = false;
+                        trailingEdgeContexts = [];
+                    }
+                    onStartEdges = true; // we are now on starting edges.
+                }
+            } while (false);  // End of block of code to use break
+            var nextResult = self.layoutContext.nextInTree(nodeContext, atUnforcedBreak);
+            if (nextResult.isPending()) {
+                nextResult.then(function(nodeContextParam) {
+                    nodeContext = nodeContextParam;
+                    loopFrame.continueLoop();
+                });
+                return;
+            } else {
+                nodeContext = nextResult.get();
+            }
+        }
+        if (self.saveEdgeAndCheckForOverflow(lastAfterNodeContext, trailingEdgeContexts, false, breakAtTheEdge)) {
+            if (lastAfterNodeContext) {
+                nodeContext = lastAfterNodeContext.modify();
+                nodeContext.overflow = true;
+            } else {
+                // TODO: what to return here??
+            }
+        } else if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
+            self.pageBreakType = breakAtTheEdge;
+        }
+        loopFrame.breakLoop();
+    }).then(function() {
+        frame.finish(nodeContext);
+    });
+    return frame.result();
 };
 
 /**
@@ -2009,104 +2009,104 @@ adapt.layout.Column.prototype.skipEdges = function(nodeContext, leadingEdge) {
  * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.skipTailEdges = function(nodeContext) {
-	var resultNodeContext = nodeContext.copy();
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("skipEdges");
-	var breakAtTheEdge = null;
-	var onStartEdges = false;
-	frame.loopWithFrame(function(loopFrame) {
-		while (nodeContext) {
-			// A code block to be able to use break. Break moves to the next node position.
-			do {
-				if (!nodeContext.viewNode) {
-					// Non-displayable content, skip
-					break;
-				}
-				if (nodeContext.inline && nodeContext.viewNode.nodeType != 1) {
-					if (adapt.vtree.canIgnore(nodeContext.viewNode, nodeContext.whitespace)) {
-						// Ignorable text content, skip
-						break;
-					}
-					if (!nodeContext.after) {
-						// Leading edge of non-empty block -> finished going through all starting edges of the box
-						if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
-							self.pageBreakType = breakAtTheEdge;
-						}
-						loopFrame.breakLoop();
-						return;
-					}
-				}
-				if (!nodeContext.after) {
-					if (nodeContext.floatSide || nodeContext.flexContainer) {
-						// float or flex container (unbreakable)
-						breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
-						// check if a forced break must occur before the block.
-						if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
-							self.pageBreakType = breakAtTheEdge;
-						}
-						loopFrame.breakLoop();
-						return;
-					}
-				}
-				if (nodeContext.viewNode.nodeType != 1) {
-					// not an element
-					break;
-				}
-				var style = (/** @type {HTMLElement} */ (nodeContext.viewNode)).style;
-				if (nodeContext.after) {
-					// Trailing edge
-					if (onStartEdges) {
-						// finished going through all starting edges of the box.
-						// check if a forced break must occur before the block.
-						if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
-							self.pageBreakType = breakAtTheEdge;
-							loopFrame.breakLoop();
-							return;
-						}
-						// since a break did not occur, move to the next edge.
-						breakAtTheEdge = null;
-					}
-					onStartEdges = false; // we are now on end edges.
-					breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakAfter);
-				} else {
-					// Leading edge
-					breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
-					var viewTag = nodeContext.viewNode.localName;
-					if (adapt.layout.mediaTags[viewTag]) {
-						// elements that have inherent content
-						// check if a forced break must occur before the block.
-						if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
-							self.pageBreakType = breakAtTheEdge;
-						}
-						loopFrame.breakLoop();
-						return;
-					}
-					if (style && !(self.zeroIndent(style.paddingTop) && self.zeroIndent(style.borderTopWidth))) {
-						// Non-zero leading inset
-						loopFrame.breakLoop();
-						return;
-					}
-				}
-				onStartEdges = true; // we are now on starting edges.
-			} while(false);  // End of block of code to use break
-			var nextResult = self.layoutContext.nextInTree(nodeContext);
-			if (nextResult.isPending()) {
-				nextResult.then(function(nodeContextParam) {
-					nodeContext = nodeContextParam;
-					loopFrame.continueLoop();
-				});
-				return;
-			} else {
-				nodeContext = nextResult.get();
-			}
-		}
-		resultNodeContext = null;
-		loopFrame.breakLoop();
-	}).then(function() {
-		frame.finish(resultNodeContext);
-	});
-	return frame.result();
+    var resultNodeContext = nodeContext.copy();
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("skipEdges");
+    var breakAtTheEdge = null;
+    var onStartEdges = false;
+    frame.loopWithFrame(function(loopFrame) {
+        while (nodeContext) {
+            // A code block to be able to use break. Break moves to the next node position.
+            do {
+                if (!nodeContext.viewNode) {
+                    // Non-displayable content, skip
+                    break;
+                }
+                if (nodeContext.inline && nodeContext.viewNode.nodeType != 1) {
+                    if (adapt.vtree.canIgnore(nodeContext.viewNode, nodeContext.whitespace)) {
+                        // Ignorable text content, skip
+                        break;
+                    }
+                    if (!nodeContext.after) {
+                        // Leading edge of non-empty block -> finished going through all starting edges of the box
+                        if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
+                            self.pageBreakType = breakAtTheEdge;
+                        }
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                }
+                if (!nodeContext.after) {
+                    if (nodeContext.floatSide || nodeContext.flexContainer) {
+                        // float or flex container (unbreakable)
+                        breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
+                        // check if a forced break must occur before the block.
+                        if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
+                            self.pageBreakType = breakAtTheEdge;
+                        }
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                }
+                if (nodeContext.viewNode.nodeType != 1) {
+                    // not an element
+                    break;
+                }
+                var style = (/** @type {HTMLElement} */ (nodeContext.viewNode)).style;
+                if (nodeContext.after) {
+                    // Trailing edge
+                    if (onStartEdges) {
+                        // finished going through all starting edges of the box.
+                        // check if a forced break must occur before the block.
+                        if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
+                            self.pageBreakType = breakAtTheEdge;
+                            loopFrame.breakLoop();
+                            return;
+                        }
+                        // since a break did not occur, move to the next edge.
+                        breakAtTheEdge = null;
+                    }
+                    onStartEdges = false; // we are now on end edges.
+                    breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakAfter);
+                } else {
+                    // Leading edge
+                    breakAtTheEdge = vivliostyle.break.resolveEffectiveBreakValue(breakAtTheEdge, nodeContext.breakBefore);
+                    var viewTag = nodeContext.viewNode.localName;
+                    if (adapt.layout.mediaTags[viewTag]) {
+                        // elements that have inherent content
+                        // check if a forced break must occur before the block.
+                        if (vivliostyle.break.isForcedBreakValue(breakAtTheEdge)) {
+                            self.pageBreakType = breakAtTheEdge;
+                        }
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                    if (style && !(self.zeroIndent(style.paddingTop) && self.zeroIndent(style.borderTopWidth))) {
+                        // Non-zero leading inset
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                }
+                onStartEdges = true; // we are now on starting edges.
+            } while (false);  // End of block of code to use break
+            var nextResult = self.layoutContext.nextInTree(nodeContext);
+            if (nextResult.isPending()) {
+                nextResult.then(function(nodeContextParam) {
+                    nodeContext = nodeContextParam;
+                    loopFrame.continueLoop();
+                });
+                return;
+            } else {
+                nodeContext = nextResult.get();
+            }
+        }
+        resultNodeContext = null;
+        loopFrame.breakLoop();
+    }).then(function() {
+        frame.finish(resultNodeContext);
+    });
+    return frame.result();
 };
 
 /**
@@ -2114,9 +2114,9 @@ adapt.layout.Column.prototype.skipTailEdges = function(nodeContext) {
  * @return {adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.layoutFloatOrFootnote = function(nodeContext) {
-	if (nodeContext.floatSide == "footnote") {
-		return this.layoutFootnote(nodeContext);
-	}
+    if (nodeContext.floatSide == "footnote") {
+        return this.layoutFootnote(nodeContext);
+    }
     return this.layoutFloat(nodeContext);
 };
 
@@ -2127,24 +2127,24 @@ adapt.layout.Column.prototype.layoutFloatOrFootnote = function(nodeContext) {
  * @return {adapt.task.Result.<adapt.vtree.NodeContext>}
  */
 adapt.layout.Column.prototype.layoutNext = function(nodeContext, leadingEdge) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("layoutNext");
-	this.skipEdges(nodeContext, leadingEdge).then(function(nodeContextParam) {
-		nodeContext = /** @type {adapt.vtree.NodeContext} */ (nodeContextParam);
-		if (!nodeContext || self.pageBreakType || nodeContext.overflow) {
-			// finished all content, explicit page break or overflow (automatic page break)
-			frame.finish(nodeContext);
-	    } else if (nodeContext.floatSide) {
-	    	// TODO: implement floats and footnotes properly for vertical writing
-	    	self.layoutFloatOrFootnote(nodeContext).thenFinish(frame);
-		} else if (self.isBreakable(nodeContext)) {
-	        self.layoutBreakableBlock(nodeContext).thenFinish(frame);
-	    } else {
-	        self.layoutUnbreakable(nodeContext).thenFinish(frame);
-	    }
-	});
-	return frame.result();
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("layoutNext");
+    this.skipEdges(nodeContext, leadingEdge).then(function(nodeContextParam) {
+        nodeContext = /** @type {adapt.vtree.NodeContext} */ (nodeContextParam);
+        if (!nodeContext || self.pageBreakType || nodeContext.overflow) {
+            // finished all content, explicit page break or overflow (automatic page break)
+            frame.finish(nodeContext);
+        } else if (nodeContext.floatSide) {
+            // TODO: implement floats and footnotes properly for vertical writing
+            self.layoutFloatOrFootnote(nodeContext).thenFinish(frame);
+        } else if (self.isBreakable(nodeContext)) {
+            self.layoutBreakableBlock(nodeContext).thenFinish(frame);
+        } else {
+            self.layoutUnbreakable(nodeContext).thenFinish(frame);
+        }
+    });
+    return frame.result();
 };
 
 /**
@@ -2154,10 +2154,10 @@ adapt.layout.Column.prototype.layoutNext = function(nodeContext, leadingEdge) {
  */
 adapt.layout.Column.prototype.clearOverflownViewNodes = function(nodePosition, removeSelf) {
     do {
-    	var parent = nodePosition.viewNode.parentNode;
-    	if (!parent)
-    		return;
-    	this.removeFollowingSiblings(parent, nodePosition.viewNode);
+        var parent = nodePosition.viewNode.parentNode;
+        if (!parent)
+            return;
+        this.removeFollowingSiblings(parent, nodePosition.viewNode);
         if (removeSelf) {
             parent.removeChild(nodePosition.viewNode);
             removeSelf = false;
@@ -2170,25 +2170,25 @@ adapt.layout.Column.prototype.clearOverflownViewNodes = function(nodePosition, r
  * @return {void}
  */
 adapt.layout.Column.prototype.initGeom = function() {
-	// TODO: we should be able to avoid querying the layout engine at this point.
-	// Create an element that fills the content area and query its size. Calling
-	// getElementClientRect on the container element includes element padding
-	// which is wrong for our purposes.
-	var probe = /** @type {HTMLElement} */ (this.element.ownerDocument.createElement("div"));
-	probe.style.position = "absolute";
+    // TODO: we should be able to avoid querying the layout engine at this point.
+    // Create an element that fills the content area and query its size. Calling
+    // getElementClientRect on the container element includes element padding
+    // which is wrong for our purposes.
+    var probe = /** @type {HTMLElement} */ (this.element.ownerDocument.createElement("div"));
+    probe.style.position = "absolute";
     probe.style.top = this.paddingTop + "px";
     probe.style.right = this.paddingRight + "px";
     probe.style.bottom = this.paddingBottom + "px";
     probe.style.left = this.paddingLeft + "px";
-	this.element.appendChild(probe);
+    this.element.appendChild(probe);
     var columnBBox = this.clientLayout.getElementClientRect(probe);
     this.element.removeChild(probe);
     var offsetX = this.originX + this.left + this.getInsetLeft();
     var offsetY = this.originY + this.top + this.getInsetTop();
     this.box = new adapt.geom.Rect(offsetX, offsetY, offsetX + this.width,
-    		offsetY + this.height);
-	this.startEdge = columnBBox ? (this.vertical ? columnBBox.top : columnBBox.left) : 0;
-	this.endEdge = columnBBox ? (this.vertical ? columnBBox.bottom : columnBBox.right) : 0;
+        offsetY + this.height);
+    this.startEdge = columnBBox ? (this.vertical ? columnBBox.top : columnBBox.left) : 0;
+    this.endEdge = columnBBox ? (this.vertical ? columnBBox.bottom : columnBBox.right) : 0;
     this.beforeEdge = columnBBox ? (this.vertical ? columnBBox.right : columnBBox.top) : 0;
     this.afterEdge = columnBBox ? (this.vertical ? columnBBox.left : columnBBox.bottom) : 0;
     this.leftFloatEdge = this.beforeEdge;
@@ -2196,16 +2196,16 @@ adapt.layout.Column.prototype.initGeom = function() {
     this.bottommostFloatTop = this.beforeEdge;
     this.footnoteEdge = this.afterEdge;
     this.bands = adapt.geom.shapesToBands(this.box, [this.getInnerShape()],
-    		this.exclusions, 8, this.snapHeight, this.vertical);
-	this.createFloats();
-	this.footnoteItems = null;
+        this.exclusions, 8, this.snapHeight, this.vertical);
+    this.createFloats();
+    this.footnoteItems = null;
 };
 
 /**
  * @return {void}
  */
 adapt.layout.Column.prototype.init = function() {
-	this.chunkPositions = [];
+    this.chunkPositions = [];
     adapt.base.setCSSProperty(this.element, "width", this.width + "px");
     adapt.base.setCSSProperty(this.element, "height", this.height + "px");
     this.initGeom();
@@ -2224,8 +2224,8 @@ adapt.layout.Column.prototype.init = function() {
  * @return {void}
  */
 adapt.layout.Column.prototype.saveEdgeBreakPosition = function(position, breakAtEdge, overflows) {
-	var bp = new adapt.layout.EdgeBreakPosition(position.copy(), breakAtEdge, overflows, this.computedBlockSize);
-	this.breakPositions.push(bp);
+    var bp = new adapt.layout.EdgeBreakPosition(position.copy(), breakAtEdge, overflows, this.computedBlockSize);
+    this.breakPositions.push(bp);
 };
 
 /**
@@ -2233,17 +2233,17 @@ adapt.layout.Column.prototype.saveEdgeBreakPosition = function(position, breakAt
  * @return {void}
  */
 adapt.layout.Column.prototype.saveBoxBreakPosition = function(checkPoints) {
-	var penalty = checkPoints[0].breakPenalty;
-	var bp = new adapt.layout.BoxBreakPosition(checkPoints, penalty);
-	this.breakPositions.push(bp);
+    var penalty = checkPoints[0].breakPenalty;
+    var bp = new adapt.layout.BoxBreakPosition(checkPoints, penalty);
+    this.breakPositions.push(bp);
 };
 
 /**
  * @param {number} afterEdge
  */
 adapt.layout.Column.prototype.updateMaxReachedAfterEdge = function(afterEdge) {
-	var size = this.getBoxDir() * (afterEdge - this.beforeEdge);
-	this.computedBlockSize = Math.max(size, this.computedBlockSize);
+    var size = this.getBoxDir() * (afterEdge - this.beforeEdge);
+    this.computedBlockSize = Math.max(size, this.computedBlockSize);
 };
 
 /**
@@ -2253,25 +2253,25 @@ adapt.layout.Column.prototype.updateMaxReachedAfterEdge = function(afterEdge) {
  */
 adapt.layout.Column.prototype.layoutOverflownFootnotes = function(chunkPosition) {
     var footnotes = chunkPosition.footnotes;
-	if (!footnotes) {
-		return adapt.task.newResult(true);
-	}
-	var self = this;
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("layoutOverflownFootnotes");
-	var i = 0;
-	frame.loop(function() {
-		while(i < footnotes.length) {
-			var footnote = footnotes[i++];
-			var result = self.layoutFootnoteInner(0, footnote, self.beforeEdge);
-			if (result.isPending()) {
-				return result;
-			}
-		}
-		return adapt.task.newResult(false);
-	}).then(function() {
-		frame.finish(true);
-	});
-	return frame.result();
+    if (!footnotes) {
+        return adapt.task.newResult(true);
+    }
+    var self = this;
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("layoutOverflownFootnotes");
+    var i = 0;
+    frame.loop(function() {
+        while (i < footnotes.length) {
+            var footnote = footnotes[i++];
+            var result = self.layoutFootnoteInner(0, footnote, self.beforeEdge);
+            if (result.isPending()) {
+                return result;
+            }
+        }
+        return adapt.task.newResult(false);
+    }).then(function() {
+        frame.finish(true);
+    });
+    return frame.result();
 };
 
 /**
@@ -2280,139 +2280,139 @@ adapt.layout.Column.prototype.layoutOverflownFootnotes = function(chunkPosition)
  * @return {adapt.task.Result.<adapt.vtree.ChunkPosition>} holding end position.
  */
 adapt.layout.Column.prototype.layout = function(chunkPosition, leadingEdge) {
-	this.chunkPositions.push(chunkPosition);  // So we can re-layout this column later
-	if (this.overflown) {
-		return adapt.task.newResult(chunkPosition);
-	}
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.ChunkPosition>} */ var frame = adapt.task.newFrame("layout");
-	self.layoutOverflownFootnotes(chunkPosition).then(function() {
-	    // ------ start the column -----------
-	    self.openAllViews(chunkPosition.primary).then(function(nodeContext) {
-	    	var initialNodeContext = nodeContext;
-		    // ------ init backtracking list -----
-			self.breakPositions = [];
-		    // ------- fill the column -------------
-			frame.loopWithFrame(function(loopFrame) {
-			    while (nodeContext) {
-			        // fill a single block
-			    	var pending = true;
-			        self.layoutNext(nodeContext, leadingEdge).then(function(nodeContextParam) {
-			        	leadingEdge = false;
-						nodeContext = nodeContextParam;
+    this.chunkPositions.push(chunkPosition);  // So we can re-layout this column later
+    if (this.overflown) {
+        return adapt.task.newResult(chunkPosition);
+    }
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.ChunkPosition>} */ var frame = adapt.task.newFrame("layout");
+    self.layoutOverflownFootnotes(chunkPosition).then(function() {
+        // ------ start the column -----------
+        self.openAllViews(chunkPosition.primary).then(function(nodeContext) {
+            var initialNodeContext = nodeContext;
+            // ------ init backtracking list -----
+            self.breakPositions = [];
+            // ------- fill the column -------------
+            frame.loopWithFrame(function(loopFrame) {
+                while (nodeContext) {
+                    // fill a single block
+                    var pending = true;
+                    self.layoutNext(nodeContext, leadingEdge).then(function(nodeContextParam) {
+                        leadingEdge = false;
+                        nodeContext = nodeContextParam;
 
-						if (self.hasNewlyAddedPageFloats()) {
-							loopFrame.breakLoop();
-							return;
-						}
+                        if (self.hasNewlyAddedPageFloats()) {
+                            loopFrame.breakLoop();
+                            return;
+                        }
 
-						if (self.pageBreakType) {
-							// explicit page break
-				            loopFrame.breakLoop(); // Loop end							
-						} else if (nodeContext && nodeContext.overflow) {
-				        	// overflow (implicit page break): back up and find a page break
-				        	self.findAcceptableBreak(nodeContext, initialNodeContext).then(function(nodeContextParam) {
-				        		nodeContext = nodeContextParam;
-				        		loopFrame.breakLoop(); // Loop end
-				        	});
-				        } else {
-				        	if (pending) {
-				        		// Sync case
-				        		pending = false;
-				        	} else {
-				        		// Async case
-				        		loopFrame.continueLoop();
-				        	}
-				        }
-			        });
-			        if (pending) {
-			        	// Async case and loop end
-			        	pending = false;
-			        	return;
-			    	}
-			        // Sync case
-			    }
-			    loopFrame.breakLoop();
-			}).then(function() {
-				var footnoteArea = self.footnoteArea;
-			    if (footnoteArea) {
-			    	self.element.appendChild(footnoteArea.element);
-			    	if (self.vertical) {
-				    	self.computedBlockSize = this.beforeEdge - this.afterEdge;
-			    	} else {
-				    	self.computedBlockSize = footnoteArea.top + footnoteArea.getInsetTop() +
-	    					footnoteArea.computedBlockSize + footnoteArea.getInsetBottom();	
-			    	}
-			    }
-			    // TODO: look at footnotes and floats as well
-			    if (!nodeContext) {
-			    	frame.finish(null);
-			    } else if (self.hasNewlyAddedPageFloats()) {
-					frame.finish(null);
-				} else {
-				    self.overflown = true;
-				    var result = new adapt.vtree.ChunkPosition(nodeContext.toNodePosition());
-				    // Transfer overflown footnotes
-				    if (self.footnoteItems) {
-				    	var overflowFootnotes = [];
-				    	for (var i = 0; i < self.footnoteItems.length; i++) {
-				    		var overflowPosition = self.footnoteItems[i].overflowPosition;
-				    		if (overflowPosition) {
-				    			overflowFootnotes.push(overflowPosition);
-				    		}
-				    	}
-				    	result.footnotes = overflowFootnotes.length ? overflowFootnotes : null;
-				    }
-				    frame.finish(result);
-			    }
-			});
-	    });
-	});
+                        if (self.pageBreakType) {
+                            // explicit page break
+                            loopFrame.breakLoop(); // Loop end
+                        } else if (nodeContext && nodeContext.overflow) {
+                            // overflow (implicit page break): back up and find a page break
+                            self.findAcceptableBreak(nodeContext, initialNodeContext).then(function(nodeContextParam) {
+                                nodeContext = nodeContextParam;
+                                loopFrame.breakLoop(); // Loop end
+                            });
+                        } else {
+                            if (pending) {
+                                // Sync case
+                                pending = false;
+                            } else {
+                                // Async case
+                                loopFrame.continueLoop();
+                            }
+                        }
+                    });
+                    if (pending) {
+                        // Async case and loop end
+                        pending = false;
+                        return;
+                    }
+                    // Sync case
+                }
+                loopFrame.breakLoop();
+            }).then(function() {
+                var footnoteArea = self.footnoteArea;
+                if (footnoteArea) {
+                    self.element.appendChild(footnoteArea.element);
+                    if (self.vertical) {
+                        self.computedBlockSize = this.beforeEdge - this.afterEdge;
+                    } else {
+                        self.computedBlockSize = footnoteArea.top + footnoteArea.getInsetTop() +
+                            footnoteArea.computedBlockSize + footnoteArea.getInsetBottom();
+                    }
+                }
+                // TODO: look at footnotes and floats as well
+                if (!nodeContext) {
+                    frame.finish(null);
+                } else if (self.hasNewlyAddedPageFloats()) {
+                    frame.finish(null);
+                } else {
+                    self.overflown = true;
+                    var result = new adapt.vtree.ChunkPosition(nodeContext.toNodePosition());
+                    // Transfer overflown footnotes
+                    if (self.footnoteItems) {
+                        var overflowFootnotes = [];
+                        for (var i = 0; i < self.footnoteItems.length; i++) {
+                            var overflowPosition = self.footnoteItems[i].overflowPosition;
+                            if (overflowPosition) {
+                                overflowFootnotes.push(overflowPosition);
+                            }
+                        }
+                        result.footnotes = overflowFootnotes.length ? overflowFootnotes : null;
+                    }
+                    frame.finish(result);
+                }
+            });
+        });
+    });
     return frame.result();
 };
 
 /**
  * Re-layout already laid-out chunks. Return the position of the last flow if there is
  * an overflow.
- * TODO: deal with chunks that did not fit at all. 
+ * TODO: deal with chunks that did not fit at all.
  * @return {adapt.task.Result.<adapt.vtree.ChunkPosition>} holding end position.
  */
 adapt.layout.Column.prototype.redoLayout = function() {
-	var chunkPositions = this.chunkPositions;
-	var last = this.element.lastChild;
-	while (last != this.last) {
-		var prev = last.previousSibling;
-		if (!(this.element === last.parentNode && this.layoutContext.isPseudoelement(last))) {
-			this.element.removeChild(last);
-		}
-		last = prev;
-	}
-	this.killFloats();
-	this.init();
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.ChunkPosition>} */ var frame
-		= adapt.task.newFrame("redoLayout");
-	var i = 0;
-	var res = null;
-	var leadingEdge = true;
-	frame.loopWithFrame(function(loopFrame) {
-		if (i < chunkPositions.length) {
-			var chunkPosition = chunkPositions[i++];
-			self.layout(chunkPosition, leadingEdge).then(function(pos) {
-				leadingEdge = false;
-				if (pos) {
-					res = pos;
-					loopFrame.breakLoop();
-				} else {
-					loopFrame.continueLoop();
-				}
-			});
-			return;
-		}
-		loopFrame.breakLoop();
-	}).then (function() {
-		frame.finish(res);
-	});
-	return frame.result();
+    var chunkPositions = this.chunkPositions;
+    var last = this.element.lastChild;
+    while (last != this.last) {
+        var prev = last.previousSibling;
+        if (!(this.element === last.parentNode && this.layoutContext.isPseudoelement(last))) {
+            this.element.removeChild(last);
+        }
+        last = prev;
+    }
+    this.killFloats();
+    this.init();
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.ChunkPosition>} */ var frame
+        = adapt.task.newFrame("redoLayout");
+    var i = 0;
+    var res = null;
+    var leadingEdge = true;
+    frame.loopWithFrame(function(loopFrame) {
+        if (i < chunkPositions.length) {
+            var chunkPosition = chunkPositions[i++];
+            self.layout(chunkPosition, leadingEdge).then(function(pos) {
+                leadingEdge = false;
+                if (pos) {
+                    res = pos;
+                    loopFrame.breakLoop();
+                } else {
+                    loopFrame.continueLoop();
+                }
+            });
+            return;
+        }
+        loopFrame.breakLoop();
+    }).then(function() {
+        frame.finish(res);
+    });
+    return frame.result();
 };
 

--- a/src/adapt/net.js
+++ b/src/adapt/net.js
@@ -12,12 +12,12 @@ goog.require('adapt.task');
  * @enum {string}
  */
 adapt.net.XMLHttpRequestResponseType = {
-	DEFAULT: "",
-	ARRAYBUFFER: "arraybuffer",
-	BLOB: "blob",
-	DOCUMENT: "document",
-	JSON: "json",
-	TEXT: "text"
+    DEFAULT: "",
+    ARRAYBUFFER: "arraybuffer",
+    BLOB: "blob",
+    DOCUMENT: "document",
+    JSON: "json",
+    TEXT: "text"
 };
 
 /** @typedef {{status:number, url:string, contentType:?string, responseText:?string, responseXML:Document, responseBlob:Blob}} */
@@ -28,61 +28,61 @@ adapt.net.Response;
  * @param {adapt.net.XMLHttpRequestResponseType=} opt_type
  * @param {string=} opt_method
  * @param {string=} opt_data
- * @param {string=} opt_contentType 
+ * @param {string=} opt_contentType
  * @return {!adapt.task.Result.<adapt.net.Response>}
  */
 adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) {
     /** @type {!adapt.task.Frame.<adapt.net.Response>} */ var frame =
-    	adapt.task.newFrame("ajax");
+        adapt.task.newFrame("ajax");
     var request = new XMLHttpRequest();
     var continuation = frame.suspend(request);
     /** @type {adapt.net.Response} */ var response =
-    	{status: 0, url: url, contentType: null, responseText: null, responseXML: null, responseBlob: null};
+    {status: 0, url: url, contentType: null, responseText: null, responseXML: null, responseBlob: null};
     request.open(opt_method || "GET", url, true);
     if (opt_type) {
-    	request.responseType = opt_type;
+        request.responseType = opt_type;
     }
     request.onreadystatechange = function() {
         if (request.readyState === 4) {
-        	response.status = request.status;
-        	if (response.status == 200 || response.status == 0) {
-	        	if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.DOCUMENT) && request.responseXML) {
-	        		response.responseXML = request.responseXML;
-					response.contentType = request.responseXML.contentType;
-	        	} else {
-	        		var text = request.response;
-	        		if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.TEXT) && typeof text == "string") {
-	        			response.responseText = text;
-	        		} else if (!text) {
-						vivliostyle.logging.logger.warn("Unexpected empty success response for", url);
-        			} else {
-        				if (typeof text == "string") {
-        					response.responseBlob = adapt.net.makeBlob([text]);
-        				} else {
-        					response.responseBlob = /** @type {Blob} */ (text);
-        				}
-        			}
-					var contentTypeHeader = request.getResponseHeader("Content-Type");
-					if (contentTypeHeader) {
-						response.contentType = contentTypeHeader.replace(/(.*);.*$/, "$1");
-					}
-	        	}
-        	}
+            response.status = request.status;
+            if (response.status == 200 || response.status == 0) {
+                if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.DOCUMENT) && request.responseXML) {
+                    response.responseXML = request.responseXML;
+                    response.contentType = request.responseXML.contentType;
+                } else {
+                    var text = request.response;
+                    if ((!opt_type || opt_type === adapt.net.XMLHttpRequestResponseType.TEXT) && typeof text == "string") {
+                        response.responseText = text;
+                    } else if (!text) {
+                        vivliostyle.logging.logger.warn("Unexpected empty success response for", url);
+                    } else {
+                        if (typeof text == "string") {
+                            response.responseBlob = adapt.net.makeBlob([text]);
+                        } else {
+                            response.responseBlob = /** @type {Blob} */ (text);
+                        }
+                    }
+                    var contentTypeHeader = request.getResponseHeader("Content-Type");
+                    if (contentTypeHeader) {
+                        response.contentType = contentTypeHeader.replace(/(.*);.*$/, "$1");
+                    }
+                }
+            }
             continuation.schedule(response);
         }
     };
-	try {
-		if (opt_data) {
-			request.setRequestHeader("Content-Type",
-				opt_contentType || "text/plain; charset=UTF-8");
-			request.send(opt_data);
-		}
-		else
-			request.send(null);
-	} catch (e) {
-		vivliostyle.logging.logger.warn(e, "Error fetching " + url);
-		continuation.schedule(response);
-	}
+    try {
+        if (opt_data) {
+            request.setRequestHeader("Content-Type",
+                opt_contentType || "text/plain; charset=UTF-8");
+            request.send(opt_data);
+        }
+        else
+            request.send(null);
+    } catch (e) {
+        vivliostyle.logging.logger.warn(e, "Error fetching " + url);
+        continuation.schedule(response);
+    }
     return frame.result();
 };
 
@@ -92,39 +92,39 @@ adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) 
  * @return Blob
  */
 adapt.net.makeBlob = function(parts, opt_type) {
-	var type = opt_type || "application/octet-stream";
-	var builderCtr = window["WebKitBlobBuilder"] || window["MSBlobBuilder"]; // deprecated
-	if (builderCtr) {
-		var builder = new builderCtr();
-		for (var i = 0; i < parts.length; i++) {
-			builder.append(parts[i]);
-		}
-		return builder.getBlob(type);
-	}
-	return new Blob(parts, {type: type});
+    var type = opt_type || "application/octet-stream";
+    var builderCtr = window["WebKitBlobBuilder"] || window["MSBlobBuilder"]; // deprecated
+    if (builderCtr) {
+        var builder = new builderCtr();
+        for (var i = 0; i < parts.length; i++) {
+            builder.append(parts[i]);
+        }
+        return builder.getBlob(type);
+    }
+    return new Blob(parts, {type: type});
 };
 
 /**
  * @param {!Blob} blob
- * @return adapt.task.Result.<ArrayBuffer> 
+ * @return adapt.task.Result.<ArrayBuffer>
  */
 adapt.net.readBlob = function(blob) {
     /** @type {!adapt.task.Frame.<ArrayBuffer>} */ var frame =
-    	adapt.task.newFrame("readBlob");
-	var fileReader = new FileReader();
+        adapt.task.newFrame("readBlob");
+    var fileReader = new FileReader();
     var continuation = frame.suspend(fileReader);
-	fileReader.addEventListener("load", function() {
-		continuation.schedule(/** @type {ArrayBuffer} */ (fileReader.result));
-	}, false);
-	fileReader.readAsArrayBuffer(blob);
-	return frame.result();
+    fileReader.addEventListener("load", function() {
+        continuation.schedule(/** @type {ArrayBuffer} */ (fileReader.result));
+    }, false);
+    fileReader.readAsArrayBuffer(blob);
+    return frame.result();
 };
 
 /**
  * @param {string} url
  */
 adapt.net.revokeObjectURL = function(url) {
-	(window["URL"] || window["webkitURL"]).revokeObjectURL(url);	
+    (window["URL"] || window["webkitURL"]).revokeObjectURL(url);
 };
 
 /**
@@ -132,7 +132,7 @@ adapt.net.revokeObjectURL = function(url) {
  * @return {string} url
  */
 adapt.net.createObjectURL = function(blob) {
-	return (window["URL"] || window["webkitURL"]).createObjectURL(blob);
+    return (window["URL"] || window["webkitURL"]).createObjectURL(blob);
 };
 
 /**
@@ -142,10 +142,10 @@ adapt.net.createObjectURL = function(blob) {
  * @param {adapt.net.XMLHttpRequestResponseType} type
  */
 adapt.net.ResourceStore = function(parser, type) {
-	/** @const */ this.parser = parser;
-	/** @const */ this.type = type;
-	/** @type {Object.<string,Resource>} */ this.resources = {};
-	/** @type {Object.<string,adapt.taskutil.Fetcher.<Resource>>} */ this.fetchers = {};
+    /** @const */ this.parser = parser;
+    /** @const */ this.type = type;
+    /** @type {Object.<string,Resource>} */ this.resources = {};
+    /** @type {Object.<string,adapt.taskutil.Fetcher.<Resource>>} */ this.fetchers = {};
 };
 
 /**
@@ -155,12 +155,12 @@ adapt.net.ResourceStore = function(parser, type) {
  * @return {!adapt.task.Result.<Resource>} resource for the given URL
  */
 adapt.net.ResourceStore.prototype.load = function(url, opt_required, opt_message) {
-	url = adapt.base.stripFragment(url);
-	var resource = this.resources[url];
-	if (typeof resource != "undefined") {
-		return adapt.task.newResult(resource);
-	}
-	return this.fetch(url, opt_required, opt_message).get();
+    url = adapt.base.stripFragment(url);
+    var resource = this.resources[url];
+    if (typeof resource != "undefined") {
+        return adapt.task.newResult(resource);
+    }
+    return this.fetch(url, opt_required, opt_message).get();
 };
 
 /**
@@ -171,19 +171,19 @@ adapt.net.ResourceStore.prototype.load = function(url, opt_required, opt_message
  * @return {!adapt.task.Result.<Resource>}
  */
 adapt.net.ResourceStore.prototype.fetchInner = function(url, opt_required, opt_message) {
-	var self = this;
-	/** @type {adapt.task.Frame.<Resource>} */ var frame = adapt.task.newFrame("fetch");
-	adapt.net.ajax(url, self.type).then(function(response) {
-		if (opt_required && response.status >= 400) {
-			throw new Error(opt_message || ("Failed to fetch required resource: " + url));
-		}
-    	self.parser(response, self).then(function(resource) {
+    var self = this;
+    /** @type {adapt.task.Frame.<Resource>} */ var frame = adapt.task.newFrame("fetch");
+    adapt.net.ajax(url, self.type).then(function(response) {
+        if (opt_required && response.status >= 400) {
+            throw new Error(opt_message || ("Failed to fetch required resource: " + url));
+        }
+        self.parser(response, self).then(function(resource) {
             delete self.fetchers[url];
             self.resources[url] = resource;
             frame.finish(resource);
-    	});
-	});
-	return frame.result();
+        });
+    });
+    return frame.result();
 };
 
 /**
@@ -193,21 +193,21 @@ adapt.net.ResourceStore.prototype.fetchInner = function(url, opt_required, opt_m
  * @return {adapt.taskutil.Fetcher.<Resource>} fetcher for the resource for the given URL
  */
 adapt.net.ResourceStore.prototype.fetch = function(url, opt_required, opt_message) {
-	url = adapt.base.stripFragment(url);
-	var resource = this.resources[url];
-	if (resource) {
-		return null;
-	}
-	var fetcher = this.fetchers[url];
-	if (!fetcher) {
-		var self = this;
-		fetcher = new adapt.taskutil.Fetcher(function() {
-			return self.fetchInner(url, opt_required, opt_message);
-		}, "Fetch " + url);
-		self.fetchers[url] = fetcher;
-		fetcher.start();
-	}
-	return fetcher;
+    url = adapt.base.stripFragment(url);
+    var resource = this.resources[url];
+    if (resource) {
+        return null;
+    }
+    var fetcher = this.fetchers[url];
+    if (!fetcher) {
+        var self = this;
+        fetcher = new adapt.taskutil.Fetcher(function() {
+            return self.fetchInner(url, opt_required, opt_message);
+        }, "Fetch " + url);
+        self.fetchers[url] = fetcher;
+        fetcher.start();
+    }
+    return fetcher;
 };
 
 /**
@@ -215,7 +215,7 @@ adapt.net.ResourceStore.prototype.fetch = function(url, opt_required, opt_messag
  * @return {adapt.xmldoc.XMLDocHolder}
  */
 adapt.net.ResourceStore.prototype.get = function(url) {
-	return this.resources[adapt.base.stripFragment(url)];
+    return this.resources[adapt.base.stripFragment(url)];
 };
 
 /**
@@ -229,13 +229,13 @@ adapt.net.JSONStore;
  * @return {!adapt.task.Result.<adapt.base.JSON>}
  */
 adapt.net.parseJSONResource = function(response, store) {
-	var text = response.responseText;
-	return adapt.task.newResult(text ? adapt.base.stringToJSON(text) : null);
+    var text = response.responseText;
+    return adapt.task.newResult(text ? adapt.base.stringToJSON(text) : null);
 };
 
 /**
  * return {adapt.net.JSONStore}
  */
 adapt.net.newJSONStore = function() {
-	return new adapt.net.ResourceStore(adapt.net.parseJSONResource, adapt.net.XMLHttpRequestResponseType.TEXT);
+    return new adapt.net.ResourceStore(adapt.net.parseJSONResource, adapt.net.XMLHttpRequestResponseType.TEXT);
 };

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -32,16 +32,16 @@ goog.require('vivliostyle.page');
  * @type {adapt.taskutil.Fetcher.<boolean>}
  */
 adapt.ops.uaStylesheetBaseFetcher = new adapt.taskutil.Fetcher(function() {
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame =
-		adapt.task.newFrame("uaStylesheetBase");
-	adapt.cssvalid.loadValidatorSet().then(function(validatorSet) {
-	    var url = adapt.base.resolveURL("user-agent-base.css", adapt.base.resourceBaseURL);
-	    var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
-	    		validatorSet, true);
-	    handler.startStylesheet(adapt.cssparse.StylesheetFlavor.USER_AGENT);
-	    adapt.csscasc.uaBaseCascade = handler.cascade;
-	    adapt.cssparse.parseStylesheetFromURL(url, handler, null, null).thenFinish(frame);
-	});
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame =
+        adapt.task.newFrame("uaStylesheetBase");
+    adapt.cssvalid.loadValidatorSet().then(function(validatorSet) {
+        var url = adapt.base.resolveURL("user-agent-base.css", adapt.base.resourceBaseURL);
+        var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
+            validatorSet, true);
+        handler.startStylesheet(adapt.cssparse.StylesheetFlavor.USER_AGENT);
+        adapt.csscasc.uaBaseCascade = handler.cascade;
+        adapt.cssparse.parseStylesheetFromURL(url, handler, null, null).thenFinish(frame);
+    });
     return frame.result();
 }, "uaStylesheetBaseFetcher");
 
@@ -49,7 +49,7 @@ adapt.ops.uaStylesheetBaseFetcher = new adapt.taskutil.Fetcher(function() {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.ops.loadUABase = function() {
-	return adapt.ops.uaStylesheetBaseFetcher.get();
+    return adapt.ops.uaStylesheetBaseFetcher.get();
 };
 
 
@@ -73,31 +73,31 @@ adapt.ops.FontFace;
  * @constructor
  */
 adapt.ops.Style = function(store, rootScope, pageScope, cascade, rootBox,
-		fontFaces, footnoteProps, flowProps, viewportProps, pageProps) {
-	/** @const */ this.store = store;
-	/** @const */ this.rootScope = rootScope;
-	/** @const */ this.pageScope = pageScope;
-	/** @const */ this.cascade = cascade;
-	/** @const */ this.rootBox = rootBox;
-	/** @const */ this.fontFaces = fontFaces;
-	/** @const */ this.fontDeobfuscator = store.fontDeobfuscator;
-	/** @const */ this.footnoteProps = footnoteProps;
-	/** @const */ this.flowProps = flowProps;
-	/** @const */ this.viewportProps = viewportProps;
-	/** @const */ this.pageProps = pageProps;
-	/** @const */ this.validatorSet = store.validatorSet;
+                           fontFaces, footnoteProps, flowProps, viewportProps, pageProps) {
+    /** @const */ this.store = store;
+    /** @const */ this.rootScope = rootScope;
+    /** @const */ this.pageScope = pageScope;
+    /** @const */ this.cascade = cascade;
+    /** @const */ this.rootBox = rootBox;
+    /** @const */ this.fontFaces = fontFaces;
+    /** @const */ this.fontDeobfuscator = store.fontDeobfuscator;
+    /** @const */ this.footnoteProps = footnoteProps;
+    /** @const */ this.flowProps = flowProps;
+    /** @const */ this.viewportProps = viewportProps;
+    /** @const */ this.pageProps = pageProps;
+    /** @const */ this.validatorSet = store.validatorSet;
     this.pageScope.defineBuiltIn("has-content", function(name) {
-		name = /** @type {string} */ (name);
-		var styleInstance = /** @type {adapt.ops.StyleInstance} */ (this);
-		var cp = styleInstance.currentLayoutPosition;
-		var flowChunk = cp.firstFlowChunkOfFlow(name);
-		return styleInstance.matchPageSide(cp.startSideOfFlow(/** @type {string} */ (name))) &&
-			cp.hasContent(/** @type {string} */ (name), styleInstance.lookupOffset) &&
-			!!flowChunk && !styleInstance.flowChunkIsAfterParentFlowForcedBreak(flowChunk);
+        name = /** @type {string} */ (name);
+        var styleInstance = /** @type {adapt.ops.StyleInstance} */ (this);
+        var cp = styleInstance.currentLayoutPosition;
+        var flowChunk = cp.firstFlowChunkOfFlow(name);
+        return styleInstance.matchPageSide(cp.startSideOfFlow(/** @type {string} */ (name))) &&
+            cp.hasContent(/** @type {string} */ (name), styleInstance.lookupOffset) &&
+            !!flowChunk && !styleInstance.flowChunkIsAfterParentFlowForcedBreak(flowChunk);
     });
     this.pageScope.defineName("page-number", new adapt.expr.Native(this.pageScope, function() {
-    	var styleInstance = /** @type {adapt.ops.StyleInstance} */ (this);
-    	return styleInstance.pageNumberOffset + styleInstance.currentLayoutPosition.page;
+        var styleInstance = /** @type {adapt.ops.StyleInstance} */ (this);
+        return styleInstance.pageNumberOffset + styleInstance.currentLayoutPosition.page;
     }, "page-number"));
 };
 
@@ -108,33 +108,33 @@ adapt.ops.Style = function(store, rootScope, pageScope, cascade, rootBox,
  * @return {{width:number, height:number, fontSize:number}}
  */
 adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight, fontSize) {
-	if (this.viewportProps.length) {
-		var context = new adapt.expr.Context(this.rootScope, viewportWidth,
-				viewportHeight, fontSize);
-		var viewportProps = adapt.csscasc.mergeAll(context, this.viewportProps);
-		var width = viewportProps["width"];
-		var height = viewportProps["height"];
-		var textZoom = viewportProps["text-zoom"];
-		var scaleFactor = 1;
-		if ((width && height) || textZoom) {
-			var defaultFontSize = adapt.expr.defaultUnitSizes["em"];
-			var zoomVal = textZoom ? textZoom.evaluate(context, "text-zoom") : null;
-			if (zoomVal === adapt.css.ident.scale) {
-				scaleFactor = defaultFontSize / fontSize;
-				fontSize = defaultFontSize;
-				viewportWidth *= scaleFactor;
-				viewportHeight *= scaleFactor;
-			}
-			if (width && height) {
-				var widthVal = adapt.css.toNumber(width.evaluate(context, "width"), context);
-				var heightVal = adapt.css.toNumber(height.evaluate(context, "height"), context);
-				if (widthVal > 0 && heightVal > 0) {
-					return {width:widthVal, height:heightVal, fontSize: fontSize};		
-				}
-			}
-		}
-	}
-	return {width:viewportWidth, height:viewportHeight, fontSize:fontSize};	
+    if (this.viewportProps.length) {
+        var context = new adapt.expr.Context(this.rootScope, viewportWidth,
+            viewportHeight, fontSize);
+        var viewportProps = adapt.csscasc.mergeAll(context, this.viewportProps);
+        var width = viewportProps["width"];
+        var height = viewportProps["height"];
+        var textZoom = viewportProps["text-zoom"];
+        var scaleFactor = 1;
+        if ((width && height) || textZoom) {
+            var defaultFontSize = adapt.expr.defaultUnitSizes["em"];
+            var zoomVal = textZoom ? textZoom.evaluate(context, "text-zoom") : null;
+            if (zoomVal === adapt.css.ident.scale) {
+                scaleFactor = defaultFontSize / fontSize;
+                fontSize = defaultFontSize;
+                viewportWidth *= scaleFactor;
+                viewportHeight *= scaleFactor;
+            }
+            if (width && height) {
+                var widthVal = adapt.css.toNumber(width.evaluate(context, "width"), context);
+                var heightVal = adapt.css.toNumber(height.evaluate(context, "height"), context);
+                if (widthVal > 0 && heightVal > 0) {
+                    return {width:widthVal, height:heightVal, fontSize: fontSize};
+                }
+            }
+        }
+    }
+    return {width:viewportWidth, height:viewportHeight, fontSize:fontSize};
 };
 
 //-------------------------------------------------------------------------------
@@ -157,47 +157,47 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @implements {adapt.pm.InstanceHolder}
  * @implements {adapt.vgen.StylerProducer}
  */
-adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientLayout, 
-		fontMapper, customRenderer, fallbackMap, pageNumberOffset, documentURLTransformer, counterStore) {
-	adapt.expr.Context.call(this, style.rootScope, viewport.width, viewport.height, viewport.fontSize);
-	/** @const */ this.style = style;
-	/** @const */ this.xmldoc = xmldoc;
-	/** @const */ this.lang = xmldoc.lang || defaultLang;
-	/** @const */ this.viewport = viewport;
+adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientLayout,
+                                   fontMapper, customRenderer, fallbackMap, pageNumberOffset, documentURLTransformer, counterStore) {
+    adapt.expr.Context.call(this, style.rootScope, viewport.width, viewport.height, viewport.fontSize);
+    /** @const */ this.style = style;
+    /** @const */ this.xmldoc = xmldoc;
+    /** @const */ this.lang = xmldoc.lang || defaultLang;
+    /** @const */ this.viewport = viewport;
     /** @const */ this.primaryFlows = /** @type {Object.<string,boolean>} */ ({ "body": true });
     /** @const */ this.clientLayout = clientLayout;
     /** @type {adapt.pm.RootPageBoxInstance} */ this.rootPageBoxInstance = null;
     /** @type {adapt.cssstyler.Styler} */ this.styler = null;
     /** @type {Object.<string,adapt.cssstyler.Styler>} */ this.stylerMap = null;
     /** @type {adapt.vtree.LayoutPosition} */ this.currentLayoutPosition = null;
-	/** @type {adapt.vtree.LayoutPosition} */ this.layoutPositionAtPageStart = null;
+    /** @type {adapt.vtree.LayoutPosition} */ this.layoutPositionAtPageStart = null;
     /** @type {number} */ this.lookupOffset = 0;
     /** @const */ this.fontMapper = fontMapper;
     /** @const */ this.faces = new adapt.font.DocumentFaces(this.style.fontDeobfuscator);
     /** @type {Object.<string,adapt.pm.PageBoxInstance>} */ this.pageBoxInstances = {};
     /** @type {vivliostyle.page.PageManager} */ this.pageManager = null;
-	/** @const */ this.counterStore = counterStore;
+    /** @const */ this.counterStore = counterStore;
     /** @type {boolean} */ this.regionBreak = false;
     /** @type {!Object.<string,boolean>} */ this.pageBreaks = {};
     /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
     /** @const */ this.customRenderer = customRenderer;
     /** @const */ this.fallbackMap = fallbackMap;
-	/** @const @type {number} */ this.pageNumberOffset = pageNumberOffset;
-	/** @const */ this.documentURLTransformer = documentURLTransformer;
+    /** @const @type {number} */ this.pageNumberOffset = pageNumberOffset;
+    /** @const */ this.documentURLTransformer = documentURLTransformer;
     for (var flowName in style.flowProps) {
-    	var flowStyle = style.flowProps[flowName];
-    	var consume = adapt.csscasc.getProp(flowStyle, "flow-consume");
-    	if (consume) {
-    		var consumeVal = consume.evaluate(this, "flow-consume");
-    		if (consumeVal == adapt.css.ident.all) {
-    			this.primaryFlows[flowName] = true;
-    		} else {
-    			delete this.primaryFlows[flowName];
-    		}
-    	}
+        var flowStyle = style.flowProps[flowName];
+        var consume = adapt.csscasc.getProp(flowStyle, "flow-consume");
+        if (consume) {
+            var consumeVal = consume.evaluate(this, "flow-consume");
+            if (consumeVal == adapt.css.ident.all) {
+                this.primaryFlows[flowName] = true;
+            } else {
+                delete this.primaryFlows[flowName];
+            }
+        }
     }
 
-	/** @const {!Object<string, !{width: number, height: number}>} */ this.pageSheetSize = {};
+    /** @const {!Object<string, !{width: number, height: number}>} */ this.pageSheetSize = {};
 };
 goog.inherits(adapt.ops.StyleInstance, adapt.expr.Context);
 
@@ -207,12 +207,12 @@ goog.inherits(adapt.ops.StyleInstance, adapt.expr.Context);
 adapt.ops.StyleInstance.prototype.init = function() {
     var self = this;
     /** @type {!adapt.task.Frame.<boolean>} */ var frame
-    	= adapt.task.newFrame("StyleInstance.init");
-	var counterListener = self.counterStore.createCounterListener(self.xmldoc.url);
-	var counterResolver = self.counterStore.createCounterResolver(self.xmldoc.url, self.style.rootScope, self.style.pageScope);
+        = adapt.task.newFrame("StyleInstance.init");
+    var counterListener = self.counterStore.createCounterListener(self.xmldoc.url);
+    var counterResolver = self.counterStore.createCounterResolver(self.xmldoc.url, self.style.rootScope, self.style.pageScope);
     self.styler = new adapt.cssstyler.Styler(self.xmldoc, self.style.cascade,
-    		self.style.rootScope, self, this.primaryFlows, self.style.validatorSet, counterListener, counterResolver);
-	counterResolver.setStyler(self.styler);
+        self.style.rootScope, self, this.primaryFlows, self.style.validatorSet, counterListener, counterResolver);
+    counterResolver.setStyler(self.styler);
     self.styler.resetFlowChunkStream(self);
     self.stylerMap = {};
     self.stylerMap[self.xmldoc.url] = self.styler;
@@ -226,59 +226,59 @@ adapt.ops.StyleInstance.prototype.init = function() {
     this.pageManager = new vivliostyle.page.PageManager(cascadeInstance, this.style.pageScope, this.rootPageBoxInstance, self, docElementStyle);
     var srcFaces = /** @type {Array.<adapt.font.Face>} */ ([]);
     for (var i = 0; i < self.style.fontFaces.length; i++) {
-    	var fontFace = self.style.fontFaces[i];
-    	if (fontFace.condition && !fontFace.condition.evaluate(self))
-    		continue;
-    	var properties = adapt.font.prepareProperties(fontFace.properties, self);
-    	var srcFace = new adapt.font.Face(properties);
-    	srcFaces.push(srcFace);
+        var fontFace = self.style.fontFaces[i];
+        if (fontFace.condition && !fontFace.condition.evaluate(self))
+            continue;
+        var properties = adapt.font.prepareProperties(fontFace.properties, self);
+        var srcFace = new adapt.font.Face(properties);
+        srcFaces.push(srcFace);
     }
-	self.fontMapper.findOrLoadFonts(srcFaces, self.faces).thenFinish(frame);
+    self.fontMapper.findOrLoadFonts(srcFaces, self.faces).thenFinish(frame);
 
-	// Determine page sheet sizes corresponding to page selectors
-	var pageProps = self.style.pageProps;
-	Object.keys(pageProps).forEach(function(selector) {
-		var pageSizeAndBleed = vivliostyle.page.evaluatePageSizeAndBleed(
-			vivliostyle.page.resolvePageSizeAndBleed(pageProps[selector]), this);
-		this.pageSheetSize[selector] = {
-			width: pageSizeAndBleed.pageWidth + pageSizeAndBleed.cropOffset * 2,
-			height: pageSizeAndBleed.pageHeight + pageSizeAndBleed.cropOffset * 2
-		};
-	}, this);
+    // Determine page sheet sizes corresponding to page selectors
+    var pageProps = self.style.pageProps;
+    Object.keys(pageProps).forEach(function(selector) {
+        var pageSizeAndBleed = vivliostyle.page.evaluatePageSizeAndBleed(
+            vivliostyle.page.resolvePageSizeAndBleed(pageProps[selector]), this);
+        this.pageSheetSize[selector] = {
+            width: pageSizeAndBleed.pageWidth + pageSizeAndBleed.cropOffset * 2,
+            height: pageSizeAndBleed.pageHeight + pageSizeAndBleed.cropOffset * 2
+        };
+    }, this);
 
-	return frame.result();
+    return frame.result();
 };
 
 /**
  * @override
  */
 adapt.ops.StyleInstance.prototype.getStylerForDoc = function(xmldoc) {
-	var styler = this.stylerMap[xmldoc.url];
-	if (!styler) {
-		var style = this.style.store.getStyleForDoc(xmldoc);
-		// We need a separate content, so that variables can get potentially different values.
-		var context = new adapt.expr.Context(style.rootScope, this.pageWidth(), this.pageHeight(), this.initialFontSize);
-		var counterListener = this.counterStore.createCounterListener(xmldoc.url);
-		var counterResolver = this.counterStore.createCounterResolver(xmldoc.url, style.rootScope, style.pageScope);
-		styler = new adapt.cssstyler.Styler(xmldoc, style.cascade,
-        		style.rootScope, context, this.primaryFlows, style.validatorSet, counterListener, counterResolver);
-		this.stylerMap[xmldoc.url] = styler;
-	}
-	return styler;
+    var styler = this.stylerMap[xmldoc.url];
+    if (!styler) {
+        var style = this.style.store.getStyleForDoc(xmldoc);
+        // We need a separate content, so that variables can get potentially different values.
+        var context = new adapt.expr.Context(style.rootScope, this.pageWidth(), this.pageHeight(), this.initialFontSize);
+        var counterListener = this.counterStore.createCounterListener(xmldoc.url);
+        var counterResolver = this.counterStore.createCounterResolver(xmldoc.url, style.rootScope, style.pageScope);
+        styler = new adapt.cssstyler.Styler(xmldoc, style.cascade,
+            style.rootScope, context, this.primaryFlows, style.validatorSet, counterListener, counterResolver);
+        this.stylerMap[xmldoc.url] = styler;
+    }
+    return styler;
 };
 
 /**
  * @override
  */
 adapt.ops.StyleInstance.prototype.registerInstance = function(key, instance) {
-	this.pageBoxInstances[key] = instance;
+    this.pageBoxInstances[key] = instance;
 };
 
 /**
  * @override
  */
 adapt.ops.StyleInstance.prototype.lookupInstance = function(key) {
-	return this.pageBoxInstances[key];
+    return this.pageBoxInstances[key];
 };
 
 /**
@@ -287,20 +287,20 @@ adapt.ops.StyleInstance.prototype.lookupInstance = function(key) {
 adapt.ops.StyleInstance.prototype.encounteredFlowChunk = function(flowChunk, flow) {
     var cp = this.currentLayoutPosition;
     if (cp) {
-		if (!cp.flows[flowChunk.flowName]) {
-			cp.flows[flowChunk.flowName] = flow;
-		} else {
-			flow = cp.flows[flowChunk.flowName];
-		}
-	    var flowPosition = cp.flowPositions[flowChunk.flowName];
-	    if (!flowPosition) {
-	        flowPosition = new adapt.vtree.FlowPosition();
-	        cp.flowPositions[flowChunk.flowName] = flowPosition;
-	    }
-	    var nodePosition = adapt.vtree.newNodePositionFromNode(flowChunk.element);
-	    var chunkPosition = new adapt.vtree.ChunkPosition(nodePosition);
-	    var flowChunkPosition = new adapt.vtree.FlowChunkPosition(chunkPosition, flowChunk);
-	    flowPosition.positions.push(flowChunkPosition);
+        if (!cp.flows[flowChunk.flowName]) {
+            cp.flows[flowChunk.flowName] = flow;
+        } else {
+            flow = cp.flows[flowChunk.flowName];
+        }
+        var flowPosition = cp.flowPositions[flowChunk.flowName];
+        if (!flowPosition) {
+            flowPosition = new adapt.vtree.FlowPosition();
+            cp.flowPositions[flowChunk.flowName] = flowPosition;
+        }
+        var nodePosition = adapt.vtree.newNodePositionFromNode(flowChunk.element);
+        var chunkPosition = new adapt.vtree.ChunkPosition(nodePosition);
+        var flowChunkPosition = new adapt.vtree.FlowChunkPosition(chunkPosition, flowChunk);
+        flowPosition.positions.push(flowChunkPosition);
     }
 };
 
@@ -317,10 +317,10 @@ adapt.ops.StyleInstance.prototype.getConsumedOffset = function(flowPosition) {
         var after = pos.after;
         var k = 0;
         while (node.ownerDocument != this.xmldoc.document) {
-        	k++;
-        	node = pos.steps[k].node;
-        	after = false;
-        	offsetInNode = 0;
+            k++;
+            node = pos.steps[k].node;
+            after = false;
+            offsetInNode = 0;
         }
         var chunkOffset = this.xmldoc.getNodeOffset(node, offsetInNode, after);
         if (chunkOffset < offset)
@@ -334,19 +334,19 @@ adapt.ops.StyleInstance.prototype.getConsumedOffset = function(flowPosition) {
  * @return {number} document offset of the given layoutPosition
  */
 adapt.ops.StyleInstance.prototype.getPosition = function(layoutPosition) {
-	if (!layoutPosition)
-		return 0;
+    if (!layoutPosition)
+        return 0;
     var currentPosition = Number.POSITIVE_INFINITY;
     for (var flowName in this.primaryFlows) {
         var flowPosition = layoutPosition.flowPositions[flowName];
         if ((!flowPosition || flowPosition.positions.length == 0) && this.currentLayoutPosition) {
             this.styler.styleUntilFlowIsReached(flowName);
-        	flowPosition = this.currentLayoutPosition.flowPositions[flowName];
+            flowPosition = this.currentLayoutPosition.flowPositions[flowName];
             if (layoutPosition != this.currentLayoutPosition) {
-            	if (flowPosition) {
-            		flowPosition = flowPosition.clone();
-            		layoutPosition.flowPositions[flowName] = flowPosition;
-            	}
+                if (flowPosition) {
+                    flowPosition = flowPosition.clone();
+                    layoutPosition.flowPositions[flowName] = flowPosition;
+                }
             }
         }
         if (flowPosition) {
@@ -359,16 +359,16 @@ adapt.ops.StyleInstance.prototype.getPosition = function(layoutPosition) {
 };
 
 adapt.ops.StyleInstance.prototype.dumpLocation = function(position) {
-	vivliostyle.logging.logger.debug("Location - page", this.currentLayoutPosition.page);
-	vivliostyle.logging.logger.debug("  current:", position);
-	vivliostyle.logging.logger.debug("  lookup:", this.lookupOffset);
-	for (var flowName in this.currentLayoutPosition.flowPositions) {
-		var flowPosition = this.currentLayoutPosition.flowPositions[flowName];
-		for (var i = 0; i < flowPosition.positions.length; i++) {
-			var p = flowPosition.positions[i];
-			vivliostyle.logging.logger.debug("  Chunk", flowName + ":", p.flowChunk.startOffset);
-		}
-	}
+    vivliostyle.logging.logger.debug("Location - page", this.currentLayoutPosition.page);
+    vivliostyle.logging.logger.debug("  current:", position);
+    vivliostyle.logging.logger.debug("  lookup:", this.lookupOffset);
+    for (var flowName in this.currentLayoutPosition.flowPositions) {
+        var flowPosition = this.currentLayoutPosition.flowPositions[flowName];
+        for (var i = 0; i < flowPosition.positions.length; i++) {
+            var p = flowPosition.positions[i];
+            vivliostyle.logging.logger.debug("  Chunk", flowName + ":", p.flowChunk.startOffset);
+        }
+    }
 };
 
 /**
@@ -376,33 +376,33 @@ adapt.ops.StyleInstance.prototype.dumpLocation = function(position) {
  * @returns {boolean}
  */
 adapt.ops.StyleInstance.prototype.matchPageSide = function(side) {
-	switch (side) {
-		case "left":
-		case "right":
-		case "recto":
-		case "verso":
-			return /** @type {boolean} */ (new adapt.expr.Named(this.style.pageScope, side + "-page").evaluate(this));
-		default:
-			return true;
-	}
+    switch (side) {
+        case "left":
+        case "right":
+        case "recto":
+        case "verso":
+            return /** @type {boolean} */ (new adapt.expr.Named(this.style.pageScope, side + "-page").evaluate(this));
+        default:
+            return true;
+    }
 };
 
 /**
  * @param {!adapt.vtree.LayoutPosition} layoutPosition
  */
 adapt.ops.StyleInstance.prototype.updateStartSide = function(layoutPosition) {
-	for (var name in layoutPosition.flowPositions) {
-		var flowPos = layoutPosition.flowPositions[name];
-		if (flowPos && flowPos.positions.length > 0) {
-			var flowChunk = flowPos.positions[0].flowChunk;
-			if (this.getConsumedOffset(flowPos) === flowChunk.startOffset) {
-				var flowChunkBreakBefore = flowPos.positions[0].flowChunk.breakBefore;
-				var flowBreakAfter = vivliostyle.break.startSideValueToBreakValue(flowPos.startSide);
-				flowPos.startSide = vivliostyle.break.breakValueToStartSideValue(
-					vivliostyle.break.resolveEffectiveBreakValue(flowBreakAfter, flowChunkBreakBefore));
-			}
-		}
-	}
+    for (var name in layoutPosition.flowPositions) {
+        var flowPos = layoutPosition.flowPositions[name];
+        if (flowPos && flowPos.positions.length > 0) {
+            var flowChunk = flowPos.positions[0].flowChunk;
+            if (this.getConsumedOffset(flowPos) === flowChunk.startOffset) {
+                var flowChunkBreakBefore = flowPos.positions[0].flowChunk.breakBefore;
+                var flowBreakAfter = vivliostyle.break.startSideValueToBreakValue(flowPos.startSide);
+                flowPos.startSide = vivliostyle.break.breakValueToStartSideValue(
+                    vivliostyle.break.resolveEffectiveBreakValue(flowBreakAfter, flowChunkBreakBefore));
+            }
+        }
+    }
 };
 
 /**
@@ -410,16 +410,16 @@ adapt.ops.StyleInstance.prototype.updateStartSide = function(layoutPosition) {
  * @return {adapt.pm.PageMasterInstance}
  */
 adapt.ops.StyleInstance.prototype.selectPageMaster = function(cascadedPageStyle) {
-	var self = this;
+    var self = this;
     var cp = this.currentLayoutPosition;
     // 3.5. Page Layout Processing Model
     // 1. Determine current position in the document: Find the minimal consumed-offset for all elements
     // not fully-consumed in each primary flow. Current position is maximum of the results among all
     // primary flows.
     var currentPosition = this.getPosition(cp);
-    if (currentPosition == Number.POSITIVE_INFINITY ) {
-    	// end of primary content is reached
-    	return null;
+    if (currentPosition == Number.POSITIVE_INFINITY) {
+        // end of primary content is reached
+        return null;
     }
     // 2. Page master selection: for each page master:
     var pageMasters = /** @type {Array.<adapt.pm.PageMasterInstance>} */ (this.rootPageBoxInstance.children);
@@ -442,10 +442,10 @@ adapt.ops.StyleInstance.prototype.selectPageMaster = function(cascadedPageStyle)
         // it is is not marked as fully consumed and it comes in the document before the lookup position.
         // Feed lookupOffset and flow availability into the context
         this.lookupOffset = this.styler.styleUntil(currentPosition, lookup);
-		goog.asserts.assert(cp);
-		this.updateStartSide(cp);
-		// update layoutPositionAtPageStart since startSide of FlowChunks may be updated
-		this.layoutPositionAtPageStart = cp.clone();
+        goog.asserts.assert(cp);
+        this.updateStartSide(cp);
+        // update layoutPositionAtPageStart since startSide of FlowChunks may be updated
+        this.layoutPositionAtPageStart = cp.clone();
         this.initLingering();
         self.clearScope(this.style.pageScope);
         // C. Determine content availability. Flow has content available if it contains eligible elements.
@@ -454,7 +454,7 @@ adapt.ops.StyleInstance.prototype.selectPageMaster = function(cascadedPageStyle)
         // E. First enabled page master is used for the next page
         if (!enabled || enabled === adapt.css.ident._true) {
             if (goog.DEBUG) {
-            	this.dumpLocation(currentPosition);
+                this.dumpLocation(currentPosition);
             }
             // Apply @page rules
             return this.pageManager.getPageRulePageMaster(pageMaster, cascadedPageStyle);
@@ -468,31 +468,32 @@ adapt.ops.StyleInstance.prototype.selectPageMaster = function(cascadedPageStyle)
  * @returns {boolean}
  */
 adapt.ops.StyleInstance.prototype.flowChunkIsAfterParentFlowForcedBreak = function(flowChunk) {
-	var flows = this.layoutPositionAtPageStart.flows;
-	var parentFlowName = flows[flowChunk.flowName].parentFlowName;
-	if (parentFlowName) {
-		var startOffset = flowChunk.startOffset;
-		var forcedBreakOffsets = flows[parentFlowName].forcedBreakOffsets;
-		if (!forcedBreakOffsets.length || startOffset < forcedBreakOffsets[0]) {
-			return false;
-		}
-		var breakOffsetBeforeStartIndex = adapt.base.binarySearch(forcedBreakOffsets.length, function(i) {
-			return forcedBreakOffsets[i] > startOffset;
-		}) - 1;
-		var breakOffsetBeforeStart = forcedBreakOffsets[breakOffsetBeforeStartIndex];
-		var parentFlowPosition = this.layoutPositionAtPageStart.flowPositions[parentFlowName];
-		var parentStartOffset = this.getConsumedOffset(parentFlowPosition);
-		if (breakOffsetBeforeStart < parentStartOffset) {
-			return false;
-		}
-		if (parentStartOffset < breakOffsetBeforeStart) {
-			return true;
-		}
-		// Special case: parentStartOffset === breakOffsetBeforeStart
-		// In this case, the flowChunk can be used if the start side of the parent flow matches the current page side.
-		return !this.matchPageSide(parentFlowPosition.startSide);
-	}
-	return false;
+    var flows = this.layoutPositionAtPageStart.flows;
+    var parentFlowName = flows[flowChunk.flowName].parentFlowName;
+    if (parentFlowName) {
+        var startOffset = flowChunk.startOffset;
+        var forcedBreakOffsets = flows[parentFlowName].forcedBreakOffsets;
+        if (!forcedBreakOffsets.length || startOffset < forcedBreakOffsets[0]) {
+            return false;
+        }
+        var breakOffsetBeforeStartIndex = adapt.base.binarySearch(forcedBreakOffsets.length,
+                function(i) {
+                    return forcedBreakOffsets[i] > startOffset;
+                }) - 1;
+        var breakOffsetBeforeStart = forcedBreakOffsets[breakOffsetBeforeStartIndex];
+        var parentFlowPosition = this.layoutPositionAtPageStart.flowPositions[parentFlowName];
+        var parentStartOffset = this.getConsumedOffset(parentFlowPosition);
+        if (breakOffsetBeforeStart < parentStartOffset) {
+            return false;
+        }
+        if (parentStartOffset < breakOffsetBeforeStart) {
+            return true;
+        }
+        // Special case: parentStartOffset === breakOffsetBeforeStart
+        // In this case, the flowChunk can be used if the start side of the parent flow matches the current page side.
+        return !this.matchPageSide(parentFlowPosition.startSide);
+    }
+    return false;
 };
 
 /**
@@ -514,90 +515,90 @@ adapt.ops.StyleInstance.prototype.layoutColumn = function(region, flowName, regi
     }
     var self = this;
     /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("layoutColumn");
-	// Record indices of repeated positions and removed positions
+    // Record indices of repeated positions and removed positions
     var repeatedIndices = /** @type {Array.<number>} */ ([]);
-	var removedIndices = /** @type {Array.<number>} */ ([]);
-	var leadingEdge = true;
+    var removedIndices = /** @type {Array.<number>} */ ([]);
+    var leadingEdge = true;
     frame.loopWithFrame(function(loopFrame) {
-	    while (flowPosition.positions.length - removedIndices.length > 0) {
-	        var index = 0;
-			// Skip all removed positions
-			while (removedIndices.indexOf(index) >= 0)
-				index++;
-	        var selected = flowPosition.positions[index];
-	        if (selected.flowChunk.startOffset > self.lookupOffset ||
-				self.flowChunkIsAfterParentFlowForcedBreak(selected.flowChunk))
-	            break;
-	        for (var k = index + 1; k < flowPosition.positions.length; k++) {
-				if (removedIndices.indexOf(k) >= 0) continue; // Skip removed positions
-	            var alt = flowPosition.positions[k];
-	            if (alt.flowChunk.startOffset > self.lookupOffset ||
-					self.flowChunkIsAfterParentFlowForcedBreak(alt.flowChunk))
-	                break;
-	            if (alt.flowChunk.isBetter(selected.flowChunk)) {
-	                selected = alt;
-	                index = k;
-	            }
-	        }
-	        var flowChunk = selected.flowChunk;
-	        var pending = true;
-	        region.layout(selected.chunkPosition, leadingEdge).then(function(newPosition) {
-		        leadingEdge = false;
-		        // static: keep in the flow
-		        if (selected.flowChunk.repeated && (newPosition === null || flowChunk.exclusive))
-		            repeatedIndices.push(index);
-		        if (flowChunk.exclusive) {
-		            // exclusive, only can have one, remove from the flow even if it did not fit
-					removedIndices.push(index);
-		        	loopFrame.breakLoop();
-		        	return;
-		        } else {
-		            // not exclusive
-		            if (newPosition) {
-		                // did not fit completely
-		                selected.chunkPosition = newPosition;
-		            } else {
-		                // go to the next element in the flow
-		                removedIndices.push(index);
-		            }
-		            if (region.pageBreakType) {
-		                // forced break
-		                flowPosition.startSide = vivliostyle.break.breakValueToStartSideValue(region.pageBreakType);
-		            }
-		            if (newPosition || region.pageBreakType) {
-		                loopFrame.breakLoop();
-		                return;
-		            }
-		        }
-		        if (pending) {
-		        	// Sync result
-		        	pending = false;
-		        } else {
-		        	// Async result
-		        	loopFrame.continueLoop();
-		        }
-	        });
-	        if (pending) {
-	        	// Async result
-	        	pending = false;
-	        	return; 
-	        }
-	        // Sync result
-	    }
-	    loopFrame.breakLoop();
+        while (flowPosition.positions.length - removedIndices.length > 0) {
+            var index = 0;
+            // Skip all removed positions
+            while (removedIndices.indexOf(index) >= 0)
+                index++;
+            var selected = flowPosition.positions[index];
+            if (selected.flowChunk.startOffset > self.lookupOffset ||
+                self.flowChunkIsAfterParentFlowForcedBreak(selected.flowChunk))
+                break;
+            for (var k = index + 1; k < flowPosition.positions.length; k++) {
+                if (removedIndices.indexOf(k) >= 0) continue; // Skip removed positions
+                var alt = flowPosition.positions[k];
+                if (alt.flowChunk.startOffset > self.lookupOffset ||
+                    self.flowChunkIsAfterParentFlowForcedBreak(alt.flowChunk))
+                    break;
+                if (alt.flowChunk.isBetter(selected.flowChunk)) {
+                    selected = alt;
+                    index = k;
+                }
+            }
+            var flowChunk = selected.flowChunk;
+            var pending = true;
+            region.layout(selected.chunkPosition, leadingEdge).then(function(newPosition) {
+                leadingEdge = false;
+                // static: keep in the flow
+                if (selected.flowChunk.repeated && (newPosition === null || flowChunk.exclusive))
+                    repeatedIndices.push(index);
+                if (flowChunk.exclusive) {
+                    // exclusive, only can have one, remove from the flow even if it did not fit
+                    removedIndices.push(index);
+                    loopFrame.breakLoop();
+                    return;
+                } else {
+                    // not exclusive
+                    if (newPosition) {
+                        // did not fit completely
+                        selected.chunkPosition = newPosition;
+                    } else {
+                        // go to the next element in the flow
+                        removedIndices.push(index);
+                    }
+                    if (region.pageBreakType) {
+                        // forced break
+                        flowPosition.startSide = vivliostyle.break.breakValueToStartSideValue(region.pageBreakType);
+                    }
+                    if (newPosition || region.pageBreakType) {
+                        loopFrame.breakLoop();
+                        return;
+                    }
+                }
+                if (pending) {
+                    // Sync result
+                    pending = false;
+                } else {
+                    // Async result
+                    loopFrame.continueLoop();
+                }
+            });
+            if (pending) {
+                // Async result
+                pending = false;
+                return;
+            }
+            // Sync result
+        }
+        loopFrame.breakLoop();
     }).then(function() {
-	    // Keep positions repeated or not removed
-		flowPosition.positions = flowPosition.positions.filter(function(pos, i) {
-			return repeatedIndices.indexOf(i) >= 0 || removedIndices.indexOf(i) < 0;
-		});
-	    frame.finish(true);
+        // Keep positions repeated or not removed
+        flowPosition.positions = flowPosition.positions.filter(function(pos, i) {
+            return repeatedIndices.indexOf(i) >= 0 || removedIndices.indexOf(i) < 0;
+        });
+        frame.finish(true);
     });
     return frame.result();
 };
 
 adapt.ops.StyleInstance.prototype.createLayoutConstraint = function() {
-	var pageIndex = this.currentLayoutPosition.page - 1;
-	return this.counterStore.createLayoutConstraint(pageIndex);
+    var pageIndex = this.currentLayoutPosition.page - 1;
+    return this.counterStore.createLayoutConstraint(pageIndex);
 };
 
 /**
@@ -610,21 +611,21 @@ adapt.ops.StyleInstance.prototype.createLayoutConstraint = function() {
  * @param {!vivliostyle.pagefloat.FloatHolder} pageFloatHolder
  * @return {adapt.task.Result.<boolean>} holding true
  */
-adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance, 
-		parentContainer, offsetX, offsetY, exclusions, pageFloatHolder) {
-	var self = this;
-	boxInstance.reset();
+adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
+                                                             parentContainer, offsetX, offsetY, exclusions, pageFloatHolder) {
+    var self = this;
+    boxInstance.reset();
     var enabled = boxInstance.getProp(self, "enabled");
     if (enabled && enabled !== adapt.css.ident._true) {
-    	return adapt.task.newResult(true);
+        return adapt.task.newResult(true);
     }
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame
-		= adapt.task.newFrame("layoutContainer");
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame
+        = adapt.task.newFrame("layoutContainer");
     var wrapFlow = boxInstance.getProp(self, "wrap-flow");
     var dontExclude = wrapFlow === adapt.css.ident.auto;
     var dontApplyExclusions = boxInstance.vertical
-    	? boxInstance.isAutoWidth && boxInstance.isRightDependentOnAutoWidth
-    	: boxInstance.isAutoHeight && boxInstance.isTopDependentOnAutoHeight;
+        ? boxInstance.isAutoWidth && boxInstance.isRightDependentOnAutoWidth
+        : boxInstance.isAutoHeight && boxInstance.isTopDependentOnAutoHeight;
     var flowName = boxInstance.getProp(self, "flow-from");
     var boxContainer = self.viewport.document.createElement("div");
     var position = boxInstance.getProp(self, "position");
@@ -638,24 +639,24 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
     offsetX += layoutContainer.left + layoutContainer.marginLeft + layoutContainer.borderLeft;
     offsetY += layoutContainer.top + layoutContainer.marginTop + layoutContainer.borderTop;
     var cont;
-	var removed = false;
+    var removed = false;
     if (!flowName || !flowName.isIdent()) {
-	    var contentVal = boxInstance.getProp(self, "content");
-	    if (contentVal && adapt.vtree.nonTrivialContent(contentVal)) {
-			var innerContainer = self.viewport.document.createElement("span");
-			contentVal.visit(new adapt.vtree.ContentPropertyHandler(innerContainer, self));
-			boxContainer.appendChild(innerContainer);
-			boxInstance.transferContentProps(self, layoutContainer, page, self.faces);
-		} else if (boxInstance.suppressEmptyBoxGeneration) {
-			parentContainer.removeChild(boxContainer);
-			removed = true;
-		}
-		if (!removed) {
-			boxInstance.finishContainer(self, layoutContainer, page, null, 1, self.clientLayout, self.faces);
-		}
-    	cont = adapt.task.newResult(true);
+        var contentVal = boxInstance.getProp(self, "content");
+        if (contentVal && adapt.vtree.nonTrivialContent(contentVal)) {
+            var innerContainer = self.viewport.document.createElement("span");
+            contentVal.visit(new adapt.vtree.ContentPropertyHandler(innerContainer, self));
+            boxContainer.appendChild(innerContainer);
+            boxInstance.transferContentProps(self, layoutContainer, page, self.faces);
+        } else if (boxInstance.suppressEmptyBoxGeneration) {
+            parentContainer.removeChild(boxContainer);
+            removed = true;
+        }
+        if (!removed) {
+            boxInstance.finishContainer(self, layoutContainer, page, null, 1, self.clientLayout, self.faces);
+        }
+        cont = adapt.task.newResult(true);
     } else if (!self.pageBreaks[flowName.toString()]) {
-    	/** @type {!adapt.task.Frame.<boolean>} */ var innerFrame = adapt.task.newFrame("layoutContainer.inner");
+        /** @type {!adapt.task.Frame.<boolean>} */ var innerFrame = adapt.task.newFrame("layoutContainer.inner");
         var flowNameStr = flowName.toString();
         // for now only a single column in vertical case
         var columnCount = boxInstance.getPropAsNumber(self, "column-count");
@@ -667,130 +668,130 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
         var computedBlockSize = 0;
         var innerShapeVal = boxInstance.getProp(self, "shape-inside");
         var innerShape = adapt.cssprop.toShape(innerShapeVal, 0, 0,
-        		layoutContainer.width, layoutContainer.height, self);
+            layoutContainer.width, layoutContainer.height, self);
         var layoutContext = new adapt.vgen.ViewFactory(flowNameStr, self,
-                self.viewport, self.styler, regionIds, self.xmldoc, self.faces,
-                self.style.footnoteProps, self, page, self.customRenderer,
-                self.fallbackMap, pageFloatHolder, this.documentURLTransformer);
-		var layoutConstraint = this.createLayoutConstraint();
+            self.viewport, self.styler, regionIds, self.xmldoc, self.faces,
+            self.style.footnoteProps, self, page, self.customRenderer,
+            self.fallbackMap, pageFloatHolder, this.documentURLTransformer);
+        var layoutConstraint = this.createLayoutConstraint();
         var columnIndex = 0;
         var region = null;
         frame.loopWithFrame(function(loopFrame) {
-	        while(columnIndex < columnCount) {
-	        	var column = columnIndex++;
-	            if (columnCount > 1) {
-	                var columnContainer = self.viewport.document.createElement("div");
-	                adapt.base.setCSSProperty(columnContainer, "position", "absolute");
-	                boxContainer.appendChild(columnContainer);
-	                region = new adapt.layout.Column(columnContainer, layoutContext, self.clientLayout, layoutConstraint);
-	                region.vertical = layoutContainer.vertical;
-	                region.snapHeight = layoutContainer.snapHeight;
-	                region.snapWidth = layoutContainer.snapWidth;
-	                if (layoutContainer.vertical) {
-		                adapt.base.setCSSProperty(columnContainer, "margin-left", layoutContainer.paddingLeft + "px");
-		                adapt.base.setCSSProperty(columnContainer, "margin-right", layoutContainer.paddingRight + "px");
-		                var columnY = column * (columnWidth + columnGap) + layoutContainer.paddingTop;
-		                region.setHorizontalPosition(0, layoutContainer.width);
-		                region.setVerticalPosition(columnY, columnWidth);	                	
-	                } else {
-		                adapt.base.setCSSProperty(columnContainer, "margin-top", layoutContainer.paddingTop + "px");
-		                adapt.base.setCSSProperty(columnContainer, "margin-bottom", layoutContainer.paddingBottom + "px");
-		                var columnX = column * (columnWidth + columnGap) + layoutContainer.paddingLeft;
-		                region.setVerticalPosition(0, layoutContainer.height);
-		                region.setHorizontalPosition(columnX, columnWidth);
-	                }
-	                region.originX = offsetX + layoutContainer.paddingLeft;
-	                region.originY = offsetY + layoutContainer.paddingTop;
-	            } else {
-	                region = new adapt.layout.Column(boxContainer, layoutContext, self.clientLayout, layoutConstraint);
-	                region.copyFrom(layoutContainer);
-	                layoutContainer = region;
-	            }
-	            region.exclusions = dontApplyExclusions ? [] : exclusions;
-	            region.innerShape = innerShape;
-	            var lr;
-	            if (region.width >= 0) {
-	                // region.element.style.outline = "1px dotted green";
-	            	/** @type {!adapt.task.Frame.<boolean>} */ var innerFrame = adapt.task.newFrame("inner");
-	                self.layoutColumn(region, flowNameStr, regionIds).then(function() {
-		                if (region.pageBreakType) {
-		                	if (region.pageBreakType != "column") {
-		                		// skip remaining columns
-		                		columnIndex = columnCount;
-		                		if (region.pageBreakType != "region") {
-		                			// skip remaining regions
-		                			self.pageBreaks[flowNameStr] = true;
-		                		}
-		                	}
-		                }
-		                innerFrame.finish(true);
-	                });
-	                lr = innerFrame.result();
-	            } else {
-	            	lr = adapt.task.newResult(true);
-	            }
-	            if (lr.isPending()) {
-					lr.then(function () {
-						if (pageFloatHolder.hasNewlyAddedFloats()) {
-							loopFrame.breakLoop();
-						} else {
-							computedBlockSize = Math.max(computedBlockSize, region.computedBlockSize);
-							loopFrame.continueLoop();
-						}
-					});
-					return;
-				} else if (!pageFloatHolder.hasNewlyAddedFloats()) {
-	            	computedBlockSize = Math.max(computedBlockSize, region.computedBlockSize);
-	            }
-	        }
-	        loopFrame.breakLoop();
+            while (columnIndex < columnCount) {
+                var column = columnIndex++;
+                if (columnCount > 1) {
+                    var columnContainer = self.viewport.document.createElement("div");
+                    adapt.base.setCSSProperty(columnContainer, "position", "absolute");
+                    boxContainer.appendChild(columnContainer);
+                    region = new adapt.layout.Column(columnContainer, layoutContext, self.clientLayout, layoutConstraint);
+                    region.vertical = layoutContainer.vertical;
+                    region.snapHeight = layoutContainer.snapHeight;
+                    region.snapWidth = layoutContainer.snapWidth;
+                    if (layoutContainer.vertical) {
+                        adapt.base.setCSSProperty(columnContainer, "margin-left", layoutContainer.paddingLeft + "px");
+                        adapt.base.setCSSProperty(columnContainer, "margin-right", layoutContainer.paddingRight + "px");
+                        var columnY = column * (columnWidth + columnGap) + layoutContainer.paddingTop;
+                        region.setHorizontalPosition(0, layoutContainer.width);
+                        region.setVerticalPosition(columnY, columnWidth);
+                    } else {
+                        adapt.base.setCSSProperty(columnContainer, "margin-top", layoutContainer.paddingTop + "px");
+                        adapt.base.setCSSProperty(columnContainer, "margin-bottom", layoutContainer.paddingBottom + "px");
+                        var columnX = column * (columnWidth + columnGap) + layoutContainer.paddingLeft;
+                        region.setVerticalPosition(0, layoutContainer.height);
+                        region.setHorizontalPosition(columnX, columnWidth);
+                    }
+                    region.originX = offsetX + layoutContainer.paddingLeft;
+                    region.originY = offsetY + layoutContainer.paddingTop;
+                } else {
+                    region = new adapt.layout.Column(boxContainer, layoutContext, self.clientLayout, layoutConstraint);
+                    region.copyFrom(layoutContainer);
+                    layoutContainer = region;
+                }
+                region.exclusions = dontApplyExclusions ? [] : exclusions;
+                region.innerShape = innerShape;
+                var lr;
+                if (region.width >= 0) {
+                    // region.element.style.outline = "1px dotted green";
+                    /** @type {!adapt.task.Frame.<boolean>} */ var innerFrame = adapt.task.newFrame("inner");
+                    self.layoutColumn(region, flowNameStr, regionIds).then(function() {
+                        if (region.pageBreakType) {
+                            if (region.pageBreakType != "column") {
+                                // skip remaining columns
+                                columnIndex = columnCount;
+                                if (region.pageBreakType != "region") {
+                                    // skip remaining regions
+                                    self.pageBreaks[flowNameStr] = true;
+                                }
+                            }
+                        }
+                        innerFrame.finish(true);
+                    });
+                    lr = innerFrame.result();
+                } else {
+                    lr = adapt.task.newResult(true);
+                }
+                if (lr.isPending()) {
+                    lr.then(function() {
+                        if (pageFloatHolder.hasNewlyAddedFloats()) {
+                            loopFrame.breakLoop();
+                        } else {
+                            computedBlockSize = Math.max(computedBlockSize, region.computedBlockSize);
+                            loopFrame.continueLoop();
+                        }
+                    });
+                    return;
+                } else if (!pageFloatHolder.hasNewlyAddedFloats()) {
+                    computedBlockSize = Math.max(computedBlockSize, region.computedBlockSize);
+                }
+            }
+            loopFrame.breakLoop();
         }).then(function() {
-	        layoutContainer.computedBlockSize = computedBlockSize;
-	        boxInstance.finishContainer(self, layoutContainer, page, region, 
-	        		columnCount, self.clientLayout, self.faces);
-	        innerFrame.finish(true);
+            layoutContainer.computedBlockSize = computedBlockSize;
+            boxInstance.finishContainer(self, layoutContainer, page, region,
+                columnCount, self.clientLayout, self.faces);
+            innerFrame.finish(true);
         });
         cont = innerFrame.result();
     } else {
         boxInstance.finishContainer(self, layoutContainer, page, null, 1, self.clientLayout, self.faces);
-    	cont = adapt.task.newResult(true);
+        cont = adapt.task.newResult(true);
     }
     cont.then(function() {
         if (!boxInstance.isAutoHeight || Math.floor(layoutContainer.computedBlockSize) > 0) {
-        	if (!removed && !dontExclude) {
-	            var outerX = layoutContainer.originX + layoutContainer.left;
-	            var outerY = layoutContainer.originY + layoutContainer.top;
-	            var outerWidth = layoutContainer.getInsetLeft() + layoutContainer.width + layoutContainer.getInsetRight();
-	            var outerHeight = layoutContainer.getInsetTop() + layoutContainer.height + layoutContainer.getInsetBottom();
-	            var outerShapeProp = boxInstance.getProp(self, "shape-outside");
-	            var outerShape = adapt.cssprop.toShape(outerShapeProp, outerX, outerY,
-	            		outerWidth, outerHeight, self);
-	            // Though it seems that LShapeFloatBug still exists in Firefox, it apparently does not occur on exclusion floats. See the test file: test/files/column-break-bug.html
-	            // if (adapt.base.checkLShapeFloatBug(self.viewport.root)) {
-	            // 	// Simplistic bug workaround: add a copy of the shape translated up.
-		        //     exclusions.push(outerShape.withOffset(0, -1.25 * self.queryUnitSize("em", false)));
-	            // }
-	            exclusions.push(outerShape);
-        	}
+            if (!removed && !dontExclude) {
+                var outerX = layoutContainer.originX + layoutContainer.left;
+                var outerY = layoutContainer.originY + layoutContainer.top;
+                var outerWidth = layoutContainer.getInsetLeft() + layoutContainer.width + layoutContainer.getInsetRight();
+                var outerHeight = layoutContainer.getInsetTop() + layoutContainer.height + layoutContainer.getInsetBottom();
+                var outerShapeProp = boxInstance.getProp(self, "shape-outside");
+                var outerShape = adapt.cssprop.toShape(outerShapeProp, outerX, outerY,
+                    outerWidth, outerHeight, self);
+                // Though it seems that LShapeFloatBug still exists in Firefox, it apparently does not occur on exclusion floats. See the test file: test/files/column-break-bug.html
+                // if (adapt.base.checkLShapeFloatBug(self.viewport.root)) {
+                // 	// Simplistic bug workaround: add a copy of the shape translated up.
+                //     exclusions.push(outerShape.withOffset(0, -1.25 * self.queryUnitSize("em", false)));
+                // }
+                exclusions.push(outerShape);
+            }
         } else if (boxInstance.children.length == 0) {
             parentContainer.removeChild(boxContainer);
             frame.finish(true);
             return;
         }
-	    var i = boxInstance.children.length - 1;
-	    frame.loop(function() {
-	    	while (i >= 0) {
-	    		var child = boxInstance.children[i--];
-		        var r = self.layoutContainer(page, child, /** @type {HTMLElement} */ (boxContainer),
-		             offsetX, offsetY, exclusions, pageFloatHolder);
-		        if (r.isPending()) {
-		        	return r;
-		        }
-	    	}
-	    	return adapt.task.newResult(false);
-	    }).then(function() {
-		    frame.finish(true);
-	    });
+        var i = boxInstance.children.length - 1;
+        frame.loop(function() {
+            while (i >= 0) {
+                var child = boxInstance.children[i--];
+                var r = self.layoutContainer(page, child, /** @type {HTMLElement} */ (boxContainer),
+                    offsetX, offsetY, exclusions, pageFloatHolder);
+                if (r.isPending()) {
+                    return r;
+                }
+            }
+            return adapt.task.newResult(false);
+        }).then(function() {
+            frame.finish(true);
+        });
     });
     return frame.result();
 };
@@ -799,13 +800,13 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance,
  * @return {void}
  */
 adapt.ops.StyleInstance.prototype.processLinger = function() {
-	var pageNumber = this.currentLayoutPosition.page;
+    var pageNumber = this.currentLayoutPosition.page;
     for (var flowName in this.currentLayoutPosition.flowPositions) {
         var flowPosition = this.currentLayoutPosition.flowPositions[flowName];
         for (var i = flowPosition.positions.length - 1; i >= 0; i--) {
             var pos = flowPosition.positions[i];
-            if (pos.flowChunk.startPage >= 0 && 
-            		pos.flowChunk.startPage + pos.flowChunk.linger - 1 <= pageNumber) {
+            if (pos.flowChunk.startPage >= 0 &&
+                pos.flowChunk.startPage + pos.flowChunk.linger - 1 <= pageNumber) {
                 flowPosition.positions.splice(i, 1);
             }
         }
@@ -816,13 +817,13 @@ adapt.ops.StyleInstance.prototype.processLinger = function() {
  * @return {void}
  */
 adapt.ops.StyleInstance.prototype.initLingering = function() {
-	var pageNumber = this.currentLayoutPosition.page;
+    var pageNumber = this.currentLayoutPosition.page;
     for (var flowName in this.currentLayoutPosition.flowPositions) {
         var flowPosition = this.currentLayoutPosition.flowPositions[flowName];
         for (var i = flowPosition.positions.length - 1; i >= 0; i--) {
             var pos = flowPosition.positions[i];
             if (pos.flowChunk.startPage < 0 && pos.flowChunk.startOffset < this.lookupOffset) {
-            	pos.flowChunk.startPage = pageNumber;
+                pos.flowChunk.startPage = pageNumber;
             }
         }
     }
@@ -833,13 +834,13 @@ adapt.ops.StyleInstance.prototype.initLingering = function() {
  * @return {boolean}
  */
 adapt.ops.StyleInstance.prototype.noMorePrimaryFlows = function(cp) {
-	for (var flowName in this.primaryFlows) {
-		var flowPosition = cp.flowPositions[flowName];
-		if (flowPosition && flowPosition.positions.length > 0) {
-			return false;
-		}
-	}
-	return true;
+    for (var flowName in this.primaryFlows) {
+        var flowPosition = cp.flowPositions[flowName];
+        if (flowPosition && flowPosition.positions.length > 0) {
+            return false;
+        }
+    }
+    return true;
 };
 
 /**
@@ -848,8 +849,8 @@ adapt.ops.StyleInstance.prototype.noMorePrimaryFlows = function(cp) {
  * @return {adapt.task.Result.<adapt.vtree.LayoutPosition>}
  */
 adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
-	var self = this;
-	self.pageBreaks = {};
+    var self = this;
+    self.pageBreaks = {};
     if (cp) {
         self.currentLayoutPosition = cp.clone();
         self.styler.replayFlowElementsFromOffset(cp.highestSeenOffset);
@@ -858,72 +859,72 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
         self.styler.replayFlowElementsFromOffset(-1);
     }
     if (this.lang) {
-    	page.bleedBox.setAttribute("lang", this.lang);
+        page.bleedBox.setAttribute("lang", this.lang);
     }
     cp = self.currentLayoutPosition;
     cp.page++;
     self.clearScope(self.style.pageScope);
-	self.layoutPositionAtPageStart = cp.clone();
+    self.layoutPositionAtPageStart = cp.clone();
 
     // Resolve page size before page master selection.
     var cascadedPageStyle = self.pageManager.getCascadedPageStyle();
     var pageMaster = self.selectPageMaster(cascadedPageStyle);
     if (!pageMaster) {
-    	// end of primary content
-    	return adapt.task.newResult(/** @type {adapt.vtree.LayoutPosition}*/ (null));
+        // end of primary content
+        return adapt.task.newResult(/** @type {adapt.vtree.LayoutPosition}*/ (null));
     }
 
     if (pageMaster.pageBox.specified["width"].value === adapt.css.fullWidth) {
-		page.setAutoPageWidth(true);
+        page.setAutoPageWidth(true);
     }
     if (pageMaster.pageBox.specified["height"].value === adapt.css.fullHeight) {
-		page.setAutoPageHeight(true);
+        page.setAutoPageHeight(true);
     }
-	self.counterStore.setCurrentPage(page);
-	self.counterStore.updatePageCounters(cascadedPageStyle, self);
+    self.counterStore.setCurrentPage(page);
+    self.counterStore.updatePageCounters(cascadedPageStyle, self);
 
-	// setup bleed area and crop marks
-	var evaluatedPageSizeAndBleed = vivliostyle.page.evaluatePageSizeAndBleed(
-		vivliostyle.page.resolvePageSizeAndBleed(cascadedPageStyle), this);
-	self.setPageSizeAndBleed(evaluatedPageSizeAndBleed, page);
-	vivliostyle.page.addPrinterMarks(cascadedPageStyle, evaluatedPageSizeAndBleed, page, this);
-	var bleedBoxPaddingEdge = evaluatedPageSizeAndBleed.bleedOffset + evaluatedPageSizeAndBleed.bleed;
+    // setup bleed area and crop marks
+    var evaluatedPageSizeAndBleed = vivliostyle.page.evaluatePageSizeAndBleed(
+        vivliostyle.page.resolvePageSizeAndBleed(cascadedPageStyle), this);
+    self.setPageSizeAndBleed(evaluatedPageSizeAndBleed, page);
+    vivliostyle.page.addPrinterMarks(cascadedPageStyle, evaluatedPageSizeAndBleed, page, this);
+    var bleedBoxPaddingEdge = evaluatedPageSizeAndBleed.bleedOffset + evaluatedPageSizeAndBleed.bleed;
 
-	var writingMode = pageMaster.getProp(self, "writing-mode") || adapt.css.ident.horizontal_tb;
-	var direction = pageMaster.getProp(self, "direction") || adapt.css.ident.ltr;
-	var pageFloatHolder = new vivliostyle.pagefloat.FloatHolder(page.getPageAreaElement.bind(page), writingMode, direction);
-	var exclusions = [];
+    var writingMode = pageMaster.getProp(self, "writing-mode") || adapt.css.ident.horizontal_tb;
+    var direction = pageMaster.getProp(self, "direction") || adapt.css.ident.ltr;
+    var pageFloatHolder = new vivliostyle.pagefloat.FloatHolder(page.getPageAreaElement.bind(page), writingMode, direction);
+    var exclusions = [];
 
     /** @type {!adapt.task.Frame.<adapt.vtree.LayoutPosition>} */ var frame
-    	= adapt.task.newFrame("layoutNextPage");
-	frame.loopWithFrame(function(loopFrame) {
-		self.layoutContainer(page, pageMaster, page.bleedBox, bleedBoxPaddingEdge, bleedBoxPaddingEdge, exclusions.concat(), pageFloatHolder).then(function() {
-			if (pageFloatHolder.hasNewlyAddedFloats()) {
-				exclusions = exclusions.concat(pageFloatHolder.getShapesOfNewlyAddedFloats());
-				pageFloatHolder.clearNewlyAddedFloats();
-				cp = self.currentLayoutPosition = self.layoutPositionAtPageStart.clone();
-				var c;
-				while (c = page.bleedBox.lastChild) {
-					page.bleedBox.removeChild(c);
-				}
-				loopFrame.continueLoop();
-			} else {
-				loopFrame.breakLoop();
-			}
-		});
-	}).then(function() {
-		pageMaster.adjustPageLayout(self, page, self.clientLayout);
+        = adapt.task.newFrame("layoutNextPage");
+    frame.loopWithFrame(function(loopFrame) {
+        self.layoutContainer(page, pageMaster, page.bleedBox, bleedBoxPaddingEdge, bleedBoxPaddingEdge, exclusions.concat(), pageFloatHolder).then(function() {
+            if (pageFloatHolder.hasNewlyAddedFloats()) {
+                exclusions = exclusions.concat(pageFloatHolder.getShapesOfNewlyAddedFloats());
+                pageFloatHolder.clearNewlyAddedFloats();
+                cp = self.currentLayoutPosition = self.layoutPositionAtPageStart.clone();
+                var c;
+                while (c = page.bleedBox.lastChild) {
+                    page.bleedBox.removeChild(c);
+                }
+                loopFrame.continueLoop();
+            } else {
+                loopFrame.breakLoop();
+            }
+        });
+    }).then(function() {
+        pageMaster.adjustPageLayout(self, page, self.clientLayout);
         var isLeftPage = new adapt.expr.Named(pageMaster.pageBox.scope, "left-page");
         page.side = isLeftPage.evaluate(self) ? vivliostyle.constants.PageSide.LEFT : vivliostyle.constants.PageSide.RIGHT;
-	    self.processLinger();
-	    self.currentLayoutPosition = self.layoutPositionAtPageStart = null;
-	    cp.highestSeenOffset = self.styler.getReachedOffset();
+        self.processLinger();
+        self.currentLayoutPosition = self.layoutPositionAtPageStart = null;
+        cp.highestSeenOffset = self.styler.getReachedOffset();
         var triggers = self.style.store.getTriggersForDoc(self.xmldoc);
-	    page.finish(triggers, self.clientLayout);
-	    if (self.noMorePrimaryFlows(cp)) {
-	    	cp = null;
-	    }
-	    frame.finish(cp);
+        page.finish(triggers, self.clientLayout);
+        if (self.noMorePrimaryFlows(cp)) {
+            cp = null;
+        }
+        frame.finish(cp);
     });
     return frame.result();
 };
@@ -935,15 +936,15 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
  * @param {adapt.vtree.Page} page
  */
 adapt.ops.StyleInstance.prototype.setPageSizeAndBleed = function(evaluatedPageSizeAndBleed, page) {
-	this.actualPageWidth = evaluatedPageSizeAndBleed.pageWidth;
-	this.actualPageHeight = evaluatedPageSizeAndBleed.pageHeight;
-	page.container.style.width = (evaluatedPageSizeAndBleed.pageWidth + evaluatedPageSizeAndBleed.cropOffset * 2) + "px";
-	page.container.style.height = (evaluatedPageSizeAndBleed.pageHeight + evaluatedPageSizeAndBleed.cropOffset * 2) + "px";
-	page.bleedBox.style.left = evaluatedPageSizeAndBleed.bleedOffset + "px";
-	page.bleedBox.style.right = evaluatedPageSizeAndBleed.bleedOffset + "px";
-	page.bleedBox.style.top = evaluatedPageSizeAndBleed.bleedOffset + "px";
-	page.bleedBox.style.bottom = evaluatedPageSizeAndBleed.bleedOffset + "px";
-	page.bleedBox.style.padding = evaluatedPageSizeAndBleed.bleed + "px";
+    this.actualPageWidth = evaluatedPageSizeAndBleed.pageWidth;
+    this.actualPageHeight = evaluatedPageSizeAndBleed.pageHeight;
+    page.container.style.width = (evaluatedPageSizeAndBleed.pageWidth + evaluatedPageSizeAndBleed.cropOffset * 2) + "px";
+    page.container.style.height = (evaluatedPageSizeAndBleed.pageHeight + evaluatedPageSizeAndBleed.cropOffset * 2) + "px";
+    page.bleedBox.style.left = evaluatedPageSizeAndBleed.bleedOffset + "px";
+    page.bleedBox.style.right = evaluatedPageSizeAndBleed.bleedOffset + "px";
+    page.bleedBox.style.top = evaluatedPageSizeAndBleed.bleedOffset + "px";
+    page.bleedBox.style.bottom = evaluatedPageSizeAndBleed.bleedOffset + "px";
+    page.bleedBox.style.padding = evaluatedPageSizeAndBleed.bleed + "px";
 };
 
 /**
@@ -955,8 +956,8 @@ adapt.ops.StyleInstance.prototype.setPageSizeAndBleed = function(evaluatedPageSi
  * @extends {adapt.csscasc.CascadeParserHandler}
  */
 adapt.ops.BaseParserHandler = function(masterHandler, condition, parent, regionId) {
-	adapt.csscasc.CascadeParserHandler.call(this, masterHandler.rootScope, masterHandler,
-			condition, parent, regionId, masterHandler.validatorSet, !parent);
+    adapt.csscasc.CascadeParserHandler.call(this, masterHandler.rootScope, masterHandler,
+        condition, parent, regionId, masterHandler.validatorSet, !parent);
     /** @type {adapt.ops.StyleParserHandler} */ this.masterHandler = masterHandler;
     /** @type {boolean} */ this.insideRegion = false;
 };
@@ -974,9 +975,9 @@ adapt.ops.BaseParserHandler.prototype.startPageTemplateRule = function() {
  */
 adapt.ops.BaseParserHandler.prototype.startPageMasterRule = function(name, pseudoName, classes) {
     var pageMaster = new adapt.pm.PageMaster(this.masterHandler.pageScope, name, pseudoName,
-    		classes, this.masterHandler.rootBox, this.condition, this.owner.getBaseSpecificity());
+        classes, this.masterHandler.rootBox, this.condition, this.owner.getBaseSpecificity());
     this.masterHandler.pushHandler(new adapt.pm.PageMasterParserHandler(pageMaster.scope,
-    		this.masterHandler, pageMaster, this.validatorSet));
+        this.masterHandler, pageMaster, this.validatorSet));
 };
 
 /**
@@ -987,7 +988,7 @@ adapt.ops.BaseParserHandler.prototype.startWhenRule = function(conditionVal) {
     if (this.condition != null)
         condition = adapt.expr.and(this.scope, this.condition, condition);
     this.masterHandler.pushHandler(new adapt.ops.BaseParserHandler(
-    		this.masterHandler, condition, this, this.regionId));
+        this.masterHandler, condition, this, this.regionId));
 };
 
 /**
@@ -995,60 +996,60 @@ adapt.ops.BaseParserHandler.prototype.startWhenRule = function(conditionVal) {
  */
 adapt.ops.BaseParserHandler.prototype.startDefineRule = function() {
     this.masterHandler.pushHandler(new adapt.csscasc.DefineParserHandler(
-    		this.scope, this.owner));
+        this.scope, this.owner));
 };
 
 /**
  * @override
  */
 adapt.ops.BaseParserHandler.prototype.startFontFaceRule = function() {
-	var properties = /** @type {adapt.csscasc.ElementStyle} */ ({});
-	this.masterHandler.fontFaces.push({properties: properties, condition: this.condition});
+    var properties = /** @type {adapt.csscasc.ElementStyle} */ ({});
+    this.masterHandler.fontFaces.push({properties: properties, condition: this.condition});
     this.masterHandler.pushHandler(new adapt.csscasc.PropSetParserHandler(
-    		this.scope, this.owner, null, properties, this.masterHandler.validatorSet));
+        this.scope, this.owner, null, properties, this.masterHandler.validatorSet));
 };
 
 /**
  * @override
  */
 adapt.ops.BaseParserHandler.prototype.startFlowRule = function(flowName) {
-	var style = this.masterHandler.flowProps[flowName];
-	if (!style) {
-		style = /** @type {adapt.csscasc.ElementStyle} */ ({});
-		this.masterHandler.flowProps[flowName] = style;
-	}
+    var style = this.masterHandler.flowProps[flowName];
+    if (!style) {
+        style = /** @type {adapt.csscasc.ElementStyle} */ ({});
+        this.masterHandler.flowProps[flowName] = style;
+    }
     this.masterHandler.pushHandler(new adapt.csscasc.PropSetParserHandler(
-    		this.scope, this.owner, null, style,
-    		this.masterHandler.validatorSet));
+        this.scope, this.owner, null, style,
+        this.masterHandler.validatorSet));
 };
 
 /**
  * @override
  */
 adapt.ops.BaseParserHandler.prototype.startViewportRule = function() {
-	var viewportProps = /** @type {adapt.csscasc.ElementStyle} */ ({});
-	this.masterHandler.viewportProps.push(viewportProps);
+    var viewportProps = /** @type {adapt.csscasc.ElementStyle} */ ({});
+    this.masterHandler.viewportProps.push(viewportProps);
     this.masterHandler.pushHandler(new adapt.csscasc.PropSetParserHandler(
-    		this.scope, this.owner, this.condition, viewportProps,
-    		this.masterHandler.validatorSet));
+        this.scope, this.owner, this.condition, viewportProps,
+        this.masterHandler.validatorSet));
 };
 
 /**
  * @override
  */
 adapt.ops.BaseParserHandler.prototype.startFootnoteRule = function(pseudoelement) {
-	var style = this.masterHandler.footnoteProps;
-	if (pseudoelement) {
-		var pseudos = adapt.csscasc.getMutableStyleMap(style, "_pseudos");
+    var style = this.masterHandler.footnoteProps;
+    if (pseudoelement) {
+        var pseudos = adapt.csscasc.getMutableStyleMap(style, "_pseudos");
         style = pseudos[pseudoelement];
         if (!style) {
             style = /** @type {adapt.csscasc.ElementStyle} */ ({});
             pseudos[pseudoelement] = style;
-        }		
-	}
+        }
+    }
     this.masterHandler.pushHandler(new adapt.csscasc.PropSetParserHandler(
-    		this.scope, this.owner, null, style,
-    		this.masterHandler.validatorSet));
+        this.scope, this.owner, null, style,
+        this.masterHandler.validatorSet));
 };
 
 /**
@@ -1079,8 +1080,8 @@ adapt.ops.BaseParserHandler.prototype.startRuleBody = function() {
         var regionId = "R" + this.masterHandler.regionCount++;
         this.special("region-id", adapt.css.getName(regionId));
         this.endRule();
-        var regionHandler = new adapt.ops.BaseParserHandler(this.masterHandler, this.condition, 
-        		this, regionId);
+        var regionHandler = new adapt.ops.BaseParserHandler(this.masterHandler, this.condition,
+            this, regionId);
         this.masterHandler.pushHandler(regionHandler);
         regionHandler.startRuleBody();
     }
@@ -1092,22 +1093,22 @@ adapt.ops.BaseParserHandler.prototype.startRuleBody = function() {
  * @return {string}
  */
 adapt.ops.processViewportMeta = function(meta) {
-	var content = meta.getAttribute("content");
-	if (!content) {
-		return "";
-	}
-	var vals = {};
-	var r;
-	while ((r = content.match(/^,?\s*([-A-Za-z_.][-A-Za-z_0-9.]*)\s*=\s*([-+A-Za-z_0-9.]*)\s*/)) != null) {
-		content = content.substr(r[0].length);
-		vals[r[1]] = r[2];
-	}
-	var width = vals["width"] - 0;
-	var height = vals["height"] - 0;
-	if (width && height) {
-		return "@-epubx-viewport{width:" + width + "px;height:" + height + "px;}";
-	}
-	return "";
+    var content = meta.getAttribute("content");
+    if (!content) {
+        return "";
+    }
+    var vals = {};
+    var r;
+    while ((r = content.match(/^,?\s*([-A-Za-z_.][-A-Za-z_0-9.]*)\s*=\s*([-+A-Za-z_0-9.]*)\s*/)) != null) {
+        content = content.substr(r[0].length);
+        vals[r[1]] = r[2];
+    }
+    var width = vals["width"] - 0;
+    var height = vals["height"] - 0;
+    if (width && height) {
+        return "@-epubx-viewport{width:" + width + "px;height:" + height + "px;}";
+    }
+    return "";
 };
 
 
@@ -1117,19 +1118,19 @@ adapt.ops.processViewportMeta = function(meta) {
  * @extends {adapt.cssparse.DispatchParserHandler}
  */
 adapt.ops.StyleParserHandler = function(validatorSet) {
-	adapt.cssparse.DispatchParserHandler.call(this);
-	/** @const */ this.validatorSet = validatorSet;
+    adapt.cssparse.DispatchParserHandler.call(this);
+    /** @const */ this.validatorSet = validatorSet;
     /** @const */ this.rootScope = new adapt.expr.LexicalScope(null);
     /** @const */ this.pageScope = new adapt.expr.LexicalScope(this.rootScope);
     /** @const */ this.rootBox = new adapt.pm.RootPageBox(this.rootScope);
     /** @const */ this.cascadeParserHandler =
-    	new adapt.ops.BaseParserHandler(this, null, null, null);
+        new adapt.ops.BaseParserHandler(this, null, null, null);
     /** @type {number} */ this.regionCount = 0;
-	/** @const */ this.fontFaces = /** @type {Array.<adapt.ops.FontFace>} */ ([]);
-	/** @const */ this.footnoteProps = /** @type {adapt.csscasc.ElementStyle} */ ({});
-	/** @const */ this.flowProps = /** @type {Object.<string,adapt.csscasc.ElementStyle>} */ ({});
-	/** @const */ this.viewportProps = /** @type {Array.<adapt.csscasc.ElementStyle>} */ ([]);
-	/** @const */ this.pageProps = /** @type {!Object.<string,!adapt.csscasc.ElementStyle>} */ ({});
+    /** @const */ this.fontFaces = /** @type {Array.<adapt.ops.FontFace>} */ ([]);
+    /** @const */ this.footnoteProps = /** @type {adapt.csscasc.ElementStyle} */ ({});
+    /** @const */ this.flowProps = /** @type {Object.<string,adapt.csscasc.ElementStyle>} */ ({});
+    /** @const */ this.viewportProps = /** @type {Array.<adapt.csscasc.ElementStyle>} */ ([]);
+    /** @const */ this.pageProps = /** @type {!Object.<string,!adapt.csscasc.ElementStyle>} */ ({});
 
     this.slave = this.cascadeParserHandler;
 };
@@ -1139,7 +1140,7 @@ goog.inherits(adapt.ops.StyleParserHandler, adapt.cssparse.DispatchParserHandler
  * @override
  */
 adapt.ops.StyleParserHandler.prototype.error = function(mnemonics, token) {
-	vivliostyle.logging.logger.warn("CSS parser:", mnemonics);
+    vivliostyle.logging.logger.warn("CSS parser:", mnemonics);
 };
 
 /**
@@ -1159,7 +1160,7 @@ adapt.ops.StyleSource;
  * @return {!adapt.task.Result.<adapt.xmldoc.XMLDocHolder>}
  */
 adapt.ops.parseOPSResource = function(response, store) {
-	return (/** @type {adapt.ops.OPSDocStore} */ (store)).parseOPSResource(response);
+    return (/** @type {adapt.ops.OPSDocStore} */ (store)).parseOPSResource(response);
 };
 
 /**
@@ -1168,13 +1169,13 @@ adapt.ops.parseOPSResource = function(response, store) {
  * @extends {adapt.xmldoc.XMLDocStore}
  */
 adapt.ops.OPSDocStore = function(fontDeobfuscator) {
-	adapt.net.ResourceStore.call(this, adapt.ops.parseOPSResource, adapt.net.XMLHttpRequestResponseType.DOCUMENT);
-	/** @type {?function(string):?function(Blob):adapt.task.Result.<Blob>} */ this.fontDeobfuscator = fontDeobfuscator;
-	/** @type {Object.<string,adapt.ops.Style>} */ this.styleByKey = {};
-	/** @type {Object.<string,adapt.taskutil.Fetcher.<adapt.ops.Style>>} */ this.styleFetcherByKey = {};
-	/** @type {Object.<string,adapt.ops.Style>} */ this.styleByDocURL = {};
-	/** @type {Object.<string,Array.<adapt.vtree.Trigger>>} */ this.triggersByDocURL = {};
-	/** @type {adapt.cssvalid.ValidatorSet} */ this.validatorSet = null;
+    adapt.net.ResourceStore.call(this, adapt.ops.parseOPSResource, adapt.net.XMLHttpRequestResponseType.DOCUMENT);
+    /** @type {?function(string):?function(Blob):adapt.task.Result.<Blob>} */ this.fontDeobfuscator = fontDeobfuscator;
+    /** @type {Object.<string,adapt.ops.Style>} */ this.styleByKey = {};
+    /** @type {Object.<string,adapt.taskutil.Fetcher.<adapt.ops.Style>>} */ this.styleFetcherByKey = {};
+    /** @type {Object.<string,adapt.ops.Style>} */ this.styleByDocURL = {};
+    /** @type {Object.<string,Array.<adapt.vtree.Trigger>>} */ this.triggersByDocURL = {};
+    /** @type {adapt.cssvalid.ValidatorSet} */ this.validatorSet = null;
     /** @private @const @type {Array.<adapt.ops.StyleSource>} */ this.userStyleSheets = [];
 };
 goog.inherits(adapt.ops.OPSDocStore, adapt.net.ResourceStore);
@@ -1185,14 +1186,14 @@ goog.inherits(adapt.ops.OPSDocStore, adapt.net.ResourceStore);
 adapt.ops.OPSDocStore.prototype.init = function() {
     var userAgentXML = adapt.base.resolveURL("user-agent.xml", adapt.base.resourceBaseURL);
     var frame = adapt.task.newFrame("OPSDocStore.init");
-	var self = this;
+    var self = this;
     adapt.cssvalid.loadValidatorSet().then(function(validatorSet) {
-    	self.validatorSet = validatorSet;
-    	adapt.ops.loadUABase().then(function() {
-    		self.load(userAgentXML).then(function() {
-    			frame.finish(true);
-    		});
-    	});
+        self.validatorSet = validatorSet;
+        adapt.ops.loadUABase().then(function() {
+            self.load(userAgentXML).then(function() {
+                frame.finish(true);
+            });
+        });
     });
     return frame.result();
 };
@@ -1202,7 +1203,7 @@ adapt.ops.OPSDocStore.prototype.init = function() {
  * @return {adapt.ops.Style}
  */
 adapt.ops.OPSDocStore.prototype.getStyleForDoc = function(xmldoc) {
-	return this.styleByDocURL[xmldoc.url];
+    return this.styleByDocURL[xmldoc.url];
 };
 
 /**
@@ -1210,7 +1211,7 @@ adapt.ops.OPSDocStore.prototype.getStyleForDoc = function(xmldoc) {
  * @return {Array.<adapt.vtree.Trigger>}
  */
 adapt.ops.OPSDocStore.prototype.getTriggersForDoc = function(xmldoc) {
-	return this.triggersByDocURL[xmldoc.url];
+    return this.triggersByDocURL[xmldoc.url];
 };
 
 /**
@@ -1227,66 +1228,66 @@ adapt.ops.OPSDocStore.prototype.addUserStyleSheet = function(stylesheet) {
  */
 adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
     /** @type {!adapt.task.Frame.<adapt.xmldoc.XMLDocHolder>} */ var frame
-    	= adapt.task.newFrame("OPSDocStore.load");
-	var self = this;
-	var url = response.url;
-	adapt.xmldoc.parseXMLResource(response, self).then(function(xmldoc) {
-		if (!xmldoc) {
-			frame.finish(null);
-			return;
-		}
-		var triggers = [];
-		var triggerList = xmldoc.document.getElementsByTagNameNS(adapt.base.NS.epub, "trigger");
-		for (var i = 0; i < triggerList.length; i++) {
-			var triggerElem = triggerList[i];
-			var observer = triggerElem.getAttributeNS(adapt.base.NS.EV, "observer");
-			var event = triggerElem.getAttributeNS(adapt.base.NS.EV, "event");
-			var action = triggerElem.getAttribute("action");
-			var ref = triggerElem.getAttribute("ref");
-			if (observer && event && action && ref) {
-				triggers.push({observer:observer, event:event, action:action, ref:ref});
-			}
-		}
-    	self.triggersByDocURL[url] = triggers;
-		var sources = /** @type {Array.<adapt.ops.StyleSource>} */ ([]);
-	    var userAgentURL = adapt.base.resolveURL("user-agent-page.css", adapt.base.resourceBaseURL);
-		sources.push({url: userAgentURL, text:null,
-			flavor:adapt.cssparse.StylesheetFlavor.USER_AGENT, classes: null, media: null});
+        = adapt.task.newFrame("OPSDocStore.load");
+    var self = this;
+    var url = response.url;
+    adapt.xmldoc.parseXMLResource(response, self).then(function(xmldoc) {
+        if (!xmldoc) {
+            frame.finish(null);
+            return;
+        }
+        var triggers = [];
+        var triggerList = xmldoc.document.getElementsByTagNameNS(adapt.base.NS.epub, "trigger");
+        for (var i = 0; i < triggerList.length; i++) {
+            var triggerElem = triggerList[i];
+            var observer = triggerElem.getAttributeNS(adapt.base.NS.EV, "observer");
+            var event = triggerElem.getAttributeNS(adapt.base.NS.EV, "event");
+            var action = triggerElem.getAttribute("action");
+            var ref = triggerElem.getAttribute("ref");
+            if (observer && event && action && ref) {
+                triggers.push({observer:observer, event:event, action:action, ref:ref});
+            }
+        }
+        self.triggersByDocURL[url] = triggers;
+        var sources = /** @type {Array.<adapt.ops.StyleSource>} */ ([]);
+        var userAgentURL = adapt.base.resolveURL("user-agent-page.css", adapt.base.resourceBaseURL);
+        sources.push({url: userAgentURL, text:null,
+            flavor:adapt.cssparse.StylesheetFlavor.USER_AGENT, classes: null, media: null});
         for (var i = 0; i < self.userStyleSheets.length; i++) {
             sources.push(self.userStyleSheets[i]);
         }
-	    var head = xmldoc.head;
-	    if (head) {
-	        for (var c = head.firstChild ; c ; c = c.nextSibling) {
-	        	if (c.nodeType != 1)
-	        		continue;
-	        	var child = /** @type {Element} */ (c);
-	        	var ns = child.namespaceURI;
-	        	var localName = child.localName;
-	        	if (ns == adapt.base.NS.XHTML) {
-		            if (localName == "style") {
-		                sources.push({url:url, text:child.textContent, 
-		                	flavor:adapt.cssparse.StylesheetFlavor.AUTHOR, classes: null, media: null});
-		            } else if (localName == "link") {
-		            	var rel = child.getAttribute("rel");
-		            	var classes = child.getAttribute("class");
-		            	var media = child.getAttribute("media");
-		            	if (rel == "stylesheet" || (rel == "alternate stylesheet" && classes)) {
-			            	var src = child.getAttribute("href");
-			            	src = adapt.base.resolveURL(src, url);
-			            	sources.push({url:src, text:null, classes: classes, media: media,
-			            		flavor:adapt.cssparse.StylesheetFlavor.AUTHOR});
-		            	}
-		            } else if (localName == "meta" && child.getAttribute("name") == "viewport") {
-		            	sources.push({url:url, text: adapt.ops.processViewportMeta(child),
-		            		flavor:adapt.cssparse.StylesheetFlavor.AUTHOR, condition: null, media: null});
-		            }
-	        	} else if (ns == adapt.base.NS.FB2) {
-		            if (localName == "stylesheet" && child.getAttribute("type") == "text/css") {
-		                sources.push({url:url, text:child.textContent, 
-		                	flavor:adapt.cssparse.StylesheetFlavor.AUTHOR, classes: null, media: null});
-		            }        		
-	        	} else if (ns == adapt.base.NS.SSE && localName === "property") {
+        var head = xmldoc.head;
+        if (head) {
+            for (var c = head.firstChild; c; c = c.nextSibling) {
+                if (c.nodeType != 1)
+                    continue;
+                var child = /** @type {Element} */ (c);
+                var ns = child.namespaceURI;
+                var localName = child.localName;
+                if (ns == adapt.base.NS.XHTML) {
+                    if (localName == "style") {
+                        sources.push({url:url, text:child.textContent,
+                            flavor:adapt.cssparse.StylesheetFlavor.AUTHOR, classes: null, media: null});
+                    } else if (localName == "link") {
+                        var rel = child.getAttribute("rel");
+                        var classes = child.getAttribute("class");
+                        var media = child.getAttribute("media");
+                        if (rel == "stylesheet" || (rel == "alternate stylesheet" && classes)) {
+                            var src = child.getAttribute("href");
+                            src = adapt.base.resolveURL(src, url);
+                            sources.push({url:src, text:null, classes: classes, media: media,
+                                flavor:adapt.cssparse.StylesheetFlavor.AUTHOR});
+                        }
+                    } else if (localName == "meta" && child.getAttribute("name") == "viewport") {
+                        sources.push({url:url, text: adapt.ops.processViewportMeta(child),
+                            flavor:adapt.cssparse.StylesheetFlavor.AUTHOR, condition: null, media: null});
+                    }
+                } else if (ns == adapt.base.NS.FB2) {
+                    if (localName == "stylesheet" && child.getAttribute("type") == "text/css") {
+                        sources.push({url:url, text:child.textContent,
+                            flavor:adapt.cssparse.StylesheetFlavor.AUTHOR, classes: null, media: null});
+                    }
+                } else if (ns == adapt.base.NS.SSE && localName === "property") {
                     // look for stylesheet specification like:
                     // <property><name>stylesheet</name><value>style.css</value></property>
                     var name = child.getElementsByTagName("name")[0];
@@ -1301,59 +1302,59 @@ adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
                         }
                     }
                 }
-	        }
-	    }
-	    var key = "";
-	    for (var i = 0; i < sources.length; i++) {
-	    	key += sources[i].url;
-	    	key += "^";
-	    	if (sources[i].text) {
-	    		key += sources[i].text;
-	    	}
-	    	key += "^";
-	    }
-	    var style = self.styleByKey[key];
-	    if (style) {
-	    	self.styleByDocURL[url] = style;
-	    	frame.finish(xmldoc);
-	    	return;
-	    }
-		var fetcher = self.styleFetcherByKey[key];
-		if (!fetcher) {
-			fetcher = new adapt.taskutil.Fetcher(function() {
-				/** @type {!adapt.task.Frame.<adapt.ops.Style>} */ var innerFrame
-					= adapt.task.newFrame("fetchStylesheet");
-		    	var index = 0;
-		    	var sph = new adapt.ops.StyleParserHandler(self.validatorSet);
-		    	innerFrame.loop(function() {
-		            if (index < sources.length) {
-		                var source = sources[index++];
-		                sph.startStylesheet(source.flavor);
-		                if (source.text !== null) {
-							return adapt.cssparse.parseStylesheetFromText(source.text, sph, source.url, source.classes, source.media).thenReturn(true);
-		                } else {
-		                    return adapt.cssparse.parseStylesheetFromURL(source.url, sph, source.classes, source.media);
-		                }
-		            }
-		            return adapt.task.newResult(false);
-		        }).then(function() {
-		        	var cascade = sph.cascadeParserHandler.finish();
-		        	style = new adapt.ops.Style(self, sph.rootScope, sph.pageScope, cascade, sph.rootBox,
-		        			sph.fontFaces, sph.footnoteProps, sph.flowProps, sph.viewportProps, sph.pageProps);
-			    	self.styleByKey[key] = style;
-			    	delete self.styleFetcherByKey[key];
-		        	innerFrame.finish(style);
-		        });
-		    	return innerFrame.result();
-			}, "FetchStylesheet " + url);
-			self.styleFetcherByKey[key] = fetcher;
-	        fetcher.start();
-		}
-		fetcher.get().then(function(style) {
-	    	self.styleByDocURL[url] = style;
-			frame.finish(xmldoc);			
-		});
-	});
+            }
+        }
+        var key = "";
+        for (var i = 0; i < sources.length; i++) {
+            key += sources[i].url;
+            key += "^";
+            if (sources[i].text) {
+                key += sources[i].text;
+            }
+            key += "^";
+        }
+        var style = self.styleByKey[key];
+        if (style) {
+            self.styleByDocURL[url] = style;
+            frame.finish(xmldoc);
+            return;
+        }
+        var fetcher = self.styleFetcherByKey[key];
+        if (!fetcher) {
+            fetcher = new adapt.taskutil.Fetcher(function() {
+                /** @type {!adapt.task.Frame.<adapt.ops.Style>} */ var innerFrame
+                    = adapt.task.newFrame("fetchStylesheet");
+                var index = 0;
+                var sph = new adapt.ops.StyleParserHandler(self.validatorSet);
+                innerFrame.loop(function() {
+                    if (index < sources.length) {
+                        var source = sources[index++];
+                        sph.startStylesheet(source.flavor);
+                        if (source.text !== null) {
+                            return adapt.cssparse.parseStylesheetFromText(source.text, sph, source.url, source.classes, source.media).thenReturn(true);
+                        } else {
+                            return adapt.cssparse.parseStylesheetFromURL(source.url, sph, source.classes, source.media);
+                        }
+                    }
+                    return adapt.task.newResult(false);
+                }).then(function() {
+                    var cascade = sph.cascadeParserHandler.finish();
+                    style = new adapt.ops.Style(self, sph.rootScope, sph.pageScope, cascade, sph.rootBox,
+                        sph.fontFaces, sph.footnoteProps, sph.flowProps, sph.viewportProps, sph.pageProps);
+                    self.styleByKey[key] = style;
+                    delete self.styleFetcherByKey[key];
+                    innerFrame.finish(style);
+                });
+                return innerFrame.result();
+            }, "FetchStylesheet " + url);
+            self.styleFetcherByKey[key] = fetcher;
+            fetcher.start();
+        }
+        fetcher.get().then(function(style) {
+            self.styleByDocURL[url] = style;
+            frame.finish(xmldoc);
+        });
+    });
     return frame.result();
 };
 

--- a/src/adapt/pm.js
+++ b/src/adapt/pm.js
@@ -49,7 +49,7 @@ adapt.pm.PageBox = function(scope, name, pseudoName, classes, parent) {
  * @return {!adapt.pm.PageBoxInstance}
  */
 adapt.pm.PageBox.prototype.createInstance = function(parentInstance) {
-	throw new Error("E_UNEXPECTED_CALL");
+    throw new Error("E_UNEXPECTED_CALL");
 };
 
 /**
@@ -170,7 +170,7 @@ goog.inherits(adapt.pm.PageMaster, adapt.pm.PageBox);
  * @return {!adapt.pm.PageMasterInstance}
  */
 adapt.pm.PageMaster.prototype.createInstance = function(parentInstance) {
-	return new adapt.pm.PageMasterInstance(parentInstance, this);
+    return new adapt.pm.PageMasterInstance(parentInstance, this);
 };
 
 /**
@@ -208,7 +208,7 @@ adapt.pm.PartitionGroup = function(scope, name, pseudoName, classes, parent) {
     adapt.pm.PageBox.call(this, scope, name, pseudoName, classes, parent);
     this.pageMaster = parent.pageMaster;
     if (name) {
-    	this.pageMaster.keyMap[name] = this.key;
+        this.pageMaster.keyMap[name] = this.key;
     }
     this.specified["wrap-flow"] =  new adapt.csscasc.CascadeValue(adapt.css.ident.auto, 0);
 };
@@ -218,7 +218,7 @@ goog.inherits(adapt.pm.PartitionGroup, adapt.pm.PageBox);
  * @override
  */
 adapt.pm.PartitionGroup.prototype.createInstance = function(parentInstance) {
-	return new adapt.pm.PartitionGroupInstance(parentInstance, this);
+    return new adapt.pm.PartitionGroupInstance(parentInstance, this);
 };
 
 /**
@@ -247,7 +247,7 @@ adapt.pm.Partition = function(scope, name, pseudoName, classes, parent) {
     adapt.pm.PageBox.call(this, scope, name, pseudoName, classes, parent);
     this.pageMaster = parent.pageMaster;
     if (name) {
-    	this.pageMaster.keyMap[name] = this.key;
+        this.pageMaster.keyMap[name] = this.key;
     }
 };
 goog.inherits(adapt.pm.Partition, adapt.pm.PageBox);
@@ -256,7 +256,7 @@ goog.inherits(adapt.pm.Partition, adapt.pm.PageBox);
  * @override
  */
 adapt.pm.Partition.prototype.createInstance = function(parentInstance) {
-	return new adapt.pm.PartitionInstance(parentInstance, this);
+    return new adapt.pm.PartitionInstance(parentInstance, this);
 };
 
 /**
@@ -392,8 +392,8 @@ adapt.pm.InstanceHolder.prototype.lookupInstance = function(key) {};
  * @constructor
  */
 adapt.pm.PageBoxInstance = function(parentInstance, pageBox) {
-	/** @const */ this.parentInstance = parentInstance;
-	/** @const */ this.pageBox = pageBox;
+    /** @const */ this.parentInstance = parentInstance;
+    /** @const */ this.pageBox = pageBox;
     /**
      * cascaded styles, geometric ones converted to adapt.css.Expr
      * @protected @const
@@ -415,7 +415,7 @@ adapt.pm.PageBoxInstance = function(parentInstance, pageBox) {
     /** @type {boolean} */ this.vertical = false;
     /** @type {boolean} */ this.suppressEmptyBoxGeneration = false;
     if (parentInstance) {
-    	parentInstance.children.push(this);
+        parentInstance.children.push(this);
     }
 };
 
@@ -434,11 +434,11 @@ adapt.pm.PageBoxInstance.prototype.reset = function() {
  * @return {adapt.expr.Val}
  */
 adapt.pm.PageBoxInstance.prototype.addNamedValues = function(name1, name2) {
-	var v1 = this.resolveName(name1);
-	var v2 = this.resolveName(name2);
-	if (!v1 || !v2)
-		throw new Error("E_INTERNAL");
-	return adapt.expr.add(this.pageBox.scope, v1, v2);	
+    var v1 = this.resolveName(name1);
+    var v2 = this.resolveName(name2);
+    if (!v1 || !v2)
+        throw new Error("E_INTERNAL");
+    return adapt.expr.add(this.pageBox.scope, v1, v2);
 };
 
 /**
@@ -446,104 +446,104 @@ adapt.pm.PageBoxInstance.prototype.addNamedValues = function(name1, name2) {
  * @return {adapt.expr.Val}
  */
 adapt.pm.PageBoxInstance.prototype.resolveName = function(name) {
-	var expr = this.namedValues[name];
-	if (expr)
-		return expr;
-	var val = this.style[name];
-	if (val)
-		expr = val.toExpr(this.pageBox.scope, this.pageBox.scope.zero);
-	switch (name) {
-	case "margin-left-edge":
-		expr = this.resolveName("left");
-		break;
-	case "margin-top-edge":
-		expr = this.resolveName("top");
-		break;
-	case "margin-right-edge":
-		expr = this.addNamedValues("border-right-edge", "margin-right");
-		break;
-	case "margin-bottom-edge":
-		expr = this.addNamedValues("border-bottom-edge", "margin-bottom");
-		break;
-	case "border-left-edge":
-		expr = this.addNamedValues("margin-left-edge", "margin-left");
-		break;
-	case "border-top-edge":
-		expr = this.addNamedValues("margin-top-edge", "margin-top");
-		break;
-	case "border-right-edge":
-		expr = this.addNamedValues("padding-right-edge", "border-right-width");
-		break;
-	case "border-bottom-edge":
-		expr = this.addNamedValues("padding-bottom-edge", "border-bottom-width");
-		break;
-	case "padding-left-edge":
-		expr = this.addNamedValues("border-left-edge", "border-left-width");
-		break;
-	case "padding-top-edge":
-		expr = this.addNamedValues("border-top-edge", "border-top-width");
-		break;
-	case "padding-right-edge":
-		expr = this.addNamedValues("right-edge", "padding-right");
-		break;
-	case "padding-bottom-edge":
-		expr = this.addNamedValues("bottom-edge", "padding-bottom");
-		break;
-	case "left-edge":
-		expr = this.addNamedValues("padding-left-edge", "padding-left");
-		break;
-	case "top-edge":
-		expr = this.addNamedValues("padding-top-edge", "padding-top");
-		break;
-	case "right-edge":
-		expr = this.addNamedValues("left-edge", "width");
-		break;
-	case "bottom-edge":
-		expr = this.addNamedValues("top-edge", "height");
-		break;
-	}
-	if (!expr) {
-		var altName;
-		if (name == "extent") {
-			altName = this.vertical ? "width" : "height";
-		} else if (name == "measure") {
-			altName = this.vertical ? "height" : "width";
-		} else {
-			var map = this.vertical ? adapt.csscasc.couplingMapVert : adapt.csscasc.couplingMapHor;
-			altName = name;
-			for (var key in map) {
-				altName = altName.replace(key, map[key]);
-			}
-		}
-		if (altName != name) {
-			expr = this.resolveName(altName);
-		}
-	}
-	if (expr)
-		this.namedValues[name] = expr;
-	return expr;
+    var expr = this.namedValues[name];
+    if (expr)
+        return expr;
+    var val = this.style[name];
+    if (val)
+        expr = val.toExpr(this.pageBox.scope, this.pageBox.scope.zero);
+    switch (name) {
+        case "margin-left-edge":
+            expr = this.resolveName("left");
+            break;
+        case "margin-top-edge":
+            expr = this.resolveName("top");
+            break;
+        case "margin-right-edge":
+            expr = this.addNamedValues("border-right-edge", "margin-right");
+            break;
+        case "margin-bottom-edge":
+            expr = this.addNamedValues("border-bottom-edge", "margin-bottom");
+            break;
+        case "border-left-edge":
+            expr = this.addNamedValues("margin-left-edge", "margin-left");
+            break;
+        case "border-top-edge":
+            expr = this.addNamedValues("margin-top-edge", "margin-top");
+            break;
+        case "border-right-edge":
+            expr = this.addNamedValues("padding-right-edge", "border-right-width");
+            break;
+        case "border-bottom-edge":
+            expr = this.addNamedValues("padding-bottom-edge", "border-bottom-width");
+            break;
+        case "padding-left-edge":
+            expr = this.addNamedValues("border-left-edge", "border-left-width");
+            break;
+        case "padding-top-edge":
+            expr = this.addNamedValues("border-top-edge", "border-top-width");
+            break;
+        case "padding-right-edge":
+            expr = this.addNamedValues("right-edge", "padding-right");
+            break;
+        case "padding-bottom-edge":
+            expr = this.addNamedValues("bottom-edge", "padding-bottom");
+            break;
+        case "left-edge":
+            expr = this.addNamedValues("padding-left-edge", "padding-left");
+            break;
+        case "top-edge":
+            expr = this.addNamedValues("padding-top-edge", "padding-top");
+            break;
+        case "right-edge":
+            expr = this.addNamedValues("left-edge", "width");
+            break;
+        case "bottom-edge":
+            expr = this.addNamedValues("top-edge", "height");
+            break;
+    }
+    if (!expr) {
+        var altName;
+        if (name == "extent") {
+            altName = this.vertical ? "width" : "height";
+        } else if (name == "measure") {
+            altName = this.vertical ? "height" : "width";
+        } else {
+            var map = this.vertical ? adapt.csscasc.couplingMapVert : adapt.csscasc.couplingMapHor;
+            altName = name;
+            for (var key in map) {
+                altName = altName.replace(key, map[key]);
+            }
+        }
+        if (altName != name) {
+            expr = this.resolveName(altName);
+        }
+    }
+    if (expr)
+        this.namedValues[name] = expr;
+    return expr;
 };
 
 adapt.pm.PageBoxInstance.prototype.resolveFunc = function(name) {
-	var expr = this.namedFuncs[name];
-	if (expr)
-		return expr;
-	switch (name) {
-	case "columns":
-		// min(count,column-count) * (column-width + column-gap) - column-gap
-		var scope = this.pageBox.scope;
-		var count = new adapt.expr.Param(scope, 0);
-		var columnCount = this.resolveName("column-count");
-		var columnWidth = this.resolveName("column-width");
-		var columnGap = this.resolveName("column-gap");
-		expr = adapt.expr.sub(scope, adapt.expr.mul(scope,
-				new adapt.expr.Call(scope, "min", [count, columnCount]),
-				adapt.expr.add(scope, columnWidth, columnGap)), columnGap);	
-		break;
-	}
-	if (expr)
-		this.namedFuncs[name] = expr;
-	return expr;
+    var expr = this.namedFuncs[name];
+    if (expr)
+        return expr;
+    switch (name) {
+        case "columns":
+            // min(count,column-count) * (column-width + column-gap) - column-gap
+            var scope = this.pageBox.scope;
+            var count = new adapt.expr.Param(scope, 0);
+            var columnCount = this.resolveName("column-count");
+            var columnWidth = this.resolveName("column-width");
+            var columnGap = this.resolveName("column-gap");
+            expr = adapt.expr.sub(scope, adapt.expr.mul(scope,
+                new adapt.expr.Call(scope, "min", [count, columnCount]),
+                adapt.expr.add(scope, columnWidth, columnGap)), columnGap);
+            break;
+    }
+    if (expr)
+        this.namedFuncs[name] = expr;
+    return expr;
 };
 
 /**
@@ -561,13 +561,13 @@ adapt.pm.PageBoxInstance.prototype.initEnabled = function() {
     }
     var minPageWidth = adapt.pm.toExprAuto(scope, style["min-page-width"], scope.zero);
     if (minPageWidth) {
-    	enabled = adapt.expr.and(scope, enabled, 
-    			new adapt.expr.Ge(scope, new adapt.expr.Named(scope, "page-width"), minPageWidth));
+        enabled = adapt.expr.and(scope, enabled,
+            new adapt.expr.Ge(scope, new adapt.expr.Named(scope, "page-width"), minPageWidth));
     }
     var minPageHeight = adapt.pm.toExprAuto(scope, style["min-page-height"], scope.zero);
     if (minPageHeight) {
-    	enabled = adapt.expr.and(scope, enabled, 
-    			new adapt.expr.Ge(scope, new adapt.expr.Named(scope, "page-height"), minPageHeight));
+        enabled = adapt.expr.and(scope, enabled,
+            new adapt.expr.Ge(scope, new adapt.expr.Named(scope, "page-height"), minPageHeight));
     }
     enabled = this.boxSpecificEnabled(enabled);
     style["enabled"] = new adapt.css.Expr(enabled);
@@ -579,7 +579,7 @@ adapt.pm.PageBoxInstance.prototype.initEnabled = function() {
  * @return {adapt.expr.Val}
  */
 adapt.pm.PageBoxInstance.prototype.boxSpecificEnabled = function(enabled) {
-	return enabled;
+    return enabled;
 };
 
 /**
@@ -589,8 +589,8 @@ adapt.pm.PageBoxInstance.prototype.boxSpecificEnabled = function(enabled) {
 adapt.pm.PageBoxInstance.prototype.initHorizontal = function() {
     var scope = this.pageBox.scope;
     var style = this.style;
-    var parentWidth = this.parentInstance ? 
-    		this.parentInstance.style["width"].toExpr(scope, null) : null;
+    var parentWidth = this.parentInstance ?
+        this.parentInstance.style["width"].toExpr(scope, null) : null;
     var left = adapt.pm.toExprAuto(scope, style["left"], parentWidth);
     var marginLeft = adapt.pm.toExprAuto(scope, style["margin-left"], parentWidth);
     var borderLeftWidth = adapt.pm.toExprZeroBorder(scope, style["border-left-width"], style["border-left-style"], parentWidth);
@@ -605,7 +605,7 @@ adapt.pm.PageBoxInstance.prototype.initHorizontal = function() {
     var rightBP = adapt.expr.add(scope, borderLeftWidth, paddingRight);
     if (left && right && width) {
         var extra = adapt.expr.sub(scope, parentWidth, adapt.expr.add(scope, width,
-        		adapt.expr.add(scope, adapt.expr.add(scope, left, leftBP), rightBP)));
+            adapt.expr.add(scope, adapt.expr.add(scope, left, leftBP), rightBP)));
         if (!marginLeft) {
             extra = adapt.expr.sub(scope, extra, right);
             if (!marginRight) {
@@ -638,9 +638,9 @@ adapt.pm.PageBoxInstance.prototype.initHorizontal = function() {
             width = this.autoWidth;
             this.isAutoWidth = true;
         }
-        var remains = adapt.expr.sub(scope, parentWidth, 
-        		adapt.expr.add(scope, adapt.expr.add(scope, marginLeft, leftBP),
-        				adapt.expr.add(scope, marginRight, rightBP)));
+        var remains = adapt.expr.sub(scope, parentWidth,
+            adapt.expr.add(scope, adapt.expr.add(scope, marginLeft, leftBP),
+                adapt.expr.add(scope, marginRight, rightBP)));
         if (this.isAutoWidth) {
             if (!maxWidth) {
                 // TODO: handle the case when right/left depends on width
@@ -648,7 +648,7 @@ adapt.pm.PageBoxInstance.prototype.initHorizontal = function() {
             }
             // For multi-column layout, width is max-width.
             if (!this.vertical && (adapt.pm.toExprAuto(scope, style["column-width"], null) ||
-            		adapt.pm.toExprAuto(scope, style["column-count"], null))) {
+                adapt.pm.toExprAuto(scope, style["column-count"], null))) {
                 width = maxWidth;
                 this.isAutoWidth = false;
             }
@@ -662,8 +662,8 @@ adapt.pm.PageBoxInstance.prototype.initHorizontal = function() {
         }
     }
     // snap-width is inherited
-    var snapWidthVal = style["snap-width"] || 
-    	(this.parentInstance ? this.parentInstance.style["snap-width"] : null);
+    var snapWidthVal = style["snap-width"] ||
+        (this.parentInstance ? this.parentInstance.style["snap-width"] : null);
     var snapWidth = adapt.pm.toExprZero(scope, snapWidthVal, parentWidth);
     style["left"] = new adapt.css.Expr(left);
     style["margin-left"] = new adapt.css.Expr(marginLeft);
@@ -685,10 +685,10 @@ adapt.pm.PageBoxInstance.prototype.initHorizontal = function() {
 adapt.pm.PageBoxInstance.prototype.initVertical = function() {
     var scope = this.pageBox.scope;
     var style = this.style;
-    var parentWidth = this.parentInstance ? 
-    		this.parentInstance.style["width"].toExpr(scope, null) : null;
-    var parentHeight = this.parentInstance ? 
-    		this.parentInstance.style["height"].toExpr(scope, null) : null;
+    var parentWidth = this.parentInstance ?
+        this.parentInstance.style["width"].toExpr(scope, null) : null;
+    var parentHeight = this.parentInstance ?
+        this.parentInstance.style["height"].toExpr(scope, null) : null;
     var top = adapt.pm.toExprAuto(scope, style["top"], parentHeight);
     var marginTop = adapt.pm.toExprAuto(scope, style["margin-top"], parentWidth);
     var borderTopWidth = adapt.pm.toExprZeroBorder(scope, style["border-top-width"], style["border-top-style"], parentWidth);
@@ -702,9 +702,9 @@ adapt.pm.PageBoxInstance.prototype.initVertical = function() {
     var topBP = adapt.expr.add(scope, borderTopWidth, paddingTop);
     var bottomBP = adapt.expr.add(scope, borderBottomWidth, paddingBottom);
     if (top && bottom && height) {
-        var extra = adapt.expr.sub(scope, parentHeight, 
-        		adapt.expr.add(scope, height, adapt.expr.add(scope, 
-        				adapt.expr.add(scope, top, topBP), bottomBP)));
+        var extra = adapt.expr.sub(scope, parentHeight,
+            adapt.expr.add(scope, height, adapt.expr.add(scope,
+                adapt.expr.add(scope, top, topBP), bottomBP)));
         if (!marginTop) {
             extra = adapt.expr.sub(scope, extra, bottom);
             if (!marginBottom) {
@@ -715,8 +715,8 @@ adapt.pm.PageBoxInstance.prototype.initVertical = function() {
             }
         } else {
             if (!marginBottom) {
-                marginBottom = adapt.expr.sub(scope, extra, 
-                		adapt.expr.add(scope, bottom, marginTop));
+                marginBottom = adapt.expr.sub(scope, extra,
+                    adapt.expr.add(scope, bottom, marginTop));
             } else {
                 // overconstraint
                 bottom = adapt.expr.sub(scope, extra, marginTop);
@@ -738,17 +738,17 @@ adapt.pm.PageBoxInstance.prototype.initVertical = function() {
             height = this.autoHeight;
             this.isAutoHeight = true;
         }
-        var remains = adapt.expr.sub(scope, parentHeight, 
-        		adapt.expr.add(scope, adapt.expr.add(scope, marginTop, topBP), 
-        				adapt.expr.add(scope, marginBottom, bottomBP)));
+        var remains = adapt.expr.sub(scope, parentHeight,
+            adapt.expr.add(scope, adapt.expr.add(scope, marginTop, topBP),
+                adapt.expr.add(scope, marginBottom, bottomBP)));
         if (this.isAutoHeight) {
-        	if (!maxHeight) {
-	            // TODO: handle the case when top/bottom depends on height
-	            maxHeight = adapt.expr.sub(scope, remains, (top ? top : bottom));
-	        }
+            if (!maxHeight) {
+                // TODO: handle the case when top/bottom depends on height
+                maxHeight = adapt.expr.sub(scope, remains, (top ? top : bottom));
+            }
             // For multi-column layout in vertical writing, height is max-height.
             if (this.vertical && (adapt.pm.toExprAuto(scope, style["column-width"], null) ||
-            		adapt.pm.toExprAuto(scope, style["column-count"], null))) {
+                adapt.pm.toExprAuto(scope, style["column-count"], null))) {
                 height = maxHeight;
                 this.isAutoHeight = false;
             }
@@ -762,8 +762,8 @@ adapt.pm.PageBoxInstance.prototype.initVertical = function() {
         }
     }
     // snap-height is inherited
-    var snapHeightVal = style["snap-height"] || 
-    	(this.parentInstance ? this.parentInstance.style["snap-height"] : null);
+    var snapHeightVal = style["snap-height"] ||
+        (this.parentInstance ? this.parentInstance.style["snap-height"] : null);
     var snapHeight = adapt.pm.toExprZero(scope, snapHeightVal, parentWidth);
     style["top"] = new adapt.css.Expr(top);
     style["margin-top"] = new adapt.css.Expr(marginTop);
@@ -792,14 +792,14 @@ adapt.pm.PageBoxInstance.prototype.initColumns = function() {
     if (!columnGap)
         columnGap = new adapt.expr.Numeric(scope, 1, "em");
     if (columnWidth && !columnCount) {
-        columnCount = new adapt.expr.Call(scope, "floor", [adapt.expr.div(scope, 
-        		adapt.expr.add(scope, width, columnGap), adapt.expr.add(scope, columnWidth, columnGap))]);
+        columnCount = new adapt.expr.Call(scope, "floor", [adapt.expr.div(scope,
+            adapt.expr.add(scope, width, columnGap), adapt.expr.add(scope, columnWidth, columnGap))]);
         columnCount = new adapt.expr.Call(scope, "max", [scope.one, columnCount]);
     }
     if (!columnCount)
         columnCount = scope.one;
-    columnWidth = adapt.expr.sub(scope, adapt.expr.div(scope, 
-    		adapt.expr.add(scope, width, columnGap), columnCount), columnGap);
+    columnWidth = adapt.expr.sub(scope, adapt.expr.div(scope,
+        adapt.expr.add(scope, width, columnGap), columnCount), columnGap);
     style["column-width"] = new adapt.css.Expr(columnWidth);
     style["column-count"] = new adapt.css.Expr(columnCount);
     style["column-gap"] = new adapt.css.Expr(columnGap);
@@ -822,10 +822,10 @@ adapt.pm.PageBoxInstance.prototype.depends = function(propName, val, context) {
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.init = function(context) {
-	// If context does not implement InstanceHolder we would not be able to resolve
-	// "partition.property" names later.
-	var holder = /** @type {adapt.pm.InstanceHolder} */ (context);
-	holder.registerInstance(this.pageBox.key, this);
+    // If context does not implement InstanceHolder we would not be able to resolve
+    // "partition.property" names later.
+    var holder = /** @type {adapt.pm.InstanceHolder} */ (context);
+    holder.registerInstance(this.pageBox.key, this);
     var scope = this.pageBox.scope;
     var style = this.style;
     var self = this;
@@ -837,13 +837,13 @@ adapt.pm.PageBoxInstance.prototype.init = function(context) {
         return cascVal.value;
     });
     this.autoWidth = new adapt.expr.Native(scope,
-    		function() { 
-    			return self.calculatedWidth;
-    		}, "autoWidth");
-    this.autoHeight = new adapt.expr.Native(scope, 
-    		function() {
-    			return self.calculatedHeight;
-    		}, "autoHeight");
+        function() {
+            return self.calculatedWidth;
+        }, "autoWidth");
+    this.autoHeight = new adapt.expr.Native(scope,
+        function() {
+            return self.calculatedHeight;
+        }, "autoHeight");
     this.initHorizontal();
     this.initVertical();
     this.initColumns();
@@ -973,7 +973,7 @@ adapt.pm.PageBoxInstance.prototype.assignLeftPosition = function(context, contai
  */
 adapt.pm.PageBoxInstance.prototype.assignRightPosition = function(context, container) {
     var right = this.getPropAsNumber(context, "right");
-	var snapWidth = this.getPropAsNumber(context, "snap-height");
+    var snapWidth = this.getPropAsNumber(context, "snap-height");
     var marginRight = this.getPropAsNumber(context, "margin-right");
     var paddingRight = this.getPropAsNumber(context, "padding-right");
     var borderRightWidth = this.getPropAsNumber(context, "border-right-width");
@@ -983,13 +983,13 @@ adapt.pm.PageBoxInstance.prototype.assignRightPosition = function(context, conta
     container.marginRight = marginRight;
     container.borderRight = borderRightWidth;
     if (this.vertical && snapWidth > 0) {
-    	var xpos = right + container.getInsetRight();
-    	var r = xpos - Math.floor(xpos / snapWidth) * snapWidth;
-    	if (r > 0) {
-    		container.snapOffsetX = snapWidth - r;
-    		paddingRight += container.snapOffsetX;
-    	}
-    }    
+        var xpos = right + container.getInsetRight();
+        var r = xpos - Math.floor(xpos / snapWidth) * snapWidth;
+        if (r > 0) {
+            container.snapOffsetX = snapWidth - r;
+            paddingRight += container.snapOffsetX;
+        }
+    }
     container.paddingRight = paddingRight;
     container.snapWidth = snapWidth;
 };
@@ -1000,7 +1000,7 @@ adapt.pm.PageBoxInstance.prototype.assignRightPosition = function(context, conta
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.assignTopPosition = function(context, container) {
-	var snapHeight = this.getPropAsNumber(context, "snap-height");
+    var snapHeight = this.getPropAsNumber(context, "snap-height");
     var top = this.getPropAsNumber(context, "top");
     var marginTop = this.getPropAsNumber(context, "margin-top");
     var paddingTop = this.getPropAsNumber(context, "padding-top");
@@ -1010,14 +1010,14 @@ adapt.pm.PageBoxInstance.prototype.assignTopPosition = function(context, contain
     container.borderTop = borderTopWidth;
     container.snapHeight = snapHeight;
     if (!this.vertical && snapHeight > 0) {
-    	var ypos = top + container.getInsetTop();
-    	var r = ypos - Math.floor(ypos / snapHeight) * snapHeight;
-    	if (r > 0) {
-    		container.snapOffsetY = snapHeight - r;
-    		paddingTop += container.snapOffsetY;
-    	}
+        var ypos = top + container.getInsetTop();
+        var r = ypos - Math.floor(ypos / snapHeight) * snapHeight;
+        if (r > 0) {
+            container.snapOffsetY = snapHeight - r;
+            paddingTop += container.snapOffsetY;
+        }
     }
-	container.paddingTop = paddingTop;
+    container.paddingTop = paddingTop;
     adapt.base.setCSSProperty(container.element, "top", top + "px");
     adapt.base.setCSSProperty(container.element, "margin-top", marginTop + "px");
     adapt.base.setCSSProperty(container.element, "padding-top", paddingTop + "px");
@@ -1051,10 +1051,10 @@ adapt.pm.PageBoxInstance.prototype.assignBottomPosition = function(context, cont
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.assignBeforePosition = function(context, container) {
-	if (this.vertical)
-		this.assignRightPosition(context, container);
-	else
-		this.assignTopPosition(context, container);
+    if (this.vertical)
+        this.assignRightPosition(context, container);
+    else
+        this.assignTopPosition(context, container);
 };
 
 /**
@@ -1063,10 +1063,10 @@ adapt.pm.PageBoxInstance.prototype.assignBeforePosition = function(context, cont
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.assignAfterPosition = function(context, container) {
-	if (this.vertical)
-		this.assignLeftPosition(context, container);
-	else
-		this.assignBottomPosition(context, container);
+    if (this.vertical)
+        this.assignLeftPosition(context, container);
+    else
+        this.assignBottomPosition(context, container);
 };
 
 /**
@@ -1075,13 +1075,13 @@ adapt.pm.PageBoxInstance.prototype.assignAfterPosition = function(context, conta
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.assignStartEndPosition = function(context, container) {
-	if (this.vertical) {
-		this.assignTopPosition(context, container);
-		this.assignBottomPosition(context, container);
-	} else {
-		this.assignRightPosition(context, container);
-		this.assignLeftPosition(context, container);		
-	}
+    if (this.vertical) {
+        this.assignTopPosition(context, container);
+        this.assignBottomPosition(context, container);
+    } else {
+        this.assignRightPosition(context, container);
+        this.assignLeftPosition(context, container);
+    }
 };
 
 /**
@@ -1099,7 +1099,7 @@ adapt.pm.PageBoxInstance.prototype.sizeWithMaxHeight = function(context, contain
         height -= container.snapOffsetY;
         container.height = height;
         adapt.base.setCSSProperty(container.element, "height", height + "px");
-	}
+    }
 };
 
 /**
@@ -1111,14 +1111,14 @@ adapt.pm.PageBoxInstance.prototype.sizeWithMaxWidth = function(context, containe
     adapt.base.setCSSProperty(container.element, "border-left-width", "0px");
     var width = this.getPropAsNumber(context, "max-width");
     if (this.isRightDependentOnAutoWidth) {
-    	container.setHorizontalPosition(0, width);
+        container.setHorizontalPosition(0, width);
     } else {
         this.assignRightPosition(context, container);
         width -= container.snapOffsetX;
         container.width = width;
         var right = this.getPropAsNumber(context, "right");
-        adapt.base.setCSSProperty(container.element, "right", right + "px");    	
-        adapt.base.setCSSProperty(container.element, "width", width + "px");    	
+        adapt.base.setCSSProperty(container.element, "right", right + "px");
+        adapt.base.setCSSProperty(container.element, "width", width + "px");
     }
 };
 
@@ -1127,18 +1127,18 @@ adapt.pm.PageBoxInstance.prototype.sizeWithMaxWidth = function(context, containe
  * @const
  */
 adapt.pm.passPreProperties = [
-	"border-left-style",
-	"border-right-style",
-	"border-top-style",
-	"border-bottom-style",
-	"border-left-color",
-	"border-right-color",
-	"border-top-color",
-	"border-bottom-color",
+    "border-left-style",
+    "border-right-style",
+    "border-top-style",
+    "border-bottom-style",
+    "border-left-color",
+    "border-right-color",
+    "border-top-color",
+    "border-bottom-color",
     "outline-style",
     "outline-color",
     "outline-width",
-	"overflow",
+    "overflow",
     "visibility"
 ];
 
@@ -1147,25 +1147,25 @@ adapt.pm.passPreProperties = [
  * @const
  */
 adapt.pm.passPostProperties = [
-   	"border-top-left-radius",
-	"border-top-right-radius",
-	"border-bottom-right-radius",
-	"border-bottom-left-radius",
-	"border-image-source",
-	"border-image-slice",
-	"border-image-width",
-	"border-image-outset",
-	"border-image-repeat",
-	"background-attachment",
-	"background-color",
-	"background-image",
-	"background-repeat",
-	"background-position",
-	"background-clip",
-	"background-origin",
-	"background-size",
-	"opacity",
-	"z-index"
+    "border-top-left-radius",
+    "border-top-right-radius",
+    "border-bottom-right-radius",
+    "border-bottom-left-radius",
+    "border-image-source",
+    "border-image-slice",
+    "border-image-width",
+    "border-image-outset",
+    "border-image-repeat",
+    "background-attachment",
+    "background-color",
+    "background-image",
+    "background-repeat",
+    "background-position",
+    "background-clip",
+    "background-origin",
+    "background-size",
+    "opacity",
+    "z-index"
 ];
 
 /**
@@ -1193,8 +1193,8 @@ adapt.pm.passContentProperties = [
  * @const
  */
 adapt.pm.delayedProperties = [
-	"transform",
-	"transform-origin"
+    "transform",
+    "transform-origin"
 ];
 
 /**
@@ -1206,23 +1206,23 @@ adapt.pm.delayedProperties = [
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.prepareContainer = function(context, container, page, docFaces, clientLayout) {
-	if (!this.parentInstance || this.vertical != this.parentInstance.vertical) {
-		adapt.base.setCSSProperty(container.element, "writing-mode", (this.vertical ? "vertical-rl" : "horizontal-tb"));
-	}
+    if (!this.parentInstance || this.vertical != this.parentInstance.vertical) {
+        adapt.base.setCSSProperty(container.element, "writing-mode", (this.vertical ? "vertical-rl" : "horizontal-tb"));
+    }
     if (this.vertical ? this.isAutoWidth : this.isAutoHeight) {
-    	if (this.vertical)
+        if (this.vertical)
             this.sizeWithMaxWidth(context, container);
-    	else
-    		this.sizeWithMaxHeight(context, container);
+        else
+            this.sizeWithMaxHeight(context, container);
     } else {
         this.assignBeforePosition(context, container);
         this.assignAfterPosition(context, container);
     }
     if (this.vertical ? this.isAutoHeight : this.isAutoWidth) {
-    	if (this.vertical)
+        if (this.vertical)
             this.sizeWithMaxHeight(context, container);
-    	else
-    		this.sizeWithMaxWidth(context, container);
+        else
+            this.sizeWithMaxWidth(context, container);
     } else {
         this.assignStartEndPosition(context, container);
     }
@@ -1255,39 +1255,39 @@ adapt.pm.PageBoxInstance.prototype.transferContentProps = function(context, cont
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.finishContainer = function(
-		context, container, page, column, columnCount, clientLayout, docFaces) {
-	if (this.vertical)
-	    this.calculatedWidth = container.computedBlockSize + container.snapOffsetX;
-	else
-		this.calculatedHeight = container.computedBlockSize + container.snapOffsetY;
+    context, container, page, column, columnCount, clientLayout, docFaces) {
+    if (this.vertical)
+        this.calculatedWidth = container.computedBlockSize + container.snapOffsetX;
+    else
+        this.calculatedHeight = container.computedBlockSize + container.snapOffsetY;
     var readHeight = (this.vertical || !column) && this.isAutoHeight;
     var readWidth = (!this.vertical || !column) && this.isAutoWidth;
     var bbox = null;
     if (readWidth || readHeight) {
-    	if (readWidth) {
-    		adapt.base.setCSSProperty(container.element, "width", "auto");
-    	}
-    	if (readHeight) {
-    		adapt.base.setCSSProperty(container.element, "height", "auto");
-    	}
-        bbox = clientLayout.getElementClientRect(column ? column.element : container.element);
         if (readWidth) {
-        	this.calculatedWidth = Math.ceil(bbox.right - bbox.left
-        		- container.paddingLeft - container.borderLeft
-        		- container.paddingRight - container.borderRight);
-        	if (this.vertical)
-        	    this.calculatedWidth += container.snapOffsetX;
+            adapt.base.setCSSProperty(container.element, "width", "auto");
         }
         if (readHeight) {
-        	this.calculatedHeight = bbox.bottom - bbox.top
-        		- container.paddingTop - container.borderTop
-        		- container.paddingBottom - container.borderBottom;
-        	if (!this.vertical)
-        		this.calculatedHeight += container.snapOffsetY;
+            adapt.base.setCSSProperty(container.element, "height", "auto");
+        }
+        bbox = clientLayout.getElementClientRect(column ? column.element : container.element);
+        if (readWidth) {
+            this.calculatedWidth = Math.ceil(bbox.right - bbox.left
+                - container.paddingLeft - container.borderLeft
+                - container.paddingRight - container.borderRight);
+            if (this.vertical)
+                this.calculatedWidth += container.snapOffsetX;
+        }
+        if (readHeight) {
+            this.calculatedHeight = bbox.bottom - bbox.top
+                - container.paddingTop - container.borderTop
+                - container.paddingBottom - container.borderBottom;
+            if (!this.vertical)
+                this.calculatedHeight += container.snapOffsetY;
         }
     }
     if (this.vertical ? this.isAutoHeight : this.isAutoWidth) {
-    	this.assignStartEndPosition(context, container);    	
+        this.assignStartEndPosition(context, container);
     }
     if (this.vertical ? this.isAutoWidth : this.isAutoHeight) {
         if (this.vertical ? this.isRightDependentOnAutoWidth : this.isTopDependentOnAutoHeight)
@@ -1295,36 +1295,36 @@ adapt.pm.PageBoxInstance.prototype.finishContainer = function(
         this.assignAfterPosition(context, container);
     }
     if (columnCount > 1) {
-    	var ruleWidth = this.getPropAsNumber(context, "column-rule-width");
-    	var ruleStyle = this.getProp(context, "column-rule-style");
-    	var ruleColor = this.getProp(context, "column-rule-color");
-    	if (ruleWidth > 0 && ruleStyle && ruleStyle != adapt.css.ident.none &&
-    			ruleColor != adapt.css.ident.transparent) {
-        	var columnGap = this.getPropAsNumber(context, "column-gap");
-        	var containerSize = this.vertical ? container.height : container.width;
-        	var border = this.vertical ? "border-top" : "border-left";
-    		for (var i = 1; i < columnCount; i++) {
-    			var pos = (containerSize + columnGap) * i / columnCount - columnGap/2
-    				+ container.paddingLeft - ruleWidth/2;
-    			var size = container.height + container.paddingTop + container.paddingBottom;
-    			var rule = container.element.ownerDocument.createElement("div");
-    			adapt.base.setCSSProperty(rule, "position", "absolute");
-    			adapt.base.setCSSProperty(rule, this.vertical ? "left" : "top", "0px");
-    			adapt.base.setCSSProperty(rule, this.vertical ? "top" : "left", pos + "px");
-    			adapt.base.setCSSProperty(rule, this.vertical ? "height" : "width", "0px");
-    			adapt.base.setCSSProperty(rule, this.vertical ? "width" : "height", size + "px");
-    			adapt.base.setCSSProperty(rule, border, 
-    					ruleWidth + "px " + ruleStyle.toString() + (ruleColor ? " " + ruleColor.toString() : ""));
-    			container.element.insertBefore(rule, container.element.firstChild);
-    		}
-    	}
+        var ruleWidth = this.getPropAsNumber(context, "column-rule-width");
+        var ruleStyle = this.getProp(context, "column-rule-style");
+        var ruleColor = this.getProp(context, "column-rule-color");
+        if (ruleWidth > 0 && ruleStyle && ruleStyle != adapt.css.ident.none &&
+            ruleColor != adapt.css.ident.transparent) {
+            var columnGap = this.getPropAsNumber(context, "column-gap");
+            var containerSize = this.vertical ? container.height : container.width;
+            var border = this.vertical ? "border-top" : "border-left";
+            for (var i = 1; i < columnCount; i++) {
+                var pos = (containerSize + columnGap) * i / columnCount - columnGap/2
+                    + container.paddingLeft - ruleWidth/2;
+                var size = container.height + container.paddingTop + container.paddingBottom;
+                var rule = container.element.ownerDocument.createElement("div");
+                adapt.base.setCSSProperty(rule, "position", "absolute");
+                adapt.base.setCSSProperty(rule, this.vertical ? "left" : "top", "0px");
+                adapt.base.setCSSProperty(rule, this.vertical ? "top" : "left", pos + "px");
+                adapt.base.setCSSProperty(rule, this.vertical ? "height" : "width", "0px");
+                adapt.base.setCSSProperty(rule, this.vertical ? "width" : "height", size + "px");
+                adapt.base.setCSSProperty(rule, border,
+                    ruleWidth + "px " + ruleStyle.toString() + (ruleColor ? " " + ruleColor.toString() : ""));
+                container.element.insertBefore(rule, container.element.firstChild);
+            }
+        }
     }
     for (var i = 0; i < adapt.pm.passPostProperties.length; i++) {
         this.propagateProperty(context, container, adapt.pm.passPostProperties[i], docFaces);
     }
     for (var i = 0; i < adapt.pm.delayedProperties.length; i++) {
-        this.propagateDelayedProperty(context, container, adapt.pm.delayedProperties[i], page.delayedItems);    	
-    }    
+        this.propagateDelayedProperty(context, container, adapt.pm.delayedProperties[i], page.delayedItems);
+    }
 };
 
 adapt.pm.userAgentPageMasterPseudo = "background-host";
@@ -1335,39 +1335,39 @@ adapt.pm.userAgentPageMasterPseudo = "background-host";
  * @return {void}
  */
 adapt.pm.PageBoxInstance.prototype.applyCascadeAndInit = function(cascade, docElementStyle) {
-	var style = this.cascaded;
-	var specified = this.pageBox.specified;
-	for (var name in specified) {
-		if (adapt.csscasc.isPropName(name)) {
-			adapt.csscasc.setProp(style, name, adapt.csscasc.getProp(specified, name));
-		}
-	}
-	if (this.pageBox.pseudoName == adapt.pm.userAgentPageMasterPseudo) {
-		for (var name in docElementStyle) {
-			if (name.match(/^background-/) || name == "writing-mode") {
-				style[name] = docElementStyle[name];
-			}
-		}
-	}
-	if (this.pageBox.pseudoName == "layout-host") {
-		for (var name in docElementStyle) {
-			if (!name.match(/^background-/) && name != "writing-mode") {
-				style[name] = docElementStyle[name];
-			}
-		}
-	}
-	cascade.pushRule(this.pageBox.classes, null, style);
+    var style = this.cascaded;
+    var specified = this.pageBox.specified;
+    for (var name in specified) {
+        if (adapt.csscasc.isPropName(name)) {
+            adapt.csscasc.setProp(style, name, adapt.csscasc.getProp(specified, name));
+        }
+    }
+    if (this.pageBox.pseudoName == adapt.pm.userAgentPageMasterPseudo) {
+        for (var name in docElementStyle) {
+            if (name.match(/^background-/) || name == "writing-mode") {
+                style[name] = docElementStyle[name];
+            }
+        }
+    }
+    if (this.pageBox.pseudoName == "layout-host") {
+        for (var name in docElementStyle) {
+            if (!name.match(/^background-/) && name != "writing-mode") {
+                style[name] = docElementStyle[name];
+            }
+        }
+    }
+    cascade.pushRule(this.pageBox.classes, null, style);
     if (style["content"]) {
         style["content"] = style["content"].filterValue(
             new adapt.csscasc.ContentPropVisitor(cascade, null, cascade.counterResolver));
     }
-	this.init(cascade.context);
-	for (var i = 0; i < this.pageBox.children.length ; i++) {
-		var child = this.pageBox.children[i];
-		var childInstance = child.createInstance(this);
-	    childInstance.applyCascadeAndInit(cascade, docElementStyle);
-	}
-	cascade.popRule();
+    this.init(cascade.context);
+    for (var i = 0; i < this.pageBox.children.length; i++) {
+        var child = this.pageBox.children[i];
+        var childInstance = child.createInstance(this);
+        childInstance.applyCascadeAndInit(cascade, docElementStyle);
+    }
+    cascade.popRule();
 };
 
 /**
@@ -1388,10 +1388,10 @@ adapt.pm.PageBoxInstance.prototype.resolveAutoSizing = function(context) {
             this.depends("border-top-width", this.autoHeight, context) ||
             this.depends("padding-top", this.autoHeight, context);
     }
-	for (var i = 0; i < this.children.length ; i++) {
-		var childInstance = this.children[i];
-	    childInstance.resolveAutoSizing(context);
-	}
+    for (var i = 0; i < this.children.length; i++) {
+        var childInstance = this.children[i];
+        childInstance.resolveAutoSizing(context);
+    }
 };
 
 
@@ -1401,7 +1401,7 @@ adapt.pm.PageBoxInstance.prototype.resolveAutoSizing = function(context) {
  * @extends {adapt.pm.PageBoxInstance}
  */
 adapt.pm.RootPageBoxInstance = function(pageBox) {
-	adapt.pm.PageBoxInstance.call(this, null, pageBox);
+    adapt.pm.PageBoxInstance.call(this, null, pageBox);
 };
 goog.inherits(adapt.pm.RootPageBoxInstance, adapt.pm.PageBoxInstance);
 
@@ -1409,19 +1409,19 @@ goog.inherits(adapt.pm.RootPageBoxInstance, adapt.pm.PageBoxInstance);
  * @override
  */
 adapt.pm.RootPageBoxInstance.prototype.applyCascadeAndInit = function(cascade, docElementStyle) {
-	adapt.pm.PageBoxInstance.prototype.applyCascadeAndInit.call(this, cascade, docElementStyle);
-	// Sort page masters using order and specificity.
+    adapt.pm.PageBoxInstance.prototype.applyCascadeAndInit.call(this, cascade, docElementStyle);
+    // Sort page masters using order and specificity.
     var pageMasters = this.children;
     (/** @type {Array.<adapt.pm.PageMasterInstance>} */ (pageMasters)).sort(
-    	/**
-    	 * @param {adapt.pm.PageMasterInstance} a
-    	 * @param {adapt.pm.PageMasterInstance} b
-    	 * @return {number}
-    	 */
-    	function (a, b) { 
-    		return b.pageBox.specificity - a.pageBox.specificity || a.pageBox.index - b.pageBox.index;
-    	}
-    );	
+        /**
+         * @param {adapt.pm.PageMasterInstance} a
+         * @param {adapt.pm.PageMasterInstance} b
+         * @return {number}
+         */
+        function(a, b) {
+            return b.pageBox.specificity - a.pageBox.specificity || a.pageBox.index - b.pageBox.index;
+        }
+    );
 };
 
 /**
@@ -1431,8 +1431,8 @@ adapt.pm.RootPageBoxInstance.prototype.applyCascadeAndInit = function(cascade, d
  * @extends {adapt.pm.PageBoxInstance}
  */
 adapt.pm.PageMasterInstance = function(parentInstance, pageBox) {
-	adapt.pm.PageBoxInstance.call(this, parentInstance, pageBox);
-	this.pageMasterInstance = this;
+    adapt.pm.PageBoxInstance.call(this, parentInstance, pageBox);
+    this.pageMasterInstance = this;
 };
 goog.inherits(adapt.pm.PageMasterInstance, adapt.pm.PageBoxInstance);
 
@@ -1440,7 +1440,7 @@ goog.inherits(adapt.pm.PageMasterInstance, adapt.pm.PageBoxInstance);
  * @override
  */
 adapt.pm.PageMasterInstance.prototype.boxSpecificEnabled = function(enabled) {
-	var pageMaster = this.pageBox.pageMaster;
+    var pageMaster = this.pageBox.pageMaster;
     if (pageMaster.condition) {
         enabled = adapt.expr.and(pageMaster.scope, enabled, pageMaster.condition);
     }
@@ -1464,8 +1464,8 @@ adapt.pm.PageMasterInstance.prototype.adjustPageLayout = function(context, page,
  * @extends {adapt.pm.PageBoxInstance}
  */
 adapt.pm.PartitionGroupInstance = function(parentInstance, pageBox) {
-	adapt.pm.PageBoxInstance.call(this, parentInstance, pageBox);
-	this.pageMasterInstance = parentInstance.pageMasterInstance;
+    adapt.pm.PageBoxInstance.call(this, parentInstance, pageBox);
+    this.pageMasterInstance = parentInstance.pageMasterInstance;
 };
 goog.inherits(adapt.pm.PartitionGroupInstance, adapt.pm.PageBoxInstance);
 
@@ -1477,8 +1477,8 @@ goog.inherits(adapt.pm.PartitionGroupInstance, adapt.pm.PageBoxInstance);
  * @extends {adapt.pm.PageBoxInstance}
  */
 adapt.pm.PartitionInstance = function(parentInstance, pageBox) {
-	adapt.pm.PageBoxInstance.call(this, parentInstance, pageBox);
-	this.pageMasterInstance = parentInstance.pageMasterInstance;
+    adapt.pm.PageBoxInstance.call(this, parentInstance, pageBox);
+    this.pageMasterInstance = parentInstance.pageMasterInstance;
 };
 goog.inherits(adapt.pm.PartitionInstance, adapt.pm.PageBoxInstance);
 
@@ -1489,26 +1489,26 @@ goog.inherits(adapt.pm.PartitionInstance, adapt.pm.PageBoxInstance);
  * @return {adapt.expr.Val}
  */
 adapt.pm.PartitionInstance.prototype.processPartitionList = function(enabled, listVal, conflicting) {
-	var list = null;
-	if (listVal instanceof adapt.css.Ident) {
-		list = [listVal];
-	}
-    if (listVal instanceof adapt.css.CommaList) {
-    	list = (/** @type {adapt.css.CommaList} */ (listVal)).values;
+    var list = null;
+    if (listVal instanceof adapt.css.Ident) {
+        list = [listVal];
     }
-	if (list) {
-    	var scope = this.pageBox.scope;
-    	for (var i = 0; i < list.length; i++) {
-    		if (list[i] instanceof adapt.css.Ident) {
-    			var qname = adapt.expr.makeQualifiedName(
-    					(/** @type {adapt.css.Ident} */ (list[i])).name, "enabled");
-    			var term = new adapt.expr.Named(scope, qname);
-    			if (conflicting) {
-    				term = new adapt.expr.Not(scope, term);
-    			}
-    			enabled = adapt.expr.and(scope, enabled, term);
-    		}
-    	}
+    if (listVal instanceof adapt.css.CommaList) {
+        list = (/** @type {adapt.css.CommaList} */ (listVal)).values;
+    }
+    if (list) {
+        var scope = this.pageBox.scope;
+        for (var i = 0; i < list.length; i++) {
+            if (list[i] instanceof adapt.css.Ident) {
+                var qname = adapt.expr.makeQualifiedName(
+                    (/** @type {adapt.css.Ident} */ (list[i])).name, "enabled");
+                var term = new adapt.expr.Named(scope, qname);
+                if (conflicting) {
+                    term = new adapt.expr.Not(scope, term);
+                }
+                enabled = adapt.expr.and(scope, enabled, term);
+            }
+        }
     }
     return enabled;
 };
@@ -1517,12 +1517,12 @@ adapt.pm.PartitionInstance.prototype.processPartitionList = function(enabled, li
  * @override
  */
 adapt.pm.PartitionInstance.prototype.boxSpecificEnabled = function(enabled) {
-	var scope = this.pageBox.scope;
-	var style = this.style;
-	var required = adapt.pm.toExprBool(scope, style["required"], scope._false) !== scope._false;
+    var scope = this.pageBox.scope;
+    var style = this.style;
+    var required = adapt.pm.toExprBool(scope, style["required"], scope._false) !== scope._false;
     if (required || this.isAutoHeight) {
         var flowName = adapt.pm.toExprIdent(scope, style["flow-from"], "body");
-    	var hasContent = new adapt.expr.Call(scope, "has-content", [flowName]);
+        var hasContent = new adapt.expr.Call(scope, "has-content", [flowName]);
         enabled = adapt.expr.and(scope, enabled, hasContent);
     }
     enabled = this.processPartitionList(enabled, style["required-partitions"], false);
@@ -1540,8 +1540,8 @@ adapt.pm.PartitionInstance.prototype.boxSpecificEnabled = function(enabled) {
  * @override
  */
 adapt.pm.PartitionInstance.prototype.prepareContainer = function(context, container, delayedItems, docFaces, clientLayout) {
-	adapt.base.setCSSProperty(container.element, "overflow", "hidden");  // default value
-	adapt.pm.PageBoxInstance.prototype.prepareContainer.call(this, context, container, delayedItems, docFaces, clientLayout);
+    adapt.base.setCSSProperty(container.element, "overflow", "hidden");  // default value
+    adapt.pm.PageBoxInstance.prototype.prepareContainer.call(this, context, container, delayedItems, docFaces, clientLayout);
 };
 
 
@@ -1557,9 +1557,9 @@ adapt.pm.PartitionInstance.prototype.prepareContainer = function(context, contai
  * @implements {adapt.cssvalid.PropertyReceiver}
  */
 adapt.pm.PageBoxParserHandler = function(scope, owner, target, validatorSet) {
-	adapt.cssparse.SlaveParserHandler.call(this, scope, owner, false);
-	/** @const */ this.target = target;
-	/** @const */ this.validatorSet = validatorSet;
+    adapt.cssparse.SlaveParserHandler.call(this, scope, owner, false);
+    /** @const */ this.target = target;
+    /** @const */ this.validatorSet = validatorSet;
 };
 goog.inherits(adapt.pm.PageBoxParserHandler, adapt.cssparse.SlaveParserHandler);
 
@@ -1588,8 +1588,8 @@ adapt.pm.PageBoxParserHandler.prototype.invalidPropertyValue = function(name, va
  * @override
  */
 adapt.pm.PageBoxParserHandler.prototype.simpleProperty = function(name, value, important) {
-    this.target.specified[name] = new adapt.csscasc.CascadeValue(value, 
-    		important ? adapt.cssparse.SPECIFICITY_STYLE:adapt.cssparse.SPECIFICITY_STYLE_IMPORTANT);
+    this.target.specified[name] = new adapt.csscasc.CascadeValue(value,
+        important ? adapt.cssparse.SPECIFICITY_STYLE:adapt.cssparse.SPECIFICITY_STYLE_IMPORTANT);
 };
 
 
@@ -1602,7 +1602,7 @@ adapt.pm.PageBoxParserHandler.prototype.simpleProperty = function(name, value, i
  * @extends {adapt.pm.PageBoxParserHandler}
  */
 adapt.pm.PartitionParserHandler = function(scope, owner, target, validatorSet) {
-	adapt.pm.PageBoxParserHandler.call(this, scope, owner, target, validatorSet);
+    adapt.pm.PageBoxParserHandler.call(this, scope, owner, target, validatorSet);
 };
 goog.inherits(adapt.pm.PartitionParserHandler, adapt.pm.PageBoxParserHandler);
 
@@ -1616,7 +1616,7 @@ goog.inherits(adapt.pm.PartitionParserHandler, adapt.pm.PageBoxParserHandler);
  * @extends {adapt.pm.PageBoxParserHandler}
  */
 adapt.pm.PartitionGroupParserHandler = function(scope, owner, target, validatorSet) {
-	adapt.pm.PageBoxParserHandler.call(this, scope, owner, target, validatorSet);
+    adapt.pm.PageBoxParserHandler.call(this, scope, owner, target, validatorSet);
     target.specified["width"] = new adapt.csscasc.CascadeValue(adapt.css.hundredPercent, 0);
     target.specified["height"] = new adapt.csscasc.CascadeValue(adapt.css.hundredPercent, 0);
 };
@@ -1628,7 +1628,7 @@ goog.inherits(adapt.pm.PartitionGroupParserHandler, adapt.pm.PageBoxParserHandle
 adapt.pm.PartitionGroupParserHandler.prototype.startPartitionRule = function(name, pseudoName, classes) {
     var partition = new adapt.pm.Partition(this.scope, name, pseudoName, classes, this.target);
     var handler = new adapt.pm.PartitionParserHandler(this.scope, this.owner,
-    		partition, this.validatorSet);
+        partition, this.validatorSet);
     this.owner.pushHandler(handler);
 };
 
@@ -1638,7 +1638,7 @@ adapt.pm.PartitionGroupParserHandler.prototype.startPartitionRule = function(nam
 adapt.pm.PartitionGroupParserHandler.prototype.startPartitionGroupRule = function(name, pseudoName, classes) {
     var partitionGroup = new adapt.pm.PartitionGroup(this.scope, name, pseudoName, classes, this.target);
     var handler = new adapt.pm.PartitionGroupParserHandler(this.scope, this.owner,
-    		partitionGroup, this.validatorSet);
+        partitionGroup, this.validatorSet);
     this.owner.pushHandler(handler);
 };
 
@@ -1652,7 +1652,7 @@ adapt.pm.PartitionGroupParserHandler.prototype.startPartitionGroupRule = functio
  * @extends {adapt.pm.PageBoxParserHandler}
  */
 adapt.pm.PageMasterParserHandler = function(scope, owner, target, validatorSet) {
-	adapt.pm.PageBoxParserHandler.call(this, scope, owner, target, validatorSet);
+    adapt.pm.PageBoxParserHandler.call(this, scope, owner, target, validatorSet);
 };
 goog.inherits(adapt.pm.PageMasterParserHandler, adapt.pm.PageBoxParserHandler);
 
@@ -1662,7 +1662,7 @@ goog.inherits(adapt.pm.PageMasterParserHandler, adapt.pm.PageBoxParserHandler);
 adapt.pm.PageMasterParserHandler.prototype.startPartitionRule = function(name, pseudoName, classes) {
     var partition = new adapt.pm.Partition(this.scope, name, pseudoName, classes, this.target);
     var handler = new adapt.pm.PartitionParserHandler(this.scope, this.owner,
-    		partition, this.validatorSet);
+        partition, this.validatorSet);
     this.owner.pushHandler(handler);
 };
 
@@ -1672,8 +1672,6 @@ adapt.pm.PageMasterParserHandler.prototype.startPartitionRule = function(name, p
 adapt.pm.PageMasterParserHandler.prototype.startPartitionGroupRule = function(name, pseudoName, classes) {
     var partitionGroup = new adapt.pm.PartitionGroup(this.scope, name, pseudoName, classes, this.target);
     var handler = new adapt.pm.PartitionGroupParserHandler(this.scope, this.owner,
-    		partitionGroup, this.validatorSet);
+        partitionGroup, this.validatorSet);
     this.owner.pushHandler(handler);
 };
-
-

--- a/src/adapt/sha1.js
+++ b/src/adapt/sha1.js
@@ -11,7 +11,7 @@ goog.require("adapt.base");
  * @return {string} big-endian byte sequence
  */
 adapt.sha1.encode32 = function(n) {
-	return String.fromCharCode((n >>> 24)&0xFF, (n >>> 16)&0xFF, (n >>> 8)&0xFF, n&0xFF);
+    return String.fromCharCode((n >>> 24)&0xFF, (n >>> 16)&0xFF, (n >>> 8)&0xFF, n&0xFF);
 };
 
 /**
@@ -19,12 +19,12 @@ adapt.sha1.encode32 = function(n) {
  * @return {number}
  */
 adapt.sha1.decode32 = function(bytes) {
-	// Important facts: "".charCodeAt(0) == NaN, NaN & 0xFF == 0
-	var b0 = bytes.charCodeAt(0) & 0xFF;
-	var b1 = bytes.charCodeAt(1) & 0xFF;
-	var b2 = bytes.charCodeAt(2) & 0xFF;
-	var b3 = bytes.charCodeAt(3) & 0xFF;
-	return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+    // Important facts: "".charCodeAt(0) == NaN, NaN & 0xFF == 0
+    var b0 = bytes.charCodeAt(0) & 0xFF;
+    var b1 = bytes.charCodeAt(1) & 0xFF;
+    var b2 = bytes.charCodeAt(2) & 0xFF;
+    var b3 = bytes.charCodeAt(3) & 0xFF;
+    return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
 };
 
 /**
@@ -32,66 +32,66 @@ adapt.sha1.decode32 = function(bytes) {
  * @return {Array.<number>} big-endian uint32 numbers representing sha1 hash
  */
 adapt.sha1.bytesToSHA1Int32 = function(bytes) {
-	var sb = new adapt.base.StringBuffer();
-	sb.append(bytes);
-	var appendCount = (55 - bytes.length) & 63;
-	sb.append('\u0080');
-	while (appendCount > 0) {
-		appendCount--;
-		sb.append('\0');
-	}
-	sb.append('\0\0\0\0');
-	sb.append(adapt.sha1.encode32(bytes.length*8));
-	bytes = sb.toString();
-	
-	var h = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];
-	
-	var w = /** @type Array.<number> */ ([]);
-	var i;
-	
-	for (var bi = 0; bi < bytes.length; bi += 64) {	
-		for (i = 0; i < 16; i++) {
-			w[i] = adapt.sha1.decode32(bytes.substr(bi + 4*i, 4));
-		}
-	    for ( ; i < 80; i++) {
-	    	var q = w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16];
-	        w[i] = (q << 1) | (q >>> 31);
-	    }
-	    
-	    var a = h[0];
-	    var b = h[1];
-	    var c = h[2];
-	    var d = h[3];
-	    var e = h[4];
-	    var f;
-
-	    for (i = 0; i < 80; i++) {
-	        if (i < 20) {
-	            f = ((b & c) | (~b & d)) + 0x5A827999;
-	        } else if (i < 40) {
-	            f = (b ^ c ^ d) + 0x6ED9EBA1;
-	        } else if (i < 60) {
-	            f = ((b & c) | (b & d) | (c & d)) + 0x8F1BBCDC;
-	        } else {
-	            f = (b ^ c ^ d) + 0xCA62C1D6;
-	        }
-	        
-	        f += ((a << 5) | (a >>> 27)) + e + w[i];
-	        e = d;
-	        d = c;
-	        c = (b << 30) | (b >>> 2);
-	        b = a;
-	        a = f;
-	    }
-	    
-	    h[0] = (h[0] + a) | 0;
-	    h[1] = (h[1] + b) | 0;
-	    h[2] = (h[2] + c) | 0;
-	    h[3] = (h[3] + d) | 0;
-	    h[4] = (h[4] + e) | 0;
+    var sb = new adapt.base.StringBuffer();
+    sb.append(bytes);
+    var appendCount = (55 - bytes.length) & 63;
+    sb.append('\u0080');
+    while (appendCount > 0) {
+        appendCount--;
+        sb.append('\0');
     }
-	
-	return h;
+    sb.append('\0\0\0\0');
+    sb.append(adapt.sha1.encode32(bytes.length*8));
+    bytes = sb.toString();
+
+    var h = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];
+
+    var w = /** @type Array.<number> */ ([]);
+    var i;
+
+    for (var bi = 0; bi < bytes.length; bi += 64) {
+        for (i = 0; i < 16; i++) {
+            w[i] = adapt.sha1.decode32(bytes.substr(bi + 4*i, 4));
+        }
+        for (; i < 80; i++) {
+            var q = w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16];
+            w[i] = (q << 1) | (q >>> 31);
+        }
+
+        var a = h[0];
+        var b = h[1];
+        var c = h[2];
+        var d = h[3];
+        var e = h[4];
+        var f;
+
+        for (i = 0; i < 80; i++) {
+            if (i < 20) {
+                f = ((b & c) | (~b & d)) + 0x5A827999;
+            } else if (i < 40) {
+                f = (b ^ c ^ d) + 0x6ED9EBA1;
+            } else if (i < 60) {
+                f = ((b & c) | (b & d) | (c & d)) + 0x8F1BBCDC;
+            } else {
+                f = (b ^ c ^ d) + 0xCA62C1D6;
+            }
+
+            f += ((a << 5) | (a >>> 27)) + e + w[i];
+            e = d;
+            d = c;
+            c = (b << 30) | (b >>> 2);
+            b = a;
+            a = f;
+        }
+
+        h[0] = (h[0] + a) | 0;
+        h[1] = (h[1] + b) | 0;
+        h[2] = (h[2] + c) | 0;
+        h[3] = (h[3] + d) | 0;
+        h[4] = (h[4] + e) | 0;
+    }
+
+    return h;
 };
 
 /**
@@ -99,13 +99,13 @@ adapt.sha1.bytesToSHA1Int32 = function(bytes) {
  * @return {Array.<number>} uint8 numbers representing sha1 hash
  */
 adapt.sha1.bytesToSHA1Int8 = function(bytes) {
-	var h = adapt.sha1.bytesToSHA1Int32(bytes);	
-	var res = [];
-	for (var i = 0; i < h.length; i++) {
-		var n = h[i];
-		res.push((n >>> 24)&0xFF, (n >>> 16)&0xFF, (n >>> 8)&0xFF, n&0xFF);
-	}
-	return res;
+    var h = adapt.sha1.bytesToSHA1Int32(bytes);
+    var res = [];
+    for (var i = 0; i < h.length; i++) {
+        var n = h[i];
+        res.push((n >>> 24)&0xFF, (n >>> 16)&0xFF, (n >>> 8)&0xFF, n&0xFF);
+    }
+    return res;
 };
 
 /**
@@ -113,12 +113,12 @@ adapt.sha1.bytesToSHA1Int8 = function(bytes) {
  * @return {string} chars with codes 0 - 255 equal to SHA1 hash of the input
  */
 adapt.sha1.bytesToSHA1Bytes = function(bytes) {
-	var h = adapt.sha1.bytesToSHA1Int32(bytes);	
-	var sb = new adapt.base.StringBuffer();
-	for (var i = 0; i < h.length; i++) {
-		sb.append(adapt.sha1.encode32(h[i]));
-	}
-	return sb.toString();
+    var h = adapt.sha1.bytesToSHA1Int32(bytes);
+    var sb = new adapt.base.StringBuffer();
+    for (var i = 0; i < h.length; i++) {
+        sb.append(adapt.sha1.encode32(h[i]));
+    }
+    return sb.toString();
 };
 
 /**
@@ -126,12 +126,12 @@ adapt.sha1.bytesToSHA1Bytes = function(bytes) {
  * @return {string} hex-encoded SHA1 hash
  */
 adapt.sha1.bytesToSHA1Hex = function(bytes) {
-	var sha1 = adapt.sha1.bytesToSHA1Bytes(bytes);	
-	var sb = new adapt.base.StringBuffer();
-	for (var i = 0; i < sha1.length; i++) {
-		sb.append((sha1.charCodeAt(i)|0x100).toString(16).substr(1));
-	}
-	return sb.toString();
+    var sha1 = adapt.sha1.bytesToSHA1Bytes(bytes);
+    var sb = new adapt.base.StringBuffer();
+    for (var i = 0; i < sha1.length; i++) {
+        sb.append((sha1.charCodeAt(i)|0x100).toString(16).substr(1));
+    }
+    return sb.toString();
 };
 
 /**
@@ -139,8 +139,8 @@ adapt.sha1.bytesToSHA1Hex = function(bytes) {
  * @return {string} base64-encoded SHA1 hash of the input
  */
 adapt.sha1.bytesToSHA1Base64 = function(bytes) {
-	var sha1 = adapt.sha1.bytesToSHA1Bytes(bytes);
-	var sb = new adapt.base.StringBuffer();
-	adapt.base.appendBase64(sb, sha1);
-	return sb.toString();
+    var sha1 = adapt.sha1.bytesToSHA1Bytes(bytes);
+    var sb = new adapt.base.StringBuffer();
+    adapt.base.appendBase64(sb, sha1);
+    return sb.toString();
 };

--- a/src/adapt/task.js
+++ b/src/adapt/task.js
@@ -120,7 +120,7 @@ adapt.task.newFrame = function(name) {
     if (!adapt.task.privateCurrentTask)
         throw new Error('E_TASK_NO_CONTEXT');
     if (!adapt.task.privateCurrentTask.name)
-    	adapt.task.privateCurrentTask.name = name;
+        adapt.task.privateCurrentTask.name = name;
     var task = adapt.task.privateCurrentTask;
     var frame = new adapt.task.Frame(task, task.top, name);
     task.top = frame;
@@ -164,13 +164,13 @@ adapt.task.newResult = function(opt_value) {
  * @return {!adapt.task.Result.<T>}
  */
 adapt.task.handle = function(name, code, onErr) {
-	var frame = adapt.task.newFrame(name);
-	frame.handler = onErr;
+    var frame = adapt.task.newFrame(name);
+    frame.handler = onErr;
     try {
-    	code(frame);
+        code(frame);
     } catch (err) {
-    	// synchronous exception
-    	frame.task.raise(err, frame);
+        // synchronous exception
+        frame.task.raise(err, frame);
     }
     return frame.result();
 };
@@ -181,10 +181,10 @@ adapt.task.handle = function(name, code, onErr) {
  * @return {adapt.task.Task}
  */
 adapt.task.start = function(func, opt_name) {
-	var scheduler = adapt.task.privateCurrentTask
-		? adapt.task.privateCurrentTask.getScheduler() 
-		: adapt.task.primaryScheduler || adapt.task.newScheduler();
-	return scheduler.run(func, opt_name);
+    var scheduler = adapt.task.privateCurrentTask
+        ? adapt.task.privateCurrentTask.getScheduler()
+        : adapt.task.primaryScheduler || adapt.task.newScheduler();
+    return scheduler.run(func, opt_name);
 };
 
 /**
@@ -245,7 +245,7 @@ adapt.task.Scheduler = function(timer) {
     /** @type {boolean} */ this.inTimeSlice = false;
     /** @type {number} */ this.order = 0;
     if (!adapt.task.primaryScheduler) {
-    	adapt.task.primaryScheduler = this;
+        adapt.task.primaryScheduler = this;
     }
 };
 
@@ -254,7 +254,7 @@ adapt.task.Scheduler = function(timer) {
  * @param {number} slice length in milliseconds.
  */
 adapt.task.Scheduler.prototype.setSlice = function(slice) {
-	this.slice = slice;
+    this.slice = slice;
 };
 
 /**
@@ -262,7 +262,7 @@ adapt.task.Scheduler.prototype.setSlice = function(slice) {
  * @param {number} timeout in milliseconds.
  */
 adapt.task.Scheduler.prototype.setTimeout = function(timeout) {
-	this.timeout = timeout;
+    this.timeout = timeout;
 };
 
 /**
@@ -308,7 +308,7 @@ adapt.task.Scheduler.prototype.arm = function() {
  * @return {void}
  */
 adapt.task.Scheduler.prototype.schedule = function(
-        continuation, opt_delay) {
+    continuation, opt_delay) {
     var c = /** @type {adapt.task.Continuation} */ (continuation);
     var now = this.timer.currentTime();
     c.order = this.order++;
@@ -409,7 +409,7 @@ adapt.task.Continuation = function(task) {
  */
 adapt.task.Continuation.prototype.compare = function(otherComp) {
     // earlier wins
-	var other = /** @type {adapt.task.Continuation} */ (otherComp);
+    var other = /** @type {adapt.task.Continuation} */ (otherComp);
     return other.scheduledTime - this.scheduledTime || other.order - this.order;
 };
 
@@ -428,7 +428,7 @@ adapt.task.Continuation.prototype.getTask = function() {
  * @param {number=} opt_delay optional delay in milliseconds.
  */
 adapt.task.Continuation.prototype.schedule = function(result, opt_delay) {
-	this.result = result;
+    this.result = result;
     this.task.scheduler.schedule(this, opt_delay);
 };
 
@@ -474,7 +474,7 @@ adapt.task.Task = function(scheduler, name) {
  * @return {string} task name.
  */
 adapt.task.Task.prototype.getName = function() {
-	return this.name;
+    return this.name;
 };
 
 /**
@@ -540,20 +540,20 @@ adapt.task.Task.prototype.join = function() {
  * parent link) and sync (regular JavaScript stack).
  */
 adapt.task.Task.prototype.unwind = function() {
-	// We have a sequence of frames on the stack.
-	while(this.top && !this.top.handler) {
-		this.top = this.top.parent;
-	}
-	if (this.top) {
-		// found a handler
-		var err = this.exception;
-		this.exception = null;
-		this.top.handler(this.top, err);
-	} else {
+    // We have a sequence of frames on the stack.
+    while (this.top && !this.top.handler) {
+        this.top = this.top.parent;
+    }
+    if (this.top) {
+        // found a handler
+        var err = this.exception;
+        this.exception = null;
+        this.top.handler(this.top, err);
+    } else {
         if (this.exception) {
             vivliostyle.logging.logger.error(this.exception, 'Unhandled exception in task', this.name);
         }
-	}
+    }
 };
 
 /**
@@ -567,11 +567,11 @@ adapt.task.Task.prototype.raise = function(err, opt_frame) {
     if (opt_frame) {
         var f = this.top;
         while (f && f != opt_frame) {
-        	f = f.parent;
+            f = f.parent;
         }
         if (f == opt_frame) {
-        	this.top = f;
-        }    	
+            this.top = f;
+        }
     }
     this.exception = err;
     this.unwind();
@@ -581,16 +581,16 @@ adapt.task.Task.prototype.raise = function(err, opt_frame) {
  * Fill the stack trace in the exception
  * @param {Error} err exception
  */
-adapt.task.Task.prototype.fillStack = function(err) {	
-	var out = err['frameTrace'];
+adapt.task.Task.prototype.fillStack = function(err) {
+    var out = err['frameTrace'];
     if (!out) {
-    	out = err["stack"] ? err["stack"] + "\n\t---- async ---\n" : "";
-	    for (var f = this.top; f; f = f.parent) {
-	        out += '\t';
-	        out += f.getName();
-	        out += '\n';
-	    }
-	    err['frameTrace'] = out;
+        out = err["stack"] ? err["stack"] + "\n\t---- async ---\n" : "";
+        for (var f = this.top; f; f = f.parent) {
+            out += '\t';
+            out += f.getName();
+            out += '\n';
+        }
+        err['frameTrace'] = out;
     }
 };
 
@@ -631,7 +631,7 @@ adapt.task.SyncResultImpl.prototype.thenReturn = function(result) {
  * @override
  */
 adapt.task.SyncResultImpl.prototype.thenFinish = function(frame) {
-	frame.finish(this.value);
+    frame.finish(this.value);
 };
 
 /**
@@ -693,10 +693,10 @@ adapt.task.ResultImpl.prototype.thenAsync = function(callback) {
 adapt.task.ResultImpl.prototype.thenReturn = function(result) {
     if (this.isPending()) {
         return this.thenAsync(function() {
-        	return new adapt.task.SyncResultImpl(result);
+            return new adapt.task.SyncResultImpl(result);
         });
     } else {
-    	return new adapt.task.SyncResultImpl(result);
+        return new adapt.task.SyncResultImpl(result);
     }
 };
 
@@ -706,11 +706,11 @@ adapt.task.ResultImpl.prototype.thenReturn = function(result) {
 adapt.task.ResultImpl.prototype.thenFinish = function(frame) {
     if (this.isPending()) {
         this.then(function(res) {
-        	frame.finish(res);
+            frame.finish(res);
         });
     } else {
-    	frame.finish(this.frame.res);
-    }	
+        frame.finish(this.frame.res);
+    }
 };
 
 /**
@@ -725,7 +725,7 @@ adapt.task.ResultImpl.prototype.isPending = function() {
  */
 adapt.task.ResultImpl.prototype.get = function() {
     if (this.isPending())
-    	throw new Error("Result is pending");
+        throw new Error("Result is pending");
     return this.frame.res;
 };
 
@@ -781,13 +781,13 @@ adapt.task.Frame.prototype.finish = function(res) {
     var frame = this.parent;
     adapt.task.privateCurrentTask.top = frame;
     if (this.callback) {
-	    try {
-	        this.callback(res);
-	    } catch (err) {
-	        this.task.raise(err, frame);
-	    }
-	    // callback was called
-	    this.state = adapt.task.FrameState.DEAD;
+        try {
+            this.callback(res);
+        } catch (err) {
+            this.task.raise(err, frame);
+        }
+        // callback was called
+        this.state = adapt.task.FrameState.DEAD;
     }
 };
 
@@ -828,8 +828,8 @@ adapt.task.Frame.prototype.then = function(callback) {
             }
             break;
         case adapt.task.FrameState.FINISHED:
-        	var task = this.task;
-        	var frame = this.parent;
+            var task = this.task;
+            var frame = this.parent;
             try {
                 callback(this.res);
                 this.state = adapt.task.FrameState.DEAD;
@@ -894,7 +894,7 @@ adapt.task.Frame.prototype.loop = function(func) {
             }
             frame.finish(true);
         } catch (err) {
-        	frame.task.raise(err, frame);
+            frame.task.raise(err, frame);
         }
     };
     step(true);
@@ -909,18 +909,18 @@ adapt.task.Frame.prototype.loop = function(func) {
 adapt.task.Frame.prototype.loopWithFrame = function(func) {
     var task = adapt.task.privateCurrentTask;
     if (!task) {
-    	throw new Error("E_TASK_NO_CONTEXT");
+        throw new Error("E_TASK_NO_CONTEXT");
     }
     return this.loop(function() {
-    	var result;
-    	do {
-		    var frame = new adapt.task.LoopBodyFrame(/** @type {!adapt.task.Task} */ (task), task.top);
-		    task.top = frame;
-		    frame.state = adapt.task.FrameState.ACTIVE;
-		    func(frame);
-		    result = frame.result();
-    	} while(!result.isPending() && result.get());
-    	return result;
+        var result;
+        do {
+            var frame = new adapt.task.LoopBodyFrame(/** @type {!adapt.task.Task} */ (task), task.top);
+            task.top = frame;
+            frame.state = adapt.task.FrameState.ACTIVE;
+            func(frame);
+            result = frame.result();
+        } while (!result.isPending() && result.get());
+        return result;
     });
 };
 
@@ -933,7 +933,7 @@ adapt.task.Frame.prototype.suspend = function(opt_waitTarget) {
     if (this.task.continuation)
         throw new Error('E_TASK_ALREADY_SUSPENDED');
     /** @type {adapt.task.Continuation.<T>} */ var continuation =
-    	new adapt.task.Continuation(this.task);
+        new adapt.task.Continuation(this.task);
     this.task.continuation = continuation;
     adapt.task.privateCurrentTask = null;
     this.task.waitTarget = opt_waitTarget || null;
@@ -947,7 +947,7 @@ adapt.task.Frame.prototype.suspend = function(opt_waitTarget) {
  * @extends {adapt.task.Frame.<boolean>}
  */
 adapt.task.LoopBodyFrame = function(task, parent) {
-	adapt.task.Frame.call(this, task, parent, "loop");
+    adapt.task.Frame.call(this, task, parent, "loop");
 };
 goog.inherits(adapt.task.LoopBodyFrame, adapt.task.Frame);
 
@@ -955,14 +955,14 @@ goog.inherits(adapt.task.LoopBodyFrame, adapt.task.Frame);
  * @return {void}
  */
 adapt.task.LoopBodyFrame.prototype.continueLoop = function() {
-	this.finish(true);
+    this.finish(true);
 };
 
 /**
  * @return {void}
  */
 adapt.task.LoopBodyFrame.prototype.breakLoop = function() {
-	this.finish(false);
+    this.finish(false);
 };
 
 /**
@@ -1005,9 +1005,9 @@ adapt.task.EventSource = function() {
 adapt.task.EventSource.prototype.attach = function(target, type, opt_preventDefault) {
     var self = this;
     var listener = /** @param {adapt.base.Event} event */ function(event) {
-    	if (opt_preventDefault) {
-    		event.preventDefault();
-    	}
+        if (opt_preventDefault) {
+            event.preventDefault();
+        }
         if (self.tail.event) {
             self.tail.next = new adapt.task.EventItem(event);
             self.tail = self.tail.next;
@@ -1030,27 +1030,27 @@ adapt.task.EventSource.prototype.attach = function(target, type, opt_preventDefa
  * @return {void}
  */
 adapt.task.EventSource.prototype.detach = function(target, type) {
-	var i = 0;
-	var item = null;
-	while (i < this.listeners.length) {
-		item = this.listeners[i];
-		if (item.type == type && item.target === target) {
-			this.listeners.splice(i, 1);
-		    item.target.removeEventListener(item.type, item.listener, false);
-		    return;
-		}
-		i++;
-	}
+    var i = 0;
+    var item = null;
+    while (i < this.listeners.length) {
+        item = this.listeners[i];
+        if (item.type == type && item.target === target) {
+            this.listeners.splice(i, 1);
+            item.target.removeEventListener(item.type, item.listener, false);
+            return;
+        }
+        i++;
+    }
     throw new Error('E_TASK_EVENT_SOURCE_NOT_ATTACHED');
 };
 
 /**
  * Read next dispatched event, blocking the current task if needed.
- * @return {!adapt.task.Result.<adapt.base.Event>} 
+ * @return {!adapt.task.Result.<adapt.base.Event>}
  */
 adapt.task.EventSource.prototype.nextEvent = function() {
     /** @type {!adapt.task.Frame.<adapt.base.Event>} */ var frame =
-    	adapt.task.newFrame('EventSource.nextEvent');
+        adapt.task.newFrame('EventSource.nextEvent');
     var self = this;
     var readEvent = function() {
         if (self.head.event) {
@@ -1063,7 +1063,7 @@ adapt.task.EventSource.prototype.nextEvent = function() {
         } else if (self.continuation) {
             throw new Error('E_TASK_EVENT_SOURCE_OTHER_TASK_WAITING');
         } else {
-        	/** @type {!adapt.task.Frame.<boolean>} */ var frameInternal =
+            /** @type {!adapt.task.Frame.<boolean>} */ var frameInternal =
                 adapt.task.newFrame('EventSource.nextEventInternal');
             self.continuation = frameInternal.suspend(self);
             frameInternal.result().then(readEvent);

--- a/src/adapt/taskutil.js
+++ b/src/adapt/taskutil.js
@@ -20,12 +20,12 @@ goog.require('adapt.task');
  * @param {string=} opt_name
  */
 adapt.taskutil.Fetcher = function(fetch, opt_name) {
-	/** @const */ this.fetch = fetch;
-	/** @const */ this.name = opt_name;
-	/** @type {boolean} */ this.arrived = false;
-	/** @type {T} */ this.resource = null;
-	/** @type {adapt.task.Task} */ this.task = null;
-	/** @type {?Array.<function(*):void>} */ this.piggybacks = [];
+    /** @const */ this.fetch = fetch;
+    /** @const */ this.name = opt_name;
+    /** @type {boolean} */ this.arrived = false;
+    /** @type {T} */ this.resource = null;
+    /** @type {adapt.task.Task} */ this.task = null;
+    /** @type {?Array.<function(*):void>} */ this.piggybacks = [];
 };
 
 /**
@@ -33,30 +33,30 @@ adapt.taskutil.Fetcher = function(fetch, opt_name) {
  * @return {void}
  */
 adapt.taskutil.Fetcher.prototype.start = function() {
-	if (!this.task) {
-		var self = this;
-		this.task = adapt.task.currentTask().getScheduler().run(function() {
-			var frame = adapt.task.newFrame("Fetcher.run");
-			self.fetch().then(function(resource) {
-				var piggibacks = self.piggybacks;
-				self.arrived = true;
-				self.resource = resource;
-				self.task = null;
-				self.piggybacks = [];
-				if (piggibacks) {
-					for (var i = 0; i < piggibacks.length; i++) {
-						try {
-							piggibacks[i](resource);
-						} catch (err) {
-							vivliostyle.logging.logger.error(err, "Error:");
-						}
-					}
-				}
-				frame.finish(resource);
-			});
-			return frame.result();
-		}, this.name);
-	}
+    if (!this.task) {
+        var self = this;
+        this.task = adapt.task.currentTask().getScheduler().run(function() {
+            var frame = adapt.task.newFrame("Fetcher.run");
+            self.fetch().then(function(resource) {
+                var piggibacks = self.piggybacks;
+                self.arrived = true;
+                self.resource = resource;
+                self.task = null;
+                self.piggybacks = [];
+                if (piggibacks) {
+                    for (var i = 0; i < piggibacks.length; i++) {
+                        try {
+                            piggibacks[i](resource);
+                        } catch (err) {
+                            vivliostyle.logging.logger.error(err, "Error:");
+                        }
+                    }
+                }
+                frame.finish(resource);
+            });
+            return frame.result();
+        }, this.name);
+    }
 };
 
 /**
@@ -64,11 +64,11 @@ adapt.taskutil.Fetcher.prototype.start = function() {
  * @return {void}
  */
 adapt.taskutil.Fetcher.prototype.piggyback = function(fn) {
-	if (this.arrived) {
-		fn(this.resource);
-	} else {
-		this.piggybacks.push(fn);
-	}
+    if (this.arrived) {
+        fn(this.resource);
+    } else {
+        this.piggybacks.push(fn);
+    }
 };
 
 /**
@@ -76,17 +76,17 @@ adapt.taskutil.Fetcher.prototype.piggyback = function(fn) {
  * @return {!adapt.task.Result.<T>}
  */
 adapt.taskutil.Fetcher.prototype.get = function() {
-	if (this.arrived)
-		return adapt.task.newResult(this.resource);
-	this.start();
-	return /** @type {!adapt.task.Result.<T>} */ (this.task.join());
+    if (this.arrived)
+        return adapt.task.newResult(this.resource);
+    this.start();
+    return /** @type {!adapt.task.Result.<T>} */ (this.task.join());
 };
 
 /**
  * @return {boolean}
  */
 adapt.taskutil.Fetcher.prototype.hasArrived = function() {
-	return this.arrived;
+    return this.arrived;
 };
 
 /**
@@ -95,23 +95,23 @@ adapt.taskutil.Fetcher.prototype.hasArrived = function() {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.taskutil.waitForFetchers = function(fetchers) {
-	if (fetchers.length == 0)
-		return adapt.task.newResult(true);
-	if (fetchers.length == 1)
-		return fetchers[0].get().thenReturn(true);
-	var frame = adapt.task.newFrame("waitForFetches");
-	var i = 0;
-	frame.loop(function() {
-		while (i < fetchers.length) {
-			var fetcher = fetchers[i++];
-			if (!fetcher.hasArrived())
-				return fetcher.get().thenReturn(true);
-		}
-		return adapt.task.newResult(false);
-	}).then(function() {
-		frame.finish(true);
-	});
-	return frame.result();
+    if (fetchers.length == 0)
+        return adapt.task.newResult(true);
+    if (fetchers.length == 1)
+        return fetchers[0].get().thenReturn(true);
+    var frame = adapt.task.newFrame("waitForFetches");
+    var i = 0;
+    frame.loop(function() {
+        while (i < fetchers.length) {
+            var fetcher = fetchers[i++];
+            if (!fetcher.hasArrived())
+                return fetcher.get().thenReturn(true);
+        }
+        return adapt.task.newResult(false);
+    }).then(function() {
+        frame.finish(true);
+    });
+    return frame.result();
 };
 
 /**
@@ -120,40 +120,40 @@ adapt.taskutil.waitForFetchers = function(fetchers) {
  * @return {!adapt.taskutil.Fetcher.<string>} holding event type (load/error/abort)
  */
 adapt.taskutil.loadElement = function(elem, src) {
-	var width = null;
-	var height = null;
-	if (elem.localName == "img") {
-		width = elem.getAttribute("width");
-		height = elem.getAttribute("height");
-	}
-	var fetcher = new adapt.taskutil.Fetcher(function() {
-	    /** @type {!adapt.task.Frame.<string>} */ var frame = adapt.task.newFrame("loadImage");
-	    var continuation = frame.suspend(elem);
-	    /** @param {Event} evt */
-		var handler = function(evt) {
-			if (elem.localName == "img") {
-				// IE puts these bogus attributes, even if they were not present
-				if (!width) {
-					elem.removeAttribute("width");
-				}
-				if (!height) {
-					elem.removeAttribute("height");
-				}
-			}
-			continuation.schedule(evt ? evt.type : "timeout");
-		};
-		elem.addEventListener("load", handler, false);
-		elem.addEventListener("error", handler, false);
-		elem.addEventListener("abort", handler, false);
-		if (elem.namespaceURI == adapt.base.NS.SVG) {
-			elem.setAttributeNS(adapt.base.NS.XLINK, "xlink:href", src);
-			// SVG handlers are not reliable
-			setTimeout(handler, 300);
-		} else {
-			elem.src = src;
-		}
-		return frame.result();
-	}, "loadElement " + src);
-	fetcher.start();
-	return fetcher;
+    var width = null;
+    var height = null;
+    if (elem.localName == "img") {
+        width = elem.getAttribute("width");
+        height = elem.getAttribute("height");
+    }
+    var fetcher = new adapt.taskutil.Fetcher(function() {
+        /** @type {!adapt.task.Frame.<string>} */ var frame = adapt.task.newFrame("loadImage");
+        var continuation = frame.suspend(elem);
+        /** @param {Event} evt */
+        var handler = function(evt) {
+            if (elem.localName == "img") {
+                // IE puts these bogus attributes, even if they were not present
+                if (!width) {
+                    elem.removeAttribute("width");
+                }
+                if (!height) {
+                    elem.removeAttribute("height");
+                }
+            }
+            continuation.schedule(evt ? evt.type : "timeout");
+        };
+        elem.addEventListener("load", handler, false);
+        elem.addEventListener("error", handler, false);
+        elem.addEventListener("abort", handler, false);
+        if (elem.namespaceURI == adapt.base.NS.SVG) {
+            elem.setAttributeNS(adapt.base.NS.XLINK, "xlink:href", src);
+            // SVG handlers are not reliable
+            setTimeout(handler, 300);
+        } else {
+            elem.src = src;
+        }
+        return frame.result();
+    }, "loadElement " + src);
+    fetcher.start();
+    return fetcher;
 };

--- a/src/adapt/toc.js
+++ b/src/adapt/toc.js
@@ -37,19 +37,19 @@ adapt.toc.bulletEmpty = "\u25B9";
  * @implements {adapt.vgen.CustomRendererFactory}
  */
 adapt.toc.TOCView = function(store, url, lang, clientLayout, fontMapper, pref,
-		rendererFactory, fallbackMap, documentURLTransformer, counterStore) {
-	/** @const */ this.store = store;
-	/** @const */ this.url = url;
-	/** @const */ this.lang = lang;	
-	/** @const */ this.clientLayout = clientLayout;	
-	/** @const */ this.fontMapper = fontMapper;	
-	/** @const */ this.pref = adapt.expr.clonePreferences(pref);
-	/** @const */ this.rendererFactory = rendererFactory;
-	/** @const */ this.fallbackMap = fallbackMap;
-	/** @const */ this.documentURLTransformer = documentURLTransformer;
-	/** @const */ this.counterStore = counterStore;
-	/** @type {adapt.vtree.Page} */ this.page = null;
-	/** @type {adapt.ops.StyleInstance} */ this.instance = null;
+                             rendererFactory, fallbackMap, documentURLTransformer, counterStore) {
+    /** @const */ this.store = store;
+    /** @const */ this.url = url;
+    /** @const */ this.lang = lang;
+    /** @const */ this.clientLayout = clientLayout;
+    /** @const */ this.fontMapper = fontMapper;
+    /** @const */ this.pref = adapt.expr.clonePreferences(pref);
+    /** @const */ this.rendererFactory = rendererFactory;
+    /** @const */ this.fallbackMap = fallbackMap;
+    /** @const */ this.documentURLTransformer = documentURLTransformer;
+    /** @const */ this.counterStore = counterStore;
+    /** @type {adapt.vtree.Page} */ this.page = null;
+    /** @type {adapt.ops.StyleInstance} */ this.instance = null;
 };
 
 /**
@@ -58,102 +58,102 @@ adapt.toc.TOCView = function(store, url, lang, clientLayout, fontMapper, pref,
  * @return {void}
  */
 adapt.toc.TOCView.prototype.setAutoHeight = function(elem, depth) {
-	if (depth-- == 0) {
-		return;
-	}
-	for (var c = elem.firstChild; c; c = c.nextSibling) {
-		if (c.nodeType == 1) {
-			var e = /** @type {Element} */ (c);
-			if (adapt.base.getCSSProperty(e, "height", "auto") != "auto") {
-				adapt.base.setCSSProperty(e, "height", "auto");
-				this.setAutoHeight(e, depth);
-			}
-			if (adapt.base.getCSSProperty(e, "position", "static") == "absolute") {
-				adapt.base.setCSSProperty(e, "position", "relative");
-				this.setAutoHeight(e, depth);
-			}
-		}
-	}
+    if (depth-- == 0) {
+        return;
+    }
+    for (var c = elem.firstChild; c; c = c.nextSibling) {
+        if (c.nodeType == 1) {
+            var e = /** @type {Element} */ (c);
+            if (adapt.base.getCSSProperty(e, "height", "auto") != "auto") {
+                adapt.base.setCSSProperty(e, "height", "auto");
+                this.setAutoHeight(e, depth);
+            }
+            if (adapt.base.getCSSProperty(e, "position", "static") == "absolute") {
+                adapt.base.setCSSProperty(e, "position", "relative");
+                this.setAutoHeight(e, depth);
+            }
+        }
+    }
 };
 
 /**
  * @param {Event} evt
  */
 adapt.toc.toggleNodeExpansion = function(evt) {
-	var elem = /** @type {Element} */ (evt.target);
-	var open = elem.textContent == adapt.toc.bulletClosed;
-	elem.textContent = open ? adapt.toc.bulletOpen : adapt.toc.bulletClosed;
-	var tocNodeElem = /** @type {Element} */ (elem.parentNode);
-	var c = tocNodeElem.firstChild;
-	while (c) {
-		if (c.nodeType != 1) {
-			c = c.nextSibling;
-			continue;
-		}
-		var ce = /** @type {HTMLElement} */ (c);
-		var adaptClass = ce.getAttribute("data-adapt-class");
-		if (adaptClass == "toc-container") {
-			c = ce.firstChild;
-			continue;
-		}
-		if (ce.getAttribute("data-adapt-class") == "toc-node") {
-			ce.style.height = open ? "auto" : "0px";
-		}
-		c = c.nextSibling;
-	}
-	evt.stopPropagation();
+    var elem = /** @type {Element} */ (evt.target);
+    var open = elem.textContent == adapt.toc.bulletClosed;
+    elem.textContent = open ? adapt.toc.bulletOpen : adapt.toc.bulletClosed;
+    var tocNodeElem = /** @type {Element} */ (elem.parentNode);
+    var c = tocNodeElem.firstChild;
+    while (c) {
+        if (c.nodeType != 1) {
+            c = c.nextSibling;
+            continue;
+        }
+        var ce = /** @type {HTMLElement} */ (c);
+        var adaptClass = ce.getAttribute("data-adapt-class");
+        if (adaptClass == "toc-container") {
+            c = ce.firstChild;
+            continue;
+        }
+        if (ce.getAttribute("data-adapt-class") == "toc-node") {
+            ce.style.height = open ? "auto" : "0px";
+        }
+        c = c.nextSibling;
+    }
+    evt.stopPropagation();
 };
 
 /**
  * @override
  */
 adapt.toc.TOCView.prototype.makeCustomRenderer = function(xmldoc) {
-	var renderer = this.rendererFactory.makeCustomRenderer(xmldoc);
-	return (
-	/**
-	 * @param {Element} srcElem
-	 * @param {Element} viewParent
-	 * @return {!adapt.task.Result.<Element>}
-	 */
-	function(srcElem, viewParent, computedStyle) {
-		var behavior = computedStyle["behavior"];
-		if (!behavior || (behavior.toString() != "toc-node" && behavior.toString() != "toc-container")) {
-			return renderer(srcElem, viewParent, computedStyle);
-		}
-		var adaptParentClass = viewParent.getAttribute("data-adapt-class");
-		if (adaptParentClass == "toc-node") {
-			var button = /** @type {Element} */ (viewParent.firstChild);
-			if (button.textContent != adapt.toc.bulletClosed) {
-				button.textContent = adapt.toc.bulletClosed;
-				adapt.base.setCSSProperty(button, "cursor", "pointer");
-				button.addEventListener("click", adapt.toc.toggleNodeExpansion, false);
-			}
-		}
-		var element = viewParent.ownerDocument.createElement("div");
-		element.setAttribute("data-adapt-process-children", "true");
-		if (behavior.toString() == "toc-node") {
-			var button = viewParent.ownerDocument.createElement("div");
-			button.textContent = adapt.toc.bulletEmpty;
-			// TODO: define pseudo-element for the button?
-			adapt.base.setCSSProperty(button, "margin-left", "-1em");
-			adapt.base.setCSSProperty(button, "display", "inline-block");
-			adapt.base.setCSSProperty(button, "width", "1em");
-			adapt.base.setCSSProperty(button, "text-align", "left");
-			adapt.base.setCSSProperty(button, "cursor", "default");
-			adapt.base.setCSSProperty(button, "font-family", "Menlo,sans-serif");
-			element.appendChild(button);
-			adapt.base.setCSSProperty(element, "overflow", "hidden");
-			element.setAttribute("data-adapt-class", "toc-node");
-			if (adaptParentClass == "toc-node" || adaptParentClass == "toc-container") {
-				adapt.base.setCSSProperty(element, "height", "0px");
-			}
-		} else {
-			if (adaptParentClass == "toc-node") {
-				element.setAttribute("data-adapt-class", "toc-container");			
-			}
-		}
-		return adapt.task.newResult(/** @type {Element} */ (element));
-	});
+    var renderer = this.rendererFactory.makeCustomRenderer(xmldoc);
+    return (
+        /**
+         * @param {Element} srcElem
+         * @param {Element} viewParent
+         * @return {!adapt.task.Result.<Element>}
+         */
+        function(srcElem, viewParent, computedStyle) {
+            var behavior = computedStyle["behavior"];
+            if (!behavior || (behavior.toString() != "toc-node" && behavior.toString() != "toc-container")) {
+                return renderer(srcElem, viewParent, computedStyle);
+            }
+            var adaptParentClass = viewParent.getAttribute("data-adapt-class");
+            if (adaptParentClass == "toc-node") {
+                var button = /** @type {Element} */ (viewParent.firstChild);
+                if (button.textContent != adapt.toc.bulletClosed) {
+                    button.textContent = adapt.toc.bulletClosed;
+                    adapt.base.setCSSProperty(button, "cursor", "pointer");
+                    button.addEventListener("click", adapt.toc.toggleNodeExpansion, false);
+                }
+            }
+            var element = viewParent.ownerDocument.createElement("div");
+            element.setAttribute("data-adapt-process-children", "true");
+            if (behavior.toString() == "toc-node") {
+                var button = viewParent.ownerDocument.createElement("div");
+                button.textContent = adapt.toc.bulletEmpty;
+                // TODO: define pseudo-element for the button?
+                adapt.base.setCSSProperty(button, "margin-left", "-1em");
+                adapt.base.setCSSProperty(button, "display", "inline-block");
+                adapt.base.setCSSProperty(button, "width", "1em");
+                adapt.base.setCSSProperty(button, "text-align", "left");
+                adapt.base.setCSSProperty(button, "cursor", "default");
+                adapt.base.setCSSProperty(button, "font-family", "Menlo,sans-serif");
+                element.appendChild(button);
+                adapt.base.setCSSProperty(element, "overflow", "hidden");
+                element.setAttribute("data-adapt-class", "toc-node");
+                if (adaptParentClass == "toc-node" || adaptParentClass == "toc-container") {
+                    adapt.base.setCSSProperty(element, "height", "0px");
+                }
+            } else {
+                if (adaptParentClass == "toc-node") {
+                    element.setAttribute("data-adapt-class", "toc-container");
+                }
+            }
+            return adapt.task.newResult(/** @type {Element} */ (element));
+        });
 };
 
 /**
@@ -165,29 +165,29 @@ adapt.toc.TOCView.prototype.makeCustomRenderer = function(xmldoc) {
  * @return {!adapt.task.Result.<adapt.vtree.Page>}
  */
 adapt.toc.TOCView.prototype.showTOC = function(elem, viewport, width, height, fontSize) {
-	if (this.page) {
-		return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (this.page));
-	}
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame = adapt.task.newFrame("showTOC");
-	var page = new adapt.vtree.Page(elem, elem);
-	this.page = page;
-    this.store.load(this.url).then(function (xmldoc) {
-    	var style = self.store.getStyleForDoc(xmldoc);
-    	var viewportSize = style.sizeViewport(width, 100000, fontSize);
-    	viewport = new adapt.vgen.Viewport(viewport.window, viewportSize.fontSize, viewport.root,
-    				viewportSize.width, viewportSize.height);
-    	var customRenderer = self.makeCustomRenderer(xmldoc);
+    if (this.page) {
+        return adapt.task.newResult(/** @type {adapt.vtree.Page} */ (this.page));
+    }
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.Page>} */ var frame = adapt.task.newFrame("showTOC");
+    var page = new adapt.vtree.Page(elem, elem);
+    this.page = page;
+    this.store.load(this.url).then(function(xmldoc) {
+        var style = self.store.getStyleForDoc(xmldoc);
+        var viewportSize = style.sizeViewport(width, 100000, fontSize);
+        viewport = new adapt.vgen.Viewport(viewport.window, viewportSize.fontSize, viewport.root,
+            viewportSize.width, viewportSize.height);
+        var customRenderer = self.makeCustomRenderer(xmldoc);
         var instance = new adapt.ops.StyleInstance(style, xmldoc, self.lang,
-        		viewport, self.clientLayout, self.fontMapper, customRenderer, self.fallbackMap, 0,
-        		self.documentURLTransformer, self.counterStore);
+            viewport, self.clientLayout, self.fontMapper, customRenderer, self.fallbackMap, 0,
+            self.documentURLTransformer, self.counterStore);
         self.instance = instance;
         instance.pref = self.pref;
         instance.init().then(function() {
-        	instance.layoutNextPage(page, null).then(function() {
-        		self.setAutoHeight(elem, 2);
-    			frame.finish(page);       		
-        	});
+            instance.layoutNextPage(page, null).then(function() {
+                self.setAutoHeight(elem, 2);
+                frame.finish(page);
+            });
         });
     });
     return frame.result();
@@ -197,22 +197,22 @@ adapt.toc.TOCView.prototype.showTOC = function(elem, viewport, width, height, fo
  * @return {void}
  */
 adapt.toc.TOCView.prototype.hideTOC = function() {
-	if (this.page) {
-		var page = this.page;
-		this.page = null;
-		this.instance = null;
-		adapt.base.setCSSProperty(page.container, "visibility", "none");
-		var parent = page.container.parentNode;
-		if (parent) {
-			parent.removeChild(page.container);
-		}
-	}
+    if (this.page) {
+        var page = this.page;
+        this.page = null;
+        this.instance = null;
+        adapt.base.setCSSProperty(page.container, "visibility", "none");
+        var parent = page.container.parentNode;
+        if (parent) {
+            parent.removeChild(page.container);
+        }
+    }
 };
 
 /**
  * @return {boolean}
  */
 adapt.toc.TOCView.prototype.isTOCVisible = function() {
-	return !!this.page;
+    return !!this.page;
 };
 

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -28,8 +28,8 @@ adapt.vgen.frontEdgeBlackListHor = {
     "border-top-width": "0px",
     "border-top-style": "none",
     "border-top-color": "transparent",
-	"border-top-left-radius": "0px",
-	"border-top-right-radius": "0px"
+    "border-top-left-radius": "0px",
+    "border-top-right-radius": "0px"
 };
 
 /**
@@ -44,8 +44,8 @@ adapt.vgen.frontEdgeBlackListVert = {
     "border-right-width": "0px",
     "border-right-style": "none",
     "border-right-color": "transparent",
-	"border-top-right-radius": "0px",
-	"border-bottom-right-radius": "0px"
+    "border-top-right-radius": "0px",
+    "border-bottom-right-radius": "0px"
 };
 
 /**
@@ -54,7 +54,7 @@ adapt.vgen.frontEdgeBlackListVert = {
  * @type {!Object.<string,string>}
  */
 adapt.vgen.frontEdgeUnforcedBreakBlackListHor = {
-	"margin-top": "0px"
+    "margin-top": "0px"
 };
 
 /**
@@ -63,7 +63,7 @@ adapt.vgen.frontEdgeUnforcedBreakBlackListHor = {
  * @type {!Object.<string,string>}
  */
 adapt.vgen.frontEdgeUnforcedBreakBlackListVert = {
-	"margin-right": "0px"
+    "margin-right": "0px"
 };
 
 
@@ -98,20 +98,20 @@ adapt.vgen.namespacePrefixMap = {};
  * @param {HTMLIFrameElement} iframe
  */
 adapt.vgen.initIFrame = function(iframe) {
-	iframe.addEventListener("load", function() {
-		iframe.contentWindow.navigator["epubReadingSystem"] = {
-			"name": "adapt",
-			"version": "0.1",
-			"layoutStyle": "paginated",
-			"hasFeature": function(name, version) {
-				switch(name) {
-				case "mouse-events":
-					return true;
-				}
-				return false;
-			}
-		};
-	}, false);
+    iframe.addEventListener("load", function() {
+        iframe.contentWindow.navigator["epubReadingSystem"] = {
+            "name": "adapt",
+            "version": "0.1",
+            "layoutStyle": "paginated",
+            "hasFeature": function(name, version) {
+                switch (name) {
+                    case "mouse-events":
+                        return true;
+                }
+                return false;
+            }
+        };
+    }, false);
 };
 
 /**
@@ -127,7 +127,7 @@ adapt.vgen.StylerProducer.prototype.getStylerForDoc = function(xmldoc) {};
 
 
 adapt.vgen.pseudoelementDoc = (new DOMParser()).parseFromString(
-		'<root xmlns="' + adapt.base.NS.SHADOW + '"/>', "text/xml");
+    '<root xmlns="' + adapt.base.NS.SHADOW + '"/>', "text/xml");
 
 /**
  * Pseudoelement names in the order they should be inserted in the shadow DOM, empty string
@@ -135,8 +135,8 @@ adapt.vgen.pseudoelementDoc = (new DOMParser()).parseFromString(
  * @const
  */
 adapt.vgen.pseudoNames = ["footnote-marker", "first-5-lines", "first-4-lines",
-                          "first-3-lines", "first-2-lines", "first-line", "first-letter", "before",
-                             "" /* content */, "after"];
+    "first-3-lines", "first-2-lines", "first-line", "first-letter", "before",
+    "" /* content */, "after"];
 
 adapt.vgen.PSEUDO_ATTR = "data-adapt-pseudo";
 
@@ -145,7 +145,7 @@ adapt.vgen.PSEUDO_ATTR = "data-adapt-pseudo";
  * @returns {string}
  */
 adapt.vgen.getPseudoName = function(element) {
-	return element.getAttribute(adapt.vgen.PSEUDO_ATTR) || "";
+    return element.getAttribute(adapt.vgen.PSEUDO_ATTR) || "";
 };
 
 /**
@@ -153,7 +153,7 @@ adapt.vgen.getPseudoName = function(element) {
  * @param {string} name
  */
 adapt.vgen.setPseudoName = function(element, name) {
-	element.setAttribute(adapt.vgen.PSEUDO_ATTR, name);
+    element.setAttribute(adapt.vgen.PSEUDO_ATTR, name);
 };
 
 /**
@@ -165,45 +165,45 @@ adapt.vgen.setPseudoName = function(element, name) {
  * @implements {adapt.cssstyler.AbstractStyler}
  */
 adapt.vgen.PseudoelementStyler = function(element, style, styler, context) {
-	/** @type {adapt.csscasc.ElementStyle} */ this.style = style;
-	/** @const */ this.element = element;
-	/** @type {adapt.cssstyler.AbstractStyler} */ this.styler = styler;
-	/** @const */ this.context = context;
-	/** @type {Object.<string,boolean>} */ this.contentProcessed = {};
+    /** @type {adapt.csscasc.ElementStyle} */ this.style = style;
+    /** @const */ this.element = element;
+    /** @type {adapt.cssstyler.AbstractStyler} */ this.styler = styler;
+    /** @const */ this.context = context;
+    /** @type {Object.<string,boolean>} */ this.contentProcessed = {};
 };
 
 /**
  * @override
  */
 adapt.vgen.PseudoelementStyler.prototype.getStyle = function(element, deep) {
-	var pseudoName = adapt.vgen.getPseudoName(element);
-	if (this.styler && pseudoName && pseudoName.match(/after$/)) {
-		// after content: update style
-		this.style = this.styler.getStyle(this.element, true);
-		this.styler = null;
-	}
+    var pseudoName = adapt.vgen.getPseudoName(element);
+    if (this.styler && pseudoName && pseudoName.match(/after$/)) {
+        // after content: update style
+        this.style = this.styler.getStyle(this.element, true);
+        this.styler = null;
+    }
     var pseudoMap = adapt.csscasc.getStyleMap(this.style, "_pseudos");
-	var style = pseudoMap[pseudoName] || /** @type {adapt.csscasc.ElementStyle} */ ({});
-	if (!this.contentProcessed[pseudoName]) {
-		this.contentProcessed[pseudoName] = true;
-	    var content = style["content"];
-	    if (content) {
-	    	var contentVal = content.evaluate(this.context);
-	    	if (adapt.vtree.nonTrivialContent(contentVal))
-	    		contentVal.visit(new adapt.vtree.ContentPropertyHandler(element, this.context));
-	    }    	
-	}
-	if (pseudoName.match(/^first-/) && !style["x-first-pseudo"]) {
-		var nest = 1;
-		var r;
-		if (pseudoName == "first-letter") {
-			nest = 0;
-		} else if ((r = pseudoName.match(/^first-([0-9]+)-lines$/)) != null) {
-			nest = r[1] - 0;
-		}
-		style["x-first-pseudo"] = new adapt.csscasc.CascadeValue(new adapt.css.Int(nest), 0);
-	}
-	return style;
+    var style = pseudoMap[pseudoName] || /** @type {adapt.csscasc.ElementStyle} */ ({});
+    if (!this.contentProcessed[pseudoName]) {
+        this.contentProcessed[pseudoName] = true;
+        var content = style["content"];
+        if (content) {
+            var contentVal = content.evaluate(this.context);
+            if (adapt.vtree.nonTrivialContent(contentVal))
+                contentVal.visit(new adapt.vtree.ContentPropertyHandler(element, this.context));
+        }
+    }
+    if (pseudoName.match(/^first-/) && !style["x-first-pseudo"]) {
+        var nest = 1;
+        var r;
+        if (pseudoName == "first-letter") {
+            nest = 0;
+        } else if ((r = pseudoName.match(/^first-([0-9]+)-lines$/)) != null) {
+            nest = r[1] - 0;
+        }
+        style["x-first-pseudo"] = new adapt.csscasc.CascadeValue(new adapt.css.Int(nest), 0);
+    }
+    return style;
 };
 
 
@@ -226,29 +226,29 @@ adapt.vgen.PseudoelementStyler.prototype.getStyle = function(element, deep) {
  * @implements {adapt.vtree.LayoutContext}
  */
 adapt.vgen.ViewFactory = function(flowName, context, viewport, styler, regionIds,
-		xmldoc, docFaces, footnoteStyle, stylerProducer, page, customRenderer, fallbackMap,
-		pageFloatHolder, documentURLTransformer) {
-	// from constructor parameters
-	/** @const */ this.flowName = flowName;
-	/** @const */ this.context = context;
-	/** @const */ this.viewport = viewport;
-	/** @const */ this.document = viewport.document;
-	/** @const */ this.styler = styler;
-	/** @const */ this.regionIds = regionIds;
-	/** @const */ this.xmldoc = xmldoc;
-	/** @const */ this.docFaces = docFaces;
-	/** @const */ this.footnoteStyle = footnoteStyle;
-	/** @const */ this.stylerProducer = stylerProducer;
-	/** @const */ this.page = page;
-	/** @const */ this.customRenderer = customRenderer;
-	/** @const */ this.fallbackMap = fallbackMap;
-	/** @const */ this.pageFloatHolder = pageFloatHolder;
-	/** @const */ this.documentURLTransformer = documentURLTransformer;
-	
+                                  xmldoc, docFaces, footnoteStyle, stylerProducer, page, customRenderer, fallbackMap,
+                                  pageFloatHolder, documentURLTransformer) {
+    // from constructor parameters
+    /** @const */ this.flowName = flowName;
+    /** @const */ this.context = context;
+    /** @const */ this.viewport = viewport;
+    /** @const */ this.document = viewport.document;
+    /** @const */ this.styler = styler;
+    /** @const */ this.regionIds = regionIds;
+    /** @const */ this.xmldoc = xmldoc;
+    /** @const */ this.docFaces = docFaces;
+    /** @const */ this.footnoteStyle = footnoteStyle;
+    /** @const */ this.stylerProducer = stylerProducer;
+    /** @const */ this.page = page;
+    /** @const */ this.customRenderer = customRenderer;
+    /** @const */ this.fallbackMap = fallbackMap;
+    /** @const */ this.pageFloatHolder = pageFloatHolder;
+    /** @const */ this.documentURLTransformer = documentURLTransformer;
+
     // provided by layout
-	/** @type {adapt.vtree.NodeContext} */ this.nodeContext = null;
-	/** @type {Element} */ this.viewRoot = null;
-	/** @type {boolean} */ this.isFootnote = false;
+    /** @type {adapt.vtree.NodeContext} */ this.nodeContext = null;
+    /** @type {Element} */ this.viewRoot = null;
+    /** @type {boolean} */ this.isFootnote = false;
     /** @type {Node} */ this.sourceNode = null;
     /** @type {number} */ this.offsetInNode = 0;
 
@@ -261,10 +261,10 @@ adapt.vgen.ViewFactory = function(flowName, context, viewport, styler, regionIds
  * @override
  */
 adapt.vgen.ViewFactory.prototype.clone = function() {
-	return new adapt.vgen.ViewFactory(this.flowName, this.context, this.viewport,
-		this.styler, this.regionIds,
-		this.xmldoc, this.docFaces, this.footnoteStyle, this.stylerProducer,
-		this.page, this.customRenderer, this.fallbackMap, this.pageFloatHolder, this.documentURLTransformer);
+    return new adapt.vgen.ViewFactory(this.flowName, this.context, this.viewport,
+        this.styler, this.regionIds,
+        this.xmldoc, this.docFaces, this.footnoteStyle, this.stylerProducer,
+        this.page, this.customRenderer, this.fallbackMap, this.pageFloatHolder, this.documentURLTransformer);
 };
 
 /**
@@ -278,54 +278,54 @@ adapt.vgen.ViewFactory.prototype.clone = function() {
  * @param {adapt.vtree.ShadowContext} subShadow
  * @return {adapt.vtree.ShadowContext}
  */
-adapt.vgen.ViewFactory.prototype.createPseudoelementShadow = function(element, isRoot, 
-		cascStyle, computedStyle, styler, context, parentShadow, subShadow) {
+adapt.vgen.ViewFactory.prototype.createPseudoelementShadow = function(element, isRoot,
+                                                                      cascStyle, computedStyle, styler, context, parentShadow, subShadow) {
     var pseudoMap = adapt.csscasc.getStyleMap(cascStyle, "_pseudos");
     if (!pseudoMap) {
-    	return subShadow;
+        return subShadow;
     }
-	var addedNames = [];
-	var root = adapt.vgen.pseudoelementDoc.createElementNS(adapt.base.NS.SHADOW, "root");
-	var att = root;
+    var addedNames = [];
+    var root = adapt.vgen.pseudoelementDoc.createElementNS(adapt.base.NS.SHADOW, "root");
+    var att = root;
     for (var i = 0; i < adapt.vgen.pseudoNames.length; i++) {
-    	var name = adapt.vgen.pseudoNames[i];
-    	var elem;
-    	if (name) {
-    		if (!pseudoMap[name]) {
-    			continue;
-    		}
-    		if (name == "footnote-marker" && !(isRoot && this.isFootnote)) {
-    			continue;
-    		}
-        	if (name.match(/^first-/)) {
-        		var display = computedStyle["display"];
-        		if (!display || display === adapt.css.ident.inline) {
-        			continue;
-        		}
-        	}
-			if (name === "before" || name === "after") {
-				var content = pseudoMap[name]["content"];
-				if (!content || content === adapt.css.ident.normal || content === adapt.css.ident.none) {
-					continue;
-				}
-			}
-			addedNames.push(name);
-    		elem = adapt.vgen.pseudoelementDoc.createElementNS(adapt.base.NS.XHTML, "span");
-			adapt.vgen.setPseudoName(elem, name);
-    	} else {
-    		elem = adapt.vgen.pseudoelementDoc.createElementNS(adapt.base.NS.SHADOW, "content");
-    	}
-    	att.appendChild(elem);
-    	if (name.match(/^first-/)) {
-    		att = elem;
-    	}
+        var name = adapt.vgen.pseudoNames[i];
+        var elem;
+        if (name) {
+            if (!pseudoMap[name]) {
+                continue;
+            }
+            if (name == "footnote-marker" && !(isRoot && this.isFootnote)) {
+                continue;
+            }
+            if (name.match(/^first-/)) {
+                var display = computedStyle["display"];
+                if (!display || display === adapt.css.ident.inline) {
+                    continue;
+                }
+            }
+            if (name === "before" || name === "after") {
+                var content = pseudoMap[name]["content"];
+                if (!content || content === adapt.css.ident.normal || content === adapt.css.ident.none) {
+                    continue;
+                }
+            }
+            addedNames.push(name);
+            elem = adapt.vgen.pseudoelementDoc.createElementNS(adapt.base.NS.XHTML, "span");
+            adapt.vgen.setPseudoName(elem, name);
+        } else {
+            elem = adapt.vgen.pseudoelementDoc.createElementNS(adapt.base.NS.SHADOW, "content");
+        }
+        att.appendChild(elem);
+        if (name.match(/^first-/)) {
+            att = elem;
+        }
     }
-	if (!addedNames.length) {
-		return subShadow;
-	}
+    if (!addedNames.length) {
+        return subShadow;
+    }
     var shadowStyler = new adapt.vgen.PseudoelementStyler(element, cascStyle, styler, context);
-    return new adapt.vtree.ShadowContext(element, root, null, parentShadow, 
-    		subShadow, adapt.vtree.ShadowType.ROOTLESS, shadowStyler);
+    return new adapt.vtree.ShadowContext(element, root, null, parentShadow,
+        subShadow, adapt.vtree.ShadowType.ROOTLESS, shadowStyler);
 };
 
 /**
@@ -336,22 +336,22 @@ adapt.vgen.ViewFactory.prototype.createPseudoelementShadow = function(element, i
  * @return {adapt.task.Result.<adapt.vtree.ShadowContext>}
  */
 adapt.vgen.ViewFactory.prototype.createRefShadow = function(href, type, element, parentShadow, subShadow) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.ShadowContext>} */ var frame
-		= adapt.task.newFrame("createRefShadow");
-	self.xmldoc.store.load(href).then(function(refDocParam) {
-		var refDoc = /** @type {adapt.xmldoc.XMLDocHolder} */ (refDocParam);
-		if (refDoc) {
-			var refElement = refDoc.getElement(href);
-			if (refElement) {
-				var refStyler = self.stylerProducer.getStylerForDoc(refDoc);
-				subShadow = new adapt.vtree.ShadowContext(element, refElement, refDoc, parentShadow, 
-			    		subShadow, type, refStyler);
-			}
-		}
-		frame.finish(subShadow);
-	});
-	return frame.result();
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.ShadowContext>} */ var frame
+        = adapt.task.newFrame("createRefShadow");
+    self.xmldoc.store.load(href).then(function(refDocParam) {
+        var refDoc = /** @type {adapt.xmldoc.XMLDocHolder} */ (refDocParam);
+        if (refDoc) {
+            var refElement = refDoc.getElement(href);
+            if (refElement) {
+                var refStyler = self.stylerProducer.getStylerForDoc(refDoc);
+                subShadow = new adapt.vtree.ShadowContext(element, refElement, refDoc, parentShadow,
+                    subShadow, type, refStyler);
+            }
+        }
+        frame.finish(subShadow);
+    });
+    return frame.result();
 };
 
 /**
@@ -364,66 +364,66 @@ adapt.vgen.ViewFactory.prototype.createRefShadow = function(href, type, element,
  * @return {adapt.task.Result.<adapt.vtree.ShadowContext>}
  */
 adapt.vgen.ViewFactory.prototype.createShadows = function(element, isRoot, cascStyle,
-		computedStyle, styler, context, shadowContext) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<adapt.vtree.ShadowContext>} */ var frame
-		= adapt.task.newFrame("createShadows");
-	var shadow = null;
-	var templateURLVal = computedStyle["template"];
-	var cont;
-	if (templateURLVal instanceof adapt.css.URL) {
-		var url = (/** @type {adapt.css.URL} */ (templateURLVal)).url;
-		cont = self.createRefShadow(url, adapt.vtree.ShadowType.ROOTLESS,
-				element, shadowContext, shadow);			
-	} else {
-		cont = adapt.task.newResult(shadow);
-	}
-	cont.then(function(shadow) {
-		var cont1 = null;
-		if (element.namespaceURI == adapt.base.NS.SHADOW) {
-			if (element.localName == "include") {
-				var href = element.getAttribute("href");
-				var xmldoc = null;
-				if (href) {
-					xmldoc = shadowContext ? shadowContext.xmldoc : self.xmldoc;
-				} else if (shadowContext) {
-					if (shadowContext.owner.namespaceURI == adapt.base.NS.XHTML)
-						href = shadowContext.owner.getAttribute("href");
-					else
-						href = shadowContext.owner.getAttributeNS(adapt.base.NS.XLINK, "href");
-					xmldoc = shadowContext.parentShadow ? shadowContext.parentShadow.xmldoc : self.xmldoc;
-				}
-				if (href) {
-					href = adapt.base.resolveURL(href, xmldoc.url);
-					cont1 = self.createRefShadow(href, adapt.vtree.ShadowType.ROOTED, 
-							element, shadowContext, shadow);
-				}
-			}
-		}
-		if (cont1 == null)
-			cont1 = adapt.task.newResult(shadow);
-		cont1.then(function(shadow) {
-			shadow = self.createPseudoelementShadow(element, isRoot, cascStyle, computedStyle,
-					styler, context, shadowContext, shadow);
-			frame.finish(shadow);
-		});
-	});
-	return frame.result();
+                                                          computedStyle, styler, context, shadowContext) {
+    var self = this;
+    /** @type {!adapt.task.Frame.<adapt.vtree.ShadowContext>} */ var frame
+        = adapt.task.newFrame("createShadows");
+    var shadow = null;
+    var templateURLVal = computedStyle["template"];
+    var cont;
+    if (templateURLVal instanceof adapt.css.URL) {
+        var url = (/** @type {adapt.css.URL} */ (templateURLVal)).url;
+        cont = self.createRefShadow(url, adapt.vtree.ShadowType.ROOTLESS,
+            element, shadowContext, shadow);
+    } else {
+        cont = adapt.task.newResult(shadow);
+    }
+    cont.then(function(shadow) {
+        var cont1 = null;
+        if (element.namespaceURI == adapt.base.NS.SHADOW) {
+            if (element.localName == "include") {
+                var href = element.getAttribute("href");
+                var xmldoc = null;
+                if (href) {
+                    xmldoc = shadowContext ? shadowContext.xmldoc : self.xmldoc;
+                } else if (shadowContext) {
+                    if (shadowContext.owner.namespaceURI == adapt.base.NS.XHTML)
+                        href = shadowContext.owner.getAttribute("href");
+                    else
+                        href = shadowContext.owner.getAttributeNS(adapt.base.NS.XLINK, "href");
+                    xmldoc = shadowContext.parentShadow ? shadowContext.parentShadow.xmldoc : self.xmldoc;
+                }
+                if (href) {
+                    href = adapt.base.resolveURL(href, xmldoc.url);
+                    cont1 = self.createRefShadow(href, adapt.vtree.ShadowType.ROOTED,
+                        element, shadowContext, shadow);
+                }
+            }
+        }
+        if (cont1 == null)
+            cont1 = adapt.task.newResult(shadow);
+        cont1.then(function(shadow) {
+            shadow = self.createPseudoelementShadow(element, isRoot, cascStyle, computedStyle,
+                styler, context, shadowContext, shadow);
+            frame.finish(shadow);
+        });
+    });
+    return frame.result();
 };
 
 /**
  * @override
  */
 adapt.vgen.ViewFactory.prototype.setViewRoot = function(viewRoot, isFootnote) {
-	this.viewRoot = viewRoot;
-	this.isFootnote = isFootnote;
+    this.viewRoot = viewRoot;
+    this.isFootnote = isFootnote;
 };
 
-/**                            
- * @param {boolean} vertical                                                                                                          
- * @param {adapt.csscasc.ElementStyle} style                                                                                             
+/**
+ * @param {boolean} vertical
+ * @param {adapt.csscasc.ElementStyle} style
  * @param {!Object.<string,adapt.css.Val>} computedStyle
- * @return {boolean} vertical                                                                                                                        
+ * @return {boolean} vertical
  */
 adapt.vgen.ViewFactory.prototype.computeStyle = function(vertical, style, computedStyle) {
     var context = this.context;
@@ -437,16 +437,16 @@ adapt.vgen.ViewFactory.prototype.computeStyle = function(vertical, style, comput
         }
         return value;
     });
-	// Compute values of display, position and float
-	var position = /** @type {adapt.css.Ident} */ (computedStyle["position"]);
-	var float = /** @type {adapt.css.Ident} */ (computedStyle["float"]);
-	var displayValues = vivliostyle.display.getComputedDislayValue(
-		computedStyle["display"] || adapt.css.ident.inline, position, float, this.sourceNode === this.xmldoc.root);
-	["display", "position", "float"].forEach(function(name) {
-		if (displayValues[name]) {
-			computedStyle[name] = displayValues[name];
-		}
-	});
+    // Compute values of display, position and float
+    var position = /** @type {adapt.css.Ident} */ (computedStyle["position"]);
+    var float = /** @type {adapt.css.Ident} */ (computedStyle["float"]);
+    var displayValues = vivliostyle.display.getComputedDislayValue(
+        computedStyle["display"] || adapt.css.ident.inline, position, float, this.sourceNode === this.xmldoc.root);
+    ["display", "position", "float"].forEach(function(name) {
+        if (displayValues[name]) {
+            computedStyle[name] = displayValues[name];
+        }
+    });
     return vertical;
 };
 
@@ -456,74 +456,74 @@ adapt.vgen.ViewFactory.prototype.computeStyle = function(vertical, style, comput
  * @return {adapt.csscasc.ElementStyle}
  */
 adapt.vgen.ViewFactory.prototype.inheritFromSourceParent = function(elementStyle) {
-	var node = this.nodeContext.sourceNode;
-	var styles = [];
-	// TODO: this is hacky. We need to recover the path through the shadow trees, but we do not
-	// have the full shadow tree structure at this point. This code handles coming out of the
-	// shadow trees, but does not go back in (through shadow:content element).
-	var shadowContext = this.nodeContext.shadowContext;
-	var steps = -1;
-	while (node && node.nodeType == 1) {
-		var shadowRoot = shadowContext && shadowContext.root == node;
-		if (!shadowRoot || shadowContext.type == adapt.vtree.ShadowType.ROOTLESS) {
-		    var styler = shadowContext ? 
-		    		/** @type {adapt.cssstyler.AbstractStyler} */ (shadowContext.styler) : this.styler;	
-			var nodeStyle = styler.getStyle(/** @type {Element} */ (node), false);
-			styles.push(nodeStyle);
-		}
-		if (shadowRoot) {
-			node = shadowContext.owner;
-			shadowContext = shadowContext.parentShadow;
-		} else {
-			node = node.parentNode;
-			steps++;
-		}
-	}
-	var isRoot = steps === 0;
-	var fontSize = this.context.queryUnitSize("em", isRoot);
-	var props = /** @type {adapt.csscasc.ElementStyle} */
-		({"font-size": new adapt.csscasc.CascadeValue(new adapt.css.Numeric(fontSize, "px"), 0)});
-	var inheritanceVisitor = new adapt.csscasc.InheritanceVisitor(props, this.context);
-	for (var i = styles.length - 1; i >= 0; --i) {
-		var style = styles[i];
-		var propList = [];
-		for (var propName in style) {
-			if (adapt.csscasc.isInherited(propName)) {
-				propList.push(propName);
-			}
-		}
-		propList.sort(adapt.css.processingOrderFn);
-		for (var k = 0; k < propList.length; k++) {
-			var name = propList[k];
-			inheritanceVisitor.setPropName(name);
-			props[name] = adapt.csscasc.getProp(style, name).filterValue(inheritanceVisitor);
-		}
-	}
-	for (var sname in elementStyle) {
-		if (!adapt.csscasc.isInherited(sname)) {
-			props[sname] = elementStyle[sname];
-		}
-	}
-	return props;
+    var node = this.nodeContext.sourceNode;
+    var styles = [];
+    // TODO: this is hacky. We need to recover the path through the shadow trees, but we do not
+    // have the full shadow tree structure at this point. This code handles coming out of the
+    // shadow trees, but does not go back in (through shadow:content element).
+    var shadowContext = this.nodeContext.shadowContext;
+    var steps = -1;
+    while (node && node.nodeType == 1) {
+        var shadowRoot = shadowContext && shadowContext.root == node;
+        if (!shadowRoot || shadowContext.type == adapt.vtree.ShadowType.ROOTLESS) {
+            var styler = shadowContext ?
+                /** @type {adapt.cssstyler.AbstractStyler} */ (shadowContext.styler) : this.styler;
+            var nodeStyle = styler.getStyle(/** @type {Element} */ (node), false);
+            styles.push(nodeStyle);
+        }
+        if (shadowRoot) {
+            node = shadowContext.owner;
+            shadowContext = shadowContext.parentShadow;
+        } else {
+            node = node.parentNode;
+            steps++;
+        }
+    }
+    var isRoot = steps === 0;
+    var fontSize = this.context.queryUnitSize("em", isRoot);
+    var props = /** @type {adapt.csscasc.ElementStyle} */
+        ({"font-size": new adapt.csscasc.CascadeValue(new adapt.css.Numeric(fontSize, "px"), 0)});
+    var inheritanceVisitor = new adapt.csscasc.InheritanceVisitor(props, this.context);
+    for (var i = styles.length - 1; i >= 0; --i) {
+        var style = styles[i];
+        var propList = [];
+        for (var propName in style) {
+            if (adapt.csscasc.isInherited(propName)) {
+                propList.push(propName);
+            }
+        }
+        propList.sort(adapt.css.processingOrderFn);
+        for (var k = 0; k < propList.length; k++) {
+            var name = propList[k];
+            inheritanceVisitor.setPropName(name);
+            props[name] = adapt.csscasc.getProp(style, name).filterValue(inheritanceVisitor);
+        }
+    }
+    for (var sname in elementStyle) {
+        if (!adapt.csscasc.isInherited(sname)) {
+            props[sname] = elementStyle[sname];
+        }
+    }
+    return props;
 };
 
 adapt.vgen.fb2Remap = {
-	"a": "a",
-	"sub": "sub",
-	"sup": "sup",
-	"table": "table",
-	"tr": "tr",
-	"td": "td",
-	"th": "th",
-	"code": "code",
-	"body": "div",
-	"p": "p",
-	"v": "p",
-	"date": "p",
-	"emphasis": "em",
-	"strong": "strong",
-	"style": "span",
-	"strikethrough": "del"
+    "a": "a",
+    "sub": "sub",
+    "sup": "sup",
+    "table": "table",
+    "tr": "tr",
+    "td": "td",
+    "th": "th",
+    "code": "code",
+    "body": "div",
+    "p": "p",
+    "v": "p",
+    "date": "p",
+    "emphasis": "em",
+    "strong": "strong",
+    "style": "span",
+    "strikethrough": "del"
 };
 
 /**
@@ -540,38 +540,38 @@ adapt.vgen.ViewFactory.prototype.resolveURL = function(url) {
  * @param {!Object.<string,adapt.css.Val>} computedStyle
  */
 adapt.vgen.ViewFactory.prototype.transferPolyfilledInheritedProps = function(computedStyle) {
-	var polyfilledInheritedProps = adapt.csscasc.polyfilledInheritedProps.filter(function(name) {
-		return computedStyle[name];
-	});
-	if (polyfilledInheritedProps.length) {
-		var props = this.nodeContext.inheritedProps;
-		if (this.nodeContext.parent) {
-			props = this.nodeContext.inheritedProps = {};
-			for (var n in this.nodeContext.parent.inheritedProps) {
-				props[n] = this.nodeContext.parent.inheritedProps[n];
-			}
-		}
-		polyfilledInheritedProps.forEach(function(name) {
-			var value = computedStyle[name];
-			if (value) {
-				if (value instanceof adapt.css.Int) {
-					props[name] = (/** @type {adapt.css.Int} */ (value)).num;
-				} else if (value instanceof adapt.css.Ident) {
-					props[name] = (/** @type {adapt.css.Ident} */ (value)).name;
-				} else if (value instanceof adapt.css.Numeric) {
-					var numericVal = (/** @type {adapt.css.Numeric} */ (value));
-					switch (numericVal.unit) {
-						case "dpi":
-						case "dpcm":
-						case "dppx":
-							props[name] = numericVal.num * adapt.expr.defaultUnitSizes[numericVal.unit];
-							break;
-					}
-				}
-				delete computedStyle[name];
-			}
-		});
-	}
+    var polyfilledInheritedProps = adapt.csscasc.polyfilledInheritedProps.filter(function(name) {
+        return computedStyle[name];
+    });
+    if (polyfilledInheritedProps.length) {
+        var props = this.nodeContext.inheritedProps;
+        if (this.nodeContext.parent) {
+            props = this.nodeContext.inheritedProps = {};
+            for (var n in this.nodeContext.parent.inheritedProps) {
+                props[n] = this.nodeContext.parent.inheritedProps[n];
+            }
+        }
+        polyfilledInheritedProps.forEach(function(name) {
+            var value = computedStyle[name];
+            if (value) {
+                if (value instanceof adapt.css.Int) {
+                    props[name] = (/** @type {adapt.css.Int} */ (value)).num;
+                } else if (value instanceof adapt.css.Ident) {
+                    props[name] = (/** @type {adapt.css.Ident} */ (value)).name;
+                } else if (value instanceof adapt.css.Numeric) {
+                    var numericVal = (/** @type {adapt.css.Numeric} */ (value));
+                    switch (numericVal.unit) {
+                        case "dpi":
+                        case "dpcm":
+                        case "dppx":
+                            props[name] = numericVal.num * adapt.expr.defaultUnitSizes[numericVal.unit];
+                            break;
+                    }
+                }
+                delete computedStyle[name];
+            }
+        });
+    }
 };
 
 /**
@@ -581,333 +581,332 @@ adapt.vgen.ViewFactory.prototype.transferPolyfilledInheritedProps = function(com
  * @return {!adapt.task.Result.<boolean>} holding true if children should be processed
  */
 adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnforcedBreak) {
-	var self = this;
-	var needToProcessChildren = true;
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame
-		= adapt.task.newFrame("createElementView");
-	// Figure out element's styles
+    var self = this;
+    var needToProcessChildren = true;
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame
+        = adapt.task.newFrame("createElementView");
+    // Figure out element's styles
     var element = /** @type {Element} */ (self.sourceNode);
-    var styler = self.nodeContext.shadowContext ? 
-    		/** @type {adapt.cssstyler.AbstractStyler} */ (self.nodeContext.shadowContext.styler) : self.styler;
+    var styler = self.nodeContext.shadowContext ?
+        /** @type {adapt.cssstyler.AbstractStyler} */ (self.nodeContext.shadowContext.styler) : self.styler;
     var elementStyle = styler.getStyle(element, false);
     var computedStyle = {};
     if (!self.nodeContext.parent) {
-    	elementStyle = self.inheritFromSourceParent(elementStyle);
+        elementStyle = self.inheritFromSourceParent(elementStyle);
     }
     self.nodeContext.vertical = self.computeStyle(self.nodeContext.vertical, elementStyle, computedStyle);
 
-	this.transferPolyfilledInheritedProps(computedStyle);
+    this.transferPolyfilledInheritedProps(computedStyle);
 
-	if (computedStyle["direction"]) {
-		self.nodeContext.direction = computedStyle["direction"].toString();
-	}
+    if (computedStyle["direction"]) {
+        self.nodeContext.direction = computedStyle["direction"].toString();
+    }
     // Sort out the properties
     var flow = computedStyle["flow-into"];
     if (flow && flow.toString() != self.flowName) {
         // foreign flow, don't create a view
-    	frame.finish(false);
-    	return frame.result();
+        frame.finish(false);
+        return frame.result();
     }
     var display = computedStyle["display"];
     if (display === adapt.css.ident.none) {
         // no content
-    	frame.finish(false);
-    	return frame.result();
+        frame.finish(false);
+        return frame.result();
     }
-	var isRoot = self.nodeContext.parent == null;
-	self.nodeContext.flexContainer = (display === adapt.css.ident.flex);
-    self.createShadows(element, isRoot, elementStyle, computedStyle, styler,
-    		self.context, self.nodeContext.shadowContext).then(function(shadowParam) {
-    	self.nodeContext.nodeShadow = shadowParam;
-		var position = computedStyle["position"];
-		var floatReference = computedStyle["float-reference"];
-	    var floatSide = computedStyle["float"];
-	    var clearSide = computedStyle["clear"];
-		var writingMode = self.nodeContext.vertical ? adapt.css.ident.vertical_rl : adapt.css.ident.horizontal_tb;
-		var parentWritingMode = self.nodeContext.parent ?
-			(self.nodeContext.parent.vertical ? adapt.css.ident.vertical_rl : adapt.css.ident.horizontal_tb) :
-			writingMode;
-		self.nodeContext.establishesBFC = vivliostyle.display.establishesBFC(display, position, floatSide,
-			computedStyle["overflow"], writingMode, parentWritingMode);
-		self.nodeContext.containingBlockForAbsolute = vivliostyle.display.establishesCBForAbsolute(position);
-	    if (self.nodeContext.isInsideBFC()) {
-			// When the element is already inside a block formatting context (except one from the root),
-			// float and clear can be controlled by the browser and we don't need to care.
-	    	clearSide = null;
-	    	if (floatSide !== adapt.css.ident.footnote) {
-	    		floatSide = null;
-	    	}
-	    }
-	    var floating = floatSide === adapt.css.ident.left || 
-	    	floatSide === adapt.css.ident.right ||
-			floatSide === adapt.css.ident.top ||
-			floatSide === adapt.css.ident.bottom ||
-			floatSide === adapt.css.ident.inline_start ||
-			floatSide === adapt.css.ident.inline_end ||
-			floatSide === adapt.css.ident.block_start ||
-			floatSide === adapt.css.ident.block_end ||
-			floatSide === adapt.css.ident.footnote;
-	    if (floatSide) {
-	    	// Don't want to set it in view DOM CSS.
-	    	delete computedStyle["float"];
-		    if (floatSide === adapt.css.ident.footnote) {
-		    	if (self.isFootnote) {
-		    		// No footnotes inside footnotes. self is most likely the root of the
-		    		// footnote body being rendered in footnote area. Treat as block.
-		    		floating = false;
-		    		computedStyle["display"] = adapt.css.ident.block;
-		    	} else {
-			        computedStyle["display"] = adapt.css.ident.inline;
-		    	}
-		    }
-	    }
-	    if (clearSide) {
-	    	if (clearSide === adapt.css.ident.inherit) {
-	    		if (self.nodeContext.parent && self.nodeContext.parent.clearSide) {
-	    			clearSide = adapt.css.getName(self.nodeContext.parent.clearSide);
-	    		}
-	    	}
-	    	if (clearSide === adapt.css.ident.left || clearSide === adapt.css.ident.right ||
-	    		clearSide === adapt.css.ident.both) {
-		    	delete computedStyle["clear"];	    	
-		    	if (computedStyle["display"] && computedStyle["display"] != adapt.css.ident.inline) {
-		    		self.nodeContext.clearSide = clearSide.toString();
-		    	}
-		    }
-	    }
-	    var listItem = display === adapt.css.ident.list_item && computedStyle["ua-list-item-count"];
-	    if (floating ||
-			(computedStyle["break-inside"] && computedStyle["break-inside"] !== adapt.css.ident.auto)) {
-	    	self.nodeContext.breakPenalty++;
-	    } else if (display === adapt.css.ident.table_row) {
-	    	self.nodeContext.breakPenalty += 10;
-	    }
-	    self.nodeContext.inline = !floating && !display || display === adapt.css.ident.inline;
-		self.nodeContext.display = display ? display.toString() : "inline";
-	    self.nodeContext.floatSide = floating ? floatSide.toString() : null;
-		self.nodeContext.floatReference = floatReference ? floatReference.toString() : null;
-	    if (!self.nodeContext.inline) {
-		    var breakAfter = computedStyle["break-after"];
-		    if (breakAfter) {
-		    	self.nodeContext.breakAfter = breakAfter.toString();
-		    }
-		    var breakBefore = computedStyle["break-before"];
-		    if (breakBefore) {
-		    	self.nodeContext.breakBefore = breakBefore.toString();
-		    }
-	    }
-	    var firstPseudo = computedStyle["x-first-pseudo"];
-	    if (firstPseudo) {
-	    	var outerPseudo = self.nodeContext.parent ? self.nodeContext.parent.firstPseudo : null;
-	    	self.nodeContext.firstPseudo = new adapt.vtree.FirstPseudo(
-	    			outerPseudo, (/** adapt.css.Int */ (firstPseudo)).num);
-	    }
-	    var whitespace = computedStyle["white-space"];
-	    if (whitespace) {
-			var whitespaceValue = adapt.vtree.whitespaceFromPropertyValue(whitespace.toString());
-			if (whitespaceValue !== null) {
-				self.nodeContext.whitespace = whitespaceValue;
-			}
-	    }
-	    // Create the view element
-	    var custom = false;
-	    var inner = null;
-	    var fetchers = [];
-	    var ns = element.namespaceURI;
-	    var tag = element.localName;
-		if (ns == adapt.base.NS.XHTML) {
-			if (tag == "html" || tag == "body" || tag == "script" || tag == "link" || tag == "meta")
-				tag = "div";
-			else if (tag == "vide_")
-				tag = "video";
-			else if (tag == "audi_")
-				tag = "audio";
-			else if (tag == "object")
-				custom = !!self.customRenderer;
-		} else if (ns == adapt.base.NS.epub) {
-			tag = "span";
-			ns = adapt.base.NS.XHTML;
-		} else if (ns == adapt.base.NS.FB2) {
-			ns = adapt.base.NS.XHTML;
-			if (tag == "image") {
-				tag = "div";
-				var imageRef = element.getAttributeNS(adapt.base.NS.XLINK, "href");
-				if (imageRef && imageRef.charAt(0) == "#") {
-	    			var imageBinary = self.xmldoc.getElement(imageRef);
-	    			if (imageBinary) {
-		    			inner = self.createElement(ns, "img");
-	    				var mediaType = imageBinary.getAttribute("content-type") || "image/jpeg";
-		    			var innerSrc = "data:" + mediaType + ";base64," + 
-							imageBinary.textContent.replace(/[ \t\n\t]/g, "");
-		    			fetchers.push(adapt.taskutil.loadElement(inner, innerSrc));
-	    			}
-				}
-			} else {
-				tag = adapt.vgen.fb2Remap[tag];
-			}
-			if (!tag) {
-				tag = self.nodeContext.inline ? "span" : "div";
-			}
-		} else if (ns == adapt.base.NS.NCX) {
-			ns = adapt.base.NS.XHTML;
-			if (tag == "ncx" || tag == "navPoint") {
-				tag = "div";
-			} else if (tag == "navLabel") {
-				// Cheat here. Translate source to HTML, so it will plug in into the rest of the
-				// pipeline.
-				tag = "span";
-				var navParent = element.parentNode;
-				if (navParent) {
-					// find the content element
-					var href = null;
-					for (var c = navParent.firstChild; c; c = c.nextSibling) {
-						if (c.nodeType != 1) {
-							continue;
-						}
-						var childElement = /** @type {Element} */ (c);
-						if (childElement.namespaceURI == adapt.base.NS.NCX 
-								&& childElement.localName == "content") {
-							href = childElement.getAttribute("src");
-							break;
-						}
-					}
-					if (href) {
-						tag = "a";
-						element = element.ownerDocument.createElementNS(ns, "a");
-						element.setAttribute("href", href);
-					}
-				}
-			} else {
-				tag = "span";
-			}
-		} else if (ns == adapt.base.NS.SHADOW) {
-		    ns = adapt.base.NS.XHTML;
-			tag = self.nodeContext.inline ? "span" : "div";		
-		} else {
-			custom = !!self.customRenderer;			
-		}
-	    if (listItem) {
-	        if (firstTime) {
-	            tag = "li";
-	        } else {
-	            tag = "div";
-	            display = adapt.css.ident.block;
-	            computedStyle["display"] = display;
-	        }
-	    } else if (tag == "body" || tag == "li") {
-	        tag = "div";
-	    } else if (tag == "q") {
-	        tag = "span";
-	    } else if (tag == "a") {
-	    	var hp = computedStyle["hyperlink-processing"];
-	    	if (hp && hp.toString() != "normal") {
-	    		tag = "span";
-	    	}
-	    }
-	    if (computedStyle["behavior"]) {
-	    	var behavior = computedStyle["behavior"].toString();
-	    	if (behavior != "none" && self.customRenderer) {
-	    		custom = true;
-	    	}
-	    }
+    var isRoot = self.nodeContext.parent == null;
+    self.nodeContext.flexContainer = (display === adapt.css.ident.flex);
+    self.createShadows(element, isRoot, elementStyle, computedStyle, styler, self.context, self.nodeContext.shadowContext).then(function(shadowParam) {
+        self.nodeContext.nodeShadow = shadowParam;
+        var position = computedStyle["position"];
+        var floatReference = computedStyle["float-reference"];
+        var floatSide = computedStyle["float"];
+        var clearSide = computedStyle["clear"];
+        var writingMode = self.nodeContext.vertical ? adapt.css.ident.vertical_rl : adapt.css.ident.horizontal_tb;
+        var parentWritingMode = self.nodeContext.parent ?
+            (self.nodeContext.parent.vertical ? adapt.css.ident.vertical_rl : adapt.css.ident.horizontal_tb) :
+            writingMode;
+        self.nodeContext.establishesBFC = vivliostyle.display.establishesBFC(display, position, floatSide,
+            computedStyle["overflow"], writingMode, parentWritingMode);
+        self.nodeContext.containingBlockForAbsolute = vivliostyle.display.establishesCBForAbsolute(position);
+        if (self.nodeContext.isInsideBFC()) {
+            // When the element is already inside a block formatting context (except one from the root),
+            // float and clear can be controlled by the browser and we don't need to care.
+            clearSide = null;
+            if (floatSide !== adapt.css.ident.footnote) {
+                floatSide = null;
+            }
+        }
+        var floating = floatSide === adapt.css.ident.left ||
+            floatSide === adapt.css.ident.right ||
+            floatSide === adapt.css.ident.top ||
+            floatSide === adapt.css.ident.bottom ||
+            floatSide === adapt.css.ident.inline_start ||
+            floatSide === adapt.css.ident.inline_end ||
+            floatSide === adapt.css.ident.block_start ||
+            floatSide === adapt.css.ident.block_end ||
+            floatSide === adapt.css.ident.footnote;
+        if (floatSide) {
+            // Don't want to set it in view DOM CSS.
+            delete computedStyle["float"];
+            if (floatSide === adapt.css.ident.footnote) {
+                if (self.isFootnote) {
+                    // No footnotes inside footnotes. self is most likely the root of the
+                    // footnote body being rendered in footnote area. Treat as block.
+                    floating = false;
+                    computedStyle["display"] = adapt.css.ident.block;
+                } else {
+                    computedStyle["display"] = adapt.css.ident.inline;
+                }
+            }
+        }
+        if (clearSide) {
+            if (clearSide === adapt.css.ident.inherit) {
+                if (self.nodeContext.parent && self.nodeContext.parent.clearSide) {
+                    clearSide = adapt.css.getName(self.nodeContext.parent.clearSide);
+                }
+            }
+            if (clearSide === adapt.css.ident.left || clearSide === adapt.css.ident.right ||
+                clearSide === adapt.css.ident.both) {
+                delete computedStyle["clear"];
+                if (computedStyle["display"] && computedStyle["display"] != adapt.css.ident.inline) {
+                    self.nodeContext.clearSide = clearSide.toString();
+                }
+            }
+        }
+        var listItem = display === adapt.css.ident.list_item && computedStyle["ua-list-item-count"];
+        if (floating ||
+            (computedStyle["break-inside"] && computedStyle["break-inside"] !== adapt.css.ident.auto)) {
+            self.nodeContext.breakPenalty++;
+        } else if (display === adapt.css.ident.table_row) {
+            self.nodeContext.breakPenalty += 10;
+        }
+        self.nodeContext.inline = !floating && !display || display === adapt.css.ident.inline;
+        self.nodeContext.display = display ? display.toString() : "inline";
+        self.nodeContext.floatSide = floating ? floatSide.toString() : null;
+        self.nodeContext.floatReference = floatReference ? floatReference.toString() : null;
+        if (!self.nodeContext.inline) {
+            var breakAfter = computedStyle["break-after"];
+            if (breakAfter) {
+                self.nodeContext.breakAfter = breakAfter.toString();
+            }
+            var breakBefore = computedStyle["break-before"];
+            if (breakBefore) {
+                self.nodeContext.breakBefore = breakBefore.toString();
+            }
+        }
+        var firstPseudo = computedStyle["x-first-pseudo"];
+        if (firstPseudo) {
+            var outerPseudo = self.nodeContext.parent ? self.nodeContext.parent.firstPseudo : null;
+            self.nodeContext.firstPseudo = new adapt.vtree.FirstPseudo(
+                outerPseudo, (/** adapt.css.Int */ (firstPseudo)).num);
+        }
+        var whitespace = computedStyle["white-space"];
+        if (whitespace) {
+            var whitespaceValue = adapt.vtree.whitespaceFromPropertyValue(whitespace.toString());
+            if (whitespaceValue !== null) {
+                self.nodeContext.whitespace = whitespaceValue;
+            }
+        }
+        // Create the view element
+        var custom = false;
+        var inner = null;
+        var fetchers = [];
+        var ns = element.namespaceURI;
+        var tag = element.localName;
+        if (ns == adapt.base.NS.XHTML) {
+            if (tag == "html" || tag == "body" || tag == "script" || tag == "link" || tag == "meta")
+                tag = "div";
+            else if (tag == "vide_")
+                tag = "video";
+            else if (tag == "audi_")
+                tag = "audio";
+            else if (tag == "object")
+                custom = !!self.customRenderer;
+        } else if (ns == adapt.base.NS.epub) {
+            tag = "span";
+            ns = adapt.base.NS.XHTML;
+        } else if (ns == adapt.base.NS.FB2) {
+            ns = adapt.base.NS.XHTML;
+            if (tag == "image") {
+                tag = "div";
+                var imageRef = element.getAttributeNS(adapt.base.NS.XLINK, "href");
+                if (imageRef && imageRef.charAt(0) == "#") {
+                    var imageBinary = self.xmldoc.getElement(imageRef);
+                    if (imageBinary) {
+                        inner = self.createElement(ns, "img");
+                        var mediaType = imageBinary.getAttribute("content-type") || "image/jpeg";
+                        var innerSrc = "data:" + mediaType + ";base64," +
+                            imageBinary.textContent.replace(/[ \t\n\t]/g, "");
+                        fetchers.push(adapt.taskutil.loadElement(inner, innerSrc));
+                    }
+                }
+            } else {
+                tag = adapt.vgen.fb2Remap[tag];
+            }
+            if (!tag) {
+                tag = self.nodeContext.inline ? "span" : "div";
+            }
+        } else if (ns == adapt.base.NS.NCX) {
+            ns = adapt.base.NS.XHTML;
+            if (tag == "ncx" || tag == "navPoint") {
+                tag = "div";
+            } else if (tag == "navLabel") {
+                // Cheat here. Translate source to HTML, so it will plug in into the rest of the
+                // pipeline.
+                tag = "span";
+                var navParent = element.parentNode;
+                if (navParent) {
+                    // find the content element
+                    var href = null;
+                    for (var c = navParent.firstChild; c; c = c.nextSibling) {
+                        if (c.nodeType != 1) {
+                            continue;
+                        }
+                        var childElement = /** @type {Element} */ (c);
+                        if (childElement.namespaceURI == adapt.base.NS.NCX
+                            && childElement.localName == "content") {
+                            href = childElement.getAttribute("src");
+                            break;
+                        }
+                    }
+                    if (href) {
+                        tag = "a";
+                        element = element.ownerDocument.createElementNS(ns, "a");
+                        element.setAttribute("href", href);
+                    }
+                }
+            } else {
+                tag = "span";
+            }
+        } else if (ns == adapt.base.NS.SHADOW) {
+            ns = adapt.base.NS.XHTML;
+            tag = self.nodeContext.inline ? "span" : "div";
+        } else {
+            custom = !!self.customRenderer;
+        }
+        if (listItem) {
+            if (firstTime) {
+                tag = "li";
+            } else {
+                tag = "div";
+                display = adapt.css.ident.block;
+                computedStyle["display"] = display;
+            }
+        } else if (tag == "body" || tag == "li") {
+            tag = "div";
+        } else if (tag == "q") {
+            tag = "span";
+        } else if (tag == "a") {
+            var hp = computedStyle["hyperlink-processing"];
+            if (hp && hp.toString() != "normal") {
+                tag = "span";
+            }
+        }
+        if (computedStyle["behavior"]) {
+            var behavior = computedStyle["behavior"].toString();
+            if (behavior != "none" && self.customRenderer) {
+                custom = true;
+            }
+        }
         if (element.dataset && element.dataset["mathTypeset"] == "true")
             custom = true;
-	    var elemResult;
-	    if (custom) {
-	    	var parentNode = self.nodeContext.parent ? self.nodeContext.parent.viewNode : null;
-	    	elemResult = self.customRenderer(element, /** @type {Element} */ (parentNode), computedStyle);
-	    } else {
-	    	elemResult = adapt.task.newResult(null);
-	    }
-	    elemResult.then(/** @param {Element} result */ function(result) {
-	    	if (result) {
-	    		if (custom) {
-	    			needToProcessChildren = result.getAttribute("data-adapt-process-children") == "true";
-	    		}
-	    	} else {
-	    		result = self.createElement(ns, tag);
-	    	}
-	    	if (tag == "a") {
-	    		result.addEventListener("click", self.page.hrefHandler, false);
-	    	}
-		    if (inner) {
-				self.applyPseudoelementStyle(self.nodeContext, "inner", inner);
-		    	result.appendChild(inner);
-		    }
-		    if (result.localName == "iframe" && result.namespaceURI == adapt.base.NS.XHTML) {
-		    	adapt.vgen.initIFrame(/** @type {HTMLIFrameElement} */ (result));   	
-		    }
+        var elemResult;
+        if (custom) {
+            var parentNode = self.nodeContext.parent ? self.nodeContext.parent.viewNode : null;
+            elemResult = self.customRenderer(element, /** @type {Element} */ (parentNode), computedStyle);
+        } else {
+            elemResult = adapt.task.newResult(null);
+        }
+        elemResult.then(/** @param {Element} result */ function(result) {
+            if (result) {
+                if (custom) {
+                    needToProcessChildren = result.getAttribute("data-adapt-process-children") == "true";
+                }
+            } else {
+                result = self.createElement(ns, tag);
+            }
+            if (tag == "a") {
+                result.addEventListener("click", self.page.hrefHandler, false);
+            }
+            if (inner) {
+                self.applyPseudoelementStyle(self.nodeContext, "inner", inner);
+                result.appendChild(inner);
+            }
+            if (result.localName == "iframe" && result.namespaceURI == adapt.base.NS.XHTML) {
+                adapt.vgen.initIFrame(/** @type {HTMLIFrameElement} */ (result));
+            }
 
-			var imageResolution = /** @type {(number|undefined)} */
-				(self.nodeContext.inheritedProps["image-resolution"]);
-			/** @const {!Array<!{image: !HTMLElement, element: !HTMLElement, fetcher: !adapt.taskutil.Fetcher<string>}>} */ var images = [];
-			var cssWidth = computedStyle["width"];
-			var cssHeight = computedStyle["height"];
-			var attrWidth = element.getAttribute("width");
-			var attrHeight = element.getAttribute("height");
-			var hasAutoWidth = cssWidth === adapt.css.ident.auto || (!cssWidth && !attrWidth);
-			var hasAutoHeight = cssHeight === adapt.css.ident.auto || (!cssHeight && !attrHeight);
+            var imageResolution = /** @type {(number|undefined)} */
+                (self.nodeContext.inheritedProps["image-resolution"]);
+            /** @const {!Array<!{image: !HTMLElement, element: !HTMLElement, fetcher: !adapt.taskutil.Fetcher<string>}>} */ var images = [];
+            var cssWidth = computedStyle["width"];
+            var cssHeight = computedStyle["height"];
+            var attrWidth = element.getAttribute("width");
+            var attrHeight = element.getAttribute("height");
+            var hasAutoWidth = cssWidth === adapt.css.ident.auto || (!cssWidth && !attrWidth);
+            var hasAutoHeight = cssHeight === adapt.css.ident.auto || (!cssHeight && !attrHeight);
 
-			if (element.namespaceURI != adapt.base.NS.FB2 || tag == "td") {
-			    var attributes = element.attributes;
-			    var attributeCount = attributes.length;
-			    var delayedSrc = null;
-			    for (var i = 0 ; i < attributeCount ; i++) {
-			        var attribute = attributes[i];
-			        var attributeNS = attribute.namespaceURI;
-			        var attributeName = attribute.localName;
-			        var attributeValue = attribute.nodeValue;
-			        if (!attributeNS) {
-			            if (attributeName.match(/^on/))
-			                continue; // don't propagate JavaScript code
-			            if (attributeName == "style")
-			                continue; // we do styling ourselves
-			            if (attributeName == "id" || attributeName == "name") {
-			            	// Propagate transformed ids and collect them on the page (only first time).
-							if (firstTime) {
-								attributeValue = self.documentURLTransformer.transformFragment(attributeValue, self.xmldoc.url);
-								result.setAttribute(attributeName, attributeValue);
-								self.page.registerElementWithId(result, attributeValue);
-								continue;
-							}
-			            }
-			            // TODO: understand the element we are working with.
-			            if (attributeName == "src" || attributeName == "href" || attributeName == "poster") {
-			                attributeValue = self.resolveURL(attributeValue);
-			                if (attributeName === "href") {
-			                    attributeValue = self.documentURLTransformer.transformURL(
-			                        attributeValue, self.xmldoc.url);
-			                }
-			            } else if (attributeName == "srcset") {
-							attributeValue = attributeValue.split(",").map(function(value) {
-								return self.resolveURL(value.trim());
-							}).join(",");
-						}
-						if (attributeName === "poster" && tag === "video" && ns === adapt.base.NS.XHTML &&
-							hasAutoWidth && hasAutoHeight) {
-							var image = new Image();
-							var fetcher = adapt.taskutil.loadElement(image, attributeValue);
-							fetchers.push(fetcher);
-							images.push({image: image, element: result, fetcher: fetcher});
-						}
-			        }
-			        else if (attributeNS == "http://www.w3.org/2000/xmlns/") {
-			            continue; //namespace declaration (in Firefox)
-			        } else if (attributeNS == adapt.base.NS.XLINK) {
-			            if (attributeName == "href")
-			                attributeValue = self.resolveURL(attributeValue);		        	
-			        }
-			        if (attributeNS) {
-			            var attributePrefix = adapt.vgen.namespacePrefixMap[attributeNS];
-			            if (attributePrefix)
-			                attributeName = attributePrefix + ":" + attributeName;
-			        }
-				    if (attributeName == "src" && !attributeNS && (tag == "img" || tag == "input") && ns == adapt.base.NS.XHTML) {
-						// HTML img element should start loading only once all attributes are assigned.
-						delayedSrc = attributeValue;
-				    } else if (attributeName == "href" && tag == "image" && ns == adapt.base.NS.SVG && attributeNS == adapt.base.NS.XLINK) {
-			        	self.page.fetchers.push(adapt.taskutil.loadElement(result, attributeValue));
-			        } else {
+            if (element.namespaceURI != adapt.base.NS.FB2 || tag == "td") {
+                var attributes = element.attributes;
+                var attributeCount = attributes.length;
+                var delayedSrc = null;
+                for (var i = 0; i < attributeCount; i++) {
+                    var attribute = attributes[i];
+                    var attributeNS = attribute.namespaceURI;
+                    var attributeName = attribute.localName;
+                    var attributeValue = attribute.nodeValue;
+                    if (!attributeNS) {
+                        if (attributeName.match(/^on/))
+                            continue; // don't propagate JavaScript code
+                        if (attributeName == "style")
+                            continue; // we do styling ourselves
+                        if (attributeName == "id" || attributeName == "name") {
+                            // Propagate transformed ids and collect them on the page (only first time).
+                            if (firstTime) {
+                                attributeValue = self.documentURLTransformer.transformFragment(attributeValue, self.xmldoc.url);
+                                result.setAttribute(attributeName, attributeValue);
+                                self.page.registerElementWithId(result, attributeValue);
+                                continue;
+                            }
+                        }
+                        // TODO: understand the element we are working with.
+                        if (attributeName == "src" || attributeName == "href" || attributeName == "poster") {
+                            attributeValue = self.resolveURL(attributeValue);
+                            if (attributeName === "href") {
+                                attributeValue = self.documentURLTransformer.transformURL(
+                                    attributeValue, self.xmldoc.url);
+                            }
+                        } else if (attributeName == "srcset") {
+                            attributeValue = attributeValue.split(",").map(function(value) {
+                                return self.resolveURL(value.trim());
+                            }).join(",");
+                        }
+                        if (attributeName === "poster" && tag === "video" && ns === adapt.base.NS.XHTML &&
+                            hasAutoWidth && hasAutoHeight) {
+                            var image = new Image();
+                            var fetcher = adapt.taskutil.loadElement(image, attributeValue);
+                            fetchers.push(fetcher);
+                            images.push({image: image, element: result, fetcher: fetcher});
+                        }
+                    }
+                    else if (attributeNS == "http://www.w3.org/2000/xmlns/") {
+                        continue; //namespace declaration (in Firefox)
+                    } else if (attributeNS == adapt.base.NS.XLINK) {
+                        if (attributeName == "href")
+                            attributeValue = self.resolveURL(attributeValue);
+                    }
+                    if (attributeNS) {
+                        var attributePrefix = adapt.vgen.namespacePrefixMap[attributeNS];
+                        if (attributePrefix)
+                            attributeName = attributePrefix + ":" + attributeName;
+                    }
+                    if (attributeName == "src" && !attributeNS && (tag == "img" || tag == "input") && ns == adapt.base.NS.XHTML) {
+                        // HTML img element should start loading only once all attributes are assigned.
+                        delayedSrc = attributeValue;
+                    } else if (attributeName == "href" && tag == "image" && ns == adapt.base.NS.SVG && attributeNS == adapt.base.NS.XLINK) {
+                        self.page.fetchers.push(adapt.taskutil.loadElement(result, attributeValue));
+                    } else {
                         // When the document is not XML document (e.g. non-XML HTML)
                         // attributeNS can be null
                         if (attributeNS) {
@@ -915,69 +914,69 @@ adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnfor
                         } else {
                             result.setAttribute(attributeName, attributeValue);
                         }
-			        }
-			    }
-			    if (delayedSrc) {
-					var image = tag === "input" ? new Image() : result;
-		        	var imageFetcher = adapt.taskutil.loadElement(image, delayedSrc);
-					if (image !== result) {
-						result.src = delayedSrc;
-					}
-		        	if (!hasAutoWidth && !hasAutoHeight) {
-		        		// No need to wait for the image, does not affect layout
-		        		self.page.fetchers.push(imageFetcher);
-		        	} else {
-						if (hasAutoWidth && hasAutoHeight && imageResolution && imageResolution !== 1) {
-							images.push({image: image, element: result, fetcher: imageFetcher});
-						}
-		    			fetchers.push(imageFetcher);
-		        	}
-			    }			    
-			}
-		    delete computedStyle["content"];
-			var listStyleImage = computedStyle["list-style-image"];
-			if (listStyleImage && listStyleImage instanceof adapt.css.URL) {
-				var listStyleURL = (/** @type {adapt.css.URL} */ (listStyleImage)).url;
-    			fetchers.push(adapt.taskutil.loadElement(new Image(), listStyleURL));				
-			}
-			self.applyComputedStyles(result, computedStyle);
-			if (!self.nodeContext.inline) {
-				var blackList = null;
-				if (!firstTime) {
-					if (self.nodeContext.inheritedProps["box-decoration-break"] !== "clone") {
-						blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeBlackListVert : adapt.vgen.frontEdgeBlackListHor;
-					} else {
-						// When box-decoration-break: clone, cloned margins are always truncated to zero.
-						blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeUnforcedBreakBlackListVert : adapt.vgen.frontEdgeUnforcedBreakBlackListHor;
-					}
-				} else if (atUnforcedBreak) {
-					blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeUnforcedBreakBlackListVert : adapt.vgen.frontEdgeUnforcedBreakBlackListHor;
-				}
-				if (blackList) {
-					for (var propName in blackList) {
-						adapt.base.setCSSProperty(result, propName, blackList[propName]);
-					}
-				}
-			}
-		    if (listItem) {
-		    	result.setAttribute("value", computedStyle["ua-list-item-count"].stringValue());
-		    }
-		    self.viewNode = result;
-		    if (fetchers.length) {
-		    	adapt.taskutil.waitForFetchers(fetchers).then(function() {
-					if (imageResolution > 0) {
-						self.modifyElemDimensionWithImageResolution(images, imageResolution, computedStyle, self.nodeContext.vertical);
-					}
-		    		frame.finish(needToProcessChildren);
-		    	});
-		    } else {
-		    	frame.timeSlice().then(function() {
-		    		frame.finish(needToProcessChildren);
-		    	});
-		    }
-	    });
+                    }
+                }
+                if (delayedSrc) {
+                    var image = tag === "input" ? new Image() : result;
+                    var imageFetcher = adapt.taskutil.loadElement(image, delayedSrc);
+                    if (image !== result) {
+                        result.src = delayedSrc;
+                    }
+                    if (!hasAutoWidth && !hasAutoHeight) {
+                        // No need to wait for the image, does not affect layout
+                        self.page.fetchers.push(imageFetcher);
+                    } else {
+                        if (hasAutoWidth && hasAutoHeight && imageResolution && imageResolution !== 1) {
+                            images.push({image: image, element: result, fetcher: imageFetcher});
+                        }
+                        fetchers.push(imageFetcher);
+                    }
+                }
+            }
+            delete computedStyle["content"];
+            var listStyleImage = computedStyle["list-style-image"];
+            if (listStyleImage && listStyleImage instanceof adapt.css.URL) {
+                var listStyleURL = (/** @type {adapt.css.URL} */ (listStyleImage)).url;
+                fetchers.push(adapt.taskutil.loadElement(new Image(), listStyleURL));
+            }
+            self.applyComputedStyles(result, computedStyle);
+            if (!self.nodeContext.inline) {
+                var blackList = null;
+                if (!firstTime) {
+                    if (self.nodeContext.inheritedProps["box-decoration-break"] !== "clone") {
+                        blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeBlackListVert : adapt.vgen.frontEdgeBlackListHor;
+                    } else {
+                        // When box-decoration-break: clone, cloned margins are always truncated to zero.
+                        blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeUnforcedBreakBlackListVert : adapt.vgen.frontEdgeUnforcedBreakBlackListHor;
+                    }
+                } else if (atUnforcedBreak) {
+                    blackList = self.nodeContext.vertical ? adapt.vgen.frontEdgeUnforcedBreakBlackListVert : adapt.vgen.frontEdgeUnforcedBreakBlackListHor;
+                }
+                if (blackList) {
+                    for (var propName in blackList) {
+                        adapt.base.setCSSProperty(result, propName, blackList[propName]);
+                    }
+                }
+            }
+            if (listItem) {
+                result.setAttribute("value", computedStyle["ua-list-item-count"].stringValue());
+            }
+            self.viewNode = result;
+            if (fetchers.length) {
+                adapt.taskutil.waitForFetchers(fetchers).then(function() {
+                    if (imageResolution > 0) {
+                        self.modifyElemDimensionWithImageResolution(images, imageResolution, computedStyle, self.nodeContext.vertical);
+                    }
+                    frame.finish(needToProcessChildren);
+                });
+            } else {
+                frame.timeSlice().then(function() {
+                    frame.finish(needToProcessChildren);
+                });
+            }
+        });
     });
-	return frame.result();    
+    return frame.result();
 };
 
 /**
@@ -987,90 +986,90 @@ adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnfor
  * @param {boolean} isVertical
  */
 adapt.vgen.ViewFactory.prototype.modifyElemDimensionWithImageResolution = function(images, imageResolution, computedStyle, isVertical) {
-	var self = this;
-	images.forEach(function(param) {
-		if (param.fetcher.get().get() === "load") {
-			var img = param.image;
-			var scaledWidth = img.width / imageResolution;
-			var scaledHeight = img.height / imageResolution;
-			var elem = param.element;
-			if (scaledWidth > 0 && scaledHeight > 0) {
-				if (computedStyle["box-sizing"] === adapt.css.ident.border_box) {
-					if (computedStyle["border-left-style"] !== adapt.css.ident.none) {
-						scaledWidth += adapt.css.toNumber(computedStyle["border-left-width"], self.context);
-					}
-					if (computedStyle["border-right-style"] !== adapt.css.ident.none) {
-						scaledWidth += adapt.css.toNumber(computedStyle["border-right-width"], self.context);
-					}
-					if (computedStyle["border-top-style"] !== adapt.css.ident.none) {
-						scaledHeight += adapt.css.toNumber(computedStyle["border-top-width"], self.context);
-					}
-					if (computedStyle["border-bottom-style"] !== adapt.css.ident.none) {
-						scaledHeight += adapt.css.toNumber(computedStyle["border-bottom-width"], self.context);
-					}
-				}
-				if (imageResolution > 1) {
-					var maxWidth = computedStyle["max-width"] || adapt.css.ident.none;
-					var maxHeight = computedStyle["max-height"] || adapt.css.ident.none;
-					if (maxWidth === adapt.css.ident.none && maxHeight === adapt.css.ident.none) {
-						adapt.base.setCSSProperty(elem, "max-width", scaledWidth + "px");
-					} else if (maxWidth !== adapt.css.ident.none && maxHeight === adapt.css.ident.none) {
-						adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
-					} else if (maxWidth === adapt.css.ident.none && maxHeight !== adapt.css.ident.none) {
-						adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
-					} else {
-						// maxWidth != none && maxHeight != none
-						goog.asserts.assert(maxWidth.isNumeric());
-						goog.asserts.assert(maxHeight.isNumeric());
-						var numericMaxWidth = /** @type {adapt.css.Numeric} */ (maxWidth);
-						var numericMaxHeight = /** @type {adapt.css.Numeric} */ (maxHeight);
-						if (numericMaxWidth.unit !== "%") {
-							adapt.base.setCSSProperty(elem, "max-width",
-								Math.min(scaledWidth, adapt.css.toNumber(numericMaxWidth, self.context)) + "px");
-						} else if (numericMaxHeight.unit !== "%") {
-							adapt.base.setCSSProperty(elem, "max-height",
-								Math.min(scaledHeight, adapt.css.toNumber(numericMaxHeight, self.context)) + "px");
-						} else {
-							if (isVertical) {
-								adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
-							} else {
-								adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
-							}
-						}
-					}
-				} else if (imageResolution < 1) {
-					var minWidth = computedStyle["min-width"] || adapt.css.numericZero;
-					var minHeight = computedStyle["min-height"] || adapt.css.numericZero;
-					goog.asserts.assert(minWidth.isNumeric());
-					goog.asserts.assert(minWidth.isNumeric());
-					var numericMinWidth = /** @type {adapt.css.Numeric} */ (minWidth);
-					var numericMinHeight = /** @type {adapt.css.Numeric} */ (minHeight);
-					if (numericMinWidth.num === 0 && numericMinHeight.num === 0) {
-						adapt.base.setCSSProperty(elem, "min-width", scaledWidth + "px");
-					} else if (numericMinWidth.num !== 0 && numericMinHeight.num === 0) {
-						adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
-					} else if (numericMinWidth.num === 0 && numericMinHeight.num !== 0) {
-						adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
-					} else {
-						// minWidth != 0 && minHeight != 0
-						if (numericMinWidth.unit !== "%") {
-							adapt.base.setCSSProperty(elem, "min-width",
-								Math.max(scaledWidth, adapt.css.toNumber(numericMinWidth, self.context)) + "px");
-						} else if (numericMinHeight.unit !== "%") {
-							adapt.base.setCSSProperty(elem, "min-height",
-								Math.max(scaledHeight, adapt.css.toNumber(numericMinHeight, self.context)) + "px");
-						} else {
-							if (isVertical) {
-								adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
-							} else {
-								adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
-							}
-						}
-					}
-				}
-			}
-		}
-	});
+    var self = this;
+    images.forEach(function(param) {
+        if (param.fetcher.get().get() === "load") {
+            var img = param.image;
+            var scaledWidth = img.width / imageResolution;
+            var scaledHeight = img.height / imageResolution;
+            var elem = param.element;
+            if (scaledWidth > 0 && scaledHeight > 0) {
+                if (computedStyle["box-sizing"] === adapt.css.ident.border_box) {
+                    if (computedStyle["border-left-style"] !== adapt.css.ident.none) {
+                        scaledWidth += adapt.css.toNumber(computedStyle["border-left-width"], self.context);
+                    }
+                    if (computedStyle["border-right-style"] !== adapt.css.ident.none) {
+                        scaledWidth += adapt.css.toNumber(computedStyle["border-right-width"], self.context);
+                    }
+                    if (computedStyle["border-top-style"] !== adapt.css.ident.none) {
+                        scaledHeight += adapt.css.toNumber(computedStyle["border-top-width"], self.context);
+                    }
+                    if (computedStyle["border-bottom-style"] !== adapt.css.ident.none) {
+                        scaledHeight += adapt.css.toNumber(computedStyle["border-bottom-width"], self.context);
+                    }
+                }
+                if (imageResolution > 1) {
+                    var maxWidth = computedStyle["max-width"] || adapt.css.ident.none;
+                    var maxHeight = computedStyle["max-height"] || adapt.css.ident.none;
+                    if (maxWidth === adapt.css.ident.none && maxHeight === adapt.css.ident.none) {
+                        adapt.base.setCSSProperty(elem, "max-width", scaledWidth + "px");
+                    } else if (maxWidth !== adapt.css.ident.none && maxHeight === adapt.css.ident.none) {
+                        adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
+                    } else if (maxWidth === adapt.css.ident.none && maxHeight !== adapt.css.ident.none) {
+                        adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
+                    } else {
+                        // maxWidth != none && maxHeight != none
+                        goog.asserts.assert(maxWidth.isNumeric());
+                        goog.asserts.assert(maxHeight.isNumeric());
+                        var numericMaxWidth = /** @type {adapt.css.Numeric} */ (maxWidth);
+                        var numericMaxHeight = /** @type {adapt.css.Numeric} */ (maxHeight);
+                        if (numericMaxWidth.unit !== "%") {
+                            adapt.base.setCSSProperty(elem, "max-width",
+                                Math.min(scaledWidth, adapt.css.toNumber(numericMaxWidth, self.context)) + "px");
+                        } else if (numericMaxHeight.unit !== "%") {
+                            adapt.base.setCSSProperty(elem, "max-height",
+                                Math.min(scaledHeight, adapt.css.toNumber(numericMaxHeight, self.context)) + "px");
+                        } else {
+                            if (isVertical) {
+                                adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
+                            } else {
+                                adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
+                            }
+                        }
+                    }
+                } else if (imageResolution < 1) {
+                    var minWidth = computedStyle["min-width"] || adapt.css.numericZero;
+                    var minHeight = computedStyle["min-height"] || adapt.css.numericZero;
+                    goog.asserts.assert(minWidth.isNumeric());
+                    goog.asserts.assert(minWidth.isNumeric());
+                    var numericMinWidth = /** @type {adapt.css.Numeric} */ (minWidth);
+                    var numericMinHeight = /** @type {adapt.css.Numeric} */ (minHeight);
+                    if (numericMinWidth.num === 0 && numericMinHeight.num === 0) {
+                        adapt.base.setCSSProperty(elem, "min-width", scaledWidth + "px");
+                    } else if (numericMinWidth.num !== 0 && numericMinHeight.num === 0) {
+                        adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
+                    } else if (numericMinWidth.num === 0 && numericMinHeight.num !== 0) {
+                        adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
+                    } else {
+                        // minWidth != 0 && minHeight != 0
+                        if (numericMinWidth.unit !== "%") {
+                            adapt.base.setCSSProperty(elem, "min-width",
+                                Math.max(scaledWidth, adapt.css.toNumber(numericMinWidth, self.context)) + "px");
+                        } else if (numericMinHeight.unit !== "%") {
+                            adapt.base.setCSSProperty(elem, "min-height",
+                                Math.max(scaledHeight, adapt.css.toNumber(numericMinHeight, self.context)) + "px");
+                        } else {
+                            if (isVertical) {
+                                adapt.base.setCSSProperty(elem, "height", scaledHeight + "px");
+                            } else {
+                                adapt.base.setCSSProperty(elem, "width", scaledWidth + "px");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
 };
 
 /**
@@ -1079,32 +1078,32 @@ adapt.vgen.ViewFactory.prototype.modifyElemDimensionWithImageResolution = functi
  * @return {!adapt.task.Result.<boolean>} holding true if children should be processed
  */
 adapt.vgen.ViewFactory.prototype.createNodeView = function(firstTime, atUnforcedBreak) {
-	var self = this;
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame
-		= adapt.task.newFrame("createNodeView");
-	var result;
-	var needToProcessChildren = true;
+    var self = this;
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame
+        = adapt.task.newFrame("createNodeView");
+    var result;
+    var needToProcessChildren = true;
     if (self.sourceNode.nodeType == 1) {
         result = self.createElementView(firstTime, atUnforcedBreak);
     } else {
-    	if (self.sourceNode.nodeType == 8) {
-	    	self.viewNode = null; // comment node
-	    } else {
-	        var offsetInNode = self.offsetInNode || 0;
-	        self.viewNode = document.createTextNode(self.sourceNode.textContent.substr(offsetInNode));
-	    }
-    	result = adapt.task.newResult(true);
+        if (self.sourceNode.nodeType == 8) {
+            self.viewNode = null; // comment node
+        } else {
+            var offsetInNode = self.offsetInNode || 0;
+            self.viewNode = document.createTextNode(self.sourceNode.textContent.substr(offsetInNode));
+        }
+        result = adapt.task.newResult(true);
     }
     result.then(function(processChildren) {
-    	needToProcessChildren = processChildren;
-	    self.nodeContext.viewNode = self.viewNode;
-	    if (self.viewNode) {
-		    var parent = self.nodeContext.parent ? self.nodeContext.parent.viewNode : self.viewRoot;
-		    if (parent) {
-		    	parent.appendChild(self.viewNode);
-		    }
-	    }
-	    frame.finish(needToProcessChildren);
+        needToProcessChildren = processChildren;
+        self.nodeContext.viewNode = self.viewNode;
+        if (self.viewNode) {
+            var parent = self.nodeContext.parent ? self.nodeContext.parent.viewNode : self.viewRoot;
+            if (parent) {
+                parent.appendChild(self.viewNode);
+            }
+        }
+        frame.finish(needToProcessChildren);
     });
     return frame.result();
 };
@@ -1113,67 +1112,67 @@ adapt.vgen.ViewFactory.prototype.createNodeView = function(firstTime, atUnforced
  * @override
  */
 adapt.vgen.ViewFactory.prototype.setCurrent = function(nodeContext, firstTime, atUnforcedBreak) {
-	this.nodeContext = nodeContext;
+    this.nodeContext = nodeContext;
     if (nodeContext) {
-    	this.sourceNode = nodeContext.sourceNode;
-    	this.offsetInNode = nodeContext.offsetInNode;
+        this.sourceNode = nodeContext.sourceNode;
+        this.offsetInNode = nodeContext.offsetInNode;
     } else {
-    	this.sourceNode = null;
-    	this.offsetInNode = -1;    	
+        this.sourceNode = null;
+        this.offsetInNode = -1;
     }
     this.viewNode = null;
     if (this.nodeContext) {
-    	return this.createNodeView(firstTime, !!atUnforcedBreak);
+        return this.createNodeView(firstTime, !!atUnforcedBreak);
     }
     return adapt.task.newResult(true);
 };
 
 adapt.vgen.ViewFactory.prototype.processShadowContent = function(pos) {
-	if (pos.shadowContext == null || 
-			pos.sourceNode.localName != "content" || pos.sourceNode.namespaceURI != adapt.base.NS.SHADOW) {
-		return pos;
-	}
-	var boxOffset = pos.boxOffset;
-	var shadow = pos.shadowContext;
-	var parent = pos.parent;
-	
-	// content that will be inserted
+    if (pos.shadowContext == null ||
+        pos.sourceNode.localName != "content" || pos.sourceNode.namespaceURI != adapt.base.NS.SHADOW) {
+        return pos;
+    }
+    var boxOffset = pos.boxOffset;
+    var shadow = pos.shadowContext;
+    var parent = pos.parent;
+
+    // content that will be inserted
     var contentNode;
     var contentShadowType;
     var contentShadow;
     if (shadow.subShadow) {
-    	contentShadow = shadow.subShadow;
-    	contentNode = shadow.root;
-    	contentShadowType = shadow.type;
-    	if (contentShadowType == adapt.vtree.ShadowType.ROOTLESS) {
-    		contentNode = contentNode.firstChild;
-    	}
+        contentShadow = shadow.subShadow;
+        contentNode = shadow.root;
+        contentShadowType = shadow.type;
+        if (contentShadowType == adapt.vtree.ShadowType.ROOTLESS) {
+            contentNode = contentNode.firstChild;
+        }
     } else {
-    	contentShadow = shadow.parentShadow;
-    	contentNode = shadow.owner.firstChild;
-    	contentShadowType = adapt.vtree.ShadowType.ROOTLESS;
+        contentShadow = shadow.parentShadow;
+        contentNode = shadow.owner.firstChild;
+        contentShadowType = adapt.vtree.ShadowType.ROOTLESS;
     }
     var nextSibling = pos.sourceNode.nextSibling;
     if (nextSibling) {
-    	pos.sourceNode = nextSibling;
-	    pos.resetView();
-    } else if (pos.shadowSibling) { 
+        pos.sourceNode = nextSibling;
+        pos.resetView();
+    } else if (pos.shadowSibling) {
         pos = pos.shadowSibling;
     } else if (contentNode) {
-    	pos = null;
+        pos = null;
     } else {
         pos = pos.parent.modify();
         pos.after = true;
     }
     if (contentNode) {
-	    var r = new adapt.vtree.NodeContext(contentNode, parent, boxOffset);
-	    r.shadowContext = contentShadow;
-	    r.shadowType = contentShadowType;
-	    r.shadowSibling = pos;
-	    return r;
+        var r = new adapt.vtree.NodeContext(contentNode, parent, boxOffset);
+        r.shadowContext = contentShadow;
+        r.shadowType = contentShadowType;
+        r.shadowSibling = pos;
+        return r;
     }
-	pos.boxOffset = boxOffset;
-	return pos;
+    pos.boxOffset = boxOffset;
+    return pos;
 };
 
 /**
@@ -1189,20 +1188,20 @@ adapt.vgen.ViewFactory.prototype.nextPositionInTree = function(pos) {
         // we are done with this sourceNode, see if there is a next sibling, unless
         // this is the root of the shadow tree
         if (pos.shadowType != adapt.vtree.ShadowType.ROOTED) {
-	        var next = pos.sourceNode.nextSibling;
-	        if (next) {
-	            pos = pos.modify();
-	            // keep shadowType
-	            pos.boxOffset = boxOffset;
-	            pos.sourceNode = next;
-	            pos.resetView();
-	            return this.processShadowContent(pos);
-	        }
+            var next = pos.sourceNode.nextSibling;
+            if (next) {
+                pos = pos.modify();
+                // keep shadowType
+                pos.boxOffset = boxOffset;
+                pos.sourceNode = next;
+                pos.resetView();
+                return this.processShadowContent(pos);
+            }
         }
         // if no viable siblings, check if there are shadow siblings
         if (pos.shadowSibling) {
-        	// our next position is the element after shadow:content in the parent shadow tree
-        	pos = pos.shadowSibling.modify();
+            // our next position is the element after shadow:content in the parent shadow tree
+            pos = pos.shadowSibling.modify();
             pos.boxOffset = boxOffset;
             return pos;
         }
@@ -1212,23 +1211,23 @@ adapt.vgen.ViewFactory.prototype.nextPositionInTree = function(pos) {
         pos.after = true;
         return pos;
     } else {
-    	// any shadow trees?
+        // any shadow trees?
         if (pos.nodeShadow) {
-        	var shadowNode = pos.nodeShadow.root;
-        	if (pos.nodeShadow.type == adapt.vtree.ShadowType.ROOTLESS) {
-        		shadowNode = shadowNode.firstChild;
-        	}
-        	if (shadowNode) {
-	    		var sr = new adapt.vtree.NodeContext(shadowNode, pos, boxOffset);
-	    		sr.shadowContext = pos.nodeShadow;
-	    		sr.shadowType = pos.nodeShadow.type;
-	            return this.processShadowContent(sr);
-        	}
-    	}
+            var shadowNode = pos.nodeShadow.root;
+            if (pos.nodeShadow.type == adapt.vtree.ShadowType.ROOTLESS) {
+                shadowNode = shadowNode.firstChild;
+            }
+            if (shadowNode) {
+                var sr = new adapt.vtree.NodeContext(shadowNode, pos, boxOffset);
+                sr.shadowContext = pos.nodeShadow;
+                sr.shadowType = pos.nodeShadow.type;
+                return this.processShadowContent(sr);
+            }
+        }
         // any children?
         var child = pos.sourceNode.firstChild;
         if (child) {
-        	return this.processShadowContent(new adapt.vtree.NodeContext(child, pos, boxOffset));
+            return this.processShadowContent(new adapt.vtree.NodeContext(child, pos, boxOffset));
         }
         // no children - was there text content?
         if (pos.sourceNode.nodeType != 1) {
@@ -1247,13 +1246,13 @@ adapt.vgen.ViewFactory.prototype.nextPositionInTree = function(pos) {
  * @param {?string} transclusionType
  */
 adapt.vgen.ViewFactory.prototype.isTransclusion = function(element, elementStyle, transclusionType) {
-	var proc = adapt.csscasc.getProp(elementStyle, "hyperlink-processing");
-	if (!proc)
-		return false;
-	var prop = proc.evaluate(this.context, "hyperlink-processing");
-	if (!prop)
-		return false;
-	return prop.toString() == transclusionType;
+    var proc = adapt.csscasc.getProp(elementStyle, "hyperlink-processing");
+    if (!proc)
+        return false;
+    var prop = proc.evaluate(this.context, "hyperlink-processing");
+    if (!prop)
+        return false;
+    return prop.toString() == transclusionType;
 };
 
 
@@ -1261,48 +1260,48 @@ adapt.vgen.ViewFactory.prototype.isTransclusion = function(element, elementStyle
  * @override
  */
 adapt.vgen.ViewFactory.prototype.nextInTree = function(nodeContext, atUnforcedBreak) {
-	nodeContext = this.nextPositionInTree(nodeContext);
-	if (!nodeContext || nodeContext.after) {
-		return adapt.task.newResult(nodeContext);
-	}
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("nextInTree");
-	this.setCurrent(nodeContext, true, atUnforcedBreak).then(function(processChildren) {
-	    if (!nodeContext.viewNode || !processChildren) {
-	    	nodeContext = nodeContext.modify();
-	    	nodeContext.after = true; // skip
-	    	if (!nodeContext.viewNode) {
-	    		nodeContext.inline = true;
-	    	}
-	    }
-		frame.finish(nodeContext);
-	});
-	return frame.result();
+    nodeContext = this.nextPositionInTree(nodeContext);
+    if (!nodeContext || nodeContext.after) {
+        return adapt.task.newResult(nodeContext);
+    }
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("nextInTree");
+    this.setCurrent(nodeContext, true, atUnforcedBreak).then(function(processChildren) {
+        if (!nodeContext.viewNode || !processChildren) {
+            nodeContext = nodeContext.modify();
+            nodeContext.after = true; // skip
+            if (!nodeContext.viewNode) {
+                nodeContext.inline = true;
+            }
+        }
+        frame.finish(nodeContext);
+    });
+    return frame.result();
 };
 
 adapt.vgen.ViewFactory.prototype.addImageFetchers = function(bg) {
-	if (bg instanceof adapt.css.CommaList) {
-		var values = (/** @type {adapt.css.CommaList} */ (bg)).values;
-		for (var i = 0; i < values.length; i++) {
-			this.addImageFetchers(values[i]);
-		}
-	} else if (bg instanceof adapt.css.URL) {
-		var url = (/** @type {adapt.css.URL} */(bg)).url;
-		this.page.fetchers.push(adapt.taskutil.loadElement(new Image(), url));				
-	}
+    if (bg instanceof adapt.css.CommaList) {
+        var values = (/** @type {adapt.css.CommaList} */ (bg)).values;
+        for (var i = 0; i < values.length; i++) {
+            this.addImageFetchers(values[i]);
+        }
+    } else if (bg instanceof adapt.css.URL) {
+        var url = (/** @type {adapt.css.URL} */(bg)).url;
+        this.page.fetchers.push(adapt.taskutil.loadElement(new Image(), url));
+    }
 };
 
 /**
  * @const
  */
 adapt.vgen.propertiesNotPassedToDOM = {
-	"box-decoration-break": true,
-	"flow-into": true,
-	"flow-linger": true,
-	"flow-priority": true,
-	"flow-options": true,
-	"page": true,
-	"float-reference": true
+    "box-decoration-break": true,
+    "flow-into": true,
+    "flow-linger": true,
+    "flow-priority": true,
+    "flow-options": true,
+    "page": true,
+    "float-reference": true
 };
 
 /**
@@ -1310,49 +1309,49 @@ adapt.vgen.propertiesNotPassedToDOM = {
  * @param {Object.<string,adapt.css.Val>} computedStyle
  */
 adapt.vgen.ViewFactory.prototype.applyComputedStyles = function(target, computedStyle) {
-	var bg = computedStyle["background-image"];
-	if (bg) {
-		this.addImageFetchers(bg);
-	}
-	var isRelativePositioned = computedStyle["position"] === adapt.css.ident.relative;
-	for (var propName in computedStyle) {
-		if (adapt.vgen.propertiesNotPassedToDOM[propName]) {
-			continue;
-		}
-		var value = computedStyle[propName];
-		if (adapt.vtree.delayedProps[propName] ||
-			(isRelativePositioned && adapt.vtree.delayedPropsIfRelativePositioned[propName])) {
-			// Set it after page layout is done.
-			this.page.delayedItems.push(
-				new adapt.vtree.DelayedItem(target, propName, value));
-			continue;
-		}
-		if (value.isNumeric() && adapt.expr.needUnitConversion(value.unit)) {
-			// font-size for the root element is already converted to px
-			value = adapt.css.convertNumericToPx(value, this.context);
-		}
-	    adapt.base.setCSSProperty(target, propName, value.toString());
-	}	
+    var bg = computedStyle["background-image"];
+    if (bg) {
+        this.addImageFetchers(bg);
+    }
+    var isRelativePositioned = computedStyle["position"] === adapt.css.ident.relative;
+    for (var propName in computedStyle) {
+        if (adapt.vgen.propertiesNotPassedToDOM[propName]) {
+            continue;
+        }
+        var value = computedStyle[propName];
+        if (adapt.vtree.delayedProps[propName] ||
+            (isRelativePositioned && adapt.vtree.delayedPropsIfRelativePositioned[propName])) {
+            // Set it after page layout is done.
+            this.page.delayedItems.push(
+                new adapt.vtree.DelayedItem(target, propName, value));
+            continue;
+        }
+        if (value.isNumeric() && adapt.expr.needUnitConversion(value.unit)) {
+            // font-size for the root element is already converted to px
+            value = adapt.css.convertNumericToPx(value, this.context);
+        }
+        adapt.base.setCSSProperty(target, propName, value.toString());
+    }
 };
 
 /**
  * @override
  */
 adapt.vgen.ViewFactory.prototype.applyPseudoelementStyle = function(nodeContext, pseudoName, target) {
-	if (nodeContext.after)
-		return;
+    if (nodeContext.after)
+        return;
     var element = /** @type {Element} */ (this.sourceNode);
-    var styler = nodeContext.shadowContext ? 
-    		/** @type {adapt.cssstyler.AbstractStyler} */ (nodeContext.shadowContext.styler) : this.styler;
+    var styler = nodeContext.shadowContext ?
+        /** @type {adapt.cssstyler.AbstractStyler} */ (nodeContext.shadowContext.styler) : this.styler;
     var elementStyle = styler.getStyle(element, false);
     var pseudoMap = adapt.csscasc.getStyleMap(elementStyle, "_pseudos");
     if (!pseudoMap)
-    	return;
+        return;
     elementStyle = pseudoMap[pseudoName];
-	if (!elementStyle)
-		return;
+    if (!elementStyle)
+        return;
     var computedStyle = {};
-	nodeContext.vertical = this.computeStyle(nodeContext.vertical, elementStyle, computedStyle);
+    nodeContext.vertical = this.computeStyle(nodeContext.vertical, elementStyle, computedStyle);
     var content = computedStyle["content"];
     if (adapt.vtree.nonTrivialContent(content)) {
         content.visit(new adapt.vtree.ContentPropertyHandler(target, this.context));
@@ -1365,51 +1364,51 @@ adapt.vgen.ViewFactory.prototype.applyPseudoelementStyle = function(nodeContext,
  * @override
  */
 adapt.vgen.ViewFactory.prototype.peelOff = function(nodeContext, nodeOffset) {
-	/** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
-		= adapt.task.newFrame("peelOff");
-	var firstPseudo = nodeContext.firstPseudo;
-	var offsetInNode = nodeContext.offsetInNode;
-	var after = nodeContext.after;
-	if (nodeOffset > 0) {
-		var text = nodeContext.viewNode.textContent;
-		nodeContext.viewNode.textContent = text.substr(0, nodeOffset);
-		offsetInNode += nodeOffset;
-	} else if (!after && nodeContext.viewNode && offsetInNode == 0) {
-		var parent = nodeContext.viewNode.parentNode;
-		if (parent)
-			parent.removeChild(nodeContext.viewNode);
-	}
-	var boxOffset = nodeContext.boxOffset + nodeOffset;
-	var arr = [];
-	while (nodeContext.firstPseudo === firstPseudo) {
-		arr.push(nodeContext);
-		nodeContext = nodeContext.parent;
-	}
-	var pn = arr.pop(); // container for that pseudoelement
-	var shadowSibling = pn.shadowSibling;
-	var self = this;
-	frame.loop(function() {
-		while (arr.length > 0) {
-			pn = arr.pop();
-			nodeContext = new adapt.vtree.NodeContext(pn.sourceNode, nodeContext, boxOffset);
-			if (arr.length == 0) {
-				nodeContext.offsetInNode = offsetInNode;
-				nodeContext.after = after;
-			}
-			nodeContext.shadowType = pn.shadowType;
-			nodeContext.shadowContext = pn.shadowContext,
-			nodeContext.nodeShadow = pn.nodeShadow;
-			nodeContext.shadowSibling = pn.shadowSibling ? pn.shadowSibling : shadowSibling;
-			shadowSibling = null;
-			var result = self.setCurrent(nodeContext, false);
-			if (result.isPending())
-				return result;
-		}
-		return adapt.task.newResult(false);
-	}).then(function() {
-		frame.finish(nodeContext);
-	});
-	return frame.result();
+    /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame
+        = adapt.task.newFrame("peelOff");
+    var firstPseudo = nodeContext.firstPseudo;
+    var offsetInNode = nodeContext.offsetInNode;
+    var after = nodeContext.after;
+    if (nodeOffset > 0) {
+        var text = nodeContext.viewNode.textContent;
+        nodeContext.viewNode.textContent = text.substr(0, nodeOffset);
+        offsetInNode += nodeOffset;
+    } else if (!after && nodeContext.viewNode && offsetInNode == 0) {
+        var parent = nodeContext.viewNode.parentNode;
+        if (parent)
+            parent.removeChild(nodeContext.viewNode);
+    }
+    var boxOffset = nodeContext.boxOffset + nodeOffset;
+    var arr = [];
+    while (nodeContext.firstPseudo === firstPseudo) {
+        arr.push(nodeContext);
+        nodeContext = nodeContext.parent;
+    }
+    var pn = arr.pop(); // container for that pseudoelement
+    var shadowSibling = pn.shadowSibling;
+    var self = this;
+    frame.loop(function() {
+        while (arr.length > 0) {
+            pn = arr.pop();
+            nodeContext = new adapt.vtree.NodeContext(pn.sourceNode, nodeContext, boxOffset);
+            if (arr.length == 0) {
+                nodeContext.offsetInNode = offsetInNode;
+                nodeContext.after = after;
+            }
+            nodeContext.shadowType = pn.shadowType;
+            nodeContext.shadowContext = pn.shadowContext,
+                nodeContext.nodeShadow = pn.nodeShadow;
+            nodeContext.shadowSibling = pn.shadowSibling ? pn.shadowSibling : shadowSibling;
+            shadowSibling = null;
+            var result = self.setCurrent(nodeContext, false);
+            if (result.isPending())
+                return result;
+        }
+        return adapt.task.newResult(false);
+    }).then(function() {
+        frame.finish(nodeContext);
+    });
+    return frame.result();
 };
 
 
@@ -1419,9 +1418,9 @@ adapt.vgen.ViewFactory.prototype.peelOff = function(nodeContext, nodeOffset) {
  * @return {!Element}
  */
 adapt.vgen.ViewFactory.prototype.createElement = function(ns, tag) {
-	if (ns == adapt.base.NS.XHTML)
-		return this.document.createElement(tag);
-	return this.document.createElementNS(ns, tag);
+    if (ns == adapt.base.NS.XHTML)
+        return this.document.createElement(tag);
+    return this.document.createElementNS(ns, tag);
 };
 
 /**
@@ -1432,41 +1431,41 @@ adapt.vgen.ViewFactory.prototype.applyFootnoteStyle = function(vertical, target)
     var pseudoMap = adapt.csscasc.getStyleMap(this.footnoteStyle, "_pseudos");
     vertical = this.computeStyle(vertical, this.footnoteStyle, computedStyle);
     if (pseudoMap && pseudoMap["before"]) {
-    	var childComputedStyle = {};
-    	var span = this.createElement(adapt.base.NS.XHTML, "span");
-		adapt.vgen.setPseudoName(span, "before");
-    	target.appendChild(span);
-    	this.computeStyle(vertical, pseudoMap["before"], childComputedStyle);
-    	delete childComputedStyle["content"];
-    	this.applyComputedStyles(span, childComputedStyle);
+        var childComputedStyle = {};
+        var span = this.createElement(adapt.base.NS.XHTML, "span");
+        adapt.vgen.setPseudoName(span, "before");
+        target.appendChild(span);
+        this.computeStyle(vertical, pseudoMap["before"], childComputedStyle);
+        delete childComputedStyle["content"];
+        this.applyComputedStyles(span, childComputedStyle);
     }
-	delete computedStyle["content"];
-	this.applyComputedStyles(target, computedStyle);
-	return vertical;
+    delete computedStyle["content"];
+    this.applyComputedStyles(target, computedStyle);
+    return vertical;
 };
 
 /**
  * @override
  */
 adapt.vgen.ViewFactory.prototype.processFragmentedBlockEdge = function(nodeContext) {
-	nodeContext.walkBlocksUpToBFC(function(block) {
-		var boxDecorationBreak = block.inheritedProps["box-decoration-break"];
-		if (!boxDecorationBreak || boxDecorationBreak === "slice") {
-			var elem = block.viewNode;
-			goog.asserts.assert(elem instanceof Element);
-			if (block.vertical) {
-				adapt.base.setCSSProperty(elem, "padding-left", "0");
-				adapt.base.setCSSProperty(elem, "border-left", "none");
-				adapt.base.setCSSProperty(elem, "border-top-left-radius", "0");
-				adapt.base.setCSSProperty(elem, "border-bottom-left-radius", "0");
-			} else {
-				adapt.base.setCSSProperty(elem, "padding-bottom", "0");
-				adapt.base.setCSSProperty(elem, "border-bottom", "none");
-				adapt.base.setCSSProperty(elem, "border-bottom-left-radius", "0");
-				adapt.base.setCSSProperty(elem, "border-bottom-right-radius", "0");
-			}
-		}
-	});
+    nodeContext.walkBlocksUpToBFC(function(block) {
+        var boxDecorationBreak = block.inheritedProps["box-decoration-break"];
+        if (!boxDecorationBreak || boxDecorationBreak === "slice") {
+            var elem = block.viewNode;
+            goog.asserts.assert(elem instanceof Element);
+            if (block.vertical) {
+                adapt.base.setCSSProperty(elem, "padding-left", "0");
+                adapt.base.setCSSProperty(elem, "border-left", "none");
+                adapt.base.setCSSProperty(elem, "border-top-left-radius", "0");
+                adapt.base.setCSSProperty(elem, "border-bottom-left-radius", "0");
+            } else {
+                adapt.base.setCSSProperty(elem, "padding-bottom", "0");
+                adapt.base.setCSSProperty(elem, "border-bottom", "none");
+                adapt.base.setCSSProperty(elem, "border-bottom-left-radius", "0");
+                adapt.base.setCSSProperty(elem, "border-bottom-right-radius", "0");
+            }
+        }
+    });
 };
 
 /**
@@ -1476,41 +1475,41 @@ adapt.vgen.ViewFactory.prototype.processFragmentedBlockEdge = function(nodeConte
  * @returns {boolean}
  */
 adapt.vgen.ViewFactory.prototype.isSameNodePositionStep = function(step1, step2) {
-	if (step1.shadowContext) {
-		if (!step2.shadowContext) {
-			return false;
-		}
-		var elem1 = step1.node.nodeType === 1 ? /** @type {Element} */ (step1.node) : step1.node.parentElement;
-		var elem2 = step2.node.nodeType === 1 ? /** @type {Element} */ (step2.node) : step2.node.parentElement;
-		return step1.shadowContext.owner === step2.shadowContext.owner
-			&& adapt.vgen.getPseudoName(elem1) === adapt.vgen.getPseudoName(elem2);
-	} else {
-		return step1.node === step2.node;
-	}
+    if (step1.shadowContext) {
+        if (!step2.shadowContext) {
+            return false;
+        }
+        var elem1 = step1.node.nodeType === 1 ? /** @type {Element} */ (step1.node) : step1.node.parentElement;
+        var elem2 = step2.node.nodeType === 1 ? /** @type {Element} */ (step2.node) : step2.node.parentElement;
+        return step1.shadowContext.owner === step2.shadowContext.owner
+            && adapt.vgen.getPseudoName(elem1) === adapt.vgen.getPseudoName(elem2);
+    } else {
+        return step1.node === step2.node;
+    }
 };
 
 /**
  * @override
  */
 adapt.vgen.ViewFactory.prototype.isSameNodePosition = function(nodePosition1, nodePosition2) {
-	return nodePosition1.offsetInNode === nodePosition2.offsetInNode
-		&& nodePosition1.after == nodePosition2.after
-		&& nodePosition1.steps.length === nodePosition2.steps.length
-		&& nodePosition1.steps.every(function(step1, i) {
-			var step2 = nodePosition2.steps[i];
-			return this.isSameNodePositionStep(step1, step2);
-		}.bind(this));
+    return nodePosition1.offsetInNode === nodePosition2.offsetInNode
+        && nodePosition1.after == nodePosition2.after
+        && nodePosition1.steps.length === nodePosition2.steps.length
+        && nodePosition1.steps.every(function(step1, i) {
+            var step2 = nodePosition2.steps[i];
+            return this.isSameNodePositionStep(step1, step2);
+        }.bind(this));
 };
 
 /**
  * @override
  */
 adapt.vgen.ViewFactory.prototype.getPageFloatHolder = function() {
-	return this.pageFloatHolder;
+    return this.pageFloatHolder;
 };
 
 adapt.vgen.ViewFactory.prototype.isPseudoelement = function(elem) {
-	return !!adapt.vgen.getPseudoName(elem);
+    return !!adapt.vgen.getPseudoName(elem);
 };
 
 /**
@@ -1519,29 +1518,29 @@ adapt.vgen.ViewFactory.prototype.isPseudoelement = function(elem) {
  * @implements {adapt.vtree.ClientLayout}
  */
 adapt.vgen.DefaultClientLayout = function(window) {
-	/** @const */ this.window = window;
+    /** @const */ this.window = window;
 };
 
 /**
  * @override
  */
 adapt.vgen.DefaultClientLayout.prototype.getRangeClientRects = function(range) {
-	return range["getClientRects"]();
+    return range["getClientRects"]();
 };
 
 /**
  * @override
  */
 adapt.vgen.DefaultClientLayout.prototype.getElementClientRect = function(element) {
-	var htmlElement = /** @type {HTMLElement} */ (element);
-	return /** @type {adapt.vtree.ClientRect} */ (htmlElement.getBoundingClientRect());
+    var htmlElement = /** @type {HTMLElement} */ (element);
+    return /** @type {adapt.vtree.ClientRect} */ (htmlElement.getBoundingClientRect());
 };
 
 /**
  * @override
  */
 adapt.vgen.DefaultClientLayout.prototype.getElementComputedStyle = function(element) {
-	return this.window.getComputedStyle(element, null);
+    return this.window.getComputedStyle(element, null);
 };
 
 /**
@@ -1553,39 +1552,39 @@ adapt.vgen.DefaultClientLayout.prototype.getElementComputedStyle = function(elem
  * @param {number=} opt_height
  */
 adapt.vgen.Viewport = function(window, fontSize, opt_root, opt_width, opt_height) {
-	/** @const */ this.window = window;
-	/** @const */ this.fontSize = fontSize;
-	/** @const */ this.document = window.document;
-	/** @type {HTMLElement} */ this.root = opt_root || this.document.body;
-	var outerZoomBox = this.root.firstElementChild;
-	if (!outerZoomBox) {
-		outerZoomBox = this.document.createElement("div");
-		outerZoomBox.setAttribute("data-vivliostyle-outer-zoom-box", true);
-		this.root.appendChild(outerZoomBox);
-	}
-	var contentContainer = outerZoomBox.firstElementChild;
-	if (!contentContainer) {
-		contentContainer = this.document.createElement("div");
-		contentContainer.setAttribute("data-vivliostyle-spread-container", true);
-		outerZoomBox.appendChild(contentContainer);
-	}
-	/** @private @type {!HTMLElement} */ this.outerZoomBox = /** @type {!HTMLElement} */ (outerZoomBox);
-	/** @type {!HTMLElement} */ this.contentContainer = /** @type {!HTMLElement} */ (contentContainer);
-	var clientLayout = new adapt.vgen.DefaultClientLayout(window);
-	var computedStyle = clientLayout.getElementComputedStyle(this.root);
-	/** @type {number} */ this.width = opt_width || parseFloat(computedStyle["width"]) || window.innerWidth;
-	/** @type {number} */ this.height = opt_height || parseFloat(computedStyle["height"]) || window.innerHeight;
+    /** @const */ this.window = window;
+    /** @const */ this.fontSize = fontSize;
+    /** @const */ this.document = window.document;
+    /** @type {HTMLElement} */ this.root = opt_root || this.document.body;
+    var outerZoomBox = this.root.firstElementChild;
+    if (!outerZoomBox) {
+        outerZoomBox = this.document.createElement("div");
+        outerZoomBox.setAttribute("data-vivliostyle-outer-zoom-box", true);
+        this.root.appendChild(outerZoomBox);
+    }
+    var contentContainer = outerZoomBox.firstElementChild;
+    if (!contentContainer) {
+        contentContainer = this.document.createElement("div");
+        contentContainer.setAttribute("data-vivliostyle-spread-container", true);
+        outerZoomBox.appendChild(contentContainer);
+    }
+    /** @private @type {!HTMLElement} */ this.outerZoomBox = /** @type {!HTMLElement} */ (outerZoomBox);
+    /** @type {!HTMLElement} */ this.contentContainer = /** @type {!HTMLElement} */ (contentContainer);
+    var clientLayout = new adapt.vgen.DefaultClientLayout(window);
+    var computedStyle = clientLayout.getElementComputedStyle(this.root);
+    /** @type {number} */ this.width = opt_width || parseFloat(computedStyle["width"]) || window.innerWidth;
+    /** @type {number} */ this.height = opt_height || parseFloat(computedStyle["height"]) || window.innerHeight;
 };
 
 /**
  * Reset zoom.
  */
 adapt.vgen.Viewport.prototype.resetZoom = function() {
-	adapt.base.setCSSProperty(this.outerZoomBox, "width", "");
-	adapt.base.setCSSProperty(this.outerZoomBox, "height", "");
-	adapt.base.setCSSProperty(this.contentContainer, "width", "");
-	adapt.base.setCSSProperty(this.contentContainer, "height", "");
-	adapt.base.setCSSProperty(this.contentContainer, "transform", "");
+    adapt.base.setCSSProperty(this.outerZoomBox, "width", "");
+    adapt.base.setCSSProperty(this.outerZoomBox, "height", "");
+    adapt.base.setCSSProperty(this.contentContainer, "width", "");
+    adapt.base.setCSSProperty(this.contentContainer, "height", "");
+    adapt.base.setCSSProperty(this.contentContainer, "transform", "");
 };
 
 /**
@@ -1595,9 +1594,9 @@ adapt.vgen.Viewport.prototype.resetZoom = function() {
  * @param {number} scale Factor to which the viewport will be scaled.
  */
 adapt.vgen.Viewport.prototype.zoom = function(width, height, scale) {
-	adapt.base.setCSSProperty(this.outerZoomBox, "width", width*scale + "px");
-	adapt.base.setCSSProperty(this.outerZoomBox, "height", height*scale + "px");
-	adapt.base.setCSSProperty(this.contentContainer, "width", width + "px");
-	adapt.base.setCSSProperty(this.contentContainer, "height", height + "px");
-	adapt.base.setCSSProperty(this.contentContainer, "transform", "scale(" + scale + ")");
+    adapt.base.setCSSProperty(this.outerZoomBox, "width", width*scale + "px");
+    adapt.base.setCSSProperty(this.outerZoomBox, "height", height*scale + "px");
+    adapt.base.setCSSProperty(this.contentContainer, "width", width + "px");
+    adapt.base.setCSSProperty(this.contentContainer, "height", height + "px");
+    adapt.base.setCSSProperty(this.contentContainer, "transform", "scale(" + scale + ")");
 };

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -49,21 +49,21 @@ adapt.viewer.SingleDocumentParam;
  * @constructor
  */
 adapt.viewer.Viewer = function(window, viewportElement, instanceId, callbackFn) {
-	var self = this;
-	/** @const */ this.window = window;
+    var self = this;
+    /** @const */ this.window = window;
     /** @const */ this.viewportElement = viewportElement;
     viewportElement.setAttribute("data-vivliostyle-viewer-viewport", true);
     viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "loading");
-	/** @const */ this.instanceId = instanceId;
-	/** @const */ this.callbackFn = callbackFn;
-	var document = window.document;
+    /** @const */ this.instanceId = instanceId;
+    /** @const */ this.callbackFn = callbackFn;
+    var document = window.document;
     /** @const */ this.fontMapper = new adapt.font.Mapper(document.head, viewportElement);
     this.init();
-    /** @type {function():void} */ this.kick = function(){};
-    /** @type {function((adapt.base.JSON|string)):void} */ this.sendCommand = function(){};
+    /** @type {function():void} */ this.kick = function() {};
+    /** @type {function((adapt.base.JSON|string)):void} */ this.sendCommand = function() {};
     /** @const */ this.resizeListener = function() {
-    	self.needResize = true;
-    	self.kick();
+        self.needResize = true;
+        self.kick();
     };
     /** @const */ this.pageReplacedListener = this.pageReplacedListener.bind(this);
     /** @type {adapt.base.EventListener} */ this.hyperlinkListener = function(evt) {};
@@ -76,8 +76,8 @@ adapt.viewer.Viewer = function(window, viewportElement, instanceId, callbackFn) 
         "loadEPUB": this.loadEPUB,
         "loadXML": this.loadXML,
         "configure": this.configure,
-    	"moveTo": this.moveTo,
-    	"toc": this.showTOC
+        "moveTo": this.moveTo,
+        "toc": this.showTOC
     };
     this.addLogListeners();
 };
@@ -87,8 +87,8 @@ adapt.viewer.Viewer = function(window, viewportElement, instanceId, callbackFn) 
  * @return {void}
  */
 adapt.viewer.Viewer.prototype.init = function() {
-	/** @type {!Array.<string>} */ this.packageURL = [];
-	/** @type {adapt.epub.OPFDoc} */ this.opf = null;
+    /** @type {!Array.<string>} */ this.packageURL = [];
+    /** @type {adapt.epub.OPFDoc} */ this.opf = null;
     /** @type {boolean} */ this.haveZipMetadata = false;
     /** @type {boolean} */ this.touchActive = false;
     /** @type {number} */ this.touchX = 0;
@@ -128,8 +128,8 @@ adapt.viewer.Viewer.prototype.addLogListeners = function() {
  * @return {void}
  */
 adapt.viewer.Viewer.prototype.callback = function(message) {
-	message["i"] = this.instanceId;
-	this.callbackFn(message);
+    message["i"] = this.instanceId;
+    this.callbackFn(message);
 };
 
 /**
@@ -140,37 +140,37 @@ adapt.viewer.Viewer.prototype.loadEPUB = function(command) {
     vivliostyle.profile.profiler.registerStartTiming("loadEPUB");
     vivliostyle.profile.profiler.registerStartTiming("loadFirstPage");
     this.viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "loading");
-	var url = /** @type {string} */ (command["url"]);
-	var fragment = /** @type {?string} */ (command["fragment"]);
-	var haveZipMetadata = !!command["zipmeta"];
+    var url = /** @type {string} */ (command["url"]);
+    var fragment = /** @type {?string} */ (command["fragment"]);
+    var haveZipMetadata = !!command["zipmeta"];
     var userStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["userStyleSheet"]);
     // force relayout
     this.viewport = null;
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("loadEPUB");
-	var self = this;
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("loadEPUB");
+    var self = this;
     self.configure(command).then(function() {
-	var store = new adapt.epub.EPUBDocStore();
-    if (userStyleSheet) {
-        for (var i = 0; i < userStyleSheet.length; i++) {
-            store.addUserStyleSheet(userStyleSheet[i]);
+        var store = new adapt.epub.EPUBDocStore();
+        if (userStyleSheet) {
+            for (var i = 0; i < userStyleSheet.length; i++) {
+                store.addUserStyleSheet(userStyleSheet[i]);
+            }
         }
-    }
-	store.init().then(function() {
-	    var epubURL = adapt.base.resolveURL(url, self.window.location.href);
-	    self.packageURL = [epubURL];
-	    store.loadEPUBDoc(epubURL, haveZipMetadata).then(function (opf) {
-	        self.opf = opf;
-	        self.opf.resolveFragment(fragment).then(function(position) {
-	        	self.pagePosition = position;
-                self.resize().then(function() {
-                    self.viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "complete");
-                    vivliostyle.profile.profiler.registerEndTiming("loadEPUB");
-                    self.callback({"t":"loaded", "metadata": self.opf.getMetadata()});
-                    frame.finish(true);
+        store.init().then(function() {
+            var epubURL = adapt.base.resolveURL(url, self.window.location.href);
+            self.packageURL = [epubURL];
+            store.loadEPUBDoc(epubURL, haveZipMetadata).then(function(opf) {
+                self.opf = opf;
+                self.opf.resolveFragment(fragment).then(function(position) {
+                    self.pagePosition = position;
+                    self.resize().then(function() {
+                        self.viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "complete");
+                        vivliostyle.profile.profiler.registerEndTiming("loadEPUB");
+                        self.callback({"t":"loaded", "metadata": self.opf.getMetadata()});
+                        frame.finish(true);
+                    });
                 });
-	        });
-	    });
-	});
+            });
+        });
     });
     return frame.result();
 };
@@ -185,42 +185,42 @@ adapt.viewer.Viewer.prototype.loadXML = function(command) {
     this.viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "loading");
     /** @type {!Array<!adapt.viewer.SingleDocumentParam>} */ var params = command["url"];
     var doc = /** @type {Document} */ (command["document"]);
-	var fragment = /** @type {?string} */ (command["fragment"]);
+    var fragment = /** @type {?string} */ (command["fragment"]);
     var userStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["userStyleSheet"]);
     // force relayout
     this.viewport = null;
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("loadXML");
-	var self = this;
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("loadXML");
+    var self = this;
     self.configure(command).then(function() {
-	var store = new adapt.epub.EPUBDocStore();
-    if (userStyleSheet) {
-        for (var i = 0; i < userStyleSheet.length; i++) {
-            store.addUserStyleSheet(userStyleSheet[i]);
+        var store = new adapt.epub.EPUBDocStore();
+        if (userStyleSheet) {
+            for (var i = 0; i < userStyleSheet.length; i++) {
+                store.addUserStyleSheet(userStyleSheet[i]);
+            }
         }
-    }
-	store.init().then(function() {
-        /** @type {!Array<!adapt.epub.OPFItemParam>} */ var resolvedParams = params.map(function(p, index) {
-            return {
-                url: adapt.base.resolveURL(p.url, self.window.location.href),
-                index: index,
-                startPage: p.startPage,
-                skipPagesBefore: p.skipPagesBefore
-            };
-        });
-	    self.packageURL = resolvedParams.map(function(p) { return p.url; });
-	    self.opf = new adapt.epub.OPFDoc(store, "");
-	    self.opf.initWithChapters(resolvedParams, doc).then(function() {
-            self.opf.resolveFragment(fragment).then(function(position) {
-                self.pagePosition = position;
-                self.resize().then(function() {
-                    self.viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "complete");
-                    vivliostyle.profile.profiler.registerEndTiming("loadXML");
-                    self.callback({"t":"loaded"});
-                    frame.finish(true);
+        store.init().then(function() {
+            /** @type {!Array<!adapt.epub.OPFItemParam>} */ var resolvedParams = params.map(function(p, index) {
+                return {
+                    url: adapt.base.resolveURL(p.url, self.window.location.href),
+                    index: index,
+                    startPage: p.startPage,
+                    skipPagesBefore: p.skipPagesBefore
+                };
+            });
+            self.packageURL = resolvedParams.map(function(p) { return p.url; });
+            self.opf = new adapt.epub.OPFDoc(store, "");
+            self.opf.initWithChapters(resolvedParams, doc).then(function() {
+                self.opf.resolveFragment(fragment).then(function(position) {
+                    self.pagePosition = position;
+                    self.resize().then(function() {
+                        self.viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "complete");
+                        vivliostyle.profile.profiler.registerEndTiming("loadXML");
+                        self.callback({"t":"loaded"});
+                        frame.finish(true);
+                    });
                 });
             });
         });
-	});
     });
     return frame.result();
 };
@@ -230,7 +230,7 @@ adapt.viewer.Viewer.prototype.loadXML = function(command) {
  * @param {string} specified
  * @returns {number}
  */
-adapt.viewer.Viewer.prototype.resolveLength = function (specified) {
+adapt.viewer.Viewer.prototype.resolveLength = function(specified) {
     var value = parseFloat(specified);
     var unitPattern = /[a-z]+$/;
     var matched;
@@ -255,15 +255,15 @@ adapt.viewer.Viewer.prototype.resolveLength = function (specified) {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.viewer.Viewer.prototype.configure = function(command) {
-	if (typeof command["autoresize"] == "boolean") {
-		if (command["autoresize"]) {
-			this.viewportSize = null;
-			this.window.addEventListener("resize", this.resizeListener, false);
-			this.needResize = true;
-		} else {
-			this.window.removeEventListener("resize", this.resizeListener, false);			
-		}
-	}
+    if (typeof command["autoresize"] == "boolean") {
+        if (command["autoresize"]) {
+            this.viewportSize = null;
+            this.window.addEventListener("resize", this.resizeListener, false);
+            this.needResize = true;
+        } else {
+            this.window.removeEventListener("resize", this.resizeListener, false);
+        }
+    }
     if (typeof command["fontSize"] == "number") {
         var fontSize = /** @type {number} */ (command["fontSize"]);
         if (fontSize >= 5 && fontSize <= 72 && this.fontSize != fontSize) {
@@ -271,49 +271,49 @@ adapt.viewer.Viewer.prototype.configure = function(command) {
             this.needResize = true;
         }
     }
-	if (typeof command["viewport"] == "object" && command["viewport"]) {
-		var vp = command["viewport"];
-		var viewportSize = {
-			marginLeft: this.resolveLength(vp["margin-left"]) || 0,
-			marginRight: this.resolveLength(vp["margin-right"]) || 0,
-			marginTop: this.resolveLength(vp["margin-top"]) || 0,
-			marginBottom: this.resolveLength(vp["margin-bottom"]) || 0,
-			width: this.resolveLength(vp["width"]) || 0,
-			height: this.resolveLength(vp["height"]) || 0
-		};
-		if (viewportSize.width >= 200 || viewportSize.height >= 200) {
-			this.window.removeEventListener("resize", this.resizeListener, false);			
-			this.viewportSize = viewportSize;
-			this.needResize = true;
-		}
-	}
-	if (typeof command["hyphenate"] == "boolean") {
-		this.pref.hyphenate = command["hyphenate"];
-		this.needResize = true;
-	}
-	if (typeof command["horizontal"] == "boolean") {
-		this.pref.horizontal = command["horizontal"];
-		this.needResize = true;
-	}
-	if (typeof command["nightMode"] == "boolean") {
-		this.pref.nightMode = command["nightMode"];
-		this.needResize = true;
-	}
-	if (typeof command["lineHeight"] == "number") {
-		this.pref.lineHeight = command["lineHeight"];
-		this.needResize = true;
-	}
-	if (typeof command["columnWidth"] == "number") {
-		this.pref.columnWidth = command["columnWidth"];
-		this.needResize = true;
-	}
-	if (typeof command["fontFamily"] == "string") {
-		this.pref.fontFamily = command["fontFamily"];
-		this.needResize = true;
-	}
-	if (typeof command["load"] == "boolean") {
-		this.waitForLoading = command["load"];  // Load images (and other resources) on the page.		
-	}
+    if (typeof command["viewport"] == "object" && command["viewport"]) {
+        var vp = command["viewport"];
+        var viewportSize = {
+            marginLeft: this.resolveLength(vp["margin-left"]) || 0,
+            marginRight: this.resolveLength(vp["margin-right"]) || 0,
+            marginTop: this.resolveLength(vp["margin-top"]) || 0,
+            marginBottom: this.resolveLength(vp["margin-bottom"]) || 0,
+            width: this.resolveLength(vp["width"]) || 0,
+            height: this.resolveLength(vp["height"]) || 0
+        };
+        if (viewportSize.width >= 200 || viewportSize.height >= 200) {
+            this.window.removeEventListener("resize", this.resizeListener, false);
+            this.viewportSize = viewportSize;
+            this.needResize = true;
+        }
+    }
+    if (typeof command["hyphenate"] == "boolean") {
+        this.pref.hyphenate = command["hyphenate"];
+        this.needResize = true;
+    }
+    if (typeof command["horizontal"] == "boolean") {
+        this.pref.horizontal = command["horizontal"];
+        this.needResize = true;
+    }
+    if (typeof command["nightMode"] == "boolean") {
+        this.pref.nightMode = command["nightMode"];
+        this.needResize = true;
+    }
+    if (typeof command["lineHeight"] == "number") {
+        this.pref.lineHeight = command["lineHeight"];
+        this.needResize = true;
+    }
+    if (typeof command["columnWidth"] == "number") {
+        this.pref.columnWidth = command["columnWidth"];
+        this.needResize = true;
+    }
+    if (typeof command["fontFamily"] == "string") {
+        this.pref.fontFamily = command["fontFamily"];
+        this.needResize = true;
+    }
+    if (typeof command["load"] == "boolean") {
+        this.waitForLoading = command["load"];  // Load images (and other resources) on the page.
+    }
     if (typeof command["renderAllPages"] == "boolean") {
         this.renderAllPages = command["renderAllPages"];
     }
@@ -336,7 +336,7 @@ adapt.viewer.Viewer.prototype.configure = function(command) {
         this.zoom = command["zoom"];
         this.needRefresh = true;
     }
-	return adapt.task.newResult(true);
+    return adapt.task.newResult(true);
 };
 
 /**
@@ -431,17 +431,16 @@ adapt.viewer.Viewer.prototype.reportPosition = function() {
     /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("reportPosition");
     var self = this;
     if (!self.pagePosition) {
-		self.pagePosition = self.opfView.getPagePosition();
+        self.pagePosition = self.opfView.getPagePosition();
     }
-    self.opf.getCFI(this.pagePosition.spineIndex, 
-		this.pagePosition.offsetInItem).then(function(cfi) {
-			var page = self.currentPage;
-			var r = self.waitForLoading && page.fetchers.length > 0 
-				? adapt.taskutil.waitForFetchers(page.fetchers) : adapt.task.newResult(true);
-			r.then(function() {
-				self.sendLocationNotification(page, cfi).thenFinish(frame);
-			});
-		});    
+    self.opf.getCFI(this.pagePosition.spineIndex, this.pagePosition.offsetInItem).then(function(cfi) {
+        var page = self.currentPage;
+        var r = self.waitForLoading && page.fetchers.length > 0
+            ? adapt.taskutil.waitForFetchers(page.fetchers) : adapt.task.newResult(true);
+        r.then(function() {
+            self.sendLocationNotification(page, cfi).thenFinish(frame);
+        });
+    });
     return frame.result();
 };
 
@@ -451,16 +450,16 @@ adapt.viewer.Viewer.prototype.reportPosition = function() {
  */
 adapt.viewer.Viewer.prototype.createViewport = function() {
     var viewportElement = this.viewportElement;
-	if (this.viewportSize) {
-		var vs = this.viewportSize;
-		viewportElement.style.marginLeft = vs.marginLeft + "px";
-		viewportElement.style.marginRight = vs.marginRight + "px";
-		viewportElement.style.marginTop = vs.marginTop + "px";
-		viewportElement.style.marginBottom = vs.marginBottom + "px";
-		return new adapt.vgen.Viewport(this.window, this.fontSize, viewportElement, vs.width, vs.height);
-	} else {
-		return new adapt.vgen.Viewport(this.window, this.fontSize, viewportElement);
-	}
+    if (this.viewportSize) {
+        var vs = this.viewportSize;
+        viewportElement.style.marginLeft = vs.marginLeft + "px";
+        viewportElement.style.marginRight = vs.marginRight + "px";
+        viewportElement.style.marginTop = vs.marginTop + "px";
+        viewportElement.style.marginBottom = vs.marginBottom + "px";
+        return new adapt.vgen.Viewport(this.window, this.fontSize, viewportElement, vs.width, vs.height);
+    } else {
+        return new adapt.vgen.Viewport(this.window, this.fontSize, viewportElement);
+    }
 };
 
 /**
@@ -468,11 +467,11 @@ adapt.viewer.Viewer.prototype.createViewport = function() {
  * @return {boolean}
  */
 adapt.viewer.Viewer.prototype.sizeIsGood = function() {
-	if (this.viewportSize || !this.viewport || this.viewport.fontSize != this.fontSize) {
-		return false;
-	}
-	var viewport = this.createViewport();
-	return (viewport.width == this.viewport.width && viewport.height == this.viewport.height) ||
+    if (this.viewportSize || !this.viewport || this.viewport.fontSize != this.fontSize) {
+        return false;
+    }
+    var viewport = this.createViewport();
+    return (viewport.width == this.viewport.width && viewport.height == this.viewport.height) ||
         (this.opfView && !this.opfView.hasAutoSizedPages());
 };
 
@@ -507,12 +506,12 @@ adapt.viewer.Viewer.prototype.removePageSizePageRules = function() {
  * @return {void}
  */
 adapt.viewer.Viewer.prototype.reset = function() {
-	if (this.opfView) {
-		this.opfView.hideTOC();
+    if (this.opfView) {
+        this.opfView.hideTOC();
         this.opfView.removeRenderedPages();
-	}
+    }
     this.removePageSizePageRules();
-	this.viewport = this.createViewport();
+    this.viewport = this.createViewport();
     this.viewport.resetZoom();
     this.opfView = new adapt.epub.OPFView(this.opf, this.viewport, this.fontMapper, this.pref,
         this.setPageSizePageRules.bind(this));
@@ -615,20 +614,20 @@ adapt.viewer.Viewer.prototype.queryZoomFactor = function(type) {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.viewer.Viewer.prototype.resize = function() {
-	this.needResize = false;
-	if (this.sizeIsGood()) {
-		return adapt.task.newResult(true);
-	}
-	var self = this;
+    this.needResize = false;
+    if (this.sizeIsGood()) {
+        return adapt.task.newResult(true);
+    }
+    var self = this;
     if (this.viewportElement.getAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE) === "complete") {
         this.viewportElement.setAttribute(adapt.viewer.VIEWPORT_STATUS_ATTRIBUTE, "resizing");
     }
-	self.callback({"t": "resizestart"});
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("resize");
-	if (self.opfView && !self.pagePosition) {
-		self.pagePosition = self.opfView.getPagePosition();
-	}
-	self.reset();
+    self.callback({"t": "resizestart"});
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("resize");
+    if (self.opfView && !self.pagePosition) {
+        self.pagePosition = self.opfView.getPagePosition();
+    }
+    self.reset();
 
     // With renderAllPages option specified, the rendering is performed after the initial page display,
     // otherwise users are forced to wait the rendering finish in front of a blank page.
@@ -645,7 +644,7 @@ adapt.viewer.Viewer.prototype.resize = function() {
             });
         });
     });
-	return frame.result();
+    return frame.result();
 };
 
 /**
@@ -655,20 +654,20 @@ adapt.viewer.Viewer.prototype.resize = function() {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.viewer.Viewer.prototype.sendLocationNotification = function(page, cfi) {
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("sendLocationNotification");
-	var notification = {"t": "nav", "first": page.isFirstPage,
-			"last": page.isLastPage};
-	var self = this;
-	this.opf.getEPageFromPosition(/** @type {adapt.epub.Position} */(self.pagePosition)).then(function(epage) {
-		notification["epage"] = epage;
-		notification["epageCount"] = self.opf.epageCount;
-		if (cfi) {
-			notification["cfi"] = cfi;
-		}
-		self.callback(notification);
-		frame.finish(true);
-	});
-	return frame.result();
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("sendLocationNotification");
+    var notification = {"t": "nav", "first": page.isFirstPage,
+        "last": page.isLastPage};
+    var self = this;
+    this.opf.getEPageFromPosition(/** @type {adapt.epub.Position} */(self.pagePosition)).then(function(epage) {
+        notification["epage"] = epage;
+        notification["epageCount"] = self.opf.epageCount;
+        if (cfi) {
+            notification["cfi"] = cfi;
+        }
+        self.callback(notification);
+        frame.finish(true);
+    });
+    return frame.result();
 };
 
 /**
@@ -683,50 +682,50 @@ adapt.viewer.Viewer.prototype.getCurrentPageProgression = function() {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.viewer.Viewer.prototype.moveTo = function(command) {
-	var method;
-	var self = this;
-	if (typeof command["where"] == "string") {
-		switch (command["where"]) {
-		case "next":
-			method = this.pref.spreadView ? this.opfView.nextSpread : this.opfView.nextPage;
-			break;
-		case "previous":
-			method = this.pref.spreadView ? this.opfView.previousSpread : this.opfView.previousPage;
-			break;
-		case "last":
-			method = this.opfView.lastPage;
-			break;
-		case "first":
-			method = this.opfView.firstPage;
-			break;
-		default:
-			return adapt.task.newResult(true);
-		}
-	} else if (typeof command["epage"] == "number") {
-		var epage = /** @type {number} */ (command["epage"]);
-		method = function() {
-			return self.opfView.navigateToEPage(epage);
-		};
-	} else if (typeof command["url"] == "string") {
-		var url = /** @type {string} */ (command["url"]);
-		method = function() {
-			return self.opfView.navigateTo(url);
-		};
-	} else {
-		return adapt.task.newResult(true);
-	}
-	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("nextPage");
-	method.call(self.opfView).then(/** @param {adapt.vtree.Page} page */ function(page) {
-		if (page) {
-			self.pagePosition = null;
-	    	self.showCurrent(page).then(function() {
+    var method;
+    var self = this;
+    if (typeof command["where"] == "string") {
+        switch (command["where"]) {
+            case "next":
+                method = this.pref.spreadView ? this.opfView.nextSpread : this.opfView.nextPage;
+                break;
+            case "previous":
+                method = this.pref.spreadView ? this.opfView.previousSpread : this.opfView.previousPage;
+                break;
+            case "last":
+                method = this.opfView.lastPage;
+                break;
+            case "first":
+                method = this.opfView.firstPage;
+                break;
+            default:
+                return adapt.task.newResult(true);
+        }
+    } else if (typeof command["epage"] == "number") {
+        var epage = /** @type {number} */ (command["epage"]);
+        method = function() {
+            return self.opfView.navigateToEPage(epage);
+        };
+    } else if (typeof command["url"] == "string") {
+        var url = /** @type {string} */ (command["url"]);
+        method = function() {
+            return self.opfView.navigateTo(url);
+        };
+    } else {
+        return adapt.task.newResult(true);
+    }
+    /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("nextPage");
+    method.call(self.opfView).then(/** @param {adapt.vtree.Page} page */ function(page) {
+        if (page) {
+            self.pagePosition = null;
+            self.showCurrent(page).then(function() {
                 self.reportPosition().thenFinish(frame);
             });
-		} else {
-			frame.finish(true);
-		}
-	});
-	return frame.result();
+        } else {
+            frame.finish(true);
+        }
+    });
+    return frame.result();
 };
 
 /**
@@ -734,37 +733,37 @@ adapt.viewer.Viewer.prototype.moveTo = function(command) {
  * @return {!adapt.task.Result.<boolean>}
  */
 adapt.viewer.Viewer.prototype.showTOC = function(command) {
-	var autohide = !!command["autohide"];
-	var visibility = command["v"];
-	var currentVisibility = this.opfView.isTOCVisible();
-	if (currentVisibility) {
-		if (visibility == "show") {
-			return adapt.task.newResult(true);			
-		}
-	} else {
-		if (visibility == "hide") {
-			return adapt.task.newResult(true);			
-		}		
-	}
-	if (currentVisibility) {
-		this.opfView.hideTOC();
-		return adapt.task.newResult(true);
-	} else {
-		var self = this;
-		/** @type {adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("showTOC");
-		this.opfView.showTOC(autohide).then(function(page) {
-			if (page) {
-				if (autohide) {
-					var hideTOC = function() {self.opfView.hideTOC();};
-					page.addEventListener("hyperlink", hideTOC, false);
-					page.container.addEventListener("click", hideTOC, false);
-				}
-				page.addEventListener("hyperlink", self.hyperlinkListener, false);
-			}
-			frame.finish(true);
-		});
-		return frame.result();
-	}
+    var autohide = !!command["autohide"];
+    var visibility = command["v"];
+    var currentVisibility = this.opfView.isTOCVisible();
+    if (currentVisibility) {
+        if (visibility == "show") {
+            return adapt.task.newResult(true);
+        }
+    } else {
+        if (visibility == "hide") {
+            return adapt.task.newResult(true);
+        }
+    }
+    if (currentVisibility) {
+        this.opfView.hideTOC();
+        return adapt.task.newResult(true);
+    } else {
+        var self = this;
+        /** @type {adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("showTOC");
+        this.opfView.showTOC(autohide).then(function(page) {
+            if (page) {
+                if (autohide) {
+                    var hideTOC = function() {self.opfView.hideTOC();};
+                    page.addEventListener("hyperlink", hideTOC, false);
+                    page.container.addEventListener("click", hideTOC, false);
+                }
+                page.addEventListener("hyperlink", self.hyperlinkListener, false);
+            }
+            frame.finish(true);
+        });
+        return frame.result();
+    }
 };
 
 /**
@@ -772,23 +771,23 @@ adapt.viewer.Viewer.prototype.showTOC = function(command) {
  * @return {adapt.task.Result.<boolean>}
  */
 adapt.viewer.Viewer.prototype.runCommand = function(command) {
-	var self = this;
-	var actionName = command["a"] || "";
-	return adapt.task.handle("runCommand", function(frame) {
-		var action = self.actions[actionName];
-		if (action) {
-			action.call(self, command).then(function() {
-				self.callback({"t": "done", "a": actionName});
-				frame.finish(true);
-			});
-		} else {
+    var self = this;
+    var actionName = command["a"] || "";
+    return adapt.task.handle("runCommand", function(frame) {
+        var action = self.actions[actionName];
+        if (action) {
+            action.call(self, command).then(function() {
+                self.callback({"t": "done", "a": actionName});
+                frame.finish(true);
+            });
+        } else {
             vivliostyle.logging.logger.error("No such action:", actionName);
-			frame.finish(true);
-		}
-	}, function(frame, err) {
+            frame.finish(true);
+        }
+    }, function(frame, err) {
         vivliostyle.logging.logger.error(err, "Error during action:", actionName);
-		frame.finish(true);
-	});
+        frame.finish(true);
+    });
 };
 
 /**
@@ -796,7 +795,7 @@ adapt.viewer.Viewer.prototype.runCommand = function(command) {
  * @param {*} cmd
  * @return {adapt.base.JSON}
  */
-adapt.viewer.maybeParse = function (cmd) {
+adapt.viewer.maybeParse = function(cmd) {
     if (typeof cmd == "string") {
         return adapt.base.stringToJSON(cmd);
     }
@@ -807,18 +806,19 @@ adapt.viewer.maybeParse = function (cmd) {
  * @param {adapt.base.JSON|string} cmd
  * @return {void}
  */
-adapt.viewer.Viewer.prototype.initEmbed = function (cmd) {
+adapt.viewer.Viewer.prototype.initEmbed = function(cmd) {
     var command = adapt.viewer.maybeParse(cmd);
-	var continuation = null;
-	var viewer = this;
-	adapt.task.start(function() {
-    	/** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("commandLoop");
+    var continuation = null;
+    var viewer = this;
+    adapt.task.start(function() {
+        /** @type {!adapt.task.Frame.<boolean>} */ var frame = adapt.task.newFrame("commandLoop");
         var scheduler = adapt.task.currentTask().getScheduler();
         viewer.hyperlinkListener = function(evt) {
-    		var hrefEvent = /** @type {adapt.vtree.PageHyperlinkEvent} */ (evt);
-            var internal = hrefEvent.href.charAt(0) === "#" || viewer.packageURL.some(function(url) {
-                return hrefEvent.href.substr(0, url.length) == url;
-            });
+            var hrefEvent = /** @type {adapt.vtree.PageHyperlinkEvent} */ (evt);
+            var internal = hrefEvent.href.charAt(0) === "#" ||
+                viewer.packageURL.some(function(url) {
+                    return hrefEvent.href.substr(0, url.length) == url;
+                });
             if (internal) {
                 evt.preventDefault();
                 var msg = {"t":"hyperlink", "href":hrefEvent.href, "internal": internal};
@@ -828,42 +828,42 @@ adapt.viewer.Viewer.prototype.initEmbed = function (cmd) {
                 });
             }
         };
-		frame.loopWithFrame(function(loopFrame) {
-			if (viewer.needResize) {
-				viewer.resize().then(function() {
-					loopFrame.continueLoop();
-				});
+        frame.loopWithFrame(function(loopFrame) {
+            if (viewer.needResize) {
+                viewer.resize().then(function() {
+                    loopFrame.continueLoop();
+                });
             } else if (viewer.needRefresh) {
                 if (viewer.currentPage) {
-                    viewer.showCurrent(viewer.currentPage).then(function () {
+                    viewer.showCurrent(viewer.currentPage).then(function() {
                         loopFrame.continueLoop();
                     });
                 }
-			} else if (command) {
-				var cmd = command;
-				command = null;
-				viewer.runCommand(cmd).then(function() {
-					loopFrame.continueLoop();
-				});
-			} else {
-	        	/** @type {!adapt.task.Frame.<boolean>} */ var frameInternal =
-	                adapt.task.newFrame('waitForCommand');
-	            continuation = frameInternal.suspend(self);
-	            frameInternal.result().then(function() {
-					loopFrame.continueLoop();
-				});
-			}
-		}).thenFinish(frame);
-		return frame.result();
-	});
-	
-	viewer.kick = function() {
-		var cont = continuation;
-		if (cont) {
-			continuation = null;
-			cont.schedule();
-		}
-	};
+            } else if (command) {
+                var cmd = command;
+                command = null;
+                viewer.runCommand(cmd).then(function() {
+                    loopFrame.continueLoop();
+                });
+            } else {
+                /** @type {!adapt.task.Frame.<boolean>} */ var frameInternal =
+                    adapt.task.newFrame('waitForCommand');
+                continuation = frameInternal.suspend(self);
+                frameInternal.result().then(function() {
+                    loopFrame.continueLoop();
+                });
+            }
+        }).thenFinish(frame);
+        return frame.result();
+    });
+
+    viewer.kick = function() {
+        var cont = continuation;
+        if (cont) {
+            continuation = null;
+            cont.schedule();
+        }
+    };
 
     viewer.sendCommand = function(cmd) {
         if (command) {

--- a/src/adapt/vtree.js
+++ b/src/adapt/vtree.js
@@ -16,16 +16,16 @@ goog.provide('adapt.vtree');
 
 /** @const */
 adapt.vtree.delayedProps = {
-	"transform": true,
-	"transform-origin": true
+    "transform": true,
+    "transform-origin": true
 };
 
 /** @const */
 adapt.vtree.delayedPropsIfRelativePositioned = {
-	"top": true,
-	"bottom": true,
-	"left": true,
-	"right": true
+    "top": true,
+    "bottom": true,
+    "left": true,
+    "right": true
 };
 
 /**
@@ -35,9 +35,9 @@ adapt.vtree.delayedPropsIfRelativePositioned = {
  * @param {adapt.css.Val} value
  */
 adapt.vtree.DelayedItem = function(target, name, value) {
-	this.target = target;
-	this.name = name;
-	this.value = value;
+    this.target = target;
+    this.name = name;
+    this.value = value;
 };
 
 
@@ -57,13 +57,13 @@ adapt.vtree.Trigger;
  * @const
  */
 adapt.vtree.actions = {
-	"show": function(obj) { obj.style.visibility = "visible"; },
-	"hide": function(obj) { obj.style.visibility = "hidden"; },
-	"play": function(obj) { obj.currentTime = 0; obj.play(); },
-	"pause": function(obj) { obj.pause(); },
-	"resume": function(obj) { obj.play(); },
-	"mute": function(obj) { obj.muted = true; },
-	"unmute": function(obj) { obj.muted = false; }
+    "show": function(obj) { obj.style.visibility = "visible"; },
+    "hide": function(obj) { obj.style.visibility = "hidden"; },
+    "play": function(obj) { obj.currentTime = 0; obj.play(); },
+    "pause": function(obj) { obj.pause(); },
+    "resume": function(obj) { obj.play(); },
+    "mute": function(obj) { obj.muted = true; },
+    "unmute": function(obj) { obj.muted = false; }
 };
 
 /**
@@ -72,18 +72,18 @@ adapt.vtree.actions = {
  * @return {?Function}
  */
 adapt.vtree.makeListener = function(refs, action) {
-	var actionFn = adapt.vtree.actions[action];
-	if (actionFn) {
-		return function() {
-			for (var k = 0; k < refs.length; k++) {
-				try {
-					actionFn(refs[k]);
-				} catch(err) {
-				}
-			}
-		};
-	}
-	return null;
+    var actionFn = adapt.vtree.actions[action];
+    if (actionFn) {
+        return function() {
+            for (var k = 0; k < refs.length; k++) {
+                try {
+                    actionFn(refs[k]);
+                } catch (err) {
+                }
+            }
+        };
+    }
+    return null;
 };
 
 /**
@@ -93,47 +93,47 @@ adapt.vtree.makeListener = function(refs, action) {
  * @extends {adapt.base.SimpleEventTarget}
  */
 adapt.vtree.Page = function(container, bleedBox) {
-	adapt.base.SimpleEventTarget.call(this);
-	/** @const */ this.container = container;
-	/** @const */ this.bleedBox = bleedBox;
-	/** @type {HTMLElement} */ this.pageAreaElement = null;
-	/** @type {Array.<adapt.vtree.DelayedItem>} */ this.delayedItems = [];
-	var self = this;
-	/** @param {Event} e */
-	this.hrefHandler = function(e) {
-		var anchorElement = /** @type {Element} */ (e.currentTarget);
-		var href = anchorElement.getAttribute("href") ||
-			anchorElement.getAttributeNS(adapt.base.NS.XLINK, "href");
-		if (href) {
-			var evt = {
-				type: "hyperlink",
-				target: null,
-				currentTarget: null,
-				anchorElement: anchorElement,
-				href: href,
-				preventDefault: function() { e.preventDefault(); }
-			};
-			self.dispatchEvent(evt);
-		}
-	};
-	/** @const {!Object.<string,Array.<Element>>} */ this.elementsById = {};
-	/** @const @type {{width: number, height: number}} */ this.dimensions = {width: 0, height: 0};
-	/** @type {boolean} */ this.isFirstPage = false;
-	/** @type {boolean} */ this.isLastPage = false;
-	/** @type {boolean} */ this.isAutoWidth = false;
-	/** @type {boolean} */ this.isAutoHeight = false;
-	/** @type {number} */ this.spineIndex = 0;
-	/** @type {adapt.vtree.LayoutPosition} */ this.position = null;
-	/** @type {number} */ this.offset = -1;
+    adapt.base.SimpleEventTarget.call(this);
+    /** @const */ this.container = container;
+    /** @const */ this.bleedBox = bleedBox;
+    /** @type {HTMLElement} */ this.pageAreaElement = null;
+    /** @type {Array.<adapt.vtree.DelayedItem>} */ this.delayedItems = [];
+    var self = this;
+    /** @param {Event} e */
+    this.hrefHandler = function(e) {
+        var anchorElement = /** @type {Element} */ (e.currentTarget);
+        var href = anchorElement.getAttribute("href") ||
+            anchorElement.getAttributeNS(adapt.base.NS.XLINK, "href");
+        if (href) {
+            var evt = {
+                type: "hyperlink",
+                target: null,
+                currentTarget: null,
+                anchorElement: anchorElement,
+                href: href,
+                preventDefault: function() { e.preventDefault(); }
+            };
+            self.dispatchEvent(evt);
+        }
+    };
+    /** @const {!Object.<string,Array.<Element>>} */ this.elementsById = {};
+    /** @const @type {{width: number, height: number}} */ this.dimensions = {width: 0, height: 0};
+    /** @type {boolean} */ this.isFirstPage = false;
+    /** @type {boolean} */ this.isLastPage = false;
+    /** @type {boolean} */ this.isAutoWidth = false;
+    /** @type {boolean} */ this.isAutoHeight = false;
+    /** @type {number} */ this.spineIndex = 0;
+    /** @type {adapt.vtree.LayoutPosition} */ this.position = null;
+    /** @type {number} */ this.offset = -1;
     /** @type {?vivliostyle.constants.PageSide} */ this.side = null;
-	/** @type {Array.<adapt.taskutil.Fetcher>} */ this.fetchers = [];
-	/** @const @type {{top: !Object.<string, adapt.vtree.Container>, bottom: !Object.<string, adapt.vtree.Container>, left: !Object.<string, adapt.vtree.Container>, right: !Object.<string, adapt.vtree.Container>}} */
-	this.marginBoxes = {
-		top: {},
-		bottom: {},
-		left: {},
-		right: {}
-	};
+    /** @type {Array.<adapt.taskutil.Fetcher>} */ this.fetchers = [];
+    /** @const @type {{top: !Object.<string, adapt.vtree.Container>, bottom: !Object.<string, adapt.vtree.Container>, left: !Object.<string, adapt.vtree.Container>, right: !Object.<string, adapt.vtree.Container>}} */
+    this.marginBoxes = {
+        top: {},
+        bottom: {},
+        left: {},
+        right: {}
+    };
 };
 goog.inherits(adapt.vtree.Page, adapt.base.SimpleEventTarget);
 
@@ -155,24 +155,24 @@ adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE = "data-vivliostyle-auto-page-height
  * @param {boolean} isAuto
  */
 adapt.vtree.Page.prototype.setAutoPageWidth = function(isAuto) {
-	this.isAutoPageWidth = isAuto;
-	if (isAuto) {
-		this.container.setAttribute(adapt.vtree.Page.AUTO_PAGE_WIDTH_ATTRIBUTE, true);
-	} else {
-		this.container.removeAttribute(adapt.vtree.Page.AUTO_PAGE_WIDTH_ATTRIBUTE);
-	}
+    this.isAutoPageWidth = isAuto;
+    if (isAuto) {
+        this.container.setAttribute(adapt.vtree.Page.AUTO_PAGE_WIDTH_ATTRIBUTE, true);
+    } else {
+        this.container.removeAttribute(adapt.vtree.Page.AUTO_PAGE_WIDTH_ATTRIBUTE);
+    }
 };
 
 /**
  * @param {boolean} isAuto
  */
 adapt.vtree.Page.prototype.setAutoPageHeight = function(isAuto) {
-	this.isAutoPageHeight = isAuto;
-	if (isAuto) {
-		this.container.setAttribute(adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE, true);
-	} else {
-		this.container.removeAttribute(adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE);
-	}
+    this.isAutoPageHeight = isAuto;
+    if (isAuto) {
+        this.container.setAttribute(adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE, true);
+    } else {
+        this.container.removeAttribute(adapt.vtree.Page.AUTO_PAGE_HEIGHT_ATTRIBUTE);
+    }
 };
 
 /**
@@ -180,12 +180,12 @@ adapt.vtree.Page.prototype.setAutoPageHeight = function(isAuto) {
  * @param {string} id
  */
 adapt.vtree.Page.prototype.registerElementWithId = function(element, id) {
-	var arr = this.elementsById[id];
-	if (!arr) {
-		this.elementsById[id] = [element];
-	} else {
-		arr.push(element);
-	}
+    var arr = this.elementsById[id];
+    if (!arr) {
+        this.elementsById[id] = [element];
+    } else {
+        arr.push(element);
+    }
 };
 
 /**
@@ -194,46 +194,46 @@ adapt.vtree.Page.prototype.registerElementWithId = function(element, id) {
  * @return {void}
  */
 adapt.vtree.Page.prototype.finish = function(triggers, clientLayout) {
-	// Remove ID of elements which eventually did not fit in the page
-	// (Some nodes may have been removed after registration if they did not fit in the page)
-	Object.keys(this.elementsById).forEach(function(id) {
-		var elems = this.elementsById[id];
-		for (var i = 0; i < elems.length;) {
-			if (this.container.contains(elems[i])) {
-				i++;
-			} else {
-				elems.splice(i, 1);
-			}
-		}
-		if (elems.length === 0) {
-			delete this.elementsById[id];
-		}
-	}, this);
+    // Remove ID of elements which eventually did not fit in the page
+    // (Some nodes may have been removed after registration if they did not fit in the page)
+    Object.keys(this.elementsById).forEach(function(id) {
+        var elems = this.elementsById[id];
+        for (var i = 0; i < elems.length;) {
+            if (this.container.contains(elems[i])) {
+                i++;
+            } else {
+                elems.splice(i, 1);
+            }
+        }
+        if (elems.length === 0) {
+            delete this.elementsById[id];
+        }
+    }, this);
 
-	// use size of the container of the PageMasterInstance
-	var rect = clientLayout.getElementClientRect(this.container);
-	this.dimensions.width = rect.width;
-	this.dimensions.height = rect.height;
+    // use size of the container of the PageMasterInstance
+    var rect = clientLayout.getElementClientRect(this.container);
+    this.dimensions.width = rect.width;
+    this.dimensions.height = rect.height;
 
-	var list = this.delayedItems;
-	for (var i = 0; i < list.length; i++) {
-		var item = list[i];
-		adapt.base.setCSSProperty(item.target, item.name, item.value.toString());
-	}
+    var list = this.delayedItems;
+    for (var i = 0; i < list.length; i++) {
+        var item = list[i];
+        adapt.base.setCSSProperty(item.target, item.name, item.value.toString());
+    }
 
-	for (var i = 0; i < triggers.length; i++) {
-		var trigger = triggers[i];
-		var refs = this.elementsById[trigger.ref];
-		var observers = this.elementsById[trigger.observer];
-		if (refs && observers) {
-			var listener = adapt.vtree.makeListener(refs, trigger.action);
-			if (listener) {
-				for (var k = 0; k < observers.length; k++) {
-					observers[k].addEventListener(trigger.event, listener, false);
-				}
-			}
-		}
-	}
+    for (var i = 0; i < triggers.length; i++) {
+        var trigger = triggers[i];
+        var refs = this.elementsById[trigger.ref];
+        var observers = this.elementsById[trigger.observer];
+        if (refs && observers) {
+            var listener = adapt.vtree.makeListener(refs, trigger.action);
+            if (listener) {
+                for (var k = 0; k < observers.length; k++) {
+                    observers[k].addEventListener(trigger.event, listener, false);
+                }
+            }
+        }
+    }
 };
 
 /**
@@ -241,7 +241,7 @@ adapt.vtree.Page.prototype.finish = function(triggers, clientLayout) {
  * @param {number} scale Factor to which the page will be scaled.
  */
 adapt.vtree.Page.prototype.zoom = function(scale) {
-	adapt.base.setCSSProperty(this.container, "transform", "scale(" + scale + ")");
+    adapt.base.setCSSProperty(this.container, "transform", "scale(" + scale + ")");
 };
 
 /**
@@ -249,7 +249,7 @@ adapt.vtree.Page.prototype.zoom = function(scale) {
  * @returns {!HTMLElement}
  */
 adapt.vtree.Page.prototype.getPageAreaElement = function() {
-	return this.pageAreaElement || this.container;
+    return this.pageAreaElement || this.container;
 };
 
 /**
@@ -269,9 +269,9 @@ adapt.vtree.SPECIAL_ATTR = "data-adapt-spec";
  * @enum {number}
  */
 adapt.vtree.Whitespace = {
-	IGNORE: 0,  // Whitespace sequence between blocks is ignored
-	NEWLINE: 1, // Whitespace sequence between blocks is ignored unless it containes newline
-	PRESERVE: 2 // Whitespace sequence between blocks is preserved
+    IGNORE: 0,  // Whitespace sequence between blocks is ignored
+    NEWLINE: 1, // Whitespace sequence between blocks is ignored unless it containes newline
+    PRESERVE: 2 // Whitespace sequence between blocks is preserved
 };
 
 /**
@@ -280,18 +280,18 @@ adapt.vtree.Whitespace = {
  * @returns {?adapt.vtree.Whitespace}
  */
 adapt.vtree.whitespaceFromPropertyValue = function(whitespace) {
-	switch (whitespace) {
-		case "normal" :
-		case "nowrap" :
-			return adapt.vtree.Whitespace.IGNORE;
-		case "pre-line" :
-			return adapt.vtree.Whitespace.NEWLINE;
-		case "pre" :
-		case "pre-wrap" :
-			return adapt.vtree.Whitespace.PRESERVE;
-		default:
-			return null;
-	}
+    switch (whitespace) {
+        case "normal" :
+        case "nowrap" :
+            return adapt.vtree.Whitespace.IGNORE;
+        case "pre-line" :
+            return adapt.vtree.Whitespace.NEWLINE;
+        case "pre" :
+        case "pre-wrap" :
+            return adapt.vtree.Whitespace.PRESERVE;
+        default:
+            return null;
+    }
 };
 
 /**
@@ -300,18 +300,18 @@ adapt.vtree.whitespaceFromPropertyValue = function(whitespace) {
  * @return {boolean}
  */
 adapt.vtree.canIgnore = function(node, whitespace) {
-	if (node.nodeType == 1)
-		return false;
-	var text = node.textContent;
-	switch (whitespace) {
-	case adapt.vtree.Whitespace.IGNORE:
-		return !!text.match(/^\s*$/);
-	case adapt.vtree.Whitespace.NEWLINE:
-		return !!text.match(/^[ \t\f]*$/);
-	case adapt.vtree.Whitespace.PRESERVE:
-		return text.length == 0;
-	}
-	throw new Error("Unexpected whitespace: " + whitespace);
+    if (node.nodeType == 1)
+        return false;
+    var text = node.textContent;
+    switch (whitespace) {
+        case adapt.vtree.Whitespace.IGNORE:
+            return !!text.match(/^\s*$/);
+        case adapt.vtree.Whitespace.NEWLINE:
+            return !!text.match(/^[ \t\f]*$/);
+        case adapt.vtree.Whitespace.PRESERVE:
+            return text.length == 0;
+    }
+    throw new Error("Unexpected whitespace: " + whitespace);
 };
 
 /**
@@ -320,9 +320,9 @@ adapt.vtree.canIgnore = function(node, whitespace) {
  * @constructor
  */
 adapt.vtree.Flow = function(flowName, parentFlowName) {
-	/** @const */ this.flowName = flowName;
-	/** @const */ this.parentFlowName = parentFlowName;
-	/** @const */ this.forcedBreakOffsets = /** @type {Array<number>} */ ([]);
+    /** @const */ this.flowName = flowName;
+    /** @const */ this.parentFlowName = parentFlowName;
+    /** @const */ this.forcedBreakOffsets = /** @type {Array<number>} */ ([]);
 };
 
 /**
@@ -338,17 +338,17 @@ adapt.vtree.Flow = function(flowName, parentFlowName) {
  * @constructor
  */
 adapt.vtree.FlowChunk = function(flowName, element, startOffset,
-        priority, linger, exclusive, repeated, last, breakBefore) {
-	/** @type {string} */ this.flowName = flowName;
-	/** @type {!Element} */ this.element = element;
-	/** @type {number} */ this.startOffset = startOffset;
-	/** @type {number} */ this.priority = priority;
-	/** @type {number} */ this.linger = linger;
-	/** @type {boolean} */ this.exclusive = exclusive;
-	/** @type {boolean} */ this.repeated = repeated;
-	/** @type {boolean} */ this.last = last;
-	/** @type {number} */ this.startPage = -1;
-	/** @type {?string} */ this.breakBefore = breakBefore;
+                                 priority, linger, exclusive, repeated, last, breakBefore) {
+    /** @type {string} */ this.flowName = flowName;
+    /** @type {!Element} */ this.element = element;
+    /** @type {number} */ this.startOffset = startOffset;
+    /** @type {number} */ this.priority = priority;
+    /** @type {number} */ this.linger = linger;
+    /** @type {boolean} */ this.exclusive = exclusive;
+    /** @type {boolean} */ this.repeated = repeated;
+    /** @type {boolean} */ this.last = last;
+    /** @type {number} */ this.startPage = -1;
+    /** @type {?string} */ this.breakBefore = breakBefore;
 };
 
 /**
@@ -383,7 +383,7 @@ adapt.vtree.ClientRect;
  * @return {number}
  */
 adapt.vtree.clientrectIncreasingTop = function(r1, r2) {
-	return r1.top - r2.top;
+    return r1.top - r2.top;
 };
 
 /**
@@ -392,7 +392,7 @@ adapt.vtree.clientrectIncreasingTop = function(r1, r2) {
  * @return {number}
  */
 adapt.vtree.clientrectDecreasingRight = function(r1, r2) {
-	return r2.right - r1.right;
+    return r2.right - r1.right;
 };
 
 /**
@@ -522,17 +522,17 @@ adapt.vtree.NodePositionStep;
  * @returns {boolean}
  */
 adapt.vtree.isSameNodePositionStep = function(nps1, nps2) {
-	if (nps1 === nps2) {
-		return true;
-	}
-	if (!nps1 || !nps2) {
-		return false;
-	}
-	return nps1.node === nps2.node &&
-			nps1.shadowType === nps2.shadowType &&
-			nps1.shadowContext === nps2.shadowContext &&
-			nps1.nodeShadow === nps2.nodeShadow &&
-			nps1.shadowSibling === nps2.shadowSibling;
+    if (nps1 === nps2) {
+        return true;
+    }
+    if (!nps1 || !nps2) {
+        return false;
+    }
+    return nps1.node === nps2.node &&
+        nps1.shadowType === nps2.shadowType &&
+        nps1.shadowContext === nps2.shadowContext &&
+        nps1.nodeShadow === nps2.nodeShadow &&
+        nps1.shadowSibling === nps2.shadowSibling;
 };
 
 /**
@@ -551,21 +551,21 @@ adapt.vtree.NodePosition;
  * @returns {boolean}
  */
 adapt.vtree.isSameNodePosition = function(np1, np2) {
-	if (np1 === np2) {
-		return true;
-	}
-	if (!np1 || !np2) {
-		return false;
-	}
-	if (np1.offsetInNode !== np2.offsetInNode || np1.after !== np2.after || np1.steps.length !== np2.steps.length) {
-		return false;
-	}
-	for (var i = 0; i < np1.steps.length; i++) {
-		if (!adapt.vtree.isSameNodePositionStep(np1[i], np2[i])) {
-			return false;
-		}
-	}
-	return true;
+    if (np1 === np2) {
+        return true;
+    }
+    if (!np1 || !np2) {
+        return false;
+    }
+    if (np1.offsetInNode !== np2.offsetInNode || np1.after !== np2.after || np1.steps.length !== np2.steps.length) {
+        return false;
+    }
+    for (var i = 0; i < np1.steps.length; i++) {
+        if (!adapt.vtree.isSameNodePositionStep(np1[i], np2[i])) {
+            return false;
+        }
+    }
+    return true;
 };
 
 /**
@@ -573,14 +573,14 @@ adapt.vtree.isSameNodePosition = function(np1, np2) {
  * @return {adapt.vtree.NodePosition}
  */
 adapt.vtree.newNodePositionFromNode = function(node) {
-	var step = {
-		node: node,
-		shadowType: adapt.vtree.ShadowType.NONE,
-		shadowContext: null,
-		nodeShadow: null,
-		shadowSibling: null
-	};
-	return {steps:[step], offsetInNode:0, after:false};
+    var step = {
+        node: node,
+        shadowType: adapt.vtree.ShadowType.NONE,
+        shadowContext: null,
+        nodeShadow: null,
+        shadowSibling: null
+    };
+    return {steps:[step], offsetInNode:0, after:false};
 };
 
 /**
@@ -588,24 +588,24 @@ adapt.vtree.newNodePositionFromNode = function(node) {
  * @return {adapt.vtree.NodePosition}
  */
 adapt.vtree.newNodePositionFromNodeContext = function(nodeContext) {
-	var step = {
-		node: nodeContext.sourceNode,
-		shadowType: adapt.vtree.ShadowType.NONE,
-		shadowContext: nodeContext.shadowContext,
-		nodeShadow: null,
-		shadowSibling: null
-	};
-	return {steps:[step], offsetInNode:0, after:false};
+    var step = {
+        node: nodeContext.sourceNode,
+        shadowType: adapt.vtree.ShadowType.NONE,
+        shadowContext: nodeContext.shadowContext,
+        nodeShadow: null,
+        shadowSibling: null
+    };
+    return {steps:[step], offsetInNode:0, after:false};
 };
 
 /**
  * @enum {number}
  */
 adapt.vtree.ShadowType = {
-	NONE: 0,
-	CONTENT: 1,
-	ROOTLESS: 2,
-	ROOTED: 3
+    NONE: 0,
+    CONTENT: 1,
+    ROOTLESS: 2,
+    ROOTED: 3
 };
 
 /**
@@ -620,17 +620,17 @@ adapt.vtree.ShadowType = {
  * @constructor
  */
 adapt.vtree.ShadowContext = function(owner, root, xmldoc, parentShadow, superShadow, type, styler) {
-	/** @const */ this.owner = owner;
-	/** @const */ this.parentShadow = parentShadow;
-	/** @const */ this.superShadow = superShadow;
-	/** @type {adapt.vtree.ShadowContext} */ this.subShadow = null;
-	/** @const */ this.root = root;
-	/** @const */ this.xmldoc = xmldoc;
-	/** @const */ this.type = type;
-	if (superShadow) {
-		superShadow.subShadow = this;
-	}
-	/** @const */ this.styler = styler;
+    /** @const */ this.owner = owner;
+    /** @const */ this.parentShadow = parentShadow;
+    /** @const */ this.superShadow = superShadow;
+    /** @type {adapt.vtree.ShadowContext} */ this.subShadow = null;
+    /** @const */ this.root = root;
+    /** @const */ this.xmldoc = xmldoc;
+    /** @const */ this.type = type;
+    if (superShadow) {
+        superShadow.subShadow = this;
+    }
+    /** @const */ this.styler = styler;
 };
 
 /**
@@ -640,8 +640,8 @@ adapt.vtree.ShadowContext = function(owner, root, xmldoc, parentShadow, superSha
  * @constructor
  */
 adapt.vtree.FirstPseudo = function(outer, count) {
-	/** @const */ this.outer = outer;
-	/** @const */ this.count = count;
+    /** @const */ this.outer = outer;
+    /** @const */ this.count = count;
 };
 
 /**
@@ -657,9 +657,9 @@ adapt.vtree.FirstPseudo = function(outer, count) {
  * @constructor
  */
 adapt.vtree.NodeContext = function(sourceNode, parent, boxOffset) {
-	/** @type {Node} */ this.sourceNode = sourceNode;
-	/** @type {adapt.vtree.NodeContext} */ this.parent = parent;
-	/** @type {number} */ this.boxOffset = boxOffset;
+    /** @type {Node} */ this.sourceNode = sourceNode;
+    /** @type {adapt.vtree.NodeContext} */ this.parent = parent;
+    /** @type {number} */ this.boxOffset = boxOffset;
     // position itself
     /** @type {number} */ this.offsetInNode = 0;
     /** @type {boolean} */ this.after = false;
@@ -672,21 +672,21 @@ adapt.vtree.NodeContext = function(sourceNode, parent, boxOffset) {
     /** @type {boolean} */ this.inline = true;
     /** @type {boolean} */ this.overflow = false;
     /** @type {number} */ this.breakPenalty = parent ? parent.breakPenalty : 0;
-	/** @type {?string} */ this.display = null;
-	/** @type {?string} */ this.floatReference = null;
+    /** @type {?string} */ this.display = null;
+    /** @type {?string} */ this.floatReference = null;
     /** @type {?string} */ this.floatSide = null;
     /** @type {?string} */ this.clearSide = null;
-	/** @type {boolean} */ this.flexContainer = false;
+    /** @type {boolean} */ this.flexContainer = false;
     /** @type {adapt.vtree.Whitespace} */ this.whitespace = parent ? parent.whitespace : adapt.vtree.Whitespace.IGNORE;
     /** @type {boolean} */ this.establishesBFC = false;
-	/** @type {boolean} */ this.containingBlockForAbsolute = false;
+    /** @type {boolean} */ this.containingBlockForAbsolute = false;
     /** @type {?string} */ this.breakBefore = null;
     /** @type {?string} */ this.breakAfter = null;
     /** @type {Node} */ this.viewNode = null;
-    /** @type {Node} */ this.clearSpacer = null;    
+    /** @type {Node} */ this.clearSpacer = null;
     /** @type {Object.<string,number|string>} */ this.inheritedProps = parent ? parent.inheritedProps : {};
     /** @type {boolean} */ this.vertical = parent ? parent.vertical : false;
-	/** @type {string} */ this.direction = parent ? parent.direction : "ltr";
+    /** @type {string} */ this.direction = parent ? parent.direction : "ltr";
     /** @type {adapt.vtree.FirstPseudo} */ this.firstPseudo = parent ? parent.firstPseudo : null;
 };
 
@@ -697,19 +697,19 @@ adapt.vtree.NodeContext.prototype.resetView = function() {
     this.inline = true;
     this.breakPenalty = this.parent ? this.parent.breakPenalty : 0;
     this.viewNode = null;
-    this.clearSpacer = null;        
+    this.clearSpacer = null;
     this.offsetInNode = 0;
     this.after = false;
-	this.display = null;
+    this.display = null;
     this.floatSide = null;
     this.clearSide = null;
-	this.flexContainer = false;
-	this.whitespace = this.parent ? this.parent.whitespace : adapt.vtree.Whitespace.IGNORE;
+    this.flexContainer = false;
+    this.whitespace = this.parent ? this.parent.whitespace : adapt.vtree.Whitespace.IGNORE;
     this.breakBefore = null;
-    this.breakAfter = null;	
+    this.breakAfter = null;
     this.nodeShadow = null;
     this.establishesBFC = false;
-	this.containingBlockForAbsolute = false;
+    this.containingBlockForAbsolute = false;
     this.vertical = this.parent ? this.parent.vertical : false;
     this.nodeShadow = null;
 };
@@ -728,12 +728,12 @@ adapt.vtree.NodeContext.prototype.cloneItem = function() {
     np.shadowSibling = this.shadowSibling;
     np.inline = this.inline;
     np.breakPenalty = this.breakPenalty;
-	np.display = this.display;
+    np.display = this.display;
     np.floatSide = this.floatSide;
     np.clearSide = this.clearSide;
     np.establishesBFC = this.establishesBFC;
-	np.containingBlockForAbsolute = this.containingBlockForAbsolute;
-	np.flexContainer = this.flexContainer;
+    np.containingBlockForAbsolute = this.containingBlockForAbsolute;
+    np.flexContainer = this.flexContainer;
     np.whitespace = this.whitespace;
     np.breakBefore = this.breakBefore;
     np.breakAfter = this.breakAfter;
@@ -787,57 +787,57 @@ adapt.vtree.NodeContext.prototype.clone = function() {
  * @return {adapt.vtree.NodePositionStep}
  */
 adapt.vtree.NodeContext.prototype.toNodePositionStep = function() {
-	return {
-		node: this.sourceNode,
-		shadowType: this.shadowType,
-		shadowContext: this.shadowContext,
-		nodeShadow: this.nodeShadow,
-		shadowSibling: this.shadowSibling ? this.shadowSibling.toNodePositionStep() : null
-	};	
+    return {
+        node: this.sourceNode,
+        shadowType: this.shadowType,
+        shadowContext: this.shadowContext,
+        nodeShadow: this.nodeShadow,
+        shadowSibling: this.shadowSibling ? this.shadowSibling.toNodePositionStep() : null
+    };
 };
 
 /**
  * @return {adapt.vtree.NodePosition}
  */
 adapt.vtree.NodeContext.prototype.toNodePosition = function() {
-	var nc = this;
-	var steps = [];
-	do {
-		// We need fully "peeled" path, so don't record first-XXX pseudoelement containers
-		if (!nc.firstPseudo || !nc.parent || nc.parent.firstPseudo === nc.firstPseudo) {
-			steps.push(nc.toNodePositionStep());
-		}
-		nc = nc.parent;
-	} while(nc);
-	return {steps:steps, offsetInNode: this.offsetInNode, after: this.after};
+    var nc = this;
+    var steps = [];
+    do {
+        // We need fully "peeled" path, so don't record first-XXX pseudoelement containers
+        if (!nc.firstPseudo || !nc.parent || nc.parent.firstPseudo === nc.firstPseudo) {
+            steps.push(nc.toNodePositionStep());
+        }
+        nc = nc.parent;
+    } while (nc);
+    return {steps:steps, offsetInNode: this.offsetInNode, after: this.after};
 };
 
 /**
  * @returns {boolean}
  */
 adapt.vtree.NodeContext.prototype.isInsideBFC = function() {
-	var parent = this.parent;
-	while (parent) {
-		if (parent.establishesBFC) {
-			return true;
-		}
-		parent = parent.parent;
-	}
-	return false;
+    var parent = this.parent;
+    while (parent) {
+        if (parent.establishesBFC) {
+            return true;
+        }
+        parent = parent.parent;
+    }
+    return false;
 };
 
 /**
  * @returns {adapt.vtree.NodeContext}
  */
 adapt.vtree.NodeContext.prototype.getContainingBlockForAbsolute = function() {
-	var parent = this.parent;
-	while (parent) {
-		if (parent.containingBlockForAbsolute) {
-			return parent;
-		}
-		parent = parent.parent;
-	}
-	return null;
+    var parent = this.parent;
+    while (parent) {
+        if (parent.containingBlockForAbsolute) {
+            return parent;
+        }
+        parent = parent.parent;
+    }
+    return null;
 };
 
 /**
@@ -846,15 +846,15 @@ adapt.vtree.NodeContext.prototype.getContainingBlockForAbsolute = function() {
  * @param {!function(!adapt.vtree.NodeContext)} callback
  */
 adapt.vtree.NodeContext.prototype.walkBlocksUpToBFC = function(callback) {
-	var nodeContext = this;
-	while (nodeContext) {
-		if (!nodeContext.inline) {
-			callback(nodeContext);
-		}
-		if (nodeContext.establishesBFC)
-			break;
-		nodeContext = nodeContext.parent;
-	}
+    var nodeContext = this;
+    while (nodeContext) {
+        if (!nodeContext.inline) {
+            callback(nodeContext);
+        }
+        if (nodeContext.establishesBFC)
+            break;
+        nodeContext = nodeContext.parent;
+    }
 };
 
 /**
@@ -862,29 +862,29 @@ adapt.vtree.NodeContext.prototype.walkBlocksUpToBFC = function(callback) {
  * @constructor
  */
 adapt.vtree.ChunkPosition = function(primary) {
-	/** @type {adapt.vtree.NodePosition} */ this.primary = primary;
-	/** @type {Array.<adapt.vtree.NodePosition>} */ this.floats = null;
-	/** @type {Array.<adapt.vtree.NodePosition>} */ this.footnotes = null;
+    /** @type {adapt.vtree.NodePosition} */ this.primary = primary;
+    /** @type {Array.<adapt.vtree.NodePosition>} */ this.floats = null;
+    /** @type {Array.<adapt.vtree.NodePosition>} */ this.footnotes = null;
 };
 
 /**
  * @return {adapt.vtree.ChunkPosition}
  */
 adapt.vtree.ChunkPosition.prototype.clone = function() {
-	var result = new adapt.vtree.ChunkPosition(this.primary);
-	if (this.floats) {
-		result.floats = [];
-		for (var i = 0; i < this.floats.length; ++i) {
-			result.floats[i] = this.floats[i];
-		}
-	}
-	if (this.footnotes) {
-		result.footnotes = [];
-		for (var i = 0; i < this.footnotes.length; ++i) {
-			result.footnotes[i] = this.footnotes[i];
-		}
-	}
-	return result;
+    var result = new adapt.vtree.ChunkPosition(this.primary);
+    if (this.floats) {
+        result.floats = [];
+        for (var i = 0; i < this.floats.length; ++i) {
+            result.floats[i] = this.floats[i];
+        }
+    }
+    if (this.footnotes) {
+        result.footnotes = [];
+        for (var i = 0; i < this.footnotes.length; ++i) {
+            result.footnotes[i] = this.footnotes[i];
+        }
+    }
+    return result;
 };
 
 /**
@@ -892,40 +892,40 @@ adapt.vtree.ChunkPosition.prototype.clone = function() {
  * @returns {boolean}
  */
 adapt.vtree.ChunkPosition.prototype.isSamePosition = function(other) {
-	if (!other) {
-		return false;
-	}
-	if (this === other) {
-		return true;
-	}
-	if (!adapt.vtree.isSameNodePosition(this.primary, other.primary)) {
-		return false;
-	}
-	if (this.floats) {
-		if (!other.floats || this.floats.length !== other.floats.length) {
-			return false;
-		}
-		for (var i = 0; i < this.floats.length; i++) {
-			if (!adapt.vtree.isSameNodePosition(this.floats[i], other.floats[i])) {
-				return false;
-			}
-		}
-	} else if (other.floats) {
-		return false;
-	}
-	if (this.footnotes) {
-		if (!other.footnotes || this.footnotes.length !== other.footnotes.length) {
-			return false;
-		}
-		for (var i = 0; i < this.footnotes.length; i++) {
-			if (!adapt.vtree.isSameNodePosition(this.footnotes[i], other.footnotes[i])) {
-				return false;
-			}
-		}
-	} else if (other.footnotes) {
-		return false;
-	}
-	return true;
+    if (!other) {
+        return false;
+    }
+    if (this === other) {
+        return true;
+    }
+    if (!adapt.vtree.isSameNodePosition(this.primary, other.primary)) {
+        return false;
+    }
+    if (this.floats) {
+        if (!other.floats || this.floats.length !== other.floats.length) {
+            return false;
+        }
+        for (var i = 0; i < this.floats.length; i++) {
+            if (!adapt.vtree.isSameNodePosition(this.floats[i], other.floats[i])) {
+                return false;
+            }
+        }
+    } else if (other.floats) {
+        return false;
+    }
+    if (this.footnotes) {
+        if (!other.footnotes || this.footnotes.length !== other.footnotes.length) {
+            return false;
+        }
+        for (var i = 0; i < this.footnotes.length; i++) {
+            if (!adapt.vtree.isSameNodePosition(this.footnotes[i], other.footnotes[i])) {
+                return false;
+            }
+        }
+    } else if (other.footnotes) {
+        return false;
+    }
+    return true;
 };
 
 /**
@@ -934,8 +934,8 @@ adapt.vtree.ChunkPosition.prototype.isSamePosition = function(other) {
  * @constructor
  */
 adapt.vtree.FlowChunkPosition = function(chunkPosition, flowChunk) {
-	/** @type {adapt.vtree.ChunkPosition} */ this.chunkPosition = chunkPosition;
-	/** @const */ this.flowChunk = flowChunk;
+    /** @type {adapt.vtree.ChunkPosition} */ this.chunkPosition = chunkPosition;
+    /** @const */ this.flowChunk = flowChunk;
 };
 
 /**
@@ -951,7 +951,7 @@ adapt.vtree.FlowChunkPosition.prototype.clone = function() {
  * @returns {boolean}
  */
 adapt.vtree.FlowChunkPosition.prototype.isSamePosition = function(other) {
-	return !!other && (this === other || this.chunkPosition.isSamePosition(other.chunkPosition));
+    return !!other && (this === other || this.chunkPosition.isSamePosition(other.chunkPosition));
 };
 
 /**
@@ -961,11 +961,11 @@ adapt.vtree.FlowPosition = function() {
     /**
      * @type {Array.<adapt.vtree.FlowChunkPosition>}
      */
-	this.positions = [];
-	/**
-	 * @type {string}
+    this.positions = [];
+    /**
+     * @type {string}
      */
-	this.startSide = "any";
+    this.startSide = "any";
 };
 
 /**
@@ -978,7 +978,7 @@ adapt.vtree.FlowPosition.prototype.clone = function() {
     for (var i = 0; i < arr.length; i++) {
         newarr[i] = arr[i].clone();
     }
-	newfp.startSide = this.startSide;
+    newfp.startSide = this.startSide;
     return newfp;
 };
 
@@ -987,18 +987,18 @@ adapt.vtree.FlowPosition.prototype.clone = function() {
  * @returns {boolean}
  */
 adapt.vtree.FlowPosition.prototype.isSamePosition = function(other) {
-	if (this === other) {
-		return true;
-	}
-	if (!other || this.positions.length !== other.positions.length) {
-		return false;
-	}
-	for (var i = 0; i < this.positions.length; i++) {
-		if (!this.positions[i].isSamePosition(other.positions[i])) {
-			return false;
-		}
-	}
-	return true;
+    if (this === other) {
+        return true;
+    }
+    if (!other || this.positions.length !== other.positions.length) {
+        return false;
+    }
+    for (var i = 0; i < this.positions.length; i++) {
+        if (!this.positions[i].isSamePosition(other.positions[i])) {
+            return false;
+        }
+    }
+    return true;
 };
 
 /**
@@ -1006,8 +1006,8 @@ adapt.vtree.FlowPosition.prototype.isSamePosition = function(other) {
  * @return {boolean}
  */
 adapt.vtree.FlowPosition.prototype.hasContent = function(offset) {
-	return this.positions.length > 0 &&
-	    this.positions[0].flowChunk.startOffset <= offset;
+    return this.positions.length > 0 &&
+        this.positions[0].flowChunk.startOffset <= offset;
 };
 
 /**
@@ -1018,14 +1018,14 @@ adapt.vtree.LayoutPosition = function() {
      * One-based, incremented before layout.
      * @type {number}
      */
-	this.page = 0;
-	/**
-	 * @type {!Object<string, adapt.vtree.Flow>}
+    this.page = 0;
+    /**
+     * @type {!Object<string, adapt.vtree.Flow>}
      */
-	this.flows = {};
-	/**
-	 * @type {!Object.<string,adapt.vtree.FlowPosition>}
-	 */
+    this.flows = {};
+    /**
+     * @type {!Object.<string,adapt.vtree.FlowPosition>}
+     */
     this.flowPositions = {};
     /**
      * flowPositions is built up to this offset.
@@ -1043,7 +1043,7 @@ adapt.vtree.LayoutPosition.prototype.clone = function() {
     newcp.highestSeenNode = this.highestSeenNode;
     newcp.highestSeenOffset = this.highestSeenOffset;
     newcp.lookupPositionOffset = this.lookupPositionOffset;
-	newcp.flows = this.flows;
+    newcp.flows = this.flows;
     for (var name in this.flowPositions) {
         newcp.flowPositions[name] = this.flowPositions[name].clone();
     }
@@ -1055,24 +1055,24 @@ adapt.vtree.LayoutPosition.prototype.clone = function() {
  * @returns {boolean}
  */
 adapt.vtree.LayoutPosition.prototype.isSamePosition = function(other) {
-	if (this === other) {
-		return true;
-	}
-	if (!other || this.page !== other.page || this.highestSeenOffset !== other.highestSeenOffset) {
-		return false;
-	}
-	var thisFlowNames = Object.keys(this.flowPositions);
-	var otherFlowNames = Object.keys(other.flowPositions);
-	if (thisFlowNames.length !== otherFlowNames.length) {
-		return false;
-	}
-	for (var i = 0; i < thisFlowNames.length; i++) {
-		var flowName = thisFlowNames[i];
-		if (!this.flowPositions[flowName].isSamePosition(other.flowPositions[flowName])) {
-			return false;
-		}
-	}
-	return true;
+    if (this === other) {
+        return true;
+    }
+    if (!other || this.page !== other.page || this.highestSeenOffset !== other.highestSeenOffset) {
+        return false;
+    }
+    var thisFlowNames = Object.keys(this.flowPositions);
+    var otherFlowNames = Object.keys(other.flowPositions);
+    if (thisFlowNames.length !== otherFlowNames.length) {
+        return false;
+    }
+    for (var i = 0; i < thisFlowNames.length; i++) {
+        var flowName = thisFlowNames[i];
+        if (!this.flowPositions[flowName].isSamePosition(other.flowPositions[flowName])) {
+            return false;
+        }
+    }
+    return true;
 };
 
 /**
@@ -1092,10 +1092,10 @@ adapt.vtree.LayoutPosition.prototype.hasContent = function(name, offset) {
  * @returns {string}
  */
 adapt.vtree.LayoutPosition.prototype.startSideOfFlow = function(name) {
-	var flowPos = this.flowPositions[name];
-	if (!flowPos)
-		return "any";
-	return flowPos.startSide;
+    var flowPos = this.flowPositions[name];
+    if (!flowPos)
+        return "any";
+    return flowPos.startSide;
 };
 
 /**
@@ -1103,13 +1103,13 @@ adapt.vtree.LayoutPosition.prototype.startSideOfFlow = function(name) {
  * @returns {?adapt.vtree.FlowChunk}
  */
 adapt.vtree.LayoutPosition.prototype.firstFlowChunkOfFlow = function(name) {
-	var flowPos = this.flowPositions[name];
-	if (!flowPos)
-		return null;
-	var flowChunkPosition = flowPos.positions[0];
-	if (!flowChunkPosition)
-		return null;
-	return flowChunkPosition.flowChunk;
+    var flowPos = this.flowPositions[name];
+    if (!flowPos)
+        return null;
+    var flowChunkPosition = flowPos.positions[0];
+    if (!flowChunkPosition)
+        return null;
+    return flowChunkPosition.flowChunk;
 };
 
 /**
@@ -1117,7 +1117,7 @@ adapt.vtree.LayoutPosition.prototype.firstFlowChunkOfFlow = function(name) {
  * @constructor
  */
 adapt.vtree.Container = function(element) {
-	/** @type {Element} */ this.element = element;
+    /** @type {Element} */ this.element = element;
     /** @type {number} */ this.left = 0;
     /** @type {number} */ this.top = 0;
     /** @type {number} */ this.marginLeft = 0;
@@ -1147,47 +1147,47 @@ adapt.vtree.Container = function(element) {
 };
 
 adapt.vtree.Container.prototype.getInsetTop = function() {
-	return this.marginTop + this.borderTop + this.paddingTop;
+    return this.marginTop + this.borderTop + this.paddingTop;
 };
 
 adapt.vtree.Container.prototype.getInsetBottom = function() {
-	return this.marginBottom + this.borderBottom + this.paddingBottom;
+    return this.marginBottom + this.borderBottom + this.paddingBottom;
 };
 
 adapt.vtree.Container.prototype.getInsetLeft = function() {
-	return this.marginLeft + this.borderLeft + this.paddingLeft;
+    return this.marginLeft + this.borderLeft + this.paddingLeft;
 };
 
 adapt.vtree.Container.prototype.getInsetRight = function() {
-	return this.marginRight + this.borderRight + this.paddingRight;
+    return this.marginRight + this.borderRight + this.paddingRight;
 };
 
 adapt.vtree.Container.prototype.getInsetBefore = function() {
-	if (this.vertical)
-		return this.getInsetRight();
-	else
-		return this.getInsetTop();
+    if (this.vertical)
+        return this.getInsetRight();
+    else
+        return this.getInsetTop();
 };
 
 adapt.vtree.Container.prototype.getInsetAfter = function() {
-	if (this.vertical)
-		return this.getInsetLeft();
-	else
-		return this.getInsetBottom();
+    if (this.vertical)
+        return this.getInsetLeft();
+    else
+        return this.getInsetBottom();
 };
 
 adapt.vtree.Container.prototype.getInsetStart = function() {
-	if (this.vertical)
-		return this.getInsetTop();
-	else
-		return this.getInsetLeft();
+    if (this.vertical)
+        return this.getInsetTop();
+    else
+        return this.getInsetLeft();
 };
 
 adapt.vtree.Container.prototype.getInsetEnd = function() {
-	if (this.vertical)
-		return this.getInsetBottom();
-	else
-		return this.getInsetRight();
+    if (this.vertical)
+        return this.getInsetBottom();
+    else
+        return this.getInsetRight();
 };
 
 /**
@@ -1195,7 +1195,7 @@ adapt.vtree.Container.prototype.getInsetEnd = function() {
  * @return {number}
  */
 adapt.vtree.Container.prototype.getBeforeEdge = function(box) {
-	return this.vertical ? box.right : box.top;
+    return this.vertical ? box.right : box.top;
 };
 
 /**
@@ -1203,7 +1203,7 @@ adapt.vtree.Container.prototype.getBeforeEdge = function(box) {
  * @return {number}
  */
 adapt.vtree.Container.prototype.getAfterEdge = function(box) {
-	return this.vertical ? box.left : box.bottom;
+    return this.vertical ? box.left : box.bottom;
 };
 
 /**
@@ -1211,7 +1211,7 @@ adapt.vtree.Container.prototype.getAfterEdge = function(box) {
  * @return {number}
  */
 adapt.vtree.Container.prototype.getStartEdge = function(box) {
-	return this.vertical ? box.top : box.left;
+    return this.vertical ? box.top : box.left;
 };
 
 /**
@@ -1219,7 +1219,7 @@ adapt.vtree.Container.prototype.getStartEdge = function(box) {
  * @return {number}
  */
 adapt.vtree.Container.prototype.getEndEdge = function(box) {
-	return this.vertical ? box.bottom : box.right;
+    return this.vertical ? box.bottom : box.right;
 };
 
 /**
@@ -1227,7 +1227,7 @@ adapt.vtree.Container.prototype.getEndEdge = function(box) {
  * @return {number}
  */
 adapt.vtree.Container.prototype.getInlineSize = function(box) {
-	return this.vertical ? box.bottom - box.top : box.right - box.left;
+    return this.vertical ? box.bottom - box.top : box.right - box.left;
 };
 
 /**
@@ -1235,21 +1235,21 @@ adapt.vtree.Container.prototype.getInlineSize = function(box) {
  * @return {number}
  */
 adapt.vtree.Container.prototype.getBoxSize = function(box) {
-	return this.vertical ? box.right - box.left : box.bottom - box.top;
+    return this.vertical ? box.right - box.left : box.bottom - box.top;
 };
 
 /**
  * @return {number}
  */
 adapt.vtree.Container.prototype.getBoxDir = function() {
-	return this.vertical ? -1 : 1;
+    return this.vertical ? -1 : 1;
 };
 
 /**
  * @return {number}
  */
 adapt.vtree.Container.prototype.getInlineDir = function() {
-	return 1;
+    return 1;
 };
 
 
@@ -1258,7 +1258,7 @@ adapt.vtree.Container.prototype.getInlineDir = function() {
  * @return {void}
  */
 adapt.vtree.Container.prototype.copyFrom = function(other) {
-	this.element = other.element;
+    this.element = other.element;
     this.left = other.left;
     this.top = other.top;
     this.marginLeft = other.marginLeft;
@@ -1313,12 +1313,12 @@ adapt.vtree.Container.prototype.setHorizontalPosition = function(left, width) {
  * @return {adapt.geom.Shape}
  */
 adapt.vtree.Container.prototype.getInnerShape = function() {
-	var offsetX = this.originX + this.left + this.getInsetLeft();
-	var offsetY = this.originY + this.top + this.getInsetTop();
-	if (this.innerShape)
-		return this.innerShape.withOffset(offsetX, offsetY);
-	return adapt.geom.shapeForRect(offsetX, offsetY,
-			offsetX + this.width, offsetY + this.height);
+    var offsetX = this.originX + this.left + this.getInsetLeft();
+    var offsetY = this.originY + this.top + this.getInsetTop();
+    if (this.innerShape)
+        return this.innerShape.withOffset(offsetX, offsetY);
+    return adapt.geom.shapeForRect(offsetX, offsetY,
+        offsetX + this.width, offsetY + this.height);
 };
 
 
@@ -1329,9 +1329,9 @@ adapt.vtree.Container.prototype.getInnerShape = function() {
  * @extends {adapt.css.Visitor}
  */
 adapt.vtree.ContentPropertyHandler = function(elem, context) {
-	adapt.css.Visitor.call(this);
+    adapt.css.Visitor.call(this);
     /** @const */ this.elem = elem;
-	/** @const */ this.context = context;
+    /** @const */ this.context = context;
 };
 goog.inherits(adapt.vtree.ContentPropertyHandler, adapt.css.Visitor);
 
@@ -1340,15 +1340,15 @@ goog.inherits(adapt.vtree.ContentPropertyHandler, adapt.css.Visitor);
  * @param {string} str
  */
 adapt.vtree.ContentPropertyHandler.prototype.visitStrInner = function(str) {
-	this.elem.appendChild(this.elem.ownerDocument.createTextNode(str));
+    this.elem.appendChild(this.elem.ownerDocument.createTextNode(str));
 };
 
 /** @override */
 adapt.vtree.ContentPropertyHandler.prototype.visitStr = function(str) {
-	this.visitStrInner(str.str);
+    this.visitStrInner(str.str);
     return null;
 };
-    
+
 /** @override */
 adapt.vtree.ContentPropertyHandler.prototype.visitURL = function(url) {
     var img = this.elem.ownerDocument.createElementNS(adapt.base.NS.XHTML, "img");
@@ -1365,11 +1365,11 @@ adapt.vtree.ContentPropertyHandler.prototype.visitSpaceList = function(list) {
 
 /** @override */
 adapt.vtree.ContentPropertyHandler.prototype.visitExpr = function(expr) {
-	var val = expr.toExpr().evaluate(this.context);
-	if (typeof val === "string") {
-		this.visitStrInner(val);
-	}
-	return null;
+    var val = expr.toExpr().evaluate(this.context);
+    if (typeof val === "string") {
+        this.visitStrInner(val);
+    }
+    return null;
 };
 
 /**
@@ -1377,8 +1377,6 @@ adapt.vtree.ContentPropertyHandler.prototype.visitExpr = function(expr) {
  * @return {boolean}
  */
 adapt.vtree.nonTrivialContent = function(val) {
-	return val != null && val !== adapt.css.ident.normal && val !== adapt.css.ident.none
-		&& val !== adapt.css.ident.inherit;
+    return val != null && val !== adapt.css.ident.normal && val !== adapt.css.ident.none
+        && val !== adapt.css.ident.inherit;
 };
-
-

--- a/src/adapt/xmldoc.js
+++ b/src/adapt/xmldoc.js
@@ -23,53 +23,53 @@ adapt.xmldoc.ELEMENT_OFFSET_ATTR = "data-adapt-eloff";
  * @constructor
  */
 adapt.xmldoc.XMLDocHolder = function(store, url, document) {
-	/** @const */ this.store = store;
-	/** @const */ this.url = url;
-	/** @const */ this.document = document;
-	/** @type {?string} */ this.lang = null;
-	/** @type {number} */ this.totalOffset = -1;
-	/**
-	 * @type {!Element}
-	 * @const
-	 */
-	this.root = document.documentElement;  // html element
-	var body = null;
-	var head = null;
-	if (this.root.namespaceURI == adapt.base.NS.XHTML) {
-		for (var child = this.root.firstChild; child; child = child.nextSibling) {
-			if (child.nodeType != 1)
-				continue;
-			var elem = /** @type {Element} */ (child);
-			if (elem.namespaceURI == adapt.base.NS.XHTML) {
-				switch(elem.localName) {
-				case 'head' :
-					head = elem;
-					break;
-				case 'body' :
-					body = elem;
-					break;
-				}
-			}
-		}
-		this.lang = this.root.getAttribute("lang");
-	} else if (this.root.namespaceURI == adapt.base.NS.FB2){
-		head = this.root;
-		for (var child = this.root.firstChild; child; child = child.nextSibling) {
-			if (child.nodeType != 1)
-				continue;
-			var elem = /** @type {Element} */ (child);
-			if (elem.namespaceURI == adapt.base.NS.FB2) {
-				if (elem.localName == "body") {
-					body = elem;
-				}
-			}
-		}
-		var langs = this.doc().child("FictionBook").child("description")
-				.child("title-info").child("lang").textContent();
-		if (langs.length > 0) {
-			this.lang = langs[0];
-		}		
-	} else if (this.root.namespaceURI == adapt.base.NS.SSE) {
+    /** @const */ this.store = store;
+    /** @const */ this.url = url;
+    /** @const */ this.document = document;
+    /** @type {?string} */ this.lang = null;
+    /** @type {number} */ this.totalOffset = -1;
+    /**
+     * @type {!Element}
+     * @const
+     */
+    this.root = document.documentElement;  // html element
+    var body = null;
+    var head = null;
+    if (this.root.namespaceURI == adapt.base.NS.XHTML) {
+        for (var child = this.root.firstChild; child; child = child.nextSibling) {
+            if (child.nodeType != 1)
+                continue;
+            var elem = /** @type {Element} */ (child);
+            if (elem.namespaceURI == adapt.base.NS.XHTML) {
+                switch (elem.localName) {
+                    case 'head' :
+                        head = elem;
+                        break;
+                    case 'body' :
+                        body = elem;
+                        break;
+                }
+            }
+        }
+        this.lang = this.root.getAttribute("lang");
+    } else if (this.root.namespaceURI == adapt.base.NS.FB2) {
+        head = this.root;
+        for (var child = this.root.firstChild; child; child = child.nextSibling) {
+            if (child.nodeType != 1)
+                continue;
+            var elem = /** @type {Element} */ (child);
+            if (elem.namespaceURI == adapt.base.NS.FB2) {
+                if (elem.localName == "body") {
+                    body = elem;
+                }
+            }
+        }
+        var langs = this.doc().child("FictionBook").child("description")
+            .child("title-info").child("lang").textContent();
+        if (langs.length > 0) {
+            this.lang = langs[0];
+        }
+    } else if (this.root.namespaceURI == adapt.base.NS.SSE) {
         // treat <meta> element as "head" of the document
         for (var elem = this.root.firstElementChild; elem; elem = elem.nextElementSibling) {
             var localName = elem.localName;
@@ -80,16 +80,16 @@ adapt.xmldoc.XMLDocHolder = function(store, url, document) {
             }
         }
     }
-	/** 
-	 * @type {Element}
-	 * @const
-	 */
-	this.body = body;
-	/**
-	 * @type {Element}
-	 * @const
-	 */
-	this.head = head;
+    /**
+     * @type {Element}
+     * @const
+     */
+    this.body = body;
+    /**
+     * @type {Element}
+     * @const
+     */
+    this.head = head;
     /** @type {Element} */ this.last = this.root;
     /** @type {number} */ this.lastOffset = 1;
     this.last.setAttribute(adapt.xmldoc.ELEMENT_OFFSET_ATTR, "0");
@@ -99,7 +99,7 @@ adapt.xmldoc.XMLDocHolder = function(store, url, document) {
  * @return {adapt.xmldoc.NodeList}
  */
 adapt.xmldoc.XMLDocHolder.prototype.doc = function() {
-	return new adapt.xmldoc.NodeList([this.document]);
+    return new adapt.xmldoc.NodeList([this.document]);
 };
 
 /**
@@ -156,9 +156,9 @@ adapt.xmldoc.XMLDocHolder.prototype.getNodeOffset = function(srcNode, offsetInNo
         extraOffset = offsetInNode;
         prev = node.previousSibling;
         if (!prev) {
-        	node = node.parentNode;
+            node = node.parentNode;
             extraOffset += 1;
-        	return this.getElementOffset(/** @type {Element} */ (node)) + extraOffset;
+            return this.getElementOffset(/** @type {Element} */ (node)) + extraOffset;
         }
         node = prev;
     }
@@ -167,14 +167,14 @@ adapt.xmldoc.XMLDocHolder.prototype.getNodeOffset = function(srcNode, offsetInNo
             node = node.lastChild;
         }
         if (node.nodeType == 1) {
-        	// empty element
-        	break;
+            // empty element
+            break;
         }
         extraOffset += node.textContent.length;
         prev = node.previousSibling;
         if (!prev) {
-        	node = node.parentNode;
-        	break;
+            node = node.parentNode;
+            break;
         }
         node = prev;
     }
@@ -186,10 +186,10 @@ adapt.xmldoc.XMLDocHolder.prototype.getNodeOffset = function(srcNode, offsetInNo
  * @return {number}
  */
 adapt.xmldoc.XMLDocHolder.prototype.getTotalOffset = function() {
-	if (this.totalOffset < 0) {
-		this.totalOffset = this.getNodeOffset(this.root, 0, true);
-	}
-	return this.totalOffset;
+    if (this.totalOffset < 0) {
+        this.totalOffset = this.getNodeOffset(this.root, 0, true);
+    }
+    return this.totalOffset;
 };
 
 /**
@@ -197,59 +197,59 @@ adapt.xmldoc.XMLDocHolder.prototype.getTotalOffset = function() {
  * @return {Node} last node such that its offset is less or equal to the given
  */
 adapt.xmldoc.XMLDocHolder.prototype.getNodeByOffset = function(offset) {
-	var elementOffset;
-	// First, find the last element in the document, such that
-	// this.getElementOffset(element) <= offset; if offest matches
-	// exactly, just return it.
-	var self = this;
-	var element = this.root;
-	while(true) {
-		elementOffset = this.getElementOffset(element);
-		if (elementOffset >= offset)
-			return element;
-		var children = element.children; // Element children
-		if (!children)
-			break;
-		var index = adapt.base.binarySearch(children.length, function(index) {
-			var child = children[index];
-			var childOffset = self.getElementOffset(child);
-			return childOffset > offset;
-		});
-		if (index == 0) {
-			break;
-		}
-		if (goog.DEBUG) {
-			if (index < children.length) {
-				var elemOffset = self.getElementOffset(children[index]);
-				if (elemOffset <= offset)
-					throw new Error("Consistency check failed!");
-			}
-		}
-		element = children[index-1];
-	}
-	// Now we have element with offset less than desired. Find following (non-element)
-	// node with the right offset.
-	var nodeOffset = elementOffset + 1;
-	var node = element;
-	var next = node.firstChild || node.nextSibling;
-	var lastGood = null;
-	while (true) {
-		if (next) {
-			if (next.nodeType == 1)
-				break;
-			node = next;
-			lastGood = node;
-			nodeOffset += next.textContent.length;
-			if (nodeOffset > offset)
-				break;
-		} else {
-			node = node.parentNode;
-			if (!node)
-				break;
-		}
-		next = node.nextSibling;
-	}
-	return lastGood || element;
+    var elementOffset;
+    // First, find the last element in the document, such that
+    // this.getElementOffset(element) <= offset; if offest matches
+    // exactly, just return it.
+    var self = this;
+    var element = this.root;
+    while (true) {
+        elementOffset = this.getElementOffset(element);
+        if (elementOffset >= offset)
+            return element;
+        var children = element.children; // Element children
+        if (!children)
+            break;
+        var index = adapt.base.binarySearch(children.length, function(index) {
+            var child = children[index];
+            var childOffset = self.getElementOffset(child);
+            return childOffset > offset;
+        });
+        if (index == 0) {
+            break;
+        }
+        if (goog.DEBUG) {
+            if (index < children.length) {
+                var elemOffset = self.getElementOffset(children[index]);
+                if (elemOffset <= offset)
+                    throw new Error("Consistency check failed!");
+            }
+        }
+        element = children[index-1];
+    }
+    // Now we have element with offset less than desired. Find following (non-element)
+    // node with the right offset.
+    var nodeOffset = elementOffset + 1;
+    var node = element;
+    var next = node.firstChild || node.nextSibling;
+    var lastGood = null;
+    while (true) {
+        if (next) {
+            if (next.nodeType == 1)
+                break;
+            node = next;
+            lastGood = node;
+            nodeOffset += next.textContent.length;
+            if (nodeOffset > offset)
+                break;
+        } else {
+            node = node.parentNode;
+            if (!node)
+                break;
+        }
+        next = node.nextSibling;
+    }
+    return lastGood || element;
 };
 
 /**
@@ -258,17 +258,17 @@ adapt.xmldoc.XMLDocHolder.prototype.getNodeByOffset = function(offset) {
  * @return {void}
  */
 adapt.xmldoc.XMLDocHolder.prototype.buildIdMap = function(e) {
-	var id = e.getAttribute("id");
-	if (id && !this.idMap[id]) {
-		this.idMap[id] = e;
-	}
-	var xmlid = e.getAttributeNS(adapt.base.NS.XML, "id");
-	if (xmlid && !this.idMap[xmlid]) {
-		this.idMap[xmlid] = e;
-	}
-	for (var c = e.firstElementChild ; c ; c = c.nextElementSibling) {
-		this.buildIdMap(c);
-	}
+    var id = e.getAttribute("id");
+    if (id && !this.idMap[id]) {
+        this.idMap[id] = e;
+    }
+    var xmlid = e.getAttributeNS(adapt.base.NS.XML, "id");
+    if (xmlid && !this.idMap[xmlid]) {
+        this.idMap[xmlid] = e;
+    }
+    for (var c = e.firstElementChild; c; c = c.nextElementSibling) {
+        this.buildIdMap(c);
+    }
 };
 
 /**
@@ -278,23 +278,23 @@ adapt.xmldoc.XMLDocHolder.prototype.buildIdMap = function(e) {
  * @return {Element}
  */
 adapt.xmldoc.XMLDocHolder.prototype.getElement = function(url) {
-	var m = url.match(/([^#]*)\#(.+)$/);
-	if (!m || (m[1] && m[1] != this.url)) {
-		return null;
-	}
-	var id = m[2];
-	var r = this.document.getElementById(id);
-	if (!r && this.document.getElementsByName) {
-		r = this.document.getElementsByName(id)[0];
-	}
-	if (!r) {
-		if (!this.idMap) {
-			this.idMap = {};
-			this.buildIdMap(this.document.documentElement);
-		}
-		r = this.idMap[id];
-	}
-	return r;
+    var m = url.match(/([^#]*)\#(.+)$/);
+    if (!m || (m[1] && m[1] != this.url)) {
+        return null;
+    }
+    var id = m[2];
+    var r = this.document.getElementById(id);
+    if (!r && this.document.getElementsByName) {
+        r = this.document.getElementsByName(id)[0];
+    }
+    if (!r) {
+        if (!this.idMap) {
+            this.idMap = {};
+            this.buildIdMap(this.document.documentElement);
+        }
+        r = this.idMap[id];
+    }
+    return r;
 };
 
 /**
@@ -308,11 +308,11 @@ adapt.xmldoc.XMLDocStore;
  * @private
  */
 adapt.xmldoc.DOMParserSupportedType = {
-	TEXT_HTML: "text/html",
-	TEXT_XML: "text/xml",
-	APPLICATION_XML: "application/xml",
-	APPLICATION_XHTML_XML: "application/xhtml_xml",
-	IMAGE_SVG_XML: "image/svg+xml"
+    TEXT_HTML: "text/html",
+    TEXT_XML: "text/xml",
+    APPLICATION_XML: "application/xml",
+    APPLICATION_XHTML_XML: "application/xhtml_xml",
+    IMAGE_SVG_XML: "image/svg+xml"
 };
 
 /**
@@ -324,28 +324,28 @@ adapt.xmldoc.DOMParserSupportedType = {
  * @returns {Document}
  */
 adapt.xmldoc.parseAndReturnNullIfError = function(str, type, opt_parser) {
-	var parser = opt_parser || new DOMParser();
-	var doc;
-	try {
-		doc = parser.parseFromString(str, type);
-	} catch (e) {}
+    var parser = opt_parser || new DOMParser();
+    var doc;
+    try {
+        doc = parser.parseFromString(str, type);
+    } catch (e) {}
 
-	if (!doc) {
-		return null;
-	} else {
-		var docElement = doc.documentElement;
-		var errorTagName = "parsererror";
-		if (docElement.localName === errorTagName) {
-			return null;
-		} else {
-			for (var c = docElement.firstChild; c; c = c.nextSibling) {
-				if (c.localName === errorTagName) {
-					return null;
-				}
-			}
-		}
-	}
-	return doc;
+    if (!doc) {
+        return null;
+    } else {
+        var docElement = doc.documentElement;
+        var errorTagName = "parsererror";
+        if (docElement.localName === errorTagName) {
+            return null;
+        } else {
+            for (var c = docElement.firstChild; c; c = c.nextSibling) {
+                if (c.localName === errorTagName) {
+                    return null;
+                }
+            }
+        }
+    }
+    return doc;
 };
 
 /**
@@ -354,37 +354,37 @@ adapt.xmldoc.parseAndReturnNullIfError = function(str, type, opt_parser) {
  * @returns {?string} null if contentType cannot be inferred from HTTP header and file extension
  */
 adapt.xmldoc.resolveContentType = function(response) {
-	var contentType = response.contentType;
-	if (contentType) {
-		var supportedKeys = Object.keys(adapt.xmldoc.DOMParserSupportedType);
-		for (var i = 0; i < supportedKeys.length; i++) {
-			if (adapt.xmldoc.DOMParserSupportedType[supportedKeys[i]] === contentType) {
-				return contentType;
-			}
-		}
-		if (contentType.match(/\+xml$/)) {
-			return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML;
-		}
-	}
-	var match = response.url.match(/\.([^./]+)$/);
-	if (match) {
-		var extension = match[1];
-		switch (extension) {
-			case "html":
-			case "htm":
-				return adapt.xmldoc.DOMParserSupportedType.TEXT_HTML;
-			case "xhtml":
-			case "xht":
-				return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XHTML_XML;
-			case "svg":
-			case "svgz":
-				return adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML;
-			case "opf":
-			case "xml":
-				return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML;
-		}
-	}
-	return null;
+    var contentType = response.contentType;
+    if (contentType) {
+        var supportedKeys = Object.keys(adapt.xmldoc.DOMParserSupportedType);
+        for (var i = 0; i < supportedKeys.length; i++) {
+            if (adapt.xmldoc.DOMParserSupportedType[supportedKeys[i]] === contentType) {
+                return contentType;
+            }
+        }
+        if (contentType.match(/\+xml$/)) {
+            return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML;
+        }
+    }
+    var match = response.url.match(/\.([^./]+)$/);
+    if (match) {
+        var extension = match[1];
+        switch (extension) {
+            case "html":
+            case "htm":
+                return adapt.xmldoc.DOMParserSupportedType.TEXT_HTML;
+            case "xhtml":
+            case "xht":
+                return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XHTML_XML;
+            case "svg":
+            case "svgz":
+                return adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML;
+            case "opf":
+            case "xml":
+                return adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML;
+        }
+    }
+    return null;
 };
 
 /**
@@ -393,32 +393,32 @@ adapt.xmldoc.resolveContentType = function(response) {
  * @return {!adapt.task.Result.<adapt.xmldoc.XMLDocHolder>}
  */
 adapt.xmldoc.parseXMLResource = function(response, store) {
-	var doc = response.responseXML;
-	if (!doc) {
-		var parser = new DOMParser();
-		var text = response.responseText;
-		if (text) {
-			var contentType = adapt.xmldoc.resolveContentType(response);
-			doc = adapt.xmldoc.parseAndReturnNullIfError(text, contentType || adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML, parser);
+    var doc = response.responseXML;
+    if (!doc) {
+        var parser = new DOMParser();
+        var text = response.responseText;
+        if (text) {
+            var contentType = adapt.xmldoc.resolveContentType(response);
+            doc = adapt.xmldoc.parseAndReturnNullIfError(text, contentType || adapt.xmldoc.DOMParserSupportedType.APPLICATION_XML, parser);
 
-			// When contentType cannot be inferred from HTTP header and file extension,
-			// we use root element's tag name to infer the contentType.
-			// If it is html or svg, we re-parse the source with an appropriate contentType.
-			if (doc && !contentType) {
-				var root = doc.documentElement;
-				if (root.localName.toLowerCase() === "html" && !root.namespaceURI) {
-					doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.TEXT_HTML, parser);
-				} else if (root.localName.toLowerCase() === "svg" && doc.contentType !== adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML) {
-					doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML, parser);
-				}
-			}
+            // When contentType cannot be inferred from HTTP header and file extension,
+            // we use root element's tag name to infer the contentType.
+            // If it is html or svg, we re-parse the source with an appropriate contentType.
+            if (doc && !contentType) {
+                var root = doc.documentElement;
+                if (root.localName.toLowerCase() === "html" && !root.namespaceURI) {
+                    doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.TEXT_HTML, parser);
+                } else if (root.localName.toLowerCase() === "svg" && doc.contentType !== adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML) {
+                    doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.IMAGE_SVG_XML, parser);
+                }
+            }
 
-			if (!doc) {
-				// Fallback to HTML parsing
-				doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.TEXT_HTML, parser);
-			}
-		}
-	}
+            if (!doc) {
+                // Fallback to HTML parsing
+                doc = adapt.xmldoc.parseAndReturnNullIfError(text, adapt.xmldoc.DOMParserSupportedType.TEXT_HTML, parser);
+            }
+        }
+    }
     var xmldoc = doc ? new adapt.xmldoc.XMLDocHolder(store, response.url, doc) : null;
     return adapt.task.newResult(xmldoc);
 };
@@ -427,7 +427,7 @@ adapt.xmldoc.parseXMLResource = function(response, store) {
  * @return {adapt.xmldoc.XMLDocStore}
  */
 adapt.xmldoc.newXMLDocStore = function() {
-	return new adapt.net.ResourceStore(adapt.xmldoc.parseXMLResource, adapt.net.XMLHttpRequestResponseType.DOCUMENT);
+    return new adapt.net.ResourceStore(adapt.xmldoc.parseXMLResource, adapt.net.XMLHttpRequestResponseType.DOCUMENT);
 };
 
 /**
@@ -435,7 +435,7 @@ adapt.xmldoc.newXMLDocStore = function() {
  * @param {function(Node):boolean} fn
  */
 adapt.xmldoc.Predicate = function(fn) {
-	/** @const */ this.fn = fn;
+    /** @const */ this.fn = fn;
 };
 
 /**
@@ -443,7 +443,7 @@ adapt.xmldoc.Predicate = function(fn) {
  * @return {boolean}
  */
 adapt.xmldoc.Predicate.prototype.check = function(node) {
-	return this.fn(node);
+    return this.fn(node);
 };
 
 /**
@@ -452,11 +452,11 @@ adapt.xmldoc.Predicate.prototype.check = function(node) {
  * @return {adapt.xmldoc.Predicate}
  */
 adapt.xmldoc.Predicate.prototype.withAttribute = function(name, value) {
-	var self = this;
-	return new adapt.xmldoc.Predicate(function(node) {
-		return self.check(node) && node.nodeType == 1 &&
-			(/** @type {Element} */ (node)).getAttribute(name) == value;
-	});
+    var self = this;
+    return new adapt.xmldoc.Predicate(function(node) {
+        return self.check(node) && node.nodeType == 1 &&
+            (/** @type {Element} */ (node)).getAttribute(name) == value;
+    });
 };
 
 /**
@@ -465,18 +465,18 @@ adapt.xmldoc.Predicate.prototype.withAttribute = function(name, value) {
  * @return {adapt.xmldoc.Predicate}
  */
 adapt.xmldoc.Predicate.prototype.withChild = function(name, opt_childPredicate) {
-	var self = this;
-	return new adapt.xmldoc.Predicate(function(node) {
-		if (!self.check(node)) {
-			return false;
-		}
-		var list = new adapt.xmldoc.NodeList([node]);
-		list = list.child(name);
-		if (opt_childPredicate) {
-			list = list.predicate(opt_childPredicate);
-		}
-		return list.size() > 0;
-	});
+    var self = this;
+    return new adapt.xmldoc.Predicate(function(node) {
+        if (!self.check(node)) {
+            return false;
+        }
+        var list = new adapt.xmldoc.NodeList([node]);
+        list = list.child(name);
+        if (opt_childPredicate) {
+            list = list.predicate(opt_childPredicate);
+        }
+        return list.size() > 0;
+    });
 };
 
 /**
@@ -490,79 +490,79 @@ adapt.xmldoc.predicate = new adapt.xmldoc.Predicate(function(node) {return true;
  * @constructor
  */
 adapt.xmldoc.NodeList = function(nodes) {
-	/** @const */ this.nodes = nodes;
+    /** @const */ this.nodes = nodes;
 };
 
 /**
  * @return {Array.<!Node>}
  */
 adapt.xmldoc.NodeList.prototype.asArray = function() {
-	return this.nodes;
+    return this.nodes;
 };
 
 /**
  * @return {number}
  */
 adapt.xmldoc.NodeList.prototype.size = function() {
-	return this.nodes.length;
+    return this.nodes.length;
 };
 
 /**
  * Filter with predicate
  * @param {adapt.xmldoc.Predicate} pr
  * @return {adapt.xmldoc.NodeList}
- */ 
+ */
 adapt.xmldoc.NodeList.prototype.predicate = function(pr) {
-	var arr = [];
-	for (var i = 0; i < this.nodes.length; i++) {
-		var n = this.nodes[i];
-		if (pr.check(n)) {
-			arr.push(n);
-		}
-	}
-	return new adapt.xmldoc.NodeList(arr);
+    var arr = [];
+    for (var i = 0; i < this.nodes.length; i++) {
+        var n = this.nodes[i];
+        if (pr.check(n)) {
+            arr.push(n);
+        }
+    }
+    return new adapt.xmldoc.NodeList(arr);
 };
 
 /**
  * @param {function(!Node,function(!Node):void):void} fn
  * @return {adapt.xmldoc.NodeList}
- */ 
+ */
 adapt.xmldoc.NodeList.prototype.forEachNode = function(fn) {
-	var arr = [];
-	var add = /** @param {!Node} n */ function(n) {arr.push(n);};
-	for (var i = 0; i < this.nodes.length; i++) {
-		fn(this.nodes[i], add);
-	}
-	return new adapt.xmldoc.NodeList(arr);
+    var arr = [];
+    var add = /** @param {!Node} n */ function(n) {arr.push(n);};
+    for (var i = 0; i < this.nodes.length; i++) {
+        fn(this.nodes[i], add);
+    }
+    return new adapt.xmldoc.NodeList(arr);
 };
 
 /**
  * @template T
  * @param {function(!Node):T} fn
  * @return {Array.<T>}
- */ 
+ */
 adapt.xmldoc.NodeList.prototype.forEach = function(fn) {
-	var arr = [];
-	for (var i = 0; i < this.nodes.length; i++) {
-		arr.push(fn(this.nodes[i]));
-	}
-	return arr;
+    var arr = [];
+    for (var i = 0; i < this.nodes.length; i++) {
+        arr.push(fn(this.nodes[i]));
+    }
+    return arr;
 };
 
 /**
  * @template T
  * @param {function(!Node):T} fn
  * @return {Array.<T>}
- */ 
+ */
 adapt.xmldoc.NodeList.prototype.forEachNonNull = function(fn) {
-	var arr = [];
-	for (var i = 0; i < this.nodes.length; i++) {
-		var t = fn(this.nodes[i]);
-		if (t != null) {
-			arr.push(t);
-		}
-	}
-	return arr;
+    var arr = [];
+    for (var i = 0; i < this.nodes.length; i++) {
+        var t = fn(this.nodes[i]);
+        if (t != null) {
+            arr.push(t);
+        }
+    }
+    return arr;
 };
 
 /**
@@ -570,26 +570,26 @@ adapt.xmldoc.NodeList.prototype.forEachNonNull = function(fn) {
  * @return {adapt.xmldoc.NodeList}
  */
 adapt.xmldoc.NodeList.prototype.child = function(tag) {
-	return this.forEachNode(function(node, add) {
-		for (var c = node.firstChild; c; c = c.nextSibling) {
-			if (c.localName == tag) {
-				add(c);
-			}
-		}
-	});
+    return this.forEachNode(function(node, add) {
+        for (var c = node.firstChild; c; c = c.nextSibling) {
+            if (c.localName == tag) {
+                add(c);
+            }
+        }
+    });
 };
 
 /**
  * @return {adapt.xmldoc.NodeList}
  */
 adapt.xmldoc.NodeList.prototype.childElements = function() {
-	return this.forEachNode(function(node, add) {
-		for (var c = node.firstChild; c; c = c.nextSibling) {
-			if (c.nodeType == 1) {
-				add(c);
-			}
-		}
-	});
+    return this.forEachNode(function(node, add) {
+        for (var c = node.firstChild; c; c = c.nextSibling) {
+            if (c.nodeType == 1) {
+                add(c);
+            }
+        }
+    });
 };
 
 /**
@@ -597,19 +597,19 @@ adapt.xmldoc.NodeList.prototype.childElements = function() {
  * @return {Array.<?string>}
  */
 adapt.xmldoc.NodeList.prototype.attribute = function(name) {
-	return this.forEachNonNull(function(node) {
-		if (node.nodeType == 1) {
-			return (/** @type {Element} */ (node)).getAttribute(name);
-		}
-		return null;
-	});
+    return this.forEachNonNull(function(node) {
+        if (node.nodeType == 1) {
+            return (/** @type {Element} */ (node)).getAttribute(name);
+        }
+        return null;
+    });
 };
 
 /**
  * @return {Array.<?string>}
  */
 adapt.xmldoc.NodeList.prototype.textContent = function() {
-	return this.forEach(function(node) {
-		return node.textContent;
-	});
+    return this.forEach(function(node) {
+        return node.textContent;
+    });
 };

--- a/src/debug-param.js
+++ b/src/debug-param.js
@@ -1,5 +1,6 @@
 /**
  * Copyright 2015 Vivliostyle Inc.
  */
+/*globals CLOSURE_NO_DEPS: true */
 
 CLOSURE_NO_DEPS = true;

--- a/src/source-list.js
+++ b/src/source-list.js
@@ -1,6 +1,7 @@
 /**
  * Copyright 2015 Vivliostyle Inc.
  */
+/*eslint-env node */
 (function() {
     "use strict";
 

--- a/src/vivliostyle/counters.js
+++ b/src/vivliostyle/counters.js
@@ -171,7 +171,7 @@ goog.scope(function() {
         }
         return new adapt.expr.Native(this.pageScope, function() {
             return format(getCounterNumbers());
-        }, "page-counters-" + name)
+        }, "page-counters-" + name);
     };
 
     /**
@@ -238,7 +238,7 @@ goog.scope(function() {
                         self.counterStore.resolveReference(transformedId);
                         if (pageCounters[name]) {
                             var pageCountersOfName = pageCounters[name];
-                            return format(pageCountersOfName[pageCountersOfName.length - 1] || null)
+                            return format(pageCountersOfName[pageCountersOfName.length - 1] || null);
                         } else {
                             // No corresponding counter with the name.
                             return format(0);

--- a/src/vivliostyle/display.js
+++ b/src/vivliostyle/display.js
@@ -67,6 +67,7 @@ goog.scope(function() {
      */
     vivliostyle.display.getComputedDislayValue = function(display, position, float, isRoot) {
         if (display === adapt.css.ident.none) {
+            // no need to convert values when 'display' is 'none'
         } else if (vivliostyle.display.isAbsolutelyPositioned(position)) {
             float = adapt.css.ident.none;
             display = vivliostyle.display.blockify(display);
@@ -108,7 +109,7 @@ goog.scope(function() {
         return (!!float && float !== adapt.css.ident.none) ||
             vivliostyle.display.isAbsolutelyPositioned(position) ||
             (display === adapt.css.ident.inline_block || display === adapt.css.ident.table_cell || display === adapt.css.ident.table_caption || display == adapt.css.ident.flex) ||
-            ((display === adapt.css.ident.block || display === adapt.css.ident.list_item ) &&
+            ((display === adapt.css.ident.block || display === adapt.css.ident.list_item) &&
                 (!!overflow && overflow !== adapt.css.ident.visible) ||
                 (!!parentWritingMode && writingMode !== parentWritingMode));
     };

--- a/src/vivliostyle/logical.js
+++ b/src/vivliostyle/logical.js
@@ -182,5 +182,5 @@ goog.scope(function() {
             }
         }
         return value;
-    }
+    };
 });

--- a/src/vivliostyle/namespace.js
+++ b/src/vivliostyle/namespace.js
@@ -2,6 +2,7 @@
  * Copyright 2015 Vivliostyle Inc.
  * @fileoverview Setup namespace for Vivliostyle.
  */
+/*globals enclosingObject */
 goog.provide("vivliostyle.namespace");
 
 /**

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -150,7 +150,7 @@ vivliostyle.page.resolvePageSizeAndBleed = function(style) {
         if (marks) {
             var hasCrop = false;
             if (marks.value.isSpaceList()) {
-                hasCrop = marks.value.values.some(function(v) { return v === adapt.css.ident.crop});
+                hasCrop = marks.value.values.some(function(v) { return v === adapt.css.ident.crop;});
             } else {
                 hasCrop = marks.value === adapt.css.ident.crop;
             }
@@ -389,7 +389,7 @@ vivliostyle.page.addPrinterMarks = function(cascadedPageStyle, evaluatedPageSize
                 } else if (v === adapt.css.ident.cross) {
                     cross = true;
                 }
-            })
+            });
         } else if (value === adapt.css.ident.crop) {
             crop = true;
         } else if (value === adapt.css.ident.cross) {
@@ -1681,7 +1681,7 @@ vivliostyle.page.PageMarginBoxPartitionInstance.prototype.positionAndSizeAlongFi
         } else if (insideName === "top") {
             style["top"] = new adapt.css.Expr(adapt.expr.add(scope, dim.marginTop, dim.borderBoxHeight));
         }
-};
+    };
 
 /**
  * @override
@@ -2256,7 +2256,8 @@ vivliostyle.page.PageParserHandler.prototype.startRuleBody = function() {
  */
 vivliostyle.page.PageParserHandler.prototype.simpleProperty = function(name, value, important) {
     // we limit 'bleed' and 'marks' to be effective only when specified without page selectors
-    if ((name === "bleed" || name === "marks") && !this.currentPageSelectors.some(function(s) {
+    if ((name === "bleed" || name === "marks") &&
+        !this.currentPageSelectors.some(function(s) {
             return s.selectors === null;
         })) {
         return;
@@ -2289,7 +2290,7 @@ vivliostyle.page.PageParserHandler.prototype.simpleProperty = function(name, val
                 props = pageProps[selector] = /** @type {!adapt.csscasc.ElementStyle} */ ({});
                 adapt.csscasc.setProp(props, name, result);
                 if (noPageSelectorProps) {
-                    ["bleed", "marks"].forEach(function (n) {
+                    ["bleed", "marks"].forEach(function(n) {
                         if (noPageSelectorProps[n]) {
                             adapt.csscasc.setProp(props, n, noPageSelectorProps[n]);
                         }

--- a/src/vivliostyle/plugin.js
+++ b/src/vivliostyle/plugin.js
@@ -49,7 +49,7 @@ goog.scope(function() {
      */
     vivliostyle.plugin.registerHook = function(name, fn) {
         if (!HOOKS[name]) {
-            vivliostyle.logging.logger.warn(new Error("Skipping unknown plugin hook '" + name + "'."))
+            vivliostyle.logging.logger.warn(new Error("Skipping unknown plugin hook '" + name + "'."));
         } else {
             var hooksForName = vivliostyle.plugin.hooks[name];
             if (!hooksForName) {
@@ -67,7 +67,7 @@ goog.scope(function() {
      */
     vivliostyle.plugin.removeHook = function(name, fn) {
         if (!HOOKS[name]) {
-            vivliostyle.logging.logger.warn(new Error("Ignoring unknown plugin hook '" + name + "'."))
+            vivliostyle.logging.logger.warn(new Error("Ignoring unknown plugin hook '" + name + "'."));
         } else {
             var hooksForName = vivliostyle.plugin.hooks[name];
             if (hooksForName) {

--- a/src/vivliostyle/viewerapp.js
+++ b/src/vivliostyle/viewerapp.js
@@ -22,7 +22,7 @@ goog.require('adapt.viewer');
  * @param {adapt.base.JSON} cmd
  */
 vivliostyle.viewerapp.sendCommand = function(cmd) {
-	window["adapt_command"](cmd);
+    window["adapt_command"](cmd);
 };
 
 vivliostyle.viewerapp.navigateToLeftPage = function() {
@@ -75,16 +75,16 @@ vivliostyle.viewerapp.keydown = function(evt) {
         vivliostyle.viewerapp.sendCommand({"a": "configure", "fontSize": Math.round(vivliostyle.viewerapp.fontSize)});
         evt.preventDefault();
         /*
-    } else if (key === "n" || keyIdentifier === "U+004E") {
-        // N - night toggle
-        self.pref.nightMode = !self.pref.nightMode;
-        self.viewport = null;
-        self.resize().thenFinish(frame);
-    } else if (key === "v" || keyIdentifier === "U+0056") {
-        self.pref.horizontal = !self.pref.horizontal;
-        self.viewport = null;
-        self.resize().thenFinish(frame);
-        */
+         } else if (key === "n" || keyIdentifier === "U+004E") {
+         // N - night toggle
+         self.pref.nightMode = !self.pref.nightMode;
+         self.viewport = null;
+         self.resize().thenFinish(frame);
+         } else if (key === "v" || keyIdentifier === "U+0056") {
+         self.pref.horizontal = !self.pref.horizontal;
+         self.viewport = null;
+         self.resize().thenFinish(frame);
+         */
     } else if (key === "t" || keyIdentifier === "U+0054") {
         vivliostyle.viewerapp.sendCommand({"a": "toc", "v": "toggle", "autohide": true});
         evt.preventDefault();
@@ -106,103 +106,103 @@ vivliostyle.viewerapp.keydown = function(evt) {
  * @return {void}
  */
 vivliostyle.viewerapp.touch = function(evt) {
-	if (evt.type == "touchmove") {
-		evt.preventDefault();
-	}
-	if (evt.touches.length == 1) {
-		var x = evt.touches[0].pageX;
-		var y = evt.touches[0].pageY;
-		if (evt.type == "touchstart") {
-			vivliostyle.viewerapp.touchActive = true;
-			vivliostyle.viewerapp.touchX = x;
-			vivliostyle.viewerapp.touchY = y;
-		} else if (vivliostyle.viewerapp.touchActive) {
-			var dx = x - vivliostyle.viewerapp.touchX;
-			var dy = y - vivliostyle.viewerapp.touchY;
-			if (evt.type == "touchend") {
-				vivliostyle.viewerapp.touchActive = false;
-			}
-			if (Math.abs(dy) < 0.5 * Math.abs(dx) && Math.abs(dx) > 15) {
-				vivliostyle.viewerapp.touchActive = false;
-				if (dx > 0) {
-			    	vivliostyle.viewerapp.sendCommand({
+    if (evt.type == "touchmove") {
+        evt.preventDefault();
+    }
+    if (evt.touches.length == 1) {
+        var x = evt.touches[0].pageX;
+        var y = evt.touches[0].pageY;
+        if (evt.type == "touchstart") {
+            vivliostyle.viewerapp.touchActive = true;
+            vivliostyle.viewerapp.touchX = x;
+            vivliostyle.viewerapp.touchY = y;
+        } else if (vivliostyle.viewerapp.touchActive) {
+            var dx = x - vivliostyle.viewerapp.touchX;
+            var dy = y - vivliostyle.viewerapp.touchY;
+            if (evt.type == "touchend") {
+                vivliostyle.viewerapp.touchActive = false;
+            }
+            if (Math.abs(dy) < 0.5 * Math.abs(dx) && Math.abs(dx) > 15) {
+                vivliostyle.viewerapp.touchActive = false;
+                if (dx > 0) {
+                    vivliostyle.viewerapp.sendCommand({
                         "a": "moveTo",
                         "where": vivliostyle.viewerapp.currentPageProgression === vivliostyle.constants.PageProgression.LTR ? "previous" : "next"
                     });
-				} else {
-			    	vivliostyle.viewerapp.sendCommand({
+                } else {
+                    vivliostyle.viewerapp.sendCommand({
                         "a": "moveTo",
                         "where": vivliostyle.viewerapp.currentPageProgression === vivliostyle.constants.PageProgression.LTR ? "next" : "previous"
                     });
-				}
-			}
-		}
-	} else if (evt.touches.length == 2) {
-		var px = evt.touches[0].pageX - evt.touches[1].pageX;
-		var py = evt.touches[0].pageY - evt.touches[1].pageY;
-		var pinchDist = Math.sqrt(px*px + py*py);
-		if (evt.type == "touchstart") {
-			vivliostyle.viewerapp.zoomActive = true;
-			vivliostyle.viewerapp.zoomDist = pinchDist;
-		} else if (vivliostyle.viewerapp.zoomActive) {
-			if (evt.type == "touchend") {
-				vivliostyle.viewerapp.zoomActive = false;
-			}
-			var scale = pinchDist / vivliostyle.viewerapp.zoomDist;
-			if (scale > 1.5) {
-		    	vivliostyle.viewerapp.fontSize *= 1.2;
-		    	vivliostyle.viewerapp.sendCommand({"a": "configure", "fontSize": Math.round(vivliostyle.viewerapp.fontSize)});
-			} else if (scale < 1/1.5) {
-		    	vivliostyle.viewerapp.fontSize *= 1.2;
-		    	vivliostyle.viewerapp.sendCommand({"a": "configure", "fontSize": Math.round(vivliostyle.viewerapp.fontSize)});
-			}
-		}
-	}
+                }
+            }
+        }
+    } else if (evt.touches.length == 2) {
+        var px = evt.touches[0].pageX - evt.touches[1].pageX;
+        var py = evt.touches[0].pageY - evt.touches[1].pageY;
+        var pinchDist = Math.sqrt(px*px + py*py);
+        if (evt.type == "touchstart") {
+            vivliostyle.viewerapp.zoomActive = true;
+            vivliostyle.viewerapp.zoomDist = pinchDist;
+        } else if (vivliostyle.viewerapp.zoomActive) {
+            if (evt.type == "touchend") {
+                vivliostyle.viewerapp.zoomActive = false;
+            }
+            var scale = pinchDist / vivliostyle.viewerapp.zoomDist;
+            if (scale > 1.5) {
+                vivliostyle.viewerapp.fontSize *= 1.2;
+                vivliostyle.viewerapp.sendCommand({"a": "configure", "fontSize": Math.round(vivliostyle.viewerapp.fontSize)});
+            } else if (scale < 1/1.5) {
+                vivliostyle.viewerapp.fontSize *= 1.2;
+                vivliostyle.viewerapp.sendCommand({"a": "configure", "fontSize": Math.round(vivliostyle.viewerapp.fontSize)});
+            }
+        }
+    }
 };
 
 vivliostyle.viewerapp.callback = function(msg) {
-	switch (msg["t"]) {
-	case "loaded" :
-        var viewer = msg["viewer"];
-        var pageProgression = vivliostyle.viewerapp.currentPageProgression
-            = viewer.getCurrentPageProgression();
-        viewer.viewportElement.setAttribute("data-vivliostyle-page-progression", pageProgression);
-        viewer.viewportElement.setAttribute("data-vivliostyle-spread-view", viewer.pref.spreadView);
+    switch (msg["t"]) {
+        case "loaded" :
+            var viewer = msg["viewer"];
+            var pageProgression = vivliostyle.viewerapp.currentPageProgression
+                = viewer.getCurrentPageProgression();
+            viewer.viewportElement.setAttribute("data-vivliostyle-page-progression", pageProgression);
+            viewer.viewportElement.setAttribute("data-vivliostyle-spread-view", viewer.pref.spreadView);
 
-        window.addEventListener("keydown", /** @type {Function} */ (vivliostyle.viewerapp.keydown), false);
+            window.addEventListener("keydown", /** @type {Function} */ (vivliostyle.viewerapp.keydown), false);
 //        window.addEventListener("touchstart", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
 //        window.addEventListener("touchmove", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
 //        window.addEventListener("touchend", /** @type {Function} */ (vivliostyle.viewerapp.touch), false);
 
-        document.body.setAttribute("data-vivliostyle-viewer-status", "complete");
+            document.body.setAttribute("data-vivliostyle-viewer-status", "complete");
 
-        var leftButton = document.getElementById("vivliostyle-page-navigation-left");
-        leftButton.addEventListener("click", /** @type {Function} */ (vivliostyle.viewerapp.navigateToLeftPage), false);
-        var rightButton = document.getElementById("vivliostyle-page-navigation-right");
-        rightButton.addEventListener("click", /** @type {Function} */ (vivliostyle.viewerapp.navigateToRightPage), false);
-        [leftButton, rightButton].forEach(function(button) {
-            button.setAttribute("data-vivliostyle-ui-state", "attention");
-            window.setTimeout(function() {
-                button.removeAttribute("data-vivliostyle-ui-state");
-            }, 1000);
-        });
+            var leftButton = document.getElementById("vivliostyle-page-navigation-left");
+            leftButton.addEventListener("click", /** @type {Function} */ (vivliostyle.viewerapp.navigateToLeftPage), false);
+            var rightButton = document.getElementById("vivliostyle-page-navigation-right");
+            rightButton.addEventListener("click", /** @type {Function} */ (vivliostyle.viewerapp.navigateToRightPage), false);
+            [leftButton, rightButton].forEach(function(button) {
+                button.setAttribute("data-vivliostyle-ui-state", "attention");
+                window.setTimeout(function() {
+                    button.removeAttribute("data-vivliostyle-ui-state");
+                }, 1000);
+            });
 
-		break;
-	case "error" :
-        // adapt.base.log("Error: " + msg["content"]);
-		break;
-	case "nav" :
-		var cfi = msg["cfi"];
-		if (cfi) {
-			location.replace(adapt.base.setURLParam(location.href,
-				"f", adapt.base.lightURLEncode(cfi || "")));
-		}
-		break;
-	case "hyperlink" :
-		if (msg["internal"]) {
-	    	vivliostyle.viewerapp.sendCommand({"a": "moveTo", "url": msg["href"]});			
-		}
-	}
+            break;
+        case "error" :
+            // adapt.base.log("Error: " + msg["content"]);
+            break;
+        case "nav" :
+            var cfi = msg["cfi"];
+            if (cfi) {
+                location.replace(adapt.base.setURLParam(location.href,
+                    "f", adapt.base.lightURLEncode(cfi || "")));
+            }
+            break;
+        case "hyperlink" :
+            if (msg["internal"]) {
+                vivliostyle.viewerapp.sendCommand({"a": "moveTo", "url": msg["href"]});
+            }
+    }
 };
 
 /**

--- a/test/conf/karma-common.conf.js
+++ b/test/conf/karma-common.conf.js
@@ -1,14 +1,17 @@
+/*eslint-env node */
+var sourceFiles = require("../../src/source-list").map(function(src) {
+    return "src/" + src;
+});
+
+var testFiles = [
+    "test/util/dom.js",
+    "test/util/matchers.js",
+    "test/util/mock/vivliostyle/logging-mock.js",
+    "test/util/mock/vivliostyle/plugin-mock.js",
+    "test/spec/**/*.js"
+];
+
 module.exports = function(config) {
-    var sourceFiles = require("../../src/source-list").map(function(src) {
-        return "src/" + src;
-    });
-    var testFiles = [
-        "test/util/dom.js",
-        "test/util/matchers.js",
-        "test/util/mock/vivliostyle/logging-mock.js",
-        "test/util/mock/vivliostyle/plugin-mock.js",
-        "test/spec/**/*.js"
-    ];
     return {
         basePath: "../..",
         frameworks: ["jasmine"],

--- a/test/conf/karma-local.conf.js
+++ b/test/conf/karma-local.conf.js
@@ -1,3 +1,5 @@
+/*eslint-env node */
+/*eslint global-require: "off" */
 module.exports = function(config) {
     var commonConfig = (require("./karma-common.conf"))(config);
 

--- a/test/conf/karma-sauce.conf.js
+++ b/test/conf/karma-sauce.conf.js
@@ -1,3 +1,5 @@
+/*eslint-env node */
+/*eslint global-require: "off", no-process-env: "off" */
 module.exports = function(config) {
     var commonConfig = (require("./karma-common.conf"))(config);
     var customLaunchers = {
@@ -7,9 +9,9 @@ module.exports = function(config) {
             platform: "Windows 10"
         },
         sl_firefox: {
-           base: "SauceLabs",
-           browserName: "firefox",
-           platform: "Windows 10"
+            base: "SauceLabs",
+            browserName: "firefox",
+            platform: "Windows 10"
         },
         sl_safari: {
             base: "SauceLabs",

--- a/test/spec/adapt/csscasc-spec.js
+++ b/test/spec/adapt/csscasc-spec.js
@@ -928,6 +928,6 @@ describe("csscasc", function() {
                 expect(action).toEqual(jasmine.any(adapt.csscasc.CheckConditionAction));
                 expect(action.condition).toBe("");
             });
-        })
+        });
     });
 });

--- a/test/spec/adapt/cssparse-spec.js
+++ b/test/spec/adapt/cssparse-spec.js
@@ -7,7 +7,7 @@ describe("cssparse", function() {
                 spyOn(handler, "error");
                 spyOn(handler, "pseudoclassSelector");
                 spyOn(handler, "startFuncWithSelector");
-                spyOn(handler, "endFuncWithSelector");                                
+                spyOn(handler, "endFuncWithSelector");
             });
 
             function parse(done, text, fn) {
@@ -388,7 +388,7 @@ describe("cssparse", function() {
                     parse(done, ":nth-child(-n-10) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("nth-child", [-1, -10]);
-                    })
+                    });
                 });
 
                 it("reject invalid identifier", function(done) {
@@ -445,14 +445,14 @@ describe("cssparse", function() {
                     parse(done, ":not(h1) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
-                        expect(handler.endFuncWithSelector).toHaveBeenCalled();                        
+                        expect(handler.endFuncWithSelector).toHaveBeenCalled();
                     });
                 });
                 it("can take attribute selector", function(done) {
                     parse(done, ":not([attr='foobar']) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
-                        expect(handler.endFuncWithSelector).toHaveBeenCalled();                        
+                        expect(handler.endFuncWithSelector).toHaveBeenCalled();
                     });
                 });
                 it("can take class selector", function(done) {
@@ -466,14 +466,14 @@ describe("cssparse", function() {
                     parse(done, ":not(#content) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
-                        expect(handler.endFuncWithSelector).toHaveBeenCalled();                        
+                        expect(handler.endFuncWithSelector).toHaveBeenCalled();
                     });
                 });
                 it("can take pseudo-class selector", function(done) {
                     parse(done, ":not(:lang(ja)) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("lang", ["ja"]);                        
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("lang", ["ja"]);
                         expect(handler.endFuncWithSelector).toHaveBeenCalled();
                     });
                 });
@@ -481,29 +481,29 @@ describe("cssparse", function() {
                     parse(done, ":not(div:lang(ja)) {}", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
-                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("lang", ["ja"]);                        
+                        expect(handler.pseudoclassSelector).toHaveBeenCalledWith("lang", ["ja"]);
                         expect(handler.endFuncWithSelector).toHaveBeenCalled();
                     });
                 });
                 it("error if selector is invalid", function(done) {
                     parse(done, ":not(.) {}", function() {
-                        expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");                        
+                        expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
                         expect(handler.error).toHaveBeenCalled();
-                        expect(handler.endFuncWithSelector).not.toHaveBeenCalled();                        
+                        expect(handler.endFuncWithSelector).not.toHaveBeenCalled();
                     });
                 });
                 it("error if multiple selectors", function(done) {
                     parse(done, ":not(div, .foo) {}", function() {
-                        expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");                        
+                        expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
                         expect(handler.error).toHaveBeenCalled();
-                        expect(handler.endFuncWithSelector).not.toHaveBeenCalled();                        
+                        expect(handler.endFuncWithSelector).not.toHaveBeenCalled();
                     });
                 });
                 it("error if adjacent selector is specified", function(done) {
                     parse(done, ":not(div + .foo) {}", function() {
-                        expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");                        
+                        expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
                         expect(handler.error).toHaveBeenCalled();
-                        expect(handler.endFuncWithSelector).not.toHaveBeenCalled();                        
+                        expect(handler.endFuncWithSelector).not.toHaveBeenCalled();
                     });
                 });
             });
@@ -513,7 +513,7 @@ describe("cssparse", function() {
                         expect(handler.error).not.toHaveBeenCalled();
                         expect(handler.pseudoclassSelector).toHaveBeenCalledWith("empty", null);
                     });
-                })
+                });
             });
         });
     });

--- a/test/spec/adapt/cssvalid-spec.js
+++ b/test/spec/adapt/cssvalid-spec.js
@@ -1,126 +1,126 @@
 describe("cssvalid", function() {
-  describe("ValidatorSet", function() {
-    it("should parse simple validator and simple rule", function(done) {
-      var validatorSet = new adapt.cssvalid.ValidatorSet();
-      validatorSet.initBuiltInValidators();
-      validatorSet.parse("foo-or = bar | [ baz || biz ];");
-      var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
-	    		                                           validatorSet, true);
-      var warnListener = jasmine.createSpy("warn listener");
-      vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
-      adapt.task.start(function() {
-        adapt.cssparse.parseStylesheetFromText(
-          ".test { foo-or: bar; }\n.test2 { foo-or: baz biz; }", handler, null, null, null).then(
-          function(result) {
-            expect(result).toBe(true);
-            expect(warnListener).not.toHaveBeenCalled();
-            done();
-          });
-      });
-    });
-    it("should parse validator and space rule", function(done) {
-      var validatorSet = new adapt.cssvalid.ValidatorSet();
-      validatorSet.initBuiltInValidators();
-      validatorSet.parse("foo = SPACE(IDENT+);");
-      var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
-	    		                                           validatorSet, true);
-      var warnListener = jasmine.createSpy("warn listener");
-      vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
-      adapt.task.start(function() {
-        adapt.cssparse.parseStylesheetFromText(
-          ".test { foo: bar; }\n.test2 { foo: bar baz boo; }", handler, null, null, null).then(
-          function(result) {
-            expect(result).toBe(true);
-            expect(warnListener).not.toHaveBeenCalled();
-            done();
-          });
-      });
-    });
-
-    it("should parse validator and comma rule", function(done) {
-      var validatorSet = new adapt.cssvalid.ValidatorSet();
-      validatorSet.initBuiltInValidators();
-      validatorSet.parse("foo = COMMA( IDENT+ );");
-      var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
-	    		                                           validatorSet, true);
-      var warnListener = jasmine.createSpy("warn listener");
-      vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
-      adapt.task.start(function() {
-        adapt.cssparse.parseStylesheetFromText(
-          ".test { foo: bar,baz; }\n .test2{ foo: bar; }", handler, null, null, null).then(
-          function(result) {
-            expect(result).toBe(true);
-            expect(warnListener).not.toHaveBeenCalled();
-            done();
-          });
-      });
-    });
-
-    it("should parse validator and complex comma rule", function(done) {
-      var validatorSet = new adapt.cssvalid.ValidatorSet();
-      validatorSet.initBuiltInValidators();
-      validatorSet.parse("foo-comma = none | COMMA( [ bar | baz ]+ );");
-      var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
-	    		                                           validatorSet, true);
-      var warnListener = jasmine.createSpy("warn listener");
-      vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
-      adapt.task.start(function() {
-        adapt.cssparse.parseStylesheetFromText(
-          ".test { foo-comma: none; }\n.test2 { foo-comma: bar,baz; }\n .test3 { foo-comma: bar; }", handler, null, null, null).then(
-          function(result) {
-            expect(result).toBe(true);
-            expect(warnListener).not.toHaveBeenCalled();
-            done();
-          });
-      });
-    });
-
-    it("should parse validator and complex space rule", function(done) {
-      var validatorSet = new adapt.cssvalid.ValidatorSet();
-      validatorSet.initBuiltInValidators();
-      validatorSet.parse("spacefoo = none | SPACE( [ bar | baz ]+ );");
-      var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
-	    		                                           validatorSet, true);
-      var warnListener = jasmine.createSpy("warn listener");
-      vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
-      adapt.task.start(function() {
-        adapt.cssparse.parseStylesheetFromText(
-          ".test { spacefoo: none; }\n.test2 { spacefoo: bar baz; }\n .test3 { spacefoo: bar; }", handler, null, null, null).then(
-          function(result) {
-            expect(result).toBe(true);
-            expect(warnListener).not.toHaveBeenCalled();
-            done();
-          });
-      });
-    });
-    it("should parse rule that contains function", function(done) {
-      var validatorSet = new adapt.cssvalid.ValidatorSet();
-      validatorSet.initBuiltInValidators();
-      var validation_txt = 
-          "THE_VALUE = SPACE(IDENT+);\n" +
-          "PRED_VALUE = [ fff | SPACE(bb bz)];" +
-          "THE_FUNCTION = the-function(PRED_VALUE? THE_VALUE+);\n" +
-          "AC_VALUES = STRING | THE_FUNCTION;" +
-          "accept-function = COMMA(AC_VALUES+);";
-      
-      validatorSet.parse(validation_txt);
-      var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
-	    		                                           validatorSet, true);
-      var warnListener = jasmine.createSpy("warn listener");
-      vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
-      adapt.task.start(function() {
-        adapt.cssparse.parseStylesheetFromText(
-          ".test { accept-function: the-function(foo bar); }\n" +
-            ".test2 { accept-function: the-function(foo bar, bar baz); }\n" +
-            ".test3 { accept-function: the-function(fff, foo bar, bar baz); }\n" +
-            ".test4 { accept-function: the-function(bb bz, foo bar, bar baz); }"                      
-            , handler, null, null, null).then(
-            function(result) {
-              expect(result).toBe(true);
-              expect(warnListener).not.toHaveBeenCalled();
-              done();
+    describe("ValidatorSet", function() {
+        it("should parse simple validator and simple rule", function(done) {
+            var validatorSet = new adapt.cssvalid.ValidatorSet();
+            validatorSet.initBuiltInValidators();
+            validatorSet.parse("foo-or = bar | [ baz || biz ];");
+            var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
+                validatorSet, true);
+            var warnListener = jasmine.createSpy("warn listener");
+            vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
+            adapt.task.start(function() {
+                adapt.cssparse.parseStylesheetFromText(
+                    ".test { foo-or: bar; }\n.test2 { foo-or: baz biz; }", handler, null, null, null).then(
+                    function(result) {
+                        expect(result).toBe(true);
+                        expect(warnListener).not.toHaveBeenCalled();
+                        done();
+                    });
             });
-      });
+        });
+        it("should parse validator and space rule", function(done) {
+            var validatorSet = new adapt.cssvalid.ValidatorSet();
+            validatorSet.initBuiltInValidators();
+            validatorSet.parse("foo = SPACE(IDENT+);");
+            var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
+                validatorSet, true);
+            var warnListener = jasmine.createSpy("warn listener");
+            vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
+            adapt.task.start(function() {
+                adapt.cssparse.parseStylesheetFromText(
+                    ".test { foo: bar; }\n.test2 { foo: bar baz boo; }", handler, null, null, null).then(
+                    function(result) {
+                        expect(result).toBe(true);
+                        expect(warnListener).not.toHaveBeenCalled();
+                        done();
+                    });
+            });
+        });
+
+        it("should parse validator and comma rule", function(done) {
+            var validatorSet = new adapt.cssvalid.ValidatorSet();
+            validatorSet.initBuiltInValidators();
+            validatorSet.parse("foo = COMMA( IDENT+ );");
+            var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
+                validatorSet, true);
+            var warnListener = jasmine.createSpy("warn listener");
+            vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
+            adapt.task.start(function() {
+                adapt.cssparse.parseStylesheetFromText(
+                    ".test { foo: bar,baz; }\n .test2{ foo: bar; }", handler, null, null, null).then(
+                    function(result) {
+                        expect(result).toBe(true);
+                        expect(warnListener).not.toHaveBeenCalled();
+                        done();
+                    });
+            });
+        });
+
+        it("should parse validator and complex comma rule", function(done) {
+            var validatorSet = new adapt.cssvalid.ValidatorSet();
+            validatorSet.initBuiltInValidators();
+            validatorSet.parse("foo-comma = none | COMMA( [ bar | baz ]+ );");
+            var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
+                validatorSet, true);
+            var warnListener = jasmine.createSpy("warn listener");
+            vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
+            adapt.task.start(function() {
+                adapt.cssparse.parseStylesheetFromText(
+                    ".test { foo-comma: none; }\n.test2 { foo-comma: bar,baz; }\n .test3 { foo-comma: bar; }", handler, null, null, null).then(
+                    function(result) {
+                        expect(result).toBe(true);
+                        expect(warnListener).not.toHaveBeenCalled();
+                        done();
+                    });
+            });
+        });
+
+        it("should parse validator and complex space rule", function(done) {
+            var validatorSet = new adapt.cssvalid.ValidatorSet();
+            validatorSet.initBuiltInValidators();
+            validatorSet.parse("spacefoo = none | SPACE( [ bar | baz ]+ );");
+            var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
+                validatorSet, true);
+            var warnListener = jasmine.createSpy("warn listener");
+            vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
+            adapt.task.start(function() {
+                adapt.cssparse.parseStylesheetFromText(
+                    ".test { spacefoo: none; }\n.test2 { spacefoo: bar baz; }\n .test3 { spacefoo: bar; }", handler, null, null, null).then(
+                    function(result) {
+                        expect(result).toBe(true);
+                        expect(warnListener).not.toHaveBeenCalled();
+                        done();
+                    });
+            });
+        });
+        it("should parse rule that contains function", function(done) {
+            var validatorSet = new adapt.cssvalid.ValidatorSet();
+            validatorSet.initBuiltInValidators();
+            var validation_txt =
+                "THE_VALUE = SPACE(IDENT+);\n" +
+                "PRED_VALUE = [ fff | SPACE(bb bz)];" +
+                "THE_FUNCTION = the-function(PRED_VALUE? THE_VALUE+);\n" +
+                "AC_VALUES = STRING | THE_FUNCTION;" +
+                "accept-function = COMMA(AC_VALUES+);";
+
+            validatorSet.parse(validation_txt);
+            var handler = new adapt.csscasc.CascadeParserHandler(null, null, null, null, null,
+                validatorSet, true);
+            var warnListener = jasmine.createSpy("warn listener");
+            vivliostyle.logging.logger.addListener(vivliostyle.logging.LogLevel.WARN, warnListener);
+            adapt.task.start(function() {
+                adapt.cssparse.parseStylesheetFromText(
+                    ".test { accept-function: the-function(foo bar); }\n" +
+                    ".test2 { accept-function: the-function(foo bar, bar baz); }\n" +
+                    ".test3 { accept-function: the-function(fff, foo bar, bar baz); }\n" +
+                    ".test4 { accept-function: the-function(bb bz, foo bar, bar baz); }"
+                    , handler, null, null, null).then(
+                    function(result) {
+                        expect(result).toBe(true);
+                        expect(warnListener).not.toHaveBeenCalled();
+                        done();
+                    });
+            });
+        });
     });
-  });
 });

--- a/test/spec/adapt/xmldoc-spec.js
+++ b/test/spec/adapt/xmldoc-spec.js
@@ -101,7 +101,7 @@ describe("xmldoc", function() {
                 expect(doc.documentElement.localName).toBe("svg");
                 doneSvg = true;
                 complete();
-            })
+            });
         });
 
         it("can parse application/*+xml source as an XML", function(done) {
@@ -112,7 +112,7 @@ describe("xmldoc", function() {
                 var doc = docHolder.document;
                 expect(doc.documentElement.localName).toBe("foo");
                 done();
-            })
+            });
         });
 
         it("can infer contentType from file extension", function(done) {

--- a/test/spec/vivliostyle/page-spec.js
+++ b/test/spec/vivliostyle/page-spec.js
@@ -81,9 +81,9 @@ describe("page", function() {
         });
 
         it("has the default bleed offset value when 'crop' and/or 'cross' value is specified in 'marks' property", function() {
-           var resolved = module.resolvePageSizeAndBleed({
-               marks: new adapt.csscasc.CascadeValue(adapt.css.ident.none, 0)
-           });
+            var resolved = module.resolvePageSizeAndBleed({
+                marks: new adapt.csscasc.CascadeValue(adapt.css.ident.none, 0)
+            });
             expect(resolved).toEqual(expected);
 
             expected.bleedOffset = module.defaultBleedOffset;

--- a/test/spec/vivliostyle/sizing-spec.js
+++ b/test/spec/vivliostyle/sizing-spec.js
@@ -1,5 +1,5 @@
 describe("sizing", function() {
-   "use strict";
+    "use strict";
 
     var domUtil = vivliostyle.test.util.dom;
     var sizing = vivliostyle.sizing;

--- a/test/wpt/wpt.js
+++ b/test/wpt/wpt.js
@@ -50,7 +50,7 @@
         main(config);
     }
 
-    if(window["__loaded"])
+    if (window["__loaded"])
         startViewer();
     else
         window.onload = startViewer;


### PR DESCRIPTION
- Introduced ESLint to check indentation, white spacing and other code styles.
  - The config file `.eslintrc.js` was generated with `eslint --init` first and then modified.
  - `"extends": "eslint:recommended"` is disabled in the config since there are some problems reported by this setting in code. I will try to fix problems gradually and want to enable this setting eventually.
  - ESLint for `src/` and `test/` directories can be run by `npm run lint`
  - `npm run lint` is run on Travis CI before compilation by Closure Compiler (`npm run build`).
- Fixed indentation and white spacing of JavaScript code
  - Indentation in code is fixed to be 4 spaces (not tabs).
  - Some ESLint rules for white spacing are added. See `.eslintrc.js` for details.
- Some rules for code style (no-console, no-empty, no-undef etc.) are also enabled.
- EditorConfig file (`.editorconfig`) is added to automatically set config of editors to satisfy ESLint setting.
