### PR TITLE
Support adding author style sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Additional author style sheets can be injected with 'styleSheet' property of `vivliostyle.viewer.DocumentOptions`.
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/282>
+
 ### Fixed
 - Fix bug that pages occasionally disappear when resolving cross references
   - <https://github.com/vivliostyle/vivliostyle.js/pull/268>

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -675,6 +675,9 @@ adapt.cssparse.SkippingParserHandler = function(scope, owner, topLevel) {
     /** @const */ this.topLevel = topLevel;
     /** @type {number} */ this.depth = 0;
     /** @type {adapt.cssparse.DispatchParserHandler} */ this.owner = owner;
+    if (owner) {
+        this.flavor = owner.flavor;
+    }
 };
 goog.inherits(adapt.cssparse.SkippingParserHandler, adapt.cssparse.ParserHandler);
 

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -1176,7 +1176,7 @@ adapt.ops.OPSDocStore = function(fontDeobfuscator) {
     /** @type {Object.<string,adapt.ops.Style>} */ this.styleByDocURL = {};
     /** @type {Object.<string,Array.<adapt.vtree.Trigger>>} */ this.triggersByDocURL = {};
     /** @type {adapt.cssvalid.ValidatorSet} */ this.validatorSet = null;
-    /** @private @const @type {Array.<adapt.ops.StyleSource>} */ this.userStyleSheets = [];
+    /** @private @const @type {Array.<adapt.ops.StyleSource>} */ this.styleSheets = [];
 };
 goog.inherits(adapt.ops.OPSDocStore, adapt.net.ResourceStore);
 
@@ -1217,8 +1217,16 @@ adapt.ops.OPSDocStore.prototype.getTriggersForDoc = function(xmldoc) {
 /**
  * @param {{url: ?string, text: ?string}} stylesheet
  */
+adapt.ops.OPSDocStore.prototype.addAuthorStyleSheet = function(stylesheet) {
+    this.styleSheets.push({url: stylesheet.url, text: stylesheet.text,
+        flavor: adapt.cssparse.StylesheetFlavor.AUTHOR, classes: null, media: null});
+};
+
+/**
+ * @param {{url: ?string, text: ?string}} stylesheet
+ */
 adapt.ops.OPSDocStore.prototype.addUserStyleSheet = function(stylesheet) {
-    this.userStyleSheets.push({url: stylesheet.url, text: stylesheet.text,
+    this.styleSheets.push({url: stylesheet.url, text: stylesheet.text,
         flavor: adapt.cssparse.StylesheetFlavor.USER, classes: null, media: null});
 };
 
@@ -1253,9 +1261,6 @@ adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
         var userAgentURL = adapt.base.resolveURL("user-agent-page.css", adapt.base.resourceBaseURL);
         sources.push({url: userAgentURL, text:null,
             flavor:adapt.cssparse.StylesheetFlavor.USER_AGENT, classes: null, media: null});
-        for (var i = 0; i < self.userStyleSheets.length; i++) {
-            sources.push(self.userStyleSheets[i]);
-        }
         var head = xmldoc.head;
         if (head) {
             for (var c = head.firstChild; c; c = c.nextSibling) {
@@ -1303,6 +1308,9 @@ adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
                     }
                 }
             }
+        }
+        for (var i = 0; i < self.styleSheets.length; i++) {
+            sources.push(self.styleSheets[i]);
         }
         var key = "";
         for (var i = 0; i < sources.length; i++) {

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -143,6 +143,7 @@ adapt.viewer.Viewer.prototype.loadEPUB = function(command) {
     var url = /** @type {string} */ (command["url"]);
     var fragment = /** @type {?string} */ (command["fragment"]);
     var haveZipMetadata = !!command["zipmeta"];
+    var authorStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["authorStyleSheet"]);
     var userStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["userStyleSheet"]);
     // force relayout
     this.viewport = null;
@@ -150,6 +151,11 @@ adapt.viewer.Viewer.prototype.loadEPUB = function(command) {
     var self = this;
     self.configure(command).then(function() {
         var store = new adapt.epub.EPUBDocStore();
+        if (authorStyleSheet) {
+            for (var i = 0; i < authorStyleSheet.length; i++) {
+                store.addAuthorStyleSheet(authorStyleSheet[i]);
+            }
+        }
         if (userStyleSheet) {
             for (var i = 0; i < userStyleSheet.length; i++) {
                 store.addUserStyleSheet(userStyleSheet[i]);
@@ -186,6 +192,7 @@ adapt.viewer.Viewer.prototype.loadXML = function(command) {
     /** @type {!Array<!adapt.viewer.SingleDocumentParam>} */ var params = command["url"];
     var doc = /** @type {Document} */ (command["document"]);
     var fragment = /** @type {?string} */ (command["fragment"]);
+    var authorStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["authorStyleSheet"]);
     var userStyleSheet = /** @type {Array.<{url: ?string, text: ?string}>} */ (command["userStyleSheet"]);
     // force relayout
     this.viewport = null;
@@ -193,6 +200,11 @@ adapt.viewer.Viewer.prototype.loadXML = function(command) {
     var self = this;
     self.configure(command).then(function() {
         var store = new adapt.epub.EPUBDocStore();
+        if (authorStyleSheet) {
+            for (var i = 0; i < authorStyleSheet.length; i++) {
+                store.addAuthorStyleSheet(authorStyleSheet[i]);
+            }
+        }
         if (userStyleSheet) {
             for (var i = 0; i < userStyleSheet.length; i++) {
                 store.addUserStyleSheet(userStyleSheet[i]);

--- a/src/vivliostyle/viewer.js
+++ b/src/vivliostyle/viewer.js
@@ -90,11 +90,13 @@ goog.scope(function() {
      * Options for the displayed document.
      * - documentObject: Document object for the document. If provided, it is used directly without parsing the source again.
      * - fragment: Fragmentation identifier (EPUB CFI) of the location in the document which is to be displayed.
+     * - styleSheet: An array of author style sheets to be injected after all author style sheets referenced from the document. A single stylesheet may be a URL of the style sheet or a text content of the style sheet.
      * - userStyleSheet: An array of user style sheets to be injected. A single stylesheet may be a URL of the style sheet or a text content of the style sheet.
      * @dict
      * @typedef {{
      *     documentObject: (!Document|undefined),
      *     fragment: (string|undefined),
+     *     styleSheet: (!Array<{url: (string|undefined), text: (string|undefined)}>|undefined),
      *     userStyleSheet: (!Array<{url: (string|undefined), text: (string|undefined)}>|undefined)
      * }}
      */
@@ -251,13 +253,19 @@ goog.scope(function() {
      */
     Viewer.prototype.loadDocumentOrEPUB = function(singleDocumentOptions, epubUrl, opt_documentOptions, opt_viewerOptions) {
         var documentOptions = opt_documentOptions || {};
-        var userStyleSheet;
-        var uss = documentOptions["userStyleSheet"];
-        if (uss) {
-            userStyleSheet = uss.map(function(s) {
-                return { url: s.url || null, text: s.text || null};
-            });
+
+        function convertStyleSheetArray(arr) {
+            if (arr) {
+                return arr.map(function(s) {
+                    return { url: s.url || null, text: s.text || null };
+                });
+            } else {
+                return undefined;
+            }
         }
+
+        var authorStyleSheet = convertStyleSheetArray(documentOptions["authorStyleSheet"]);
+        var userStyleSheet = convertStyleSheetArray(documentOptions["userStyleSheet"]);
 
         if (opt_viewerOptions) {
             Object.assign(this.options, opt_viewerOptions);
@@ -271,6 +279,7 @@ goog.scope(function() {
             "url": convertSingleDocumentOptions(singleDocumentOptions) || epubUrl,
             "document": documentOptions["documentObject"],
             "fragment": documentOptions["fragment"],
+            "authorStyleSheet": authorStyleSheet,
             "userStyleSheet": userStyleSheet
         }, convertViewerOptions(this.options));
         this.adaptViewer.initEmbed(command);

--- a/test/wpt/metadata/MANIFEST.json
+++ b/test/wpt/metadata/MANIFEST.json
@@ -429,13 +429,6 @@
         "url": "/css21/floats-clear/floats-015.xht"
       },
       {
-        "path": "css21/floats-clear/floats-019.xht",
-        "references": [
-          ["/css21/floats-clear/floats-019-ref.xht", "=="]
-        ],
-        "url": "/css21/floats-clear/floats-019.xht"
-      },
-      {
         "path": "css21/floats-clear/floats-022.xht",
         "references": [
           ["/css21/floats-clear/floats-022-ref.xht", "=="]

--- a/test/wpt/metadata/MANIFEST_failing.json
+++ b/test/wpt/metadata/MANIFEST_failing.json
@@ -230,6 +230,13 @@
         "url": "/css21/floats-clear/floats-009.xht"
       },
       {
+        "path": "css21/floats-clear/floats-019.xht",
+        "references": [
+          ["/css21/floats-clear/floats-019-ref.xht", "=="]
+        ],
+        "url": "/css21/floats-clear/floats-019.xht"
+      },
+      {
         "path": "css21/floats-clear/floats-028.xht",
         "references": [
           ["/css21/floats-clear/floats-028-ref.xht", "=="]


### PR DESCRIPTION
Author style sheets can be added via `styleSheet` property of `vivliostyle.viewer.DocumentOptions`.
The format of a value of this property is the same as that of `userStyleSheet` property; see #4.
