### PR TITLE
Fix bug that a footnote dissapears

### DIFF
--- a/resources/user-agent-page.css
+++ b/resources/user-agent-page.css
@@ -6,6 +6,7 @@ html|body, fb2|body {
 }
 
 @-adapt-footnote-area {
+	display: block;
 	-adapt-margin-before: 0.5em;
 	-adapt-margin-after: 0.5em;
 }

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1120,6 +1120,8 @@ adapt.layout.Column.prototype.layoutFootnoteInner = function(boxOffset, footnote
                 frame.finish(true);
                 return;
             }
+            // Cancel a computation error
+            footnoteArea.computedBlockSize += 0.01;
             if (self.vertical) {
                 self.footnoteEdge = afterEdge + (footnoteArea.computedBlockSize
                     + footnoteArea.getInsetLeft() + footnoteArea.getInsetRight());

--- a/test/files/page_floats/forced_break_and_page_floats.html
+++ b/test/files/page_floats/forced_break_and_page_floats.html
@@ -84,7 +84,6 @@
     }
     .footnote {
       float: footnote;
-      height: 50px;
     }
   </style>
 </head>


### PR DESCRIPTION
Cancel a computation error by adding an arbitrary small value to computedBlockSize.