### PR TITLE
Support Web Publications and similar multi-HTML documents with TOC navigation

### DIFF
--- a/resources/user-agent-base.css
+++ b/resources/user-agent-base.css
@@ -297,31 +297,63 @@ ncx|ncx {
     padding-bottom: 10px;
 }
 
-ncx|navPoint, nav[epub|type=toc] li {
-	display: block;
-	margin: 0px;
-	padding: 0px;
-    padding-inline-start: 1.25em;
+ncx|content {
+	display: none;
+}
+
+body > * {
+    -adapt-behavior: body-child;
+}
+
+[role=doc-toc], [role=directory], nav, .toc, #toc {
+    -adapt-behavior: toc-root;
+}
+
+[role=doc-toc] a,
+[role=directory] a,
+nav a,
+.toc a,
+#toc a,
+ncx|navLabel {
+    -adapt-behavior: toc-node-anchor;
+}
+
+[role=doc-toc] li,
+[role=directory] li,
+nav li,
+.toc li,
+#toc li,
+ncx|navPoint {
     -adapt-behavior: toc-node;
 }
 
-ncx|navPoint, nav[epub|type=toc] li > *:first-child {
-	display: inline-block;
-    margin: 0.2em;
-    vertical-align: top;
+[role=doc-toc] li > *:first-child,
+[role=directory] li > *:first-child,
+nav li > *:first-child,
+.toc li > *:first-child,
+#toc li > *:first-child {
+    -adapt-behavior: toc-node-first-child;
 }
 
-nav[epub|type=toc] ol {
+[role=doc-toc] ol,
+[role=directory] ol,
+nav ol,
+.toc ol,
+#toc ol,
+[role=doc-toc] ul,
+[role=directory] ul,
+nav ul,
+.toc ul,
+#toc ul,
+ol[role=doc-toc],
+ol[role=directory],
+ol.toc,
+ol#toc,
+ul[role=doc-toc],
+ul[role=directory],
+ul.toc,
+ul#toc {
     -adapt-behavior: toc-container;
-}
-
-ncx|navLabel, nav[epub|type=toc] a {
-	color: black;
-	text-decoration: none;
-}
-
-ncx|content {
-	display: none;
 }
 
 /*---------------- fb2 ---------------------*/

--- a/src/adapt/base.js
+++ b/src/adapt/base.js
@@ -99,13 +99,24 @@ adapt.base.resolveURL = (relURL, baseURL) => {
         return relURL;
     }
     if (relURL.match(/^\.(\/|$)/))
-        relURL = relURL.substr(1);
+        relURL = relURL.substr(2);  // './foo' => 'foo'
     baseURL = adapt.base.stripFragmentAndQuery(baseURL);
     if (relURL.match(/^\#/))
         return baseURL + relURL;
     let i = baseURL.lastIndexOf('/');
     if (i < 0)
         return relURL;
+    if (i < baseURL.length - 1) {
+        const j = baseURL.lastIndexOf('.');
+        if (j < i) {
+            // Assume the last part without '.' to be a directory name.
+            if (relURL == '') {
+                return baseURL;
+            }
+            baseURL += '/';
+            i = baseURL.length - 1;
+        }
+    }
     let url = baseURL.substr(0, i + 1) + relURL;
     while (true) {
         i = url.indexOf('/../');

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -202,10 +202,14 @@ adapt.viewer.Viewer.prototype.loadEPUB = function(command) {
             const epubURL = adapt.base.resolveURL(adapt.base.convertSpecialURL(url), self.window.location.href);
             self.packageURL = [epubURL];
             store.loadEPUBDoc(epubURL, haveZipMetadata).then(opf => {
-                self.opf = opf;
-                self.render(fragment).then(() => {
-                    frame.finish(true);
-                });
+                if (opf) {
+                    self.opf = opf;
+                    self.render(fragment).then(() => {
+                        frame.finish(true);
+                    });
+                } else {
+                    frame.finish(false);
+                }
             });
         });
     });
@@ -838,6 +842,10 @@ adapt.viewer.Viewer.prototype.resize = function() {
     this.setReadyState(vivliostyle.constants.ReadyState.LOADING);
     this.cancelRenderingTask();
     const task = adapt.task.currentTask().getScheduler().run(() => adapt.task.handle("resize", frame => {
+        if (!self.opf) {
+            frame.finish(false);
+            return;
+        }
         self.renderTask = task;
         vivliostyle.profile.profiler.registerStartTiming("render (resize)");
         self.reset();


### PR DESCRIPTION
- loadEPUB(), `#b=` URL parameter in Viewer-UI, can now load the following document types in addition to unzipped EPUB:
  - (X)HTML documents:
    - When the specified (X)HTML document has [Web Publication](https://w3c.github.io/wpub/) manifest (JSON-LD format), linked or embedded with `<link rel="publication">`, and has "readingOrder" in the manifest, load the multiple (X)HTML resources with this reading order.
    - When the manifest specifies a TOC (table of contents) (X)HTML resource, "rel": "contents" in manifest, the TOC box is enabled.
    - A variation of web publication manifest, [Readium Web Publication Manifest](https://github.com/readium/webpub-manifest/) is also supported.
      - Example: https://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#b=https://github.com/readium/webpub-manifest/blob/master/examples/MobyDick/index.html
    - If manifest is not existed or "readingOrder" is not in the manifest, find TOC element in the specified (X)HTML document with selector `[role=doc-toc]` or `[role=directory], nav, .toc, #toc`, and load the multiple (X)HTML resources linked with the TOC items.
      - For example, W3C CSS editor's drafts can be viewed with Vivliostyle with TOC navigation enabled,
        - CSS Paged Media (single HTML): https://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#b=https://drafts.csswg.org/css-page-3/
        - CSS2.2 (multiple HTML): https://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#b=https://drafts.csswg.org/css2/
  - Web publication manifest (\*.json or \*.jsonld) URL also can be specified.
    - Example: https://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#b=https://github.com/readium/webpub-manifest/blob/master/examples/MobyDick/manifest.json
  - EPUB OPF (\*.opf) URL can be specified.
    - Example: https://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#b=https://github.com/IDPF/epub3-samples/blob/master/30/accessible_epub_3/EPUB/package.opf

**Update:**
The function `loadEPUB()`, now not only for EPUB, is renamed to `loadPublication()`: https://github.com/vivliostyle/vivliostyle.js/commit/7e909f99db66df842100c68960e31decffe74a5f