### PR TITLE
add sourcemap link to bundle

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -24,8 +24,8 @@ java -jar node_modules/google-closure-compiler/compiler.jar \
 --hide_warnings_for node_modules/fast-diff/diff.js \
 --create_source_map lib/vivliostyle.min.js.map \
 --js_output_file lib/vivliostyle.min.js \
-${inputFiles.join(' ')}
-`;
+${inputFiles.join(' ')} && \
+echo "\n//# sourceMappingURL=vivliostyle.min.js.map" >> lib/vivliostyle.min.js`;
 
 mkdirp(outputDir, (err) => {
     if (err) {


### PR DESCRIPTION
@MurakamiShinyu this adds a link to the bundle for the sourcemap. This is needed for the browser and other bundlers to find the sourcemap. See https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/#toc-howwork

It is ready to merge.