### PR TITLE
Fix internally generated IDs on elements to conform to the XML specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/283>
 - Fix rem unit inside `position: relative` elements
   - <https://github.com/vivliostyle/vivliostyle.js/issues/242>
+- Fix internally generated IDs on elements to conform to the XML specification
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/295>
+  - Characters which can be used in an ID in an XML document is specified at <https://www.w3.org/TR/xml/#NT-NameStartChar>.
 
 ## [2016.7](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.7) - 2016-07-04
 

--- a/src/adapt/base.js
+++ b/src/adapt/base.js
@@ -507,10 +507,24 @@ adapt.base.isLetter = function(ch) {
 
 /**
  * @param {string} str
+ * @param {string=} prefix
  * @return {string}
  */
-adapt.base.escapeRegexpChar = function(str) {
-    return '\\u' + (0x10000|str.charCodeAt(0)).toString(16).substr(1);
+adapt.base.escapeCharToHex = function(str, prefix) {
+    prefix = typeof prefix === "string" ? prefix : '\\u';
+    return prefix + (0x10000|str.charCodeAt(0)).toString(16).substr(1);
+};
+
+/**
+ * @param {string} str
+ * @param {string=} prefix
+ * @return {string}
+ */
+adapt.base.escapeNameStrToHex = function(str, prefix) {
+    function escapeChar(s) {
+        return adapt.base.escapeCharToHex(s, prefix);
+    }
+    return str.replace(/[^-a-zA-Z0-9_]/g, escapeChar);
 };
 
 /**
@@ -518,7 +532,35 @@ adapt.base.escapeRegexpChar = function(str) {
  * @return {string}
  */
 adapt.base.escapeRegExp = function(str) {
-    return str.replace(/[^-a-zA-Z0-9_]/g, adapt.base.escapeRegexpChar);
+    return adapt.base.escapeNameStrToHex(str);
+};
+
+/**
+ * @param {string} str
+ * @param {string=} prefix
+ * @return {string}
+ */
+adapt.base.unescapeCharFromHex = function(str, prefix) {
+    prefix = typeof prefix === "string" ? prefix : '\\u';
+    if (str.indexOf(prefix) === 0) {
+        return String.fromCharCode(parseInt(str.substring(prefix.length), 16));
+    } else {
+        return str;
+    }
+};
+
+/**
+ * @param {string} str
+ * @param {string=} prefix
+ * @return {string}
+ */
+adapt.base.unescapeStrFromHex = function(str, prefix) {
+    prefix = typeof prefix === "string" ? prefix : '\\u';
+    function unescapeChar(s) {
+        return adapt.base.unescapeCharFromHex(s, prefix);
+    }
+    var regexp = new RegExp(adapt.base.escapeRegExp(prefix) + "[0-9a-fA-F]{4}", "g");
+    return str.replace(regexp, unescapeChar);
 };
 
 /**

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -521,6 +521,9 @@ adapt.epub.supportedMediaTypes = {
     "audio/mp3": true
 };
 
+/** @private @const */
+adapt.epub.transformedIdPrefix = "viv-id-";
+
 /**
  * @constructor
  * @param {adapt.epub.EPUBDocStore} store
@@ -562,7 +565,7 @@ adapt.epub.OPFDoc.prototype.createDocumentURLTransformer = function() {
      */
     OPFDocumentURLTransformer.prototype.transformFragment = function(fragment, baseURL) {
         var url = baseURL + (fragment ? "#" + fragment : "");
-        return encodeURIComponent(url);
+        return adapt.epub.transformedIdPrefix + adapt.base.escapeNameStrToHex(url, ":");
     };
     /**
      * @override
@@ -587,7 +590,10 @@ adapt.epub.OPFDoc.prototype.createDocumentURLTransformer = function() {
         if (encoded.charAt(0) === "#") {
             encoded = encoded.substring(1);
         }
-        var decoded = decodeURIComponent(encoded);
+        if (encoded.indexOf(adapt.epub.transformedIdPrefix) === 0) {
+            encoded = encoded.substring(adapt.epub.transformedIdPrefix.length);
+        }
+        var decoded = adapt.base.unescapeStrFromHex(encoded, ":");
         var r = decoded.match(/^([^#]*)#?(.*)$/);
         return r ? [r[1], r[2]] : [];
     };

--- a/test/spec/adapt/base-spec.js
+++ b/test/spec/adapt/base-spec.js
@@ -1,0 +1,47 @@
+describe("base", function() {
+    var module = adapt.base;
+
+    describe("escapeCharToHex", function() {
+        it("escape the first character to a 4-digit hex code and add the specified prefix", function() {
+            expect(module.escapeCharToHex("a", ":")).toBe(":0061");
+            expect(module.escapeCharToHex(":", ":")).toBe(":003a");
+        });
+
+        it("escape the first character to a 4-digit hex code and add '\\u' prefix when prefix is not specified", function() {
+            expect(module.escapeCharToHex("a")).toBe("\\u0061");
+            expect(module.escapeCharToHex("\\")).toBe("\\u005c");
+        });
+    });
+
+    describe("escapeNameStrToHex", function() {
+        it("escape characters other than [-a-zA-Z0-9_] to 4-digit hex codes and add the specified prefix to each of them", function() {
+            expect(module.escapeNameStrToHex("abc-_:%/\\", ":")).toBe("abc-_:003a:0025:002f:005c");
+        });
+
+        it("escape characters other than [-a-zA-Z0-9_] to 4-digit hex codes and add '\\u' prefix to each of them when prefix is not specified", function() {
+            expect(module.escapeNameStrToHex("abc-_:%/\\")).toBe("abc-_\\u003a\\u0025\\u002f\\u005c");
+        });
+    });
+
+    describe("unescapeCharFromHex", function() {
+        it("unescape a 4-digit hex code with the specified prefix to the original character", function() {
+            expect(module.unescapeCharFromHex(":0061", ":")).toBe("a");
+            expect(module.unescapeCharFromHex(":003a", ":")).toBe(":");
+        });
+
+        it("unescape a 4-digit hex code with '\\u' prefix to the original character when prefix is not specified", function() {
+            expect(module.unescapeCharFromHex("\\u0061")).toBe("a");
+            expect(module.unescapeCharFromHex("\\u005c")).toBe("\\");
+        });
+    });
+
+    describe("unescapeStrFromHex", function() {
+        it("unescape a string containing 4-digit hex codes with the specified prefix to the original string", function() {
+            expect(module.unescapeStrFromHex("abc-_:003a:0025:002f:005c", ":")).toBe("abc-_:%/\\");
+        });
+
+        it("unescape a string containing 4-digit hex codes with '\\u' prefix to the orignal string when prefix is not specified", function() {
+            expect(module.unescapeStrFromHex("abc-_\\u003a\\u0025\\u002f\\u005c")).toBe("abc-_:%/\\");
+        });
+    });
+});

--- a/test/spec/adapt/epub-spec.js
+++ b/test/spec/adapt/epub-spec.js
@@ -1,0 +1,62 @@
+describe("epub", function() {
+    describe("OPFDoc", function() {
+        describe("OPFDocumentURLTransformer", function() {
+            var opfDoc = new adapt.epub.OPFDoc(null, null);
+            opfDoc.items = [
+                {src: "http://example.com:8000/foo/bar1.html"},
+                {src: "http://example.com:8000/foo/bar2.html"}
+            ];
+            var transformer = opfDoc.createDocumentURLTransformer();
+
+            var illegalCharRegexp = /[^-a-zA-Z0-9_:]/;
+
+            describe("transformFragment / restoreURL", function() {
+                var baseURL = "http://base.org:9000/baz.html";
+                var fragment = "some-fragment";
+                var transformed = transformer.transformFragment(fragment, baseURL);
+
+                it("transforms a pair of a fragment and a base URL into an XML ID string", function() {
+                    expect(transformed).not.toMatch(illegalCharRegexp);
+                    expect(transformed.indexOf(adapt.epub.transformedIdPrefix)).toBe(0);
+                });
+
+                it("restores a pair of the original base URL and the original fragment", function() {
+                    var restored = transformer.restoreURL(transformed);
+                    expect(restored).toEqual([baseURL, fragment]);
+
+                    restored = transformer.restoreURL("#" + transformed);
+                    expect(restored).toEqual([baseURL, fragment]);
+                });
+            });
+
+            describe("transformURL", function() {
+                var fragment = "some-fragment";
+
+                it("transforms a URL internal to the document into an XML ID string", function() {
+                    var baseURL = opfDoc.items[1].src;
+
+                    var transformed = transformer.transformURL("#" + fragment, baseURL);
+                    expect(transformed.charAt(0)).toBe("#");
+                    expect(transformed.substring(1)).not.toMatch(illegalCharRegexp);
+
+                    transformed = transformer.transformURL(baseURL + "#" + fragment);
+                    expect(transformed.charAt(0)).toBe("#");
+                    expect(transformed.substring(1)).not.toMatch(illegalCharRegexp);
+
+                    var restored = transformer.restoreURL(transformed);
+                    expect(restored).toEqual([baseURL, fragment]);
+                });
+
+                it("does not transform an external URL", function() {
+                    var baseURL = "http://base.org:9000/baz.html";
+
+                    var transformed = transformer.transformURL("#" + fragment, baseURL);
+                    expect(transformed).toBe("#" + fragment);
+
+                    transformed = transformer.transformURL(baseURL + "#" + fragment);
+                    expect(transformed).toBe(baseURL + "#" + fragment);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Characters which can be used in an ID in an XML document is specified at https://www.w3.org/TR/xml/#NT-NameStartChar.
