### PR TITLE
Fix problem that content sometimes overflows a partition instead of being deferred to the next partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/356>
   - <https://github.com/vivliostyle/vivliostyle.js/pull/357>
   - <https://github.com/vivliostyle/vivliostyle.js/pull/358>
+- Fix problem that content sometimes overflows a partition instead of being deferred to the next partition
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/361>
 
 ## [2017.2](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2017.2) - 2017-2-22
 

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -698,6 +698,10 @@ adapt.ops.StyleInstance.prototype.layoutColumn = function(column, flowName) {
                             return;
                         }
                     }
+                    // Since at least one flowChunk has been placed in the column,
+                    // the next flowChunk of the primary flow can be deferred to the next partition
+                    // if there is not enough space in the current partition.
+                    column.forceNonfitting = !self.primaryFlows[flowName];
                     if (pending) {
                         // Sync result
                         pending = false;

--- a/test/files/flowchunk_overflow_bug.html
+++ b/test/files/flowchunk_overflow_bug.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Flowchunk overflow bug</title>
+  <style>
+    @-epubx-page-template {
+      .partition {
+        -epubx-flow-from: d;
+        border: 3px solid rgba(255, 0, 0, 0.5);
+        padding: 5px;
+        left: 10px;
+        right: 10px;
+        height: 30px;
+        overflow: visible;
+      }
+
+      @-epubx-page-master {
+        @-epubx-partition class(partition) {
+          top: 100px;
+        }
+        @-epubx-partition class(partition) {
+          top: 10px;
+        }
+      }
+
+      @-epubx-flow body {
+        -epubx-flow-consume: some;
+      }
+      @-epubx-flow d {
+        -epubx-flow-consume: all;
+      }
+    }
+
+    body {
+      margin: 0;
+    }
+    div {
+      -epubx-flow-into: d;
+      box-sizing: border-box;
+      min-height: 26px;
+      break-inside: avoid;
+      border: 3px solid rgba(0, 255, 0, 0.5);
+    }
+  </style>
+</head>
+<body>
+<div>div1</div>
+<div>div2: should be in the 2nd partition</div>
+</body>
+</html>

--- a/test/files/index.html
+++ b/test/files/index.html
@@ -55,6 +55,7 @@
     <li><a href="compositing.html">Compositing and Blending</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/compositing.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/compositing.html">prod</a>]</li>
     <li><a href="content-url-element.html">Content URL</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/content-url-element.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/content-url-element.html">prod</a>]</li>
     <li><a href="content-in-page-margin-box.html">Content in page margin box</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/content-in-page-margin-box.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/content-in-page-margin-box.html">prod</a>]</li>
+  <li><a href="flowchunk_overflow_bug.html">Flowchunk overflow bug</a> [<a href="../../../vivliostyle-ui/build/vivliostyle-viewer-dev.html#x=../../vivliostyle.js/test/files/flowchunk_overflow_bug.html&amp;debug=true">dev</a>|<a href="../../../vivliostyle-ui/build/vivliostyle-viewer.html#x=../../vivliostyle.js/test/files/flowchunk_overflow_bug.html">prod</a>]</li>
 </ul>
 <h2>Page breaks</h2>
 <ul>


### PR DESCRIPTION
- When at least one flowChunk has been placed in a partition, the next flowChunk of the primary flow can be deferred to the next partition if there is not enough space in the current partition.