### PR TITLE
Fix the error "Unexpected side: both" (at `clear: both` on page floats)

### DIFF
--- a/src/vivliostyle/pagefloat.js
+++ b/src/vivliostyle/pagefloat.js
@@ -1431,6 +1431,8 @@ goog.scope(() => {
         /** @type {Array<string>} */ let logicalSides;
         if (logicalClearSide === "all") {
             logicalSides = ["block-start", "block-end", "inline-start", "inline-end"];
+        } else if (logicalClearSide === "both") {
+            logicalSides = ["inline-start", "inline-end"];
         } else if (logicalClearSide === "same") {
             if (logicalFloatSide === "snap-block") {
                 logicalSides = ["block-start", "block-end"];


### PR DESCRIPTION
Fixed the bug that the `clear: both` specified on page floats caused the error "Error: Unexpected side: both".