### PR TITLE
Fix a bug that a table is occasionally fragmented immediately before the end of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   - <https://github.com/vivliostyle/vivliostyle.js/pull/386>
 - Fix a bug that a float inside an element with position:relative is positioned incorrectly
   - <https://github.com/vivliostyle/vivliostyle.js/pull/388>
+- Fix a bug that a table is occasionally fragmented immediately before the end of it
+  - <https://github.com/vivliostyle/vivliostyle.js/pull/397>
 
 ## [2017.6](https://github.com/vivliostyle/vivliostyle.js/releases/tag/2017.6) - 2017-6-22
 

--- a/src/vivliostyle/layoututil.js
+++ b/src/vivliostyle/layoututil.js
@@ -268,7 +268,7 @@ goog.scope(function() {
      * @return {boolean} Returns true if the node overflows the column.
      */
     EdgeSkipper.prototype.saveEdgeAndProcessOverflow = function(state, column) {
-        var overflow = column.saveEdgeAndCheckForOverflow(state.lastAfterNodeContext, null, true, state.breakAtTheEdge);
+        var overflow = column.checkOverflowAndSaveEdgeAndBreakPosition(state.lastAfterNodeContext, null, true, state.breakAtTheEdge);
         if (overflow) {
             state.nodeContext = (state.lastAfterNodeContext || state.nodeContext).modify();
             state.nodeContext.overflow = true;
@@ -286,7 +286,7 @@ goog.scope(function() {
         var nodeContext = state.nodeContext;
         var violateConstraint = !layoutConstraint.allowLayout(nodeContext);
         if (violateConstraint) {
-            column.saveEdgeAndCheckForOverflow(state.lastAfterNodeContext, null, false, state.breakAtTheEdge);
+            column.checkOverflowAndSaveEdgeAndBreakPosition(state.lastAfterNodeContext, null, false, state.breakAtTheEdge);
             nodeContext = state.nodeContext = nodeContext.modify();
             nodeContext.overflow = true;
         }
@@ -432,6 +432,14 @@ goog.scope(function() {
         return startNodeContext.viewNode === nodeContext.viewNode
             && startNodeContext.after === nodeContext.after
             && startNodeContext.offsetInNode === nodeContext.offsetInNode;
+    };
+
+    /**
+     * @param {adapt.vtree.NodeContext} nodeContext
+     * @return {boolean}
+     */
+    PseudoColumn.prototype.isLastAfterNodeContext = function(nodeContext) {
+        return adapt.vtree.isSameNodePosition(nodeContext.toNodePosition(), this.column.lastAfterPosition);
     };
 
     /**

--- a/src/vivliostyle/table.js
+++ b/src/vivliostyle/table.js
@@ -254,7 +254,9 @@ goog.scope(function() {
         var allCellsBreakable = acceptableCellBreakPositions.every(function(bp) {
             return !!bp.nodeContext;
         }) && acceptableCellBreakPositions.some(function(bp, index) {
-            return !cellFragments[index].pseudoColumn.isStartNodeContext(bp.nodeContext);
+            var pseudoColumn = cellFragments[index].pseudoColumn;
+            var nodeContext = bp.nodeContext;
+            return !pseudoColumn.isStartNodeContext(nodeContext) && !pseudoColumn.isLastAfterNodeContext(nodeContext);
         });
         this.beforeNodeContext.overflow = acceptableCellBreakPositions.some(function(bp) {
             return bp.nodeContext && bp.nodeContext.overflow;
@@ -1098,7 +1100,7 @@ goog.scope(function() {
         this.inRow = true;
         return this.layoutRowSpanningCellsFromPreviousFragment(state).thenAsync(function() {
             this.registerCellFragmentIndex();
-            var overflown = this.column.saveEdgeAndCheckForOverflow(state.lastAfterNodeContext, null, true,
+            var overflown = this.column.checkOverflowAndSaveEdgeAndBreakPosition(state.lastAfterNodeContext, null, true,
                 state.breakAtTheEdge);
             if (overflown &&
                 formattingContext.getRowSpanningCellsOverflowingTheRow(this.currentRowIndex - 1).length === 0) {
@@ -1249,11 +1251,7 @@ goog.scope(function() {
         if (display && TableLayoutStrategy.ignoreList[display]) {
             nodeContext.viewNode.parentNode.removeChild(nodeContext.viewNode);
         } else if (nodeContext.sourceNode === this.formattingContext.tableSourceNode) {
-            var style = (/** @type {HTMLElement} */ (nodeContext.viewNode)).style;
-            if (style && !(this.column.zeroIndent(style.paddingBottom) && this.column.zeroIndent(style.borderBottomWidth))) {
-                nodeContext.overflow = this.column.saveEdgeAndCheckForOverflow(
-                    state.lastAfterNodeContext, null, false, state.breakAtTheEdge);
-            }
+            nodeContext.overflow = this.column.checkOverflowAndSaveEdge(nodeContext, null);
             this.resetColumn();
             state.break = true;
         } else {

--- a/test/files/file-list.js
+++ b/test/files/file-list.js
@@ -99,7 +99,8 @@ module.exports = [
             {file: "table/table_vertical_align_vertical.html", title: "Table vertical-align (vertical writing-mode)"},
             {file: "table/table_repeating_header_footer.html", title: "Table repeating header/footer"},
             {file: "table/table_repeating_header_footer_vertical.html", title: "Table repeating header/footer (vertical writing-mode)"},
-            {file: "table/fragment_non-overflowing_table.html", title: "Fragment a non-overflowing table"}
+            {file: "table/fragment_non-overflowing_table.html", title: "Fragment a non-overflowing table"},
+            {file: "table/break_after_table.html", title: "Break after table"}
         ]
     },
     {

--- a/test/files/page_breaks/class_C_break_point.html
+++ b/test/files/page_breaks/class_C_break_point.html
@@ -10,6 +10,7 @@
     }
     :root {
       column-count: 2;
+      column-fill: auto;
       font-size: 16px;
       line-height: 20px;
       orphans: 1;
@@ -20,6 +21,10 @@
     }
     section {
       break-after: page;
+    }
+    td {
+      padding: 0;
+      padding-top: 1px;
     }
     .outer {
       border: 3px solid blue;
@@ -47,6 +52,21 @@
     </div>
   </div>
   <p>↑ Should not be broken between blue and orange borders.</p>
+</section>
+<section>
+  <table class="outer">
+    <tbody class="inner">
+    <tr><td>1</td></tr>
+    <tr><td>2</td></tr>
+    <tr><td>3</td></tr>
+    <tr><td>4</td></tr>
+    <tr><td>5</td></tr>
+    <tr><td>6</td></tr>
+    <tr><td>7</td></tr>
+    <tr><td>8</td></tr>
+    </tbody>
+  </table>
+  <p>↑ Should not be broken after "8" (inside blue border).</p>
 </section>
 <section>
   <div class="outer" style="height: 190px">

--- a/test/files/table/break_after_table.html
+++ b/test/files/table/break_after_table.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Break after table</title>
+  <style>
+    @page {
+      size: 220px 125px;
+      margin: 10px;
+      @bottom-center {
+        content: counter(page);
+        font-size: 10px;
+        line-height: 10px;
+      }
+    }
+    :root {
+      line-height: 20px;
+      font-size: 11px;
+      columns: 2;
+      column-fill: auto;
+      orphans: 1;
+      widows: 1;
+    }
+    body {
+      margin: 0;
+    }
+    section {
+      break-after: page;
+    }
+    table {
+      border-collapse: collapse;
+      border: 1px black solid;
+    }
+    td {
+      padding: 0;
+    }
+    .break-before-avoid {
+      break-before: avoid;
+    }
+    .column-float {
+      float-reference: column;
+      float: top;
+    }
+  </style>
+</head>
+<body>
+
+<section>
+  <table>
+    <tr><td>1</td></tr>
+    <tr><td>2</td></tr>
+    <tr><td>3</td></tr>
+    <tr><td>4</td></tr>
+    <tr><td>5</td></tr>
+  </table>
+
+  <div>
+    Line 5 from the table should be in the left column.
+  </div>
+</section>
+
+<section>
+  <table>
+    <tr><td>1</td></tr>
+    <tr><td>2</td></tr>
+    <tr><td>3</td></tr>
+    <tr><td>4</td></tr>
+    <tr><td>5</td></tr>
+  </table>
+
+  <div class="break-before-avoid">
+    Line 5 from the table should be in the right column.
+  </div>
+
+  <div class="column-float">
+  <table>
+    <tr><td>1</td></tr>
+    <tr><td>2</td></tr>
+    <tr><td>3</td></tr>
+    <tr><td>4</td></tr>
+    <tr><td>5</td></tr>
+  </table>
+
+  <div class="break-before-avoid">
+    Line 5 from the table should be in the right column.
+  </div>
+  </div>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
- When the end of a table is reached, overflow at the block-end edge should be checked but no BreakPosition should be registered.
- When all of acceptable break positions inside cells of a table row are the start or the end of the cells, fragmenting inside such a row should be avoided.