### PR TITLE
Fix bug that duplicate page margin box content appears at bottom of pages

### DIFF
--- a/resources/vivliostyle-viewport.css
+++ b/resources/vivliostyle-viewport.css
@@ -47,6 +47,10 @@
     box-sizing: border-box;
 }
 
+[data-vivliostyle-page-box] ~ [data-vivliostyle-page-box] {
+    display: none;
+}
+
 [data-vivliostyle-toc-box] {
     position: absolute;
     left: 3px;


### PR DESCRIPTION
This problem happens when there are page margin boxes (e.g. `@top-center`) and footnotes or page floats.

Examples:

* Test: Page Header + Footnote
  * https://gist.github.com/MurakamiShinyu/b4e4a5bed569cf5a0e49d8705af6c679
  * Test with Vivliostyle Viewer: https://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#x=https://gist.github.com/MurakamiShinyu/b4e4a5bed569cf5a0e49d8705af6c679
* Test: Page Header + Page Bottom Float
  * https://gist.github.com/MurakamiShinyu/a447a09293b5cc2ada6d45a042c2b628
  * Test with Vivliostyle Viewer: https://vivliostyle.github.io/vivliostyle.js/viewer/vivliostyle-viewer.html#x=https://gist.github.com/MurakamiShinyu/a447a09293b5cc2ada6d45a042c2b628

This bug existed from Vivliostyle version 2017.2, the PR #324.
The problematic change is found at:
https://github.com/vivliostyle/vivliostyle.js/pull/324/files#diff-7edc4baf380fc2f42210524025de1067L923

The removed code:
```js
-                while (c = page.bleedBox.lastChild) {
-                    page.bleedBox.removeChild(c);
```

As a result of this change, the child elements (that are page boxes, with `vivliostyle-page-box="true"` attribute) of the bleed box is not removed when `pageFloatLayoutContext.isInvalidated()` is true and repeats `self.layoutContainer(…)`, and multiple page boxes with duplicate page margin boxes are generated in one bleed box.

The problem is likely to be solved by restoring this code (remove page.bleedBox children), but there may be unexpected side effects. So, I decided to hide the duplicate page boxes by CSS instead of removing them.