### PR TITLE
 Implement renderAllPages=false rendering mode

### DIFF
--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -20,10 +20,16 @@
     position: absolute;
     left: 0;
     top: 0;
+    right: 0;
+    bottom: 0;
+    overflow: hidden;
     z-index: -1;
 }
 
 [data-vivliostyle-debug] [data-vivliostyle-layout-box] {
+    right: auto;
+    bottom: auto;
+    overflow: visible;
     z-index: auto;
 }
 

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -844,7 +844,10 @@ adapt.epub.OPFDoc.prototype.countPages = function(epageIsRenderedPage, epageCoun
             // According to the old comment,
             // "Estimate that offset=2700 roughly corresponds to 1024 bytes of compressed size."
             // However, it should depend on the language.
-            let offsetPerEPage = 2700;
+            // Further adjustment needed.
+
+            //let offsetPerEPage = 2700;
+            let offsetPerEPage = 1800;
             const lang = xmldoc.lang || this.lang;
             if (lang && lang.match(/^(ja|ko|zh)/)) {
                 offsetPerEPage /= 3;

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -1069,6 +1069,9 @@ adapt.epub.OPFView.prototype.finishPageContainer = function(viewItem, page, page
     page.container.setAttribute("data-vivliostyle-page-side", /** @type {string} */ (page.side));
     const oldPage = viewItem.pages[pageIndex];
     page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
+    if (page.isFirstPage) {
+        page.container.setAttribute("data-vivliostyle-first-page", "true");
+    }
     viewItem.pages[pageIndex] = page;
     if (oldPage) {
         viewItem.instance.viewport.contentContainer.replaceChild(page.container, oldPage.container);
@@ -1079,7 +1082,20 @@ adapt.epub.OPFView.prototype.finishPageContainer = function(viewItem, page, page
             newPage: page
         });
     } else {
-        viewItem.instance.viewport.contentContainer.appendChild(page.container);
+        // Find insert position in contentContainer.
+        let insertPos = null;
+        if (pageIndex > 0) {
+            insertPos = viewItem.pages[pageIndex - 1].container.nextElementSibling;
+        } else {
+            for (let i = viewItem.item.spineIndex + 1; i < this.spineItems.length; i++) {
+                const item = this.spineItems[i];
+                if (item && item.pages[0]) {
+                    insertPos = item.pages[0].container;
+                    break;
+                }
+            }
+        }
+        viewItem.instance.viewport.contentContainer.insertBefore(page.container, insertPos);
     }
     this.pageSheetSizeReporter({ width: viewItem.instance.pageSheetWidth, height: viewItem.instance.pageSheetHeight },
                                viewItem.instance.pageSheetSize, viewItem.item.spineIndex, viewItem.instance.pageNumberOffset + pageIndex);
@@ -1168,6 +1184,7 @@ adapt.epub.OPFView.prototype.renderSinglePage = function(viewItem, pos) {
                 if (page.isLastPage) {
                     goog.asserts.assert(self.viewport);
                     self.counterStore.finishLastPage(self.viewport);
+                    page.container.setAttribute("data-vivliostyle-last-page", "true");
                 }
                 frame.finish({
                     pageAndPosition: adapt.epub.makePageAndPosition(page, pageIndex),
@@ -1210,6 +1227,8 @@ adapt.epub.OPFView.prototype.normalizeSeekPosition = (position, viewItem) => {
             // page that contains seekOffset
             pageIndex = seekOffsetPageIndex - 1;
         }
+    } else if (pageIndex === Number.POSITIVE_INFINITY && position.offsetInItem !== -1) {
+        seekOffset = position.offsetInItem;
     }
     return (
         /** @type {!adapt.epub.Position} */ ({
@@ -1224,7 +1243,7 @@ adapt.epub.OPFView.prototype.normalizeSeekPosition = (position, viewItem) => {
  * Find a page corresponding to a specified position among already laid out pages.
  * @private
  * @param {!adapt.epub.Position} position
- * @param {boolean=} sync If true, find the page synchronously (not waiting another rendering task)
+ * @param {boolean} sync If true, find the page synchronously (not waiting another rendering task)
  * @returns {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
 adapt.epub.OPFView.prototype.findPage = function(position, sync) {
@@ -1252,6 +1271,7 @@ adapt.epub.OPFView.prototype.findPage = function(position, sync) {
                 self.renderPage(normalizedPosition).then(result => {
                     if (result) {
                         resultPage = result.page;
+                        pageIndex = result.position.pageIndex;
                     }
                     loopFrame.breakLoop();
                 });
@@ -1350,18 +1370,19 @@ adapt.epub.OPFView.prototype.renderAllPages = function() {
         spineIndex: this.opf.spine.length - 1,
         pageIndex: Number.POSITIVE_INFINITY,
         offsetInItem: -1
-    });
+    }, false);
 };
 
 /**
  * Render pages from (spineIndex=0, pageIndex=0) to the specified (spineIndex, pageIndex).
  * @param {adapt.epub.Position} position
+ * @param {boolean} singleItem If true, render from position.spineIndex.
  * @returns {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.renderPagesUpto = function(position) {
+adapt.epub.OPFView.prototype.renderPagesUpto = function(position, singleItem) {
     const self = this;
     /** @type {!adapt.task.Frame.<?adapt.epub.PageAndPosition>} */ const frame
-        = adapt.task.newFrame("renderAllPages");
+        = adapt.task.newFrame("renderPagesUpto");
 
     if (!position) {
         position = {
@@ -1372,7 +1393,7 @@ adapt.epub.OPFView.prototype.renderPagesUpto = function(position) {
     }
     const spineIndex = position.spineIndex;
     const pageIndex = position.pageIndex;
-    let s = 0;
+    let s = singleItem ? spineIndex : 0;
     let lastResult;
     frame.loopWithFrame(loopFrame => {
         const pos = {
@@ -1396,26 +1417,30 @@ adapt.epub.OPFView.prototype.renderPagesUpto = function(position) {
 
 /**
  * Move to the first page and render it.
+ * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @return {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.firstPage = function() {
+adapt.epub.OPFView.prototype.firstPage = function(position, sync) {
     return this.findPage({
         spineIndex: 0,
         pageIndex: 0,
         offsetInItem: -1
-    });
+    }, sync);
 };
 
 /**
  * Move to the last page and render it.
+ * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @return {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.lastPage = function() {
+adapt.epub.OPFView.prototype.lastPage = function(position, sync) {
     return this.findPage({
         spineIndex: this.opf.spine.length - 1,
         pageIndex: Number.POSITIVE_INFINITY,
         offsetInItem: -1
-    });
+    }, sync);
 };
 
 /**
@@ -1457,9 +1482,10 @@ adapt.epub.OPFView.prototype.nextPage = function(position, sync) {
 /**
  * Move to the previous page and render it.
  * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @return {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.previousPage = function(position) {
+adapt.epub.OPFView.prototype.previousPage = function(position, sync) {
     let spineIndex = position.spineIndex;
     let pageIndex = position.pageIndex;
     if (pageIndex == 0) {
@@ -1475,7 +1501,7 @@ adapt.epub.OPFView.prototype.previousPage = function(position) {
         spineIndex,
         pageIndex,
         offsetInItem: -1
-    });
+    }, sync);
 };
 
 /**
@@ -1508,16 +1534,24 @@ adapt.epub.OPFView.prototype.getSpread = function(position, sync) {
     const isLeft = page.side === vivliostyle.constants.PageSide.LEFT;
     let other;
     if (this.isRectoPage(page, position)) {
-        other = this.previousPage(position);
+        other = this.previousPage(position, sync);
     } else {
         other = this.nextPage(position, sync);
     }
     other.then(otherPageAndPosition => {
-        const otherPage = otherPageAndPosition && otherPageAndPosition.page;
+        // this page may be replaced during nextPage(), so get thisPage again.
+        const thisPage = this.getPage(position);
+
+        let otherPage = otherPageAndPosition && otherPageAndPosition.page;
+        if (otherPage && otherPage.side === thisPage.side) {
+            // otherPage must not be same side
+            otherPage = null;
+        }
+
         if (isLeft) {
-            frame.finish({left: page, right: otherPage});
+            frame.finish({left: thisPage, right: otherPage});
         } else {
-            frame.finish({left: otherPage, right: page});
+            frame.finish({left: otherPage, right: thisPage});
         }
     });
 
@@ -1527,7 +1561,7 @@ adapt.epub.OPFView.prototype.getSpread = function(position, sync) {
 /**
  * Move to the next spread and render pages.
  * @param {!adapt.epub.Position} position
- * @param {boolean=} sync If true, get the spread synchronously (not waiting another rendering task)
+ * @param {boolean} sync If true, get the spread synchronously (not waiting another rendering task)
  * @returns {!adapt.task.Result.<?adapt.epub.PageAndPosition>} The 'verso' page of the next spread.
  */
 adapt.epub.OPFView.prototype.nextSpread = function(position, sync) {
@@ -1536,14 +1570,18 @@ adapt.epub.OPFView.prototype.nextSpread = function(position, sync) {
         return adapt.task.newResult(/** @type {?adapt.epub.PageAndPosition} */ (null));
     }
     const isRecto = this.isRectoPage(page, position);
-    const next = this.nextPage(position, !!sync);
+    const next = this.nextPage(position, sync);
     if (isRecto) {
         return next;
     } else {
         const self = this;
         return next.thenAsync(result => {
             if (result) {
-                return self.nextPage(result.position, !!sync);
+                if (result.page.side === page.side) {
+                    // If same side, this is the next spread.
+                    return next;
+                }
+                return self.nextPage(result.position, sync);
             } else {
                 return adapt.task.newResult(/** @type {?adapt.epub.PageAndPosition} */ (null));
             }
@@ -1554,20 +1592,30 @@ adapt.epub.OPFView.prototype.nextSpread = function(position, sync) {
 /**
  * Move to the previous spread and render pages.
  * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @returns {!adapt.task.Result.<?adapt.epub.PageAndPosition>} The 'recto' page of the previous spread.
  */
-adapt.epub.OPFView.prototype.previousSpread = function(position) {
+adapt.epub.OPFView.prototype.previousSpread = function(position, sync) {
     const page = this.getPage(position);
     if (!page) {
         return adapt.task.newResult(/** @type {?adapt.epub.PageAndPosition} */ (null));
     }
     const isRecto = this.isRectoPage(page, position);
-    const prev = this.previousPage(position);
+    const prev = this.previousPage(position, sync);
+    const oldPrevPageCont = page.container.previousElementSibling;
     if (isRecto) {
         const self = this;
         return prev.thenAsync(result => {
             if (result) {
-                return self.previousPage(result.position);
+                if (result.page.side === page.side) {
+                    // If same side, this is the previous spread.
+                    return prev;
+                }
+                if (result.page.container !== oldPrevPageCont) {
+                    // If previous page is changed, return it.
+                    return prev;
+                }
+                return self.previousPage(result.position, sync);
             } else {
                 return adapt.task.newResult(/** @type {?adapt.epub.PageAndPosition} */ (null));
             }
@@ -1581,9 +1629,10 @@ adapt.epub.OPFView.prototype.previousSpread = function(position) {
  * Move to the Nth page and render it.
  * @param {number} nthPage
  * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @return {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.navigateToNthPage = function(nthPage, position) {
+adapt.epub.OPFView.prototype.navigateToNthPage = function(nthPage, position, sync) {
     if (nthPage < 1) {
         return adapt.task.newResult(/** @type {?adapt.epub.PageAndPosition} */ (null));
     }
@@ -1606,21 +1655,23 @@ adapt.epub.OPFView.prototype.navigateToNthPage = function(nthPage, position) {
         spineIndex,
         pageIndex,
         offsetInItem: -1
-    });
+    }, sync);
 };
 
 /**
  * Move to the epage specified by the given number (zero-based) and render it.
  * @param {number} epage
+ * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @return {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.navigateToEPage = function(epage) {
+adapt.epub.OPFView.prototype.navigateToEPage = function(epage, position, sync) {
     /** @type {!adapt.task.Frame.<?adapt.epub.PageAndPosition>} */ const frame
         = adapt.task.newFrame("navigateToEPage");
     const self = this;
     this.opf.resolveEPage(epage).then(position => {
         if (position) {
-            self.findPage(position).thenFinish(frame);
+            self.findPage(position, sync).thenFinish(frame);
         } else {
             frame.finish(null);
         }
@@ -1631,15 +1682,17 @@ adapt.epub.OPFView.prototype.navigateToEPage = function(epage) {
 /**
  * Move to the page specified by the given CFI and render it.
  * @param {string} fragment
+ * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @return {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.navigateToFragment = function(fragment) {
+adapt.epub.OPFView.prototype.navigateToFragment = function(fragment, position, sync) {
     /** @type {!adapt.task.Frame.<?adapt.epub.PageAndPosition>} */ const frame
         = adapt.task.newFrame("navigateToCFI");
     const self = this;
     self.opf.resolveFragment(fragment).then(position => {
         if (position) {
-            self.findPage(position).thenFinish(frame);
+            self.findPage(position, sync).thenFinish(frame);
         } else {
             frame.finish(null);
         }
@@ -1652,9 +1705,10 @@ adapt.epub.OPFView.prototype.navigateToFragment = function(fragment) {
  * Move to the page specified by the given URL and render it.
  * @param {string} href
  * @param {!adapt.epub.Position} position
+ * @param {boolean} sync
  * @return {!adapt.task.Result.<?adapt.epub.PageAndPosition>}
  */
-adapt.epub.OPFView.prototype.navigateTo = function(href, position) {
+adapt.epub.OPFView.prototype.navigateTo = function(href, position, sync) {
     vivliostyle.logging.logger.debug("Navigate to", href);
     let path = this.opf.getPathFromURL(adapt.base.stripFragment(href));
     if (!path) {
@@ -1680,7 +1734,7 @@ adapt.epub.OPFView.prototype.navigateTo = function(href, position) {
             // CFI link?
             const fragmentIndex = href.indexOf("#");
             if (fragmentIndex >= 0) {
-                return this.navigateToFragment(href.substr(fragmentIndex + 1));
+                return this.navigateToFragment(href.substr(fragmentIndex + 1), position, sync);
             }
         }
         return adapt.task.newResult(/** @type {?adapt.epub.PageAndPosition} */ (null));
@@ -1695,14 +1749,14 @@ adapt.epub.OPFView.prototype.navigateTo = function(href, position) {
                 spineIndex: item.spineIndex,
                 pageIndex: -1,
                 offsetInItem: viewItem.xmldoc.getElementOffset(target)
-            }).thenFinish(frame);
+            }, sync).thenFinish(frame);
         } else if (position.spineIndex !== item.spineIndex) {
             // no fragment, different spine item
             self.findPage({
                 spineIndex: item.spineIndex,
                 pageIndex: 0,
                 offsetInItem: -1
-            }).thenFinish(frame);
+            }, sync).thenFinish(frame);
         } else {
             frame.finish(null);
         }
@@ -1987,7 +2041,14 @@ adapt.epub.OPFView.prototype.getPageViewItem = function(spineIndex) {
         if (item.startPage !== null) {
             pageNumberOffset = item.startPage - 1;
         } else {
-            pageNumberOffset = previousViewItem ? previousViewItem.instance.pageNumberOffset + previousViewItem.pages.length : 0;
+            if (spineIndex > 0 && (!previousViewItem || !previousViewItem.complete)) {
+                // When navigate to a new spine item skipping the previous items,
+                // give up calculate pageNumberOffset and use spineIndex instead,
+                // it makes sense for fixed layout EPUBs.
+                pageNumberOffset = spineIndex;
+            } else {
+                pageNumberOffset = previousViewItem ? previousViewItem.instance.pageNumberOffset + previousViewItem.pages.length : 0;
+            }
             if (item.skipPagesBefore !== null) {
                 pageNumberOffset += item.skipPagesBefore;
             }

--- a/src/vivliostyle/viewer.js
+++ b/src/vivliostyle/viewer.js
@@ -337,7 +337,8 @@ goog.scope(() => {
         LEFT: "left",
         RIGHT: "right",
         FIRST: "first",
-        LAST: "last"
+        LAST: "last",
+        EPAGE: "epage"
     };
     /** @const */ const Navigation = vivliostyle.viewer.Navigation;
 
@@ -360,17 +361,13 @@ goog.scope(() => {
     /**
      * Navigate to the specified page.
      * @param {!vivliostyle.viewer.Navigation} nav
+     * @param {number=} opt_epage
      */
-    Viewer.prototype.navigateToPage = function(nav) {
-        this.adaptViewer.sendCommand({"a": "moveTo", "where": this.resolveNavigation(nav)});
-    };
-
-    /**
-     * Navigate to the Nth page.
-     * @param {number} nthPage
-     */
-    Viewer.prototype.navigateToNthPage = function(nthPage) {
-        this.adaptViewer.sendCommand({"a": "moveTo", "nthPage": nthPage});
+    Viewer.prototype.navigateToPage = function(nav, opt_epage) {
+        if (nav === Navigation.EPAGE)
+            this.adaptViewer.sendCommand({"a": "moveTo", "epage": opt_epage});
+        else
+            this.adaptViewer.sendCommand({"a": "moveTo", "where": this.resolveNavigation(nav)});
     };
 
     /**
@@ -416,7 +413,6 @@ goog.scope(() => {
     goog.exportProperty(Viewer.prototype, "loadEPUB", Viewer.prototype.loadEPUB);
     goog.exportProperty(Viewer.prototype, "getCurrentPageProgression", Viewer.prototype.getCurrentPageProgression);
     goog.exportProperty(Viewer.prototype, "navigateToPage", Viewer.prototype.navigateToPage);
-    goog.exportProperty(Viewer.prototype, "navigateToNthPage", Viewer.prototype.navigateToNthPage);
     goog.exportProperty(Viewer.prototype, "navigateToInternalUrl", Viewer.prototype.navigateToInternalUrl);
     goog.exportProperty(Viewer.prototype, "queryZoomFactor", Viewer.prototype.queryZoomFactor);
     goog.exportProperty(Viewer.prototype, "getPageSizes", Viewer.prototype.getPageSizes);


### PR DESCRIPTION
The viewer option `renderAllPages` (Render all pages at the document
load time. default: true) existed since the background rendering was
implemented, but the renderAllPages=false mode, which should be same
as original adaptive-layout behavior, was broken and didn't work. Now fixed.

Now Viewer.navigateToPage("epage", epage) works for epage (or page number) navigation.
epage is same as rendered page number (0 base) if renderAllPages=true or pre-paginated EPUB.
Otherwise, epage is estimated page number, using (X)HTML size and offset position of each element.

Removed Viewer.navigateToNthPage() which was added in 2018.10.100.
