### PR TITLE
Fix a bug that writing mode specified on body didn't determine the root writing mode

### DIFF
--- a/src/adapt/cssstyler.js
+++ b/src/adapt/cssstyler.js
@@ -532,14 +532,12 @@ adapt.cssstyler.columnProps = ["column-count", "column-width", "column-fill"];
  * @return {void}
  */
 adapt.cssstyler.Styler.prototype.postprocessTopStyle = function(elemStyle, isBody) {
-    if (!isBody) {
-        ["writing-mode", "direction"].forEach(function(propName) {
-            if (elemStyle[propName]) {
-                // Copy it over, but keep it at the root element as well.
-                this.rootStyle[propName] = elemStyle[propName];
-            }
-        }, this);
-    }
+    ["writing-mode", "direction"].forEach(propName => {
+        if (elemStyle[propName] && !(isBody && this.rootStyle[propName])) {
+            // Copy it over, but keep it at the root element as well.
+            this.rootStyle[propName] = elemStyle[propName];
+        }
+    });
     if (!this.rootBackgroundAssigned) {
         const backgroundColor = /** @type {adapt.css.Val} */
             (this.hasProp(elemStyle, this.validatorSet.backgroundProps, "background-color") ?


### PR DESCRIPTION
This is necessary because the CSS Writing Modes spec <https://www.w3.org/TR/css-writing-modes-3/#principal-flow> says:

> As a special case for handling HTML documents, if the root element has a [body](https://html.spec.whatwg.org/multipage/sections.html#the-body-element) child element [[HTML]](https://www.w3.org/TR/css-writing-modes-3/#biblio-html), the [principal writing mode](https://www.w3.org/TR/css-writing-modes-3/#principal-writing-mode) is instead taken from the values of [writing-mode](https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode) and [direction](https://www.w3.org/TR/css-writing-modes-3/#propdef-direction) on the first such child element instead of taken from the root element. Note that this does not affect the values of [writing-mode](https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode) or [direction](https://www.w3.org/TR/css-writing-modes-3/#propdef-direction) on the root element itself.
