### PR TITLE
Enable 'vivliostyle' media type by default

### DIFF
--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -41,7 +41,7 @@ adapt.expr.defaultPreferences = () => ({
     nightMode: false,
     spreadView: false,
     pageBorder: 1,
-    enabledMediaTypes: {"print": true},
+    enabledMediaTypes: {"vivliostyle": true, "print": true},
     defaultPaperSize: undefined
 });
 

--- a/test/files/file-list.js
+++ b/test/files/file-list.js
@@ -3,6 +3,7 @@ module.exports = [
         category: "General",
         files: [
             {file: "print_media/", title: "Print media"},
+            {file: "vivliostyle_media/", title: "'vivliostyle' vs 'screen' media"},
             {file: "running_header_adaptive.html", title: "Running header emulation with Adaptive Layout"},
             {file: "case_sensitivity/html.html", title: "HTML case sensitivity"},
             {file: "attr_selectors.html", title: "Attribute selectors"},

--- a/test/files/vivliostyle_media/import_screen.css
+++ b/test/files/vivliostyle_media/import_screen.css
@@ -1,0 +1,3 @@
+.import_screen {
+    color: red;
+}

--- a/test/files/vivliostyle_media/import_screen_or_vivliostyle.css
+++ b/test/files/vivliostyle_media/import_screen_or_vivliostyle.css
@@ -1,0 +1,3 @@
+.import_screen_or_vivliostyle {
+    color: green;
+}

--- a/test/files/vivliostyle_media/import_screen_or_vivliostyle_nocolor.css
+++ b/test/files/vivliostyle_media/import_screen_or_vivliostyle_nocolor.css
@@ -1,0 +1,3 @@
+.import_screen_or_vivliostyle_nocolor {
+    color: red;
+}

--- a/test/files/vivliostyle_media/import_vivliostyle.css
+++ b/test/files/vivliostyle_media/import_vivliostyle.css
@@ -1,0 +1,3 @@
+.import_vivliostyle {
+    color: green;
+}

--- a/test/files/vivliostyle_media/index.html
+++ b/test/files/vivliostyle_media/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>vivliostyle media test</title>
+    <style>
+        .link_vivliostyle, .link_screen_or_vivliostyle,
+        .import_vivliostyle, .import_screen_or_vivliostyle,
+        .at_media_vivliostyle, .at_media_screen_or_vivliostyle,
+        .style_vivliostyle, .style_screen_or_vivliostyle {
+            color: red;
+        }
+        .link_screen, .link_screen_or_vivliostyle_nocolor,
+        .import_screen, .import_screen_or_vivliostyle_nocolor,
+        .at_media_screen, .at_media_screen_or_vivliostyle_nocolor,
+        .style_screen, .style_screen_or_vivliostyle_nocolor {
+            color: green;
+        }
+
+        @import url(import_vivliostyle.css) vivliostyle;
+        @import url(import_screen.css) screen;
+        @import url(import_screen_or_vivliostyle.css) screen, vivliostyle;
+        @import url(import_screen_or_vivliostyle_nocolor.css) screen, vivliostyle and (color:0);
+
+        @media vivliostyle {
+            .at_media_vivliostyle {
+                color: green;
+            }
+        }
+        @media screen {
+            .at_media_screen {
+                color: red;
+            }
+        }
+        @media screen, vivliostyle {
+            .at_media_screen_or_vivliostyle {
+                color: green;
+            }
+        }
+        @media screen, vivliostyle and (color:0) {
+            .at_media_screen_or_vivliostyle_nocolor {
+                color: red;
+            }
+        }
+    </style>
+    <link rel="stylesheet" type="text/css" media="vivliostyle" href="link_vivliostyle.css">
+    <link rel="stylesheet" type="text/css" media="screen" href="link_screen.css">
+    <link rel="stylesheet" type="text/css" media="screen, vivliostyle" href="link_screen_or_vivliostyle.css">
+    <link rel="stylesheet" type="text/css" media="screen, vivliostyle and (color:0)" href="link_screen_or_vivliostyle_nocolor.css">
+    <style type="text/css" media="vivliostyle">
+        .style_vivliostyle {
+            color: green;
+        }
+    </style>
+    <style type="text/css" media="screen">
+        .style_screen {
+            color: red;
+        }
+    </style>
+    <style type="text/css" media="screen, vivliostyle">
+        .style_screen_or_vivliostyle {
+            color: green;
+        }
+    </style>
+    <style type="text/css" media="screen, vivliostyle and (color:0)">
+        .style_screen_or_vivliostyle_nocolor {
+            color: red;
+        }
+    </style>
+</head>
+<body>
+<p class="link_vivliostyle">This text should be green. (<code>link</code> element with <code>media="vivliostyle"</code>)</p>
+<p class="link_screen">This text should not be red. (<code>link</code> element with <code>media="screen"</code>)</p>
+<p class="link_screen_or_vivliostyle">This text should be green. (<code>link</code> element with <code>media="screen, vivliostyle"</code>)</p>
+<p class="link_screen_or_vivliostyle_nocolor">This text should not be red. (<code>link</code> element with <code>media="screen, vivliostyle and (color:0)"</code>)</p>
+
+<p class="import_vivliostyle">This text should be green. (<code>@import vivliostyle</code> from <code>style</code> element)</p>
+<p class="import_screen">This text should not be red. (<code>@import screen</code> from <code>style</code> element)</p>
+<p class="import_screen_or_vivliostyle">This text should be green. (<code>@import screen, vivliostyle</code> from <code>style</code> element)</p>
+<p class="import_screen_or_vivliostyle_nocolor">This text should not be red. (<code>@import screen, vivliostyle and (color:0)</code> from <code>style</code> element)</p>
+
+<p class="at_media_vivliostyle">This text should be green. (<code>@media vivliostyle</code> in <code>style</code> element)</p>
+<p class="at_media_screen">This text should not be red. (<code>@media screen</code> in <code>style</code> element)</p>
+<p class="at_media_screen_or_vivliostyle">This text should be green. (<code>@media screen, vivliostyle</code> in <code>style</code> element)</p>
+<p class="at_media_screen_or_vivliostyle_nocolor">This text should not be red. (<code>@media screen, vivliostyle and (color:0)</code> in <code>style</code> element)</p>
+
+<p class="style_vivliostyle">This text should be green. (<code>style</code> element with <code>media="vivliostyle"</code>)</p>
+<p class="style_screen">This text should not be red. (<code>style</code> element with <code>media="screen"</code>)</p>
+<p class="style_screen_or_vivliostyle">This text should be green. (<code>style</code> element with <code>media="screen, vivliostyle"</code>)</p>
+<p class="style_screen_or_vivliostyle_nocolor">This text should not be red. (<code>style</code> element with <code>media="screen, vivliostyle and (color:0)"</code>)</p>
+</body>
+</html>

--- a/test/files/vivliostyle_media/link_screen.css
+++ b/test/files/vivliostyle_media/link_screen.css
@@ -1,0 +1,3 @@
+.link_screen {
+    color: red;
+}

--- a/test/files/vivliostyle_media/link_screen_or_vivliostyle.css
+++ b/test/files/vivliostyle_media/link_screen_or_vivliostyle.css
@@ -1,0 +1,3 @@
+.link_screen_or_vivliostyle {
+    color: green;
+}

--- a/test/files/vivliostyle_media/link_screen_or_vivliostyle_nocolor.css
+++ b/test/files/vivliostyle_media/link_screen_or_vivliostyle_nocolor.css
@@ -1,0 +1,3 @@
+.link_screen_or_vivliostyle_nocolor {
+    color: red;
+}

--- a/test/files/vivliostyle_media/link_vivliostyle.css
+++ b/test/files/vivliostyle_media/link_vivliostyle.css
@@ -1,0 +1,3 @@
+.link_vivliostyle {
+    color: green;
+}


### PR DESCRIPTION
Until now, only 'print' media type has been enabled by default in vivliostyle,
but we need vivliostyle specific stylesheet sometimes,
so having 'vivliostyle' media type will be usefull.