### PR TITLE
Set the viewer print margin default to 0

### DIFF
--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -631,7 +631,7 @@ adapt.viewer.Viewer.prototype.setPageSizePageRules = function(pageSheetSize, spi
     if (!this.pageSheetSizeAlreadySet && this.pageRuleStyleElement) {
         let styleText = "";
         Object.keys(pageSheetSize).forEach(selector => {
-            styleText += `@page ${selector}{size:`;
+            styleText += `@page ${selector}{margin:0;size:`;
             const size = pageSheetSize[selector];
             styleText += `${size.width}px ${size.height}px;}`;
         });


### PR DESCRIPTION
In Chrome's Print dialog (Save as PDF), when Margins setting is Default, the default margins were added to the page margins. This default margin should be zero usually because margins are set by CSS page setting.