### PR TITLE
Fix some errors in inheritance calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/issues/276>
 - Fix cross reference bug with name attribute
   - <https://github.com/vivliostyle/vivliostyle.js/issues/278>
+- Avoid error when `inherit` value is used
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/283>
 
 ## [2016.7](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.7) - 2016-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/issues/278>
 - Avoid error when `inherit` value is used
   - <https://github.com/vivliostyle/vivliostyle.js/pull/283>
+- Avoid error when `rem` unit is used
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/283>
 
 ## [2016.7](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.7) - 2016-07-04
 

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -504,6 +504,9 @@ adapt.csscasc.InheritanceVisitor.prototype.visitNumeric = function(numeric) {
     if (numeric.unit == "em" || numeric.unit == "ex") {
         var ratio = this.context.queryUnitSize(numeric.unit, false) / this.context.queryUnitSize("em", false);
         return new adapt.css.Numeric(numeric.num * ratio * this.getFontSize(), "px");
+    } else if (numeric.unit == "rem" || numeric.unit == "rex") {
+        var ratio = this.context.queryUnitSize(numeric.unit, false) / this.context.queryUnitSize("rem", false);
+        return new adapt.css.Numeric(numeric.num * ratio * this.context.fontSize(), "px");
     } else if (numeric.unit == "%") {
         if (this.propName === "font-size") {
             return new adapt.css.Numeric(numeric.num / 100 * this.getFontSize(), "px");

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -496,7 +496,10 @@ adapt.vgen.ViewFactory.prototype.inheritFromSourceParent = function(elementStyle
         for (var k = 0; k < propList.length; k++) {
             var name = propList[k];
             inheritanceVisitor.setPropName(name);
-            props[name] = adapt.csscasc.getProp(style, name).filterValue(inheritanceVisitor);
+            var value = adapt.csscasc.getProp(style, name);
+            if (value.value !== adapt.css.ident.inherit) {
+                props[name] = value.filterValue(inheritanceVisitor);
+            }
         }
     }
     for (var sname in elementStyle) {


### PR DESCRIPTION
Fixed some errors occurring during inheritance calculation by `InheritanceVisitor` when an `inherit` value or a value with `rem` unit is used.
