### PR TITLE
Fix incorrect treatment of percentage value for line-height property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
           - https://github.com/vivliostyle/vivliostyle.js/issues/157
       - Table breaks occur between the colgroup and the first row
           - https://github.com/vivliostyle/vivliostyle.js/issues/279
+- Fix incorrect treatment of percentage value for line-height property
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/312>
 
 ## [2016.10](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.10) - 2016-10-25
 

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -536,6 +536,8 @@ adapt.csscasc.InheritanceVisitor.prototype.visitNumeric = function(numeric) {
     } else if (numeric.unit == "%") {
         if (this.propName === "font-size") {
             return new adapt.css.Numeric(numeric.num / 100 * this.getFontSize(), "px");
+        } else if (this.propName === "line-height") {
+            return numeric;
         }
         var unit = this.propName.match(/height|^(top|bottom)$/) ? "vh" : "vw";
         return new adapt.css.Numeric(numeric.num, unit);


### PR DESCRIPTION
A percentage value for `line-height` property should be treated to be relative to the element's computed font size. ([Spec](https://drafts.csswg.org/css2/visudet.html#propdef-line-height))