### PR TITLE
Fix broken layout on print on Gecko

### DIFF
--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -58,8 +58,4 @@
         height: 100% !important;
         max-height: 100%;
     }
-
-    [data-vivliostyle-bleed-box] {
-        position: relative;
-    }
 }


### PR DESCRIPTION
The print-only rule for `[data-vivliostyle-bleed-box]` was added in #335 but is no longer necessary given the fix in #338 and was causing incorrect layout when some contents are on bleed area.