### PR TITLE
Fix edge calculation with ::after-if-continues on a float

### DIFF
--- a/src/vivliostyle/selectors.js
+++ b/src/vivliostyle/selectors.js
@@ -346,7 +346,7 @@ goog.scope(function() {
      * @return {!adapt.task.Result.<adapt.vtree.NodeContext>}
      */
     function processAfterIfContinuesOfNodeContext(nodeContext, column) {
-        if (!nodeContext || !nodeContext.afterIfContinues || nodeContext.after) {
+        if (!nodeContext || !nodeContext.afterIfContinues || nodeContext.after || column.isFloatNodeContext(nodeContext)) {
             return adapt.task.newResult(nodeContext);
         }
 


### PR DESCRIPTION
- Do not add AfterIfContinuesLayoutConstraint when column.isFloatNodeContext(nodeContext) is true. Otherwise, the offset for the float anchor gets too much and affects fragmentation.
- A new Column (PageFloatArea) is created for a page float. Since an AfterIfContinuesLayoutConstraint is registered on the new Column, ::after-if-continues on a page float works as expected.
- No new Column is created for a traditional inline float. However, since fragmentation of a traditional float is not supported for now, this change should not be a problem.