### PR TITLE
Always layout a table twice so that BreakPositions are inserted appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/377>
 - Avoid invalid fragmentation occurring between an edge of a block container and its child
   - <https://github.com/vivliostyle/vivliostyle.js/pull/383>
+- Fix a bug that a table is not fragmented correctly
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/384>
 
 ## [2017.6](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2017.6) - 2017-6-22
 

--- a/src/vivliostyle/table.js
+++ b/src/vivliostyle/table.js
@@ -1437,15 +1437,8 @@ goog.scope(function() {
         var frame = adapt.task.newFrame("TableLayoutProcessor.doInitialLayout");
         this.layoutEntireTable(nodeContext, column).then(function(nodeContextAfter) {
             var tableElement = nodeContextAfter.viewNode;
-            var tableBBox = column.clientLayout.getElementClientRect(tableElement);
-            var edge = column.vertical ? tableBBox.left : tableBBox.bottom;
-            edge += (column.vertical ? -1 : 1) * adapt.layout.calculateOffset(
-                nodeContext, vivliostyle.repetitiveelements.collectElementsOffset(column)).current;
-            if (!column.isOverflown(edge)) {
-                frame.finish(nodeContextAfter);
-                return;
-            }
             this.normalizeColGroups(formattingContext, tableElement, column);
+            goog.asserts.assert(column.clientLayout);
             formattingContext.updateCellSizes(column.clientLayout);
             frame.finish(null);
         }.bind(this));


### PR DESCRIPTION
- Layout of a table has been done in two phases. The first phase invokes initial layout to measure column widths, in which no BreakPosition for the table is inserted. The second phase does re-layout of the table, inserting BreakPositions for the table, which are used later for fragmentation of the table. If it turned out after the initial layout that the table does not overflow the current column, the re-layout in the second phase was omitted.
- However, there are some cases where fragmenting the table is necessary even if the table itself does not overflow. For example, if a figure element wrapping the table has some block-end padding and the border edge of the figure overflows the column, the figure element should be fragmented. However, since it is not allowed to fragment the figure element between the padding and the table element, the fragmentation should occur inside the table. In such a case, it is necessary that BreakPositions are inserted inside the table.
- In this commit, the omission of the second phase has been removed. It means that a table is always laid out twice so that appropriate BreakPositions are always inserted.