### PR TITLE
Fix footnote layout bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix footnote layout bugs
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/332>
+
 ## [2017.2](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2017.2) - 2017-2-22
 
 ### Added

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -696,7 +696,7 @@ adapt.layout.Column.prototype.buildViewToNextBlockEdge = function(position, chec
                     // TODO: implement floats and footnotes properly
                     self.layoutFloatOrFootnote(position).then(function(positionParam) {
                         position = /** @type {adapt.vtree.NodeContext} */ (positionParam);
-                        if (!position || self.stopByOverflow(position)) {
+                        if (!position) {
                             bodyFrame.breakLoop();
                             return;
                         }
@@ -1175,6 +1175,7 @@ adapt.layout.Column.prototype.layoutFootnote = function(nodeContext) {
     self.layoutContext.applyPseudoelementStyle(nodeContext, "footnote-call", element);
     if (!element.textContent) {
         element.parentNode.removeChild(element);
+        nodeContext.viewNode = null;
     }
     var footnoteNodePosition = adapt.vtree.newNodePositionFromNodeContext(nodeContext);
     var boxOffset = nodeContext.boxOffset;


### PR DESCRIPTION
- Fix a wrong ‘widows’ behavior when a footnote call appears close to the bottom of the page
- Fix a bug that the main text is incorrectly paginated and overlaps with footnotes