### PR TITLE
Implement 'pages' counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Implement `pages` counter
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/367>
+  - Spec: [CSS Paged Media Module Level 3 - Page-based counters](https://drafts.csswg.org/css-page/#page-based-counters)
+
 ## [2017.6](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2017.6) - 2017-6-22
 
 ### Added

--- a/src/adapt/csscasc.js
+++ b/src/adapt/csscasc.js
@@ -1915,6 +1915,11 @@ adapt.csscasc.CounterListener = function() {};
 adapt.csscasc.CounterListener.prototype.countersOfId = function(id, counters) {};
 
 /**
+ * @returns {!adapt.vtree.ExprContentListener}
+ */
+adapt.csscasc.CounterListener.prototype.getExprContentListener = function() {};
+
+/**
  * @interface
  */
 adapt.csscasc.CounterResolver = function() {};

--- a/src/adapt/cssstyler.js
+++ b/src/adapt/cssstyler.js
@@ -463,6 +463,7 @@ adapt.cssstyler.Styler = function(xmldoc, cascade, scope, context, primaryFlows,
     /** @type {adapt.cssstyler.FlowListener} */ this.flowListener = null;
     /** @type {?string} */ this.flowToReach = null;
     /** @type {?string} */ this.idToReach = null;
+    /** @const */ this.counterListener = counterListener;
     /** @const */ this.cascade = cascade.createInstance(context, counterListener, counterResolver, xmldoc.lang);
     /** @const */ this.offsetMap = new adapt.cssstyler.SlipMap();
     /** @type {boolean} */ this.primary = true;

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1317,6 +1317,10 @@ adapt.epub.OPFView.prototype.renderPage = function(position) {
                     pageIndex = result.pageAndPosition.position.pageIndex;
                     viewItem.complete = true;
                     page.isLastPage = viewItem.item.spineIndex === self.opf.spine.length - 1;
+                    if (page.isLastPage) {
+                        goog.asserts.assert(self.viewport);
+                        self.counterStore.finishLastPage(self.viewport);
+                    }
                     loopFrame.breakLoop();
                 }
             });

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -915,7 +915,7 @@ adapt.ops.StyleInstance.prototype.layoutContainer = function(page, boxInstance, 
                 innerContainerTag = "img";
             }
             var innerContainer = self.viewport.document.createElement(innerContainerTag);
-            contentVal.visit(new adapt.vtree.ContentPropertyHandler(innerContainer, self, contentVal));
+            contentVal.visit(new adapt.vtree.ContentPropertyHandler(innerContainer, self, contentVal, self.counterStore.getExprContentListener()));
             boxContainer.appendChild(innerContainer);
             if (innerContainerTag == "img")
                 boxInstance.transferSinglUriContentProps(self, innerContainer, self.faces);

--- a/test/files/file-list.js
+++ b/test/files/file-list.js
@@ -51,7 +51,8 @@ module.exports = [
             {file: "compositing.html", title: "Compositing and Blending"},
             {file: "content-url-element.html", title: "Content URL"},
             {file: "content-in-page-margin-box.html", title: "Content in page margin box"},
-            {file: "flowchunk_overflow_bug.html", title: "Flowchunk overflow bug"}
+            {file: "flowchunk_overflow_bug.html", title: "Flowchunk overflow bug"},
+            {file: "pages_counter.html", title: "pages counter"}
         ]
     },
     {

--- a/test/files/pages_counter.html
+++ b/test/files/pages_counter.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>pages counter</title>
+  <style>
+    @page {
+      @bottom-center {
+        content: counter(page) " / " counter(pages);
+      }
+    }
+    @page:first {
+      counter-increment: pages 5;
+    }
+    section {
+      break-after: page;
+    }
+    .pages::after {
+      content: counter(page, lower-roman) " / " counter(pages, lower-roman);
+    }
+  </style>
+</head>
+<body>
+<section>
+  <p>Page 1</p>
+  <p>The string at the bottom of this page should be "1 / 2".</p>
+  <p class="pages">The following string should be "i / ii". → </p>
+</section>
+<section>
+  <p>Page 2</p>
+  <p>The string at the bottom of this page should be "2 / 2".</p>
+  <p class="pages">The following string should be "ii / ii". → </p>
+</section>
+</body>
+</html>


### PR DESCRIPTION
- Spec: https://drafts.csswg.org/css-page/#page-based-counters
- Note that the current implementation does not re-layout the pages but merely substitute the text contents generated by the 'pages' counter.
  It means that you need to make sure that dimension and position of a pseudo-element or a region in which 'pages' counter is rendered does not depend on the actual content of the counter.
  Such implementation is chosen in order to:
    - avoid performance degradation ('pages' counter is often used in all pages, so triggering re-layout of the pages make the total processing time twice), and
    - workaround a bug of page floats when re-layout of the pages is triggered.