### PR TITLE
Add build environment for TypeScript source

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint src test plugins/*/src plugins/*/test",
     "build": "node tools/build.js",
+    "build-ts": "webpack",
     "typecheck": "node tools/typecheck.js",
     "test": "karma start test/conf/karma-sauce.conf.js",
     "test:local": "karma start test/conf/karma-local.conf.js"
@@ -42,7 +43,10 @@
     "karma-verbose-reporter": "0.0.3",
     "mkdirp": "^0.5.1",
     "mustache": "^2.2.1",
-    "typescript": "^3.0.1"
+    "ts-loader": "^4.5.0",
+    "typescript": "^3.0.1",
+    "webpack": "^4.17.1",
+    "webpack-cli": "^3.1.0"
   },
   "dependencies": {
     "clang-format": "^1.2.4",

--- a/src/ts/vivliostyle.ts
+++ b/src/ts/vivliostyle.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+export function test() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,11 @@
 {
+  "exclude": [
+    "node_modules",
+    //FIXME
+    "src/ts/adapt/**/*",
+    "src/ts/closure/**/*",
+    "src/ts/vivliostyle/**/*"
+  ],
   "compilerOptions": {
     /* Basic Options */
     "target": "ES2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const webpack = require('webpack');
+const pkg = require('./package.json');
+
+const bannerText = `Copyright 2013 Google, Inc.
+Copyright 2015 Trim-marks Inc.
+Copyright 2018 Vivliostyle Foundation
+
+Vivliostyle.js is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vivliostyle.js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+
+Vivliostyle core ${pkg.version}`;
+
+module.exports = {
+  entry: './src/ts/vivliostyle.ts',
+  output: {
+    path: path.join(__dirname, 'lib-ts'),
+    filename: 'vivliostyle.min.js',
+    library: 'vivliostyle',
+    libraryTarget: 'umd',
+  },
+  resolve: {
+    extensions: ['.js', '.ts'],
+  },
+  module: {
+    rules: [{
+      test: /\.ts$/,
+      exclude: /\/(adapt|closure|vivliostyle)\//,   //FIXME
+      use: 'ts-loader'
+    }]
+  },
+  plugins: [
+    new webpack.BannerPlugin({
+      banner: bannerText
+    })
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,9 @@ along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
 Vivliostyle core ${pkg.version}`;
 
 module.exports = {
+  mode: process.env.NODE_ENV === 'production'? 'production' : 'development',
   entry: './src/ts/vivliostyle.ts',
+  devtool: 'source-map',
   output: {
     path: path.join(__dirname, 'lib-ts'),
     filename: 'vivliostyle.min.js',


### PR DESCRIPTION
## Overview

This pull request adds a weback settings to build TypeScript sources.

In the present, closure compiler seems to use wrapper file `src/wrapper.js`, to support UMD (Universal Model Definition) pattern. So we have to take care while rewrite from original module system to TypeScript.

## Difference with the previous bundler

#### Previous output

The previous bundled source is summarized as follows

```js
(function(factory) {
    if (typeof define === "function" && define.amd) {
        // AMD
        define([], factory);
    } else if (typeof module === "object") {
        // Node.js
        var enclosingObject = {};
        module.exports = factory(enclosingObject);
    } else if (typeof exports === "object") {
        // CommonJS
        var enclosingObject = {};
        exports = factory(enclosingObject);
    } else {
        // Attach to the window object
        factory(window);
    }
})(function(enclosingObject) {
    enclosingObject = enclosingObject || {};
    ...(minified)...
}.bind(window));
```

and public variables/functions are exported in `closure/goog/base.js` and `vivliostyle/namespace.js`.

```js
goog.exportSymbol(publicPath, object, opt_objectToExportTo) => {
  ...
  opt_objectToExportTo[namespace] = object;
};

namespace.exportSymbol(publicPath, object) => {
  goog.exportSymbol(publicPath, object, enclosingObject);
};
```

#### Webpack output

In this version, output souce is summarized as follows

```js
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else if(typeof exports === 'object')
		exports["vivliostyle"] = factory();
	else
		root["vivliostyle"] = factory();
})(window, function(module, exports, __webpack_require__) {
    ...(minified)...
});
```

and namespaces of TypeScript source are exported in `root.vivliostyle`.

## How should we fix google closure scopes to TypeScript namespaces?

I've not check all vivliostyle sources yet, however I think that we can translate them such like

```typescript
namespace.exportSymbol('vivliostyle.X.Y', obj);
↓
export namespace X {
  export const Y = obj;
}
```

```typescript
namespace.exportSymbol('vivliostyle.X.Y', Y);
goog.exportProperty(Y.prototype, 'A', Y.prototype.A);
↓
export namespace X {
  export class Y {
    A() { ... }
  }
}
```
