### PR TITLE
Fix a bug that page spread view becomes incorrect when content doc's writing mode does not match the page-progression-direction in OPF

### DIFF
--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1963,7 +1963,7 @@ adapt.epub.OPFView.prototype.getPageViewItem = function(spineIndex) {
 
         const instance = new adapt.ops.StyleInstance(style, xmldoc, self.opf.lang,
             viewport, self.clientLayout, self.fontMapper, customRenderer, self.opf.fallbackMap, pageNumberOffset,
-            self.opf.documentURLTransformer, self.counterStore);
+            self.opf.documentURLTransformer, self.counterStore, self.opf.pageProgression);
 
         instance.pref = self.pref;
         instance.init().then(() => {

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -166,6 +166,7 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @param {number} pageNumberOffset
  * @param {!adapt.base.DocumentURLTransformer} documentURLTransformer
  * @param {!vivliostyle.counters.CounterStore} counterStore
+ * @param {?vivliostyle.constants.PageProgression=} pageProgression
  * @constructor
  * @extends {adapt.expr.Context}
  * @implements {adapt.cssstyler.FlowListener}
@@ -173,7 +174,8 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @implements {adapt.vgen.StylerProducer}
  */
 adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientLayout,
-                                   fontMapper, customRenderer, fallbackMap, pageNumberOffset, documentURLTransformer, counterStore) {
+                                   fontMapper, customRenderer, fallbackMap, pageNumberOffset, documentURLTransformer, counterStore,
+                                   pageProgression) {
     adapt.expr.Context.call(this, style.rootScope, viewport.width, viewport.height, viewport.fontSize);
     /** @const */ this.style = style;
     /** @const */ this.xmldoc = xmldoc;
@@ -195,7 +197,7 @@ adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientL
     /** @private @const */ this.rootPageFloatLayoutContext =
         new vivliostyle.pagefloat.PageFloatLayoutContext(null, null, null, null, null, null, null);
     /** @type {!Object.<string,boolean>} */ this.pageBreaks = {};
-    /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
+    /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = pageProgression || null;
     /** @const */ this.customRenderer = customRenderer;
     /** @const */ this.fallbackMap = fallbackMap;
     /** @const @type {number} */ this.pageNumberOffset = pageNumberOffset;
@@ -235,7 +237,8 @@ adapt.ops.StyleInstance.prototype.init = function() {
     self.stylerMap = {};
     self.stylerMap[self.xmldoc.url] = self.styler;
     const docElementStyle = self.styler.getTopContainerStyle();
-    self.pageProgression = vivliostyle.page.resolvePageProgression(docElementStyle);
+    // if (!self.pageProgression)
+    //     self.pageProgression = vivliostyle.page.resolvePageProgression(docElementStyle);
     const rootBox = this.style.rootBox;
     this.rootPageBoxInstance = new adapt.pm.RootPageBoxInstance(rootBox);
     const cascadeInstance = this.style.cascade.createInstance(self, counterListener, counterResolver, this.lang);

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -1790,7 +1790,9 @@ vivliostyle.page.PageManager.prototype.definePageProgression = function() {
     scope.defineName("recto-page", new adapt.expr.Not(scope, isEvenPage));
     scope.defineName("verso-page", isEvenPage);
 
-    const pageProgression = vivliostyle.page.resolvePageProgression(this.docElementStyle);
+    /** @type {adapt.ops.StyleInstance} */
+    const styleInstance = this.context;
+    const pageProgression = styleInstance.pageProgression || vivliostyle.page.resolvePageProgression(this.docElementStyle);
     if (pageProgression === vivliostyle.constants.PageProgression.LTR) {
         scope.defineName("left-page", isEvenPage);
         scope.defineName("right-page", new adapt.expr.Not(scope, isEvenPage));


### PR DESCRIPTION
Fixed: When EPUB's OPF file has `page-progression-direction="rtf"` but content documents writing mode is `horizontal-tb` and `ltr` direction, the page spread view becomes incorrect, the first (cover) page is paired with the second page, and page 3 and page 4 are paired, etc.
