### PR TITLE
Fix justification

### DIFF
--- a/src/adapt/base.js
+++ b/src/adapt/base.js
@@ -989,3 +989,80 @@ adapt.base.checkInlineBlockJustificationBug = function(body) {
     }
     return adapt.base.hasInlineBlockJustificationBug;
 };
+
+/**
+ * @type {boolean|null}
+ */
+adapt.base.hasSoftWrapOpportunityAfterHyphenBug = null;
+
+/**
+ * @param {HTMLElement} body
+ * @returns {boolean}
+ */
+adapt.base.checkSoftWrapOpportunityAfterHyphenBug = function(body) {
+    if (adapt.base.hasSoftWrapOpportunityAfterHyphenBug === null) {
+        var doc = body.ownerDocument;
+        var container = /** @type {HTMLElement} */ (doc.createElement("div"));
+        container.style.position = "absolute";
+        container.style.top = "0px";
+        container.style.left = "0px";
+        container.style.width = "40px";
+        container.style.height = "100px";
+        container.style.lineHeight = "16px";
+        container.style.fontSize = "16px";
+        container.style.textAlign = "justify";
+        body.appendChild(container);
+        var t = doc.createTextNode("a a-");
+        container.appendChild(t);
+        var inlineBlock = doc.createElement("span");
+        inlineBlock.style.display = "inline-block";
+        inlineBlock.style.width = "40px";
+        container.appendChild(inlineBlock);
+        var range = doc.createRange();
+        range.setStart(t, 2);
+        range.setEnd(t, 4);
+        var box = range.getBoundingClientRect();
+        adapt.base.hasSoftWrapOpportunityAfterHyphenBug = box.right < 37;
+        body.removeChild(container);
+    }
+    return adapt.base.hasSoftWrapOpportunityAfterHyphenBug;
+};
+
+/**
+ * @type {boolean|null}
+ */
+adapt.base.hasSoftWrapOpportunityByWbrBug = null;
+
+/**
+ * @param {HTMLElement} body
+ * @returns {boolean}
+ */
+adapt.base.checkSoftWrapOpportunityByWbrBug = function(body) {
+    if (adapt.base.hasSoftWrapOpportunityByWbrBug === null) {
+        var doc = body.ownerDocument;
+        var container = /** @type {HTMLElement} */ (doc.createElement("div"));
+        container.style.position = "absolute";
+        container.style.top = "0px";
+        container.style.left = "0px";
+        container.style.width = "40px";
+        container.style.height = "100px";
+        container.style.lineHeight = "16px";
+        container.style.fontSize = "16px";
+        container.style.textAlign = "justify";
+        body.appendChild(container);
+        var t = doc.createTextNode("a a-");
+        container.appendChild(t);
+        container.appendChild(doc.createElement("wbr"));
+        var inlineBlock = doc.createElement("span");
+        inlineBlock.style.display = "inline-block";
+        inlineBlock.style.width = "40px";
+        container.appendChild(inlineBlock);
+        var range = doc.createRange();
+        range.setStart(t, 2);
+        range.setEnd(t, 4);
+        var box = range.getBoundingClientRect();
+        adapt.base.hasSoftWrapOpportunityByWbrBug = box.right < 37;
+        body.removeChild(container);
+    }
+    return adapt.base.hasSoftWrapOpportunityByWbrBug;
+};

--- a/test/files/justification.html
+++ b/test/files/justification.html
@@ -5,8 +5,8 @@
     <title>Justification</title>
     <style>
         @page {
-            size: 200px;
-            margin: 10px;
+            size: 220px;
+            margin: 20px;
         }
         :root {
             text-align: justify;
@@ -16,7 +16,7 @@
         }
         body {
             outline: blue dashed 1px;
-            width: 18.5ch;
+            width: 165px;
         }
         p::first-line {
             color: blue;

--- a/test/spec/adapt/layout-spec.js
+++ b/test/spec/adapt/layout-spec.js
@@ -82,23 +82,23 @@ describe("layout", function() {
             });
         });
 
-        describe("#resolveHyphenateCharacter", function() {
-            it("returns a value of `hyphenateCharacter` in the nodeContext.", function() {
-                expect(breaker.resolveHyphenateCharacter({
-                    hyphenateCharacter: 'a',
-                    parent: { hyphenateCharacter: 'b' }
-                })).toEqual('a');
-            });
-            it("returns a value of `hyphenateCharacter` in the parent nodeContext if nodeContext's `hyphenateCharacter` is undefined.", function() {
-                expect(breaker.resolveHyphenateCharacter({
-                    parent: { hyphenateCharacter: 'b' }
-                })).toEqual('b');
-            });
-            it("returns a default value if `hyphenateCharacter` of nodeContext and parent nodeContext are undefined.", function() {
-                expect(breaker.resolveHyphenateCharacter({})).toEqual('-');
-            });
-        });
+    });
 
+    describe("adapt.layout.resolveHyphenateCharacter", function() {
+        it("returns a value of `hyphenateCharacter` in the nodeContext.", function() {
+            expect(adapt.layout.resolveHyphenateCharacter({
+                hyphenateCharacter: 'a',
+                parent: { hyphenateCharacter: 'b' }
+            })).toEqual('a');
+        });
+        it("returns a value of `hyphenateCharacter` in the parent nodeContext if nodeContext's `hyphenateCharacter` is undefined.", function() {
+            expect(adapt.layout.resolveHyphenateCharacter({
+                parent: { hyphenateCharacter: 'b' }
+            })).toEqual('b');
+        });
+        it("returns a default value if `hyphenateCharacter` of nodeContext and parent nodeContext are undefined.", function() {
+            expect(adapt.layout.resolveHyphenateCharacter({})).toEqual('-');
+        });
     });
 
 });


### PR DESCRIPTION
- Since a spacer overflowing the page container can cause disappearance of some elements when printed from Chrome, height of the spacer for justification is kept minimum (= line-height of the block container)
- Workaround for Edge and IE is added