### PR TITLE
Avoid text wrapping around fragmented page floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   - `same` value means the same direction as one which the page float is floated to.
   - If a page float with `float: snap-block` would be placed at the block-start end but a `clear` value on it forbidden such placement, the float is instead placed at the block-end side (unless the `clear` value also forbidden such placement).
 
+### Changed
+
+- Avoid text wrapping around fragmented page floats
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/379>
+
 ### Fixed
 
 - Fix a bug that a bottom margin on a page float is not taken into account when the float has a bottom padding or border

--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -1421,7 +1421,7 @@ adapt.layout.Column.prototype.layoutSinglePageFloatFragment = function(
             if (!logicalFloatSide) {
                 failed = true;
             } else {
-                var newFragment = strategy.createPageFloatFragment(continuations, logicalFloatSide, floatArea);
+                var newFragment = strategy.createPageFloatFragment(continuations, logicalFloatSide, floatArea, !!result.newPosition);
                 context.addPageFloatFragment(newFragment, true);
                 result.pageFloatFragment = newFragment;
             }

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -630,6 +630,10 @@ adapt.ops.StyleInstance.prototype.layoutColumn = function(column, flowName) {
             frame.finish(true);
             return;
         }
+        if (column.pageFloatLayoutContext.hasContinuingFloatFragmentsInFlow(flowName)) {
+            frame.finish(true);
+            return;
+        }
         // Record indices of repeated positions and removed positions
         var repeatedIndices = /** @type {Array.<number>} */ ([]);
         var removedIndices = /** @type {Array.<number>} */ ([]);

--- a/src/vivliostyle/footnote.js
+++ b/src/vivliostyle/footnote.js
@@ -51,11 +51,12 @@ goog.scope(function() {
      * @param {!vivliostyle.pagefloat.FloatReference} floatReference
      * @param {!Array<!vivliostyle.pagefloat.PageFloatContinuation>} continuations
      * @param {!adapt.vtree.Container} area
+     * @param {boolean} continues
      * @constructor
      * @extends PageFloatFragment
      */
-    vivliostyle.footnote.FootnoteFragment = function(floatReference, continuations, area) {
-        PageFloatFragment.call(this, floatReference, "block-end", continuations, area);
+    vivliostyle.footnote.FootnoteFragment = function(floatReference, continuations, area, continues) {
+        PageFloatFragment.call(this, floatReference, "block-end", continuations, area, continues);
     };
     /** @const */ var FootnoteFragment = vivliostyle.footnote.FootnoteFragment;
     goog.inherits(FootnoteFragment, PageFloatFragment);
@@ -141,9 +142,9 @@ goog.scope(function() {
      * @override
      */
     FootnoteLayoutStrategy.prototype.createPageFloatFragment = function(
-        continuations, floatSide, floatArea) {
+        continuations, floatSide, floatArea, continues) {
         /** @const */ var f = continuations[0].float;
-        return new FootnoteFragment(f.floatReference, continuations, floatArea);
+        return new FootnoteFragment(f.floatReference, continuations, floatArea, continues);
     };
 
     /**

--- a/src/vivliostyle/pagefloat.js
+++ b/src/vivliostyle/pagefloat.js
@@ -238,13 +238,15 @@ goog.scope(function() {
      * @param {string} floatSide
      * @param {!Array<!vivliostyle.pagefloat.PageFloatContinuation>} continuations
      * @param {!adapt.vtree.Container} area
+     * @param {boolean} continues Represents whether the float is fragmented and continues after this fragment
      * @constructor
      */
-    vivliostyle.pagefloat.PageFloatFragment = function(floatReference, floatSide, continuations, area) {
+    vivliostyle.pagefloat.PageFloatFragment = function(floatReference, floatSide, continuations, area, continues) {
         /** @const */ this.floatReference = floatReference;
         /** @const */ this.floatSide = floatSide;
         /** @const */ this.continuations = continuations;
         /** @const */ this.area = area;
+        /** @const */ this.continues = continues;
     };
     /** @const */ var PageFloatFragment = vivliostyle.pagefloat.PageFloatFragment;
 
@@ -1428,9 +1430,10 @@ goog.scope(function() {
      * @param {!Array<!PageFloatContinuation>} continuations
      * @param {string} logicalFloatSide
      * @param {!adapt.layout.PageFloatArea} floatArea
+     * @param {boolean} continues
      * @returns {!PageFloatFragment}
      */
-    PageFloatLayoutStrategy.prototype.createPageFloatFragment = function(continuations, logicalFloatSide, floatArea) {};
+    PageFloatLayoutStrategy.prototype.createPageFloatFragment = function(continuations, logicalFloatSide, floatArea, continues) {};
 
     /**
      * @param {!PageFloat} float
@@ -1544,9 +1547,9 @@ goog.scope(function() {
      * @override
      */
     NormalPageFloatLayoutStrategy.prototype.createPageFloatFragment = function(
-        continuations, floatSide, floatArea) {
+        continuations, floatSide, floatArea, continues) {
         /** @const */ var f = continuations[0].float;
-        return new PageFloatFragment(f.floatReference, floatSide, continuations, floatArea);
+        return new PageFloatFragment(f.floatReference, floatSide, continuations, floatArea, continues);
     };
 
     /**

--- a/src/vivliostyle/pagefloat.js
+++ b/src/vivliostyle/pagefloat.js
@@ -311,6 +311,17 @@ goog.scope(function() {
     };
 
     /**
+     * @returns {string}
+     */
+    PageFloatFragment.prototype.getFlowName = function() {
+        var flowName = this.continuations[0].float.flowName;
+        goog.asserts.assert(this.continuations.every(function(c) {
+            return c.float.flowName === flowName;
+        }));
+        return flowName;
+    };
+
+    /**
      * @param {!vivliostyle.pagefloat.PageFloat} float
      * @param {!adapt.vtree.NodePosition} nodePosition
      * @constructor
@@ -580,16 +591,30 @@ goog.scope(function() {
     };
 
     /**
+     * @param {!function(!PageFloatFragment):boolean=} condition
      * @returns {boolean}
      */
-    PageFloatLayoutContext.prototype.hasFloatFragments = function() {
+    PageFloatLayoutContext.prototype.hasFloatFragments = function(condition) {
         if (this.floatFragments.length > 0) {
-            return true;
-        } else if (this.parent) {
-            return this.parent.hasFloatFragments();
+            if (!condition || this.floatFragments.some(condition))
+                return true;
+        }
+
+        if (this.parent) {
+            return this.parent.hasFloatFragments(condition);
         } else {
             return false;
         }
+    };
+
+    /**
+     * @param {string} flowName
+     * @returns {boolean}
+     */
+    PageFloatLayoutContext.prototype.hasContinuingFloatFragmentsInFlow = function(flowName) {
+        return this.hasFloatFragments(function(fragment) {
+            return fragment.continues && fragment.getFlowName() === flowName;
+        });
     };
 
     /**

--- a/test/files/file-list.js
+++ b/test/files/file-list.js
@@ -116,7 +116,8 @@ module.exports = [
             {file: "page_floats/float_snap-block.html", title: "float: snap-block"},
             {file: "page_floats/clear_page_floats.html", title: "Clear page floats"},
             {file: "page_floats/clear_page_floats_vertical.html", title: "Clear page floats (vertical writing-mode)"},
-            {file: "page_floats/clear_on_page_floats.html", title: "clear on page floats"}
+            {file: "page_floats/clear_on_page_floats.html", title: "clear on page floats"},
+            {file: "page_floats/text_around_fragmented_page_floats.html", title: "Forbid text around fragmented page floats"}
         ]
     },
     {

--- a/test/files/page_floats/text_around_fragmented_page_floats.html
+++ b/test/files/page_floats/text_around_fragmented_page_floats.html
@@ -5,7 +5,7 @@
   <title>Forbid text around fragmented page floats</title>
   <style>
     @page {
-      size: 300px;
+      size: 400px 300px;
     }
     @-epubx-page-template {
       @-epubx-page-master {
@@ -30,7 +30,7 @@
           bottom: 20px;
           left: 20px;
           right: 20px;
-          column-count: 2;
+          column-count: 3;
           column-gap: 10px;
         }
       }
@@ -46,6 +46,9 @@
       line-height: 20px;
       widows: 1;
       orphans: 1;
+    }
+    body {
+      margin: 0;
     }
     section {
       break-after: page;
@@ -74,6 +77,9 @@
 <body>
 <section>
   <div class="footer">footer 1</div>
+  <p>
+    This text should be placed in the 1st column of P1. Blah blah blah blah blah blah blah blah.
+  </p>
   <div class="column-float">
     Column block-start float.<br>
     Column block-start float.<br>
@@ -86,10 +92,15 @@
       Column block-start float.<br>
     </div>
   </div>
-  This text should be placed in the 2nd column of P1. It shouldn't be in the 1st column.
+  <p>
+    This text should be placed in the 1st and 3rd columns of P1. It shouldn't be in the 2nd column.
+  </p>
 </section>
 <section>
   <div class="footer">footer 2</div>
+  <p>
+    This text should be placed in P2.
+  </p>
   <div class="region-float">
     Region block-start-float.<br>
     Region block-start-float.<br>
@@ -109,10 +120,15 @@
       Region block-start-float.<br>
     </div>
   </div>
-  This text should be placed in P3. It shouldn't be in P2.
+  <p>
+    This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3. This text should be placed in the P2 and P4. It shouldn't be in P3.
+  </p>
 </section>
 <section>
   <div class="footer">footer 3</div>
+  <p>
+    This text should be placed in P5.
+  </p>
   <div class="page-float">
     Page block-start-float.<br>
     Page block-start-float.<br>
@@ -132,7 +148,9 @@
       Page block-start-float.<br>
     </div>
   </div>
-  This text should be placed in P5. It shouldn't be in P4.
+  <p>
+    This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6. This text should be placed in the P5 and P7. It shouldn't be in P6.
+  </p>
 </section>
 </body>
 </html>

--- a/test/files/page_floats/text_around_fragmented_page_floats.html
+++ b/test/files/page_floats/text_around_fragmented_page_floats.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Forbid text around fragmented page floats</title>
+  <style>
+    @page {
+      size: 300px;
+    }
+    @-epubx-page-template {
+      @-epubx-page-master {
+        @-epubx-partition {
+          left: 5px;
+          bottom: 0;
+          height: 15px;
+          width: 20px;
+          content: counter(page);
+          font-size: 10px;
+        }
+        @-epubx-partition {
+          -epubx-flow-from: running-footer;
+          right: 5px;
+          bottom: 0;
+          height: 20px;
+          width: 150px;
+        }
+        @-epubx-partition {
+          -epubx-flow-from: body;
+          top: 20px;
+          bottom: 20px;
+          left: 20px;
+          right: 20px;
+          column-count: 2;
+          column-gap: 10px;
+        }
+      }
+      .footer {
+        -epubx-flow-into: running-footer;
+        -epubx-flow-options: exclusive last static;
+        text-align: right;
+        color: green;
+      }
+    }
+    :root {
+      font-size: 16px;
+      line-height: 20px;
+      widows: 1;
+      orphans: 1;
+    }
+    section {
+      break-after: page;
+    }
+    .page-float {
+      float-reference: page;
+      float: block-start;
+      margin: 20px;
+    }
+    .region-float {
+      float-reference: region;
+      float: block-start;
+    }
+    .column-float {
+      float-reference: column;
+      float: block-start;
+    }
+    .page-float, .region-float, .column-float {
+      background: lightblue;
+    }
+    .nobreak {
+      break-inside: avoid;
+    }
+  </style>
+</head>
+<body>
+<section>
+  <div class="footer">footer 1</div>
+  <div class="column-float">
+    Column block-start float.<br>
+    Column block-start float.<br>
+    Column block-start float.<br>
+    Column block-start float.<br>
+    Column block-start float.<br>
+    Column block-start float.<br>
+    <div class="nobreak">
+      Column block-start float.<br>
+      Column block-start float.<br>
+    </div>
+  </div>
+  This text should be placed in the 2nd column of P1. It shouldn't be in the 1st column.
+</section>
+<section>
+  <div class="footer">footer 2</div>
+  <div class="region-float">
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    Region block-start-float.<br>
+    <div class="nobreak">
+      Region block-start-float.<br>
+      Region block-start-float.<br>
+      Region block-start-float.<br>
+    </div>
+  </div>
+  This text should be placed in P3. It shouldn't be in P2.
+</section>
+<section>
+  <div class="footer">footer 3</div>
+  <div class="page-float">
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    Page block-start-float.<br>
+    <div class="nobreak">
+      Page block-start-float.<br>
+      Page block-start-float.<br>
+      Page block-start-float.<br>
+    </div>
+  </div>
+  This text should be placed in P5. It shouldn't be in P4.
+</section>
+</body>
+</html>

--- a/test/spec/vivliostyle/pagefloat-spec.js
+++ b/test/spec/vivliostyle/pagefloat-spec.js
@@ -318,7 +318,7 @@ describe("pagefloat", function() {
                     null, null, null);
                 var float = new PageFloat(dummyNodePosition(), FloatReference.PAGE, "block-start", null, "body");
                 pageContext.addPageFloat(float);
-                var fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area);
+                var fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area, false);
 
                 expect(pageContext.findPageFloatFragment(float)).toBe(null);
 
@@ -330,7 +330,7 @@ describe("pagefloat", function() {
             it("A PageFloatFragment stored in one of the ancestors can be retrieved by #findPageFloatFragment", function() {
                 var float = new PageFloat(dummyNodePosition(), FloatReference.REGION, "block-start", null, "body");
                 columnContext.addPageFloat(float);
-                var fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area);
+                var fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area, false);
                 columnContext.addPageFloatFragment(fragment);
                 columnContext = new PageFloatLayoutContext(regionContext, FloatReference.COLUMN, null,
                     null, null, null, null);
@@ -341,7 +341,7 @@ describe("pagefloat", function() {
 
                 float = new PageFloat(dummyNodePosition(), FloatReference.PAGE, "block-start", null, "body");
                 columnContext.addPageFloat(float);
-                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area);
+                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area, false);
                 columnContext.addPageFloatFragment(fragment);
                 regionContext = new PageFloatLayoutContext(pageContext, FloatReference.REGION, null,
                     null, null, null, null);
@@ -356,7 +356,7 @@ describe("pagefloat", function() {
             it("When a PageFloatFragment is added by #addPageFloatFragment, the corresponding PageFloatLayoutContext is invalidated", function() {
                 var float = new PageFloat(dummyNodePosition(), FloatReference.COLUMN, "block-start", null, "body");
                 columnContext.addPageFloat(float);
-                var fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area);
+                var fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area, false);
                 columnContext.addPageFloatFragment(fragment);
 
                 expect(columnContext.invalidate).toHaveBeenCalled();
@@ -365,7 +365,7 @@ describe("pagefloat", function() {
                 reset();
                 float = new PageFloat(dummyNodePosition(), FloatReference.REGION, "block-start", null, "body");
                 columnContext.addPageFloat(float);
-                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area);
+                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area, false);
                 columnContext.addPageFloatFragment(fragment);
 
                 expect(columnContext.invalidate).toHaveBeenCalled();
@@ -376,7 +376,7 @@ describe("pagefloat", function() {
                 reset();
                 float = new PageFloat(dummyNodePosition(), FloatReference.PAGE, "block-start", null, "body");
                 columnContext.addPageFloat(float);
-                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area);
+                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area, false);
                 columnContext.addPageFloatFragment(fragment);
 
                 expect(columnContext.invalidate).toHaveBeenCalled();
@@ -402,7 +402,7 @@ describe("pagefloat", function() {
                         }
                     }
                 };
-                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area);
+                fragment = new PageFloatFragment(float.floatReference, float.floatSide, [new PageFloatContinuation(float, {})], area, false);
                 context.addPageFloatFragment(fragment);
                 context.invalidate.calls.reset();
             });
@@ -646,12 +646,12 @@ describe("pagefloat", function() {
                 spyOn(context, "removePageFloatFragment");
                 float1 = new PageFloat(dummyNodePosition(), FloatReference.COLUMN, "block-start", null, "foo");
                 context.addPageFloat(float1);
-                fragment1 = new PageFloatFragment(float1.floatReference, float1.floatSide, [new PageFloatContinuation(float1, {})], {});
+                fragment1 = new PageFloatFragment(float1.floatReference, float1.floatSide, [new PageFloatContinuation(float1, {})], {}, false);
                 context.addPageFloatFragment(fragment1);
                 cont1 = new PageFloatContinuation(float1, {});
                 float2 = new PageFloat(dummyNodePosition(), FloatReference.COLUMN, "block-start", null, "body");
                 context.addPageFloat(float2);
-                fragment2 = new PageFloatFragment(float2.floatReference, float2.floatSide, [new PageFloatContinuation(float2, {})], {});
+                fragment2 = new PageFloatFragment(float2.floatReference, float2.floatSide, [new PageFloatContinuation(float2, {})], {}, false);
                 context.addPageFloatFragment(fragment2);
                 float3 = new PageFloat(dummyNodePosition(), FloatReference.COLUMN, "block-start", null, "bar");
                 cont3 = new PageFloatContinuation(float3, {});
@@ -821,14 +821,14 @@ describe("pagefloat", function() {
                 context.addPageFloat(float1);
                 var shape1 = { foo: "shape1" };
                 var area1 = { getOuterShape: jasmine.createSpy("getOuterShape").and.returnValue(shape1) };
-                var fragment1 = new PageFloatFragment(float1.floatReference, float1.floatSide, [new PageFloatContinuation(float1, {})], area1);
+                var fragment1 = new PageFloatFragment(float1.floatReference, float1.floatSide, [new PageFloatContinuation(float1, {})], area1, false);
                 context.addPageFloatFragment(fragment1);
 
                 var float2 = new PageFloat(dummyNodePosition(), FloatReference.COLUMN, "block-start", null, "body");
                 context.addPageFloat(float2);
                 var shape2 = { foo: "shape2" };
                 var area2 = { getOuterShape: jasmine.createSpy("getOuterShape").and.returnValue(shape2) };
-                var fragment2 = new PageFloatFragment(float2.floatReference, float2.floatSide, [new PageFloatContinuation(float2, {})], area2);
+                var fragment2 = new PageFloatFragment(float2.floatReference, float2.floatSide, [new PageFloatContinuation(float2, {})], area2, false);
                 context.addPageFloatFragment(fragment2);
 
                 expect(context.getFloatFragmentExclusions()).toEqual([shape1, shape2]);
@@ -844,14 +844,14 @@ describe("pagefloat", function() {
                 regionContext.addPageFloat(float1);
                 var shape1 = { foo: "shape1" };
                 var area1 = { getOuterShape: jasmine.createSpy("getOuterShape").and.returnValue(shape1) };
-                var fragment1 = new PageFloatFragment(float1.floatReference, float1.floatSide, [new PageFloatContinuation(float1, {})], area1);
+                var fragment1 = new PageFloatFragment(float1.floatReference, float1.floatSide, [new PageFloatContinuation(float1, {})], area1, false);
                 regionContext.addPageFloatFragment(fragment1);
 
                 var float2 = new PageFloat(dummyNodePosition(), FloatReference.COLUMN, "block-start", null, "body");
                 columnContext.addPageFloat(float2);
                 var shape2 = { foo: "shape2" };
                 var area2 = { getOuterShape: jasmine.createSpy("getOuterShape").and.returnValue(shape2) };
-                var fragment2 = new PageFloatFragment(float2.floatReference, float2.floatSide, [new PageFloatContinuation(float2, {})], area2);
+                var fragment2 = new PageFloatFragment(float2.floatReference, float2.floatSide, [new PageFloatContinuation(float2, {})], area2, false);
                 columnContext.addPageFloatFragment(fragment2);
 
                 expect(columnContext.getFloatFragmentExclusions()).toEqual([shape1, shape2]);


### PR DESCRIPTION
When a page float is fragmented (since it is larger than its container), normal text in the same flow as the float is not allowed to wrap around the float. The text continues after all fragments of the float.