### PR TITLE
Specify "text/html" for file:// scheme URL for Gecko mimetype detector

### DIFF
--- a/src/adapt/net.js
+++ b/src/adapt/net.js
@@ -97,8 +97,11 @@ adapt.net.ajax = function(url, opt_type, opt_method, opt_data, opt_contentType) 
                 opt_contentType || "text/plain; charset=UTF-8");
             request.send(opt_data);
         }
-        else
+        else {
+            if (url.match(/file:\/\/.*(\.html$|\.htm$)/))
+                request.overrideMimeType("text/html");
             request.send(null);
+        }
     } catch (e) {
         vivliostyle.logging.logger.warn(e, "Error fetching " + url);
         continuation.schedule(response);


### PR DESCRIPTION
Gecko mimetype detector always fallback application/xml when
Content-Type header is empty.
But vivliostyle.js depends on DOMParser behavior for text/html file.
In Gecko, local file will treat as application/xml even if specifing
Content-Type header.
So, we should override mimetype for file:// scheme URI which terminates
.htm or .html.