### PR TITLE
Enable `env(pub-title)` and `env(doc-title)` for page headers with publication/document titles

### DIFF
--- a/src/adapt/base.js
+++ b/src/adapt/base.js
@@ -566,7 +566,7 @@ adapt.base.escapeCSSIdent = name => name.replace(/[^-_a-zA-Z0-9\u0080-\uFFFF]/g,
  * @param {string} str
  * @return {string}
  */
-adapt.base.escapeCSSStr = str => str.replace(/[\u0000-\u001F"]/g, adapt.base.escapeChar);
+adapt.base.escapeCSSStr = str => str.replace(/[\u0000-\u001F"\\]/g, adapt.base.escapeChar);
 
 /**
  * @param {string} str

--- a/src/adapt/cssparse.js
+++ b/src/adapt/cssparse.js
@@ -2105,7 +2105,7 @@ adapt.cssparse.Parser.prototype.runParser = function(count, parsingValue, parsin
                 continue;
             case adapt.cssparse.Action.VAL_FUNC:
                 text = token.text.toLowerCase();
-                if (text == "-epubx-expr" || text == "calc") {
+                if (text == "-epubx-expr" || text == "calc" || text == "env") {
                     // special case
                     this.actions = adapt.cssparse.actionsExprVal;
                     this.exprContext = adapt.cssparse.ExprContext.PROP;

--- a/src/adapt/epub.js
+++ b/src/adapt/epub.js
@@ -2356,6 +2356,12 @@ adapt.epub.OPFView.prototype.getPageViewItem = function(spineIndex) {
             self.opf.documentURLTransformer, self.counterStore, self.opf.pageProgression);
 
         instance.pref = self.pref;
+
+        // For env(pub-title) and env(doc-title)
+        const pubTitles = self.opf.metadata && self.opf.metadata[adapt.epub.metaTerms.title];
+        instance.pubTitle = pubTitles && pubTitles[0] && pubTitles[0]["v"] || "";
+        instance.docTitle = item.title || "";
+
         instance.init().then(() => {
             viewItem = {item, xmldoc, instance,
                 layoutPositions: [null], pages: [], complete: false};

--- a/src/adapt/expr.js
+++ b/src/adapt/expr.js
@@ -176,6 +176,14 @@ adapt.expr.LexicalScope = function(parent, resolver) {
             return this.pref.horizontal;
         });
         this.defineBuiltInName("pref-spread-view", function() { return this.pref.spreadView; });
+
+        // For env(pub-title) and env(doc-title)
+        this.defineBuiltInName("pub-title", function() {
+            return adapt.expr.cssString(this.pubTitle ? this.pubTitle : "");
+        });
+        this.defineBuiltInName("doc-title", function() {
+            return adapt.expr.cssString(this.docTitle ? this.docTitle : "");
+        });
     }
 };
 

--- a/src/adapt/viewer.js
+++ b/src/adapt/viewer.js
@@ -878,7 +878,7 @@ adapt.viewer.Viewer.prototype.resize = function() {
                         "first": self.currentPage.isFirstPage,
                         "last": self.currentPage.isLastPage,
                         "metadata": self.opf.metadata,
-                        "itemTitle": self.opf.spine[self.pagePosition.spineIndex].title
+                        "docTitle": self.opf.spine[self.pagePosition.spineIndex].title
                     };
                     if (self.currentPage.isFirstPage || self.pagePosition.pageIndex == 0 &&
                             self.opf.spine[self.pagePosition.spineIndex].epage) {
@@ -923,7 +923,7 @@ adapt.viewer.Viewer.prototype.resize = function() {
 adapt.viewer.Viewer.prototype.sendLocationNotification = function(page, cfi) {
     /** @type {!adapt.task.Frame.<boolean>} */ const frame = adapt.task.newFrame("sendLocationNotification");
     const notification = {"t": "nav", "first": page.isFirstPage, "last": page.isLastPage,
-        "metadata": this.opf.metadata, "itemTitle": this.opf.spine[page.spineIndex].title};
+        "metadata": this.opf.metadata, "docTitle": this.opf.spine[page.spineIndex].title};
     const self = this;
     this.opf.getEPageFromPosition(/** @type {adapt.epub.Position} */(self.pagePosition)).then(epage => {
         notification["epage"] = epage;


### PR DESCRIPTION
* env(pub-title): publication title = EPUB, Web publication, or primary entry page HTML title
* env(doc-title): document title = HTML title, which may be chapter or section title in a publication composed of multiple HTML documents

Usage example:
```css
@page {
  @top-left {
    content: env(pub-title);
  }
  @top-right {
    content: env(doc-title);
  }
}
```