### PR TITLE
Fix problem that large images may disappear when printing with zero page margin

### DIFF
--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -87,6 +87,12 @@
         padding-bottom: 0 !important;
         overflow: visible !important;
     } */
+    [data-vivliostyle-bleed-box] > div > div::before {
+        display: block;
+        content: "";
+        padding-top: 0.015625px;
+        margin-bottom: -0.015625px;
+    }
 
     /* Gecko-only hack, see https://bugzilla.mozilla.org/show_bug.cgi?id=267029#c17 */
     @-moz-document regexp('.*') {

--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -83,10 +83,10 @@
     }
 
     /* Workaround for Chrome printing problem */
-    [data-vivliostyle-page-box] {
+    /* [data-vivliostyle-page-box] {
         padding-bottom: 0 !important;
         overflow: visible !important;
-    }
+    } */
 
     /* Gecko-only hack, see https://bugzilla.mozilla.org/show_bug.cgi?id=267029#c17 */
     @-moz-document regexp('.*') {

--- a/src/adapt/ops.js
+++ b/src/adapt/ops.js
@@ -1269,7 +1269,8 @@ adapt.ops.StyleInstance.prototype.layoutNextPage = function(page, cp) {
     /** @type {!adapt.task.Frame.<adapt.vtree.LayoutPosition>} */ const frame
         = adapt.task.newFrame("layoutNextPage");
     frame.loopWithFrame(loopFrame => {
-        self.layoutContainer(page, pageMaster, page.bleedBox, bleedBoxPaddingEdge, bleedBoxPaddingEdge+1, // Compensate 'top: -1px' on page master
+        // self.layoutContainer(page, pageMaster, page.bleedBox, bleedBoxPaddingEdge, bleedBoxPaddingEdge+1, // Compensate 'top: -1px' on page master
+        self.layoutContainer(page, pageMaster, page.bleedBox, bleedBoxPaddingEdge, bleedBoxPaddingEdge,
             [], pageFloatLayoutContext).then(() => {
             if (!pageFloatLayoutContext.isInvalidated()) {
                 pageFloatLayoutContext.finish();
@@ -1328,7 +1329,7 @@ adapt.ops.StyleInstance.prototype.setPageSizeAndBleed = function(evaluatedPageSi
     page.bleedBox.style.bottom = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
     page.bleedBox.style.padding = `${evaluatedPageSizeAndBleed.bleed}px`;
     // Shift 1px to workaround Chrome printing bug
-    page.bleedBox.style.paddingTop = `${evaluatedPageSizeAndBleed.bleed+1}px`;
+    // page.bleedBox.style.paddingTop = `${evaluatedPageSizeAndBleed.bleed+1}px`;
 };
 
 /**

--- a/src/adapt/pm.js
+++ b/src/adapt/pm.js
@@ -176,7 +176,7 @@ adapt.pm.PageMaster = function(scope, name, pseudoName, classes, parent, conditi
     this.specified["position"] = new adapt.csscasc.CascadeValue(adapt.css.ident.relative, 0);
     this.specified["overflow"] = new adapt.csscasc.CascadeValue(adapt.css.ident.visible, 0);
     // Shift 1px to workaround Chrome printing bug
-    this.specified["top"] = new adapt.csscasc.CascadeValue(new adapt.css.Numeric(-1, "px"), 0);
+    // this.specified["top"] = new adapt.csscasc.CascadeValue(new adapt.css.Numeric(-1, "px"), 0);
     /** @type {Object.<string,string>} */ this.keyMap = {};
 };
 goog.inherits(adapt.pm.PageMaster, adapt.pm.PageBox);

--- a/src/vivliostyle/page.js
+++ b/src/vivliostyle/page.js
@@ -907,7 +907,8 @@ vivliostyle.page.PageRuleMasterInstance.prototype.initHorizontal = function() {
 vivliostyle.page.PageRuleMasterInstance.prototype.initVertical = function() {
     const style = this.style;
     // Shift 1px to workaround Chrome printing bug
-    style["top"] = new adapt.css.Numeric(-1, "px");
+    // style["top"] = new adapt.css.Numeric(-1, "px");
+    style["top"] = adapt.css.numericZero;
     style["margin-top"] = adapt.css.numericZero;
     style["border-top-width"] = adapt.css.numericZero;
     style["padding-top"] = adapt.css.numericZero;


### PR DESCRIPTION
This problem was a side effect of "Workaround for Chrome printing problem" (#394).
Changed  to better workaround.
