### PR TITLE
Fix bug that EPUB internal link does not work

### DIFF
--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1635,7 +1635,7 @@ adapt.epub.OPFView.prototype.navigateTo = function(href, position) {
             } else {
                 path = restored[0];
             }
-            href = path + (restored[1] ? `#${restored[1]}` : "");
+            href = restored[0] + (restored[1] ? `#${restored[1]}` : "");
         }
         if (path == null) {
             return adapt.task.newResult(/** @type {?adapt.epub.PageAndPosition} */ (null));


### PR DESCRIPTION
Internal links in EPUB documents were not working in Vivliostyle Viewer since 2016.7 release. The problem is: When you click an internal link such as `<a href="chapter1.html#section2">Section 2 in Chapter 1</a>`, it moves to the beginning of the chapter HTML file, instead of the section that the link points to.
