### PR TITLE
Support loading documents from GitHub and Aozorabunko URLs

### DIFF
--- a/src/adapt/base.js
+++ b/src/adapt/base.js
@@ -81,6 +81,15 @@ adapt.base.resolveURL = (relURL, baseURL) => {
         if (relURL.toLowerCase().match("^javascript:")) {
             return "#";
         }
+        // Convert special URLs
+        let r;
+        if (r = (/^(https?:)\/\/github\.com\/([^/]+\/[^/]+)\/(blob\/|tree\/)?(.*)$/).exec(relURL)) {
+            // Convert GitHub URL to GitHub raw URL
+            relURL = `${r[1]}//raw.githubusercontent.com/${r[2]}/${r[3] ? '' : 'master/'}${r[4]}`;
+        } else if (r = (/^(https?:)\/\/www\.aozora\.gr\.jp\/(cards\/[^/]+\/files\/[^/.]+\.html)$/).exec(relURL)) {
+            // Convert Aozorabunko (X)HTML URL to GitHub raw URL
+            relURL = `${r[1]}//raw.githubusercontent.com/aozorabunko/aozorabunko/master/${r[2]}`;
+        }
         return relURL;
     }
     if (baseURL.match(/^\w{2,}:\/\/[^\/]+$/))

--- a/src/adapt/net.js
+++ b/src/adapt/net.js
@@ -98,8 +98,19 @@ adapt.net.ajax = (url, opt_type, opt_method, opt_data, opt_contentType) => {
             request.send(opt_data);
         }
         else {
-            if (url.match(/file:\/\/.*(\.html$|\.htm$)/))
-                request.overrideMimeType("text/html");
+            if ((/^file:|^https?:\/\/[^/]+\.githubusercontent\.com/).test(url)) {
+                // File or GitHub raw URL
+                if ((/\/aozorabunko\/[^/]+\/cards\/[^/]+\/files\/[^/.]+\.html$/).test(url)) {
+                    // Aozorabunko's (X)HTML support
+                    request.overrideMimeType("text/html; charset=Shift_JIS");
+                } else if ((/\.(html|htm)$/).test(url)) {
+                    request.overrideMimeType("text/html; charset=UTF-8");
+                } else if ((/\.(xhtml|xht|xml|opf)$/).test(url)) {
+                    request.overrideMimeType("application/xml; charset=UTF-8");
+                } else if ((/\.(txt|css)$/).test(url)) {
+                    request.overrideMimeType("text/plain; charset=UTF-8");
+                }
+            }
             request.send(null);
         }
     } catch (e) {


### PR DESCRIPTION
- Convert GitHub URL to GitHub raw URL
e.g., https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/
=> https://raw.githubusercontent.com/IDPF/epub3-samples/master/30/accessible_epub_3/

- Convert Aozorabunko (X)HTML URL to GitHub raw URL
e.g., https://www.aozora.gr.jp/cards/000121/files/628_14895.html
=> https://raw.githubusercontent.com/aozorabunko/aozorabunko/master/cards/000121/files/628_14895.html

- Override MIME type on GitHub raw URLs to enable loading HTML/XML documents from GitHub raw data.
- Set charset=Shift_JIS for Aozorabunko's (X)HTML files