### PR TITLE
Fix problem that content sometimes overflows a partition instead of b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/358>
 - Fix problem that content sometimes overflows a partition instead of being deferred to the next partition
   - <https://github.com/vivliostyle/vivliostyle.js/pull/361>
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/362>
 
 ## [2017.2](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2017.2) - 2017-2-22
 

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -699,9 +699,9 @@ adapt.ops.StyleInstance.prototype.layoutColumn = function(column, flowName) {
                         }
                     }
                     // Since at least one flowChunk has been placed in the column,
-                    // the next flowChunk of the primary flow can be deferred to the next partition
+                    // the next flowChunk of the flow can be deferred to the next partition
                     // if there is not enough space in the current partition.
-                    column.forceNonfitting = !self.primaryFlows[flowName];
+                    column.forceNonfitting = false;
                     if (pending) {
                         // Sync result
                         pending = false;


### PR DESCRIPTION
…eing deferred to the next partition

- When at least one flowChunk has been placed in a partition, the next flowChunk of the flow can be deferred to the next partition if there is not enough space in the current partition.