### PR TITLE
Fix bug that ruby causes incorrect pagination (#67, #417)

### DIFF
--- a/src/adapt/layout.js
+++ b/src/adapt/layout.js
@@ -2181,6 +2181,23 @@ adapt.layout.isSpecialNodeContext = nodeContext => {
 };
 
 /**
+ * @param {string} display
+ * @return {boolean}
+ */
+adapt.layout.isSpecialInlineDisplay = display => {
+    switch (display) {
+        case "ruby":
+        case "inline-block":
+        case "inline-flex":
+        case "inline-grid":
+        case "inline-list-item":
+        case "inline-table":
+            return true;
+    }
+    return false;
+};
+
+/**
  * Read ranges skipping special elments
  * @param {Node} start
  * @param {Node} end
@@ -2218,6 +2235,18 @@ adapt.layout.Column.prototype.getRangeBoxes = function(start, end) {
             } else if (adapt.layout.isSpecial(/** @type {Element} */ (node))) {
                 // Skip special
                 seekRange = !haveStart;
+            } else if (node.localName == "ruby" ||
+                adapt.layout.isSpecialInlineDisplay(this.clientLayout.getElementComputedStyle(/** @type {Element} */ (node)).display)) {
+                // ruby, inline-block, etc.
+                seekRange = !haveStart;
+                if (seekRange) {
+                    range.setStartBefore(node);
+                    haveStart = true;
+                    lastGood = node;
+                }
+                if (node.contains(end)) {
+                    endNotReached = false;
+                }
             } else {
                 next = node.firstChild;
             }

--- a/src/adapt/vgen.js
+++ b/src/adapt/vgen.js
@@ -794,6 +794,10 @@ adapt.vgen.ViewFactory.prototype.createElementView = function(firstTime, atUnfor
             (computedStyle["break-inside"] && computedStyle["break-inside"] !== adapt.css.ident.auto)) {
             self.nodeContext.breakPenalty++;
         }
+        if (display && display !== adapt.css.ident.inline && vivliostyle.display.isInlineLevel(display)) {
+            // Don't break inside ruby, inline-block, etc.
+            self.nodeContext.breakPenalty++;
+        }
         self.nodeContext.inline = !floating && !display || vivliostyle.display.isInlineLevel(display) || vivliostyle.display.isRubyInternalDisplay(display);
         self.nodeContext.display = display ? display.toString() : "inline";
         self.nodeContext.floatSide = floating ? floatSide.toString() : null;


### PR DESCRIPTION
The bug was: incorrect page/column breaking happens when a ruby or inline-block/table element appears at near the block-end edge of a page/column area. Fixed.