### PR TITLE
Fix table layout bug on print on Chrome

### DIFF
--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -55,6 +55,7 @@
     [data-vivliostyle-page-container] {
         display: block !important;
         page-break-after: always;
+        max-width: 100%;
         height: 100% !important;
         max-height: 100%;
     }


### PR DESCRIPTION
Chrome bug: [Table header is duplicated on print](https://bugs.chromium.org/p/chromium/issues/detail?id=696474)