### PR TITLE
Fix incorrect widows behavior with footnote call close to the end of the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/312>
 - Support repeating table header/footer across pages
   - <https://github.com/vivliostyle/vivliostyle.js/pull/319>
+- Fix incorrect widows behavior with footnote call close to the end of the page
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/328>
 
 ## [2016.10](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2016.10) - 2016-10-25
 

--- a/src/adapt/geom.js
+++ b/src/adapt/geom.js
@@ -478,26 +478,25 @@ adapt.geom.shapesToBands = function(box, include, exclude,
             }
         }
     }
-    adapt.geom.normalize(box, result, false);
+    adapt.geom.normalize(box, result);
     return result;
 };
 
 /**
  * @param {adapt.geom.Rect} box
  * @param {Array.<adapt.geom.Band>} bands
- * @param {boolean} keepNonExcludingAtBottom
  * @return {void}
  */
-adapt.geom.normalize = function(box, bands, keepNonExcludingAtBottom) {
+adapt.geom.normalize = function(box, bands) {
     var k = bands.length - 1;
     // Merge bands with the same x1, x2 and remove unneeded bands at the end.
     // Create fictious last band to merge unneeded bands at the end
-    var currBand = new adapt.geom.Band(box.y2, box.y2,
-        (keepNonExcludingAtBottom ? NaN: box.x1), box.x2);
+    var currBand = new adapt.geom.Band(box.y2, box.y2, box.x1, box.x2);
     while (k >= 0) {
         var prevBand = currBand; // result[k+1]
         currBand = bands[k];
-        if (currBand.x1 == prevBand.x1 && currBand.x2 == prevBand.x2) {
+        if ((currBand.y2 - currBand.y1 < 1) || // Remove bands with height less than 1px
+            currBand.x1 == prevBand.x1 && currBand.x2 == prevBand.x2) {
             prevBand.y1 = currBand.y1; // merge
             bands.splice(k, 1);
             currBand = prevBand;
@@ -708,5 +707,5 @@ adapt.geom.addFloatToBands = function(box, bands, floatBox, floatBands, side) {
                 break;
         }
     }
-    adapt.geom.normalize(box, bands, false);
+    adapt.geom.normalize(box, bands);
 };

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1030,6 +1030,7 @@ adapt.layout.Column.prototype.layoutFootnoteInner = function(boxOffset, footnote
             null, null);
         footnoteArea = new adapt.layout.Column(footnoteContainer, layoutContext, self.clientLayout,
             self.layoutConstraint, footnotePageFloatLayoutContext);
+        footnoteArea.forceNonfitting = false;
         footnotePageFloatLayoutContext.setContainer(footnoteArea);
         self.footnoteArea = footnoteArea;
         footnoteArea.vertical = self.layoutContext.applyFootnoteStyle(self.vertical, footnoteContainer);
@@ -2308,9 +2309,10 @@ adapt.layout.Column.prototype.findAcceptableBreakPosition = function() {
 /**
  * @param {adapt.vtree.NodeContext} overflownNodeContext
  * @param {adapt.vtree.NodeContext} initialNodeContext
+ * @param {number} initialComputedBlockSize
  * @return {adapt.task.Result.<adapt.vtree.NodeContext>}
  */
-adapt.layout.Column.prototype.findAcceptableBreak = function(overflownNodeContext, initialNodeContext) {
+adapt.layout.Column.prototype.findAcceptableBreak = function(overflownNodeContext, initialNodeContext, initialComputedBlockSize) {
     /** @type {!adapt.task.Frame.<adapt.vtree.NodeContext>} */ var frame =
         adapt.task.newFrame("findAcceptableBreak");
     var self = this;
@@ -2335,6 +2337,7 @@ adapt.layout.Column.prototype.findAcceptableBreak = function(overflownNodeContex
         } else {
             nodeContext = initialNodeContext;
             forceRemoveSelf = true;
+            self.computedBlockSize = initialComputedBlockSize;
         }
     }
     this.finishBreak(nodeContext, forceRemoveSelf, true).then(function() {
@@ -2982,6 +2985,7 @@ adapt.layout.Column.prototype.layout = function(chunkPosition, leadingEdge, brea
         // ------ start the column -----------
         self.openAllViews(chunkPosition.primary).then(function(nodeContext) {
             var initialNodeContext = nodeContext;
+            var initialComputedBlockSize = self.computedBlockSize;
             // ------ init backtracking list -----
             self.breakPositions = [];
             // ------- fill the column -------------
@@ -3000,7 +3004,7 @@ adapt.layout.Column.prototype.layout = function(chunkPosition, leadingEdge, brea
                             loopFrame.breakLoop(); // Loop end
                         } else if (nodeContext && self.stopByOverflow(nodeContext)) {
                             // overflow (implicit page break): back up and find a page break
-                            self.findAcceptableBreak(nodeContext, initialNodeContext).then(function(nodeContextParam) {
+                            self.findAcceptableBreak(nodeContext, initialNodeContext, initialComputedBlockSize).then(function(nodeContextParam) {
                                 nodeContext = nodeContextParam;
                                 loopFrame.breakLoop(); // Loop end
                             });

--- a/test/files/footnotes/footnotes_widows_bug.html
+++ b/test/files/footnotes/footnotes_widows_bug.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Footnotes widows bug</title>
+  <style>
+    @-adapt-footnote-area {
+      -adapt-margin-before: 5px;
+      -adapt-margin-after: 5px;
+    }
+    @-adapt-footnote-area ::before {
+      -adapt-border-before-width: 1px;
+      -adapt-margin-after: 5px;
+    }
+    @page {
+      size: 220px;
+      margin: 10px;
+      @bottom-center {
+        font-size: 8px;
+        line-height: 1;
+        content: counter(page);
+      }
+    }
+
+    :root {
+      line-height: 20px;
+      orphans: 1;
+      widows: 2;
+    }
+
+    body, p {
+      margin: 0;
+    }
+
+    section {
+      page-break-after: always;
+    }
+
+    .footnote {
+      float: footnote;
+      counter-increment: footnote;
+    }
+
+    .tall {
+      line-height: 32px;
+    }
+
+    .footnote::footnote-marker, .footnote::footnote-call {
+      content: "[" counter(footnote) "]";
+    }
+  </style>
+</head>
+<body>
+<section>
+  <p>1: This page</p>
+  <p>
+    2: should<br>
+    3: contain<br>
+    4: 10 lines<br>
+    5: Should<br>
+    6: be<span class="footnote"><span class="tall">This line overflows p1</span><br>footnote<br>footnote</span><br>
+    7: on<br>
+    8: the<br>
+    9: 1st<br>
+    10: page<br>
+    11: 1st line of page 2<br>
+    12: This page<br>
+    13: should contain<br>
+    14: a footnote
+  </p>
+</section>
+<section>
+  1: This<br>
+  2: page<br>
+  3: should<br>
+  4: contain<span class="footnote">footnote on page 3</span><br>
+  5: 9 lines<br>
+  6: Should<span class="footnote">footnote<br>on<br>page 4</span><br>
+  7: be on<br>
+  8: the<br>
+  9: 3rd page<br>
+  10: 1st line of page 4<br>
+  11: This page<br>
+  12: should contain<br>
+  13: a footnote<br>
+  14
+</section>
+</body>
+</html>

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -107,5 +107,10 @@
   <li><a href="page_floats/test_pagefloatlayoutcontext_previous_sibling.html">Test PageFloatLayoutContext previous sibling</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/page_floats/test_pagefloatlayoutcontext_previous_sibling.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/page_floats/test_pagefloatlayoutcontext_previous_sibling.html">prod</a>]</li>
   <li><a href="page_floats/column-span_on_page_floats.html">column-span on page floats</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/page_floats/column-span_on_page_floats.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/page_floats/column-span_on_page_floats.html">prod</a>]</li>
 </ul>
+
+<h2>Footnotes</h2>
+<ul>
+  <li><a href="footnotes/footnotes_widows_bug.html">Footnotes widows bug</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/footnotes/footnotes_widows_bug.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/footnotes/footnotes_widows_bug.html">prod</a>]</li>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
When a footnote call appeared close to the bottom of the page, the paragraph containing it sometimes got fragmented too early and the rest of the paragraph was deferred to the next page/column.