### PR TITLE
Fix bug on epubcfi failing to navigate to beginning of a spine item

### DIFF
--- a/src/adapt/cfi.js
+++ b/src/adapt/cfi.js
@@ -364,10 +364,8 @@ adapt.cfi.Fragment.prototype.navigate = function(doc) {
     const pos = {node:doc.documentElement, offset:0, after:false, sideBias:null, ref:null};
     for (let i = 0; i < this.steps.length; i++) {
         if (!this.steps[i].applyTo(pos)) {
-            if (++i < this.steps.length) {
-                pos.ref = new adapt.cfi.Fragment();
-                pos.ref.steps = this.steps.slice(i);
-            }
+            pos.ref = new adapt.cfi.Fragment();
+            pos.ref.steps = this.steps.slice(i + 1);
             break;
         }
     }


### PR DESCRIPTION
The fragment parameter `f=epubcfi(…)` of vivliostyle-viewer URL did not work when trying to navigate to beginning of an EPUB spine item (e.g., beginning of a chapter of a publication).

For example, this vivliostyle-viewer URL using the `f=epubcfi()`
http://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#b=/vivliostyle_doc/ja/events/html5jpub2017/&spread=false&f=epubcfi(/4/6!)
is referring the beginning of the 3rd item ("Webと出版が融合？"),
but due to this bug the navigation failed and the first page of the publication opened.