### PR TITLE
Fix a bug that stylesheet link element is ignored when class attribute exists

### DIFF
--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -1691,7 +1691,8 @@ adapt.ops.OPSDocStore.prototype.parseOPSResource = function(response) {
                         if (rel == "stylesheet" || (rel == "alternate stylesheet" && classes)) {
                             var src = child.getAttribute("href");
                             src = adapt.base.resolveURL(src, url);
-                            sources.push({url:src, text:null, classes, media,
+                            const title = child.getAttribute("title");
+                            sources.push({url:src, text:null, classes: (title ? classes : null), media,
                                 flavor:adapt.cssparse.StylesheetFlavor.AUTHOR});
                         }
                     } else if (localName == "meta" && child.getAttribute("name") == "viewport") {


### PR DESCRIPTION
For example, `<link class="horizontal" rel="stylesheet" href="style_h.css" >` was ignored. This seemed to be caused by incorrect implementation of [EPUB Alternate Style Tags](http://www.idpf.org/epub/altss-tags/). This spec says,

> A *persistent style sheet* is one that is always enabled, regardless of which alternate style set is enabled. A persistent style sheet is indicated by omitting the `title` attribute from the `link` or `style` element that imports it.

That is, the link element with `class` attribute should be a *persistent style sheet* unless `title` attribute is specified.
