### PR TITLE
Revert "Fix a bug that page spread view becomes incorrect when content doc's writing mode does not match the page-progression-direction in OPF"

### DIFF
--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1963,7 +1963,7 @@ adapt.epub.OPFView.prototype.getPageViewItem = function(spineIndex) {
 
         const instance = new adapt.ops.StyleInstance(style, xmldoc, self.opf.lang,
             viewport, self.clientLayout, self.fontMapper, customRenderer, self.opf.fallbackMap, pageNumberOffset,
-            self.opf.documentURLTransformer, self.counterStore, self.opf.pageProgression);
+            self.opf.documentURLTransformer, self.counterStore);
 
         instance.pref = self.pref;
         instance.init().then(() => {

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -166,7 +166,6 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @param {number} pageNumberOffset
  * @param {!adapt.base.DocumentURLTransformer} documentURLTransformer
  * @param {!vivliostyle.counters.CounterStore} counterStore
- * @param {?vivliostyle.constants.PageProgression=} pageProgression
  * @constructor
  * @extends {adapt.expr.Context}
  * @implements {adapt.cssstyler.FlowListener}
@@ -174,8 +173,7 @@ adapt.ops.Style.prototype.sizeViewport = function(viewportWidth, viewportHeight,
  * @implements {adapt.vgen.StylerProducer}
  */
 adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientLayout,
-                                   fontMapper, customRenderer, fallbackMap, pageNumberOffset, documentURLTransformer, counterStore,
-                                   pageProgression) {
+                                   fontMapper, customRenderer, fallbackMap, pageNumberOffset, documentURLTransformer, counterStore) {
     adapt.expr.Context.call(this, style.rootScope, viewport.width, viewport.height, viewport.fontSize);
     /** @const */ this.style = style;
     /** @const */ this.xmldoc = xmldoc;
@@ -197,7 +195,7 @@ adapt.ops.StyleInstance = function(style, xmldoc, defaultLang, viewport, clientL
     /** @private @const */ this.rootPageFloatLayoutContext =
         new vivliostyle.pagefloat.PageFloatLayoutContext(null, null, null, null, null, null, null);
     /** @type {!Object.<string,boolean>} */ this.pageBreaks = {};
-    /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = pageProgression || null;
+    /** @type {?vivliostyle.constants.PageProgression} */ this.pageProgression = null;
     /** @const */ this.customRenderer = customRenderer;
     /** @const */ this.fallbackMap = fallbackMap;
     /** @const @type {number} */ this.pageNumberOffset = pageNumberOffset;
@@ -237,8 +235,7 @@ adapt.ops.StyleInstance.prototype.init = function() {
     self.stylerMap = {};
     self.stylerMap[self.xmldoc.url] = self.styler;
     const docElementStyle = self.styler.getTopContainerStyle();
-    // if (!self.pageProgression)
-    //     self.pageProgression = vivliostyle.page.resolvePageProgression(docElementStyle);
+    self.pageProgression = vivliostyle.page.resolvePageProgression(docElementStyle);
     const rootBox = this.style.rootBox;
     this.rootPageBoxInstance = new adapt.pm.RootPageBoxInstance(rootBox);
     const cascadeInstance = this.style.cascade.createInstance(self, counterListener, counterResolver, this.lang);

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -1790,9 +1790,7 @@ vivliostyle.page.PageManager.prototype.definePageProgression = function() {
     scope.defineName("recto-page", new adapt.expr.Not(scope, isEvenPage));
     scope.defineName("verso-page", isEvenPage);
 
-    /** @type {adapt.ops.StyleInstance} */
-    const styleInstance = this.context;
-    const pageProgression = styleInstance.pageProgression || vivliostyle.page.resolvePageProgression(this.docElementStyle);
+    const pageProgression = vivliostyle.page.resolvePageProgression(this.docElementStyle);
     if (pageProgression === vivliostyle.constants.PageProgression.LTR) {
         scope.defineName("left-page", isEvenPage);
         scope.defineName("right-page", new adapt.expr.Not(scope, isEvenPage));


### PR DESCRIPTION
Reverts vivliostyle/vivliostyle.js#453