### PR TITLE
Fix TS erros in some files

### DIFF
--- a/src/ts/adapt/base.ts
+++ b/src/ts/adapt/base.ts
@@ -593,7 +593,7 @@ export function multiIndexArray<T> (arr: T[], key: (p1: T) => string | null): {[
  * Apply function to each value of the object
  * @param fn second parameter is the key
  */
-export function mapObj<P, R> (obj: {[key: string]: P}, fn: (p1: any, p2: string) => R): {[key: string]: R} {
+export function mapObj<P, R> (obj: {[key: string]: P}, fn: (p1: P, p2: string) => R): {[key: string]: R} {
       const res: {[key: string]: R} = {};
       for (const n in obj) {
         res[n] = fn(obj[n], n);

--- a/src/ts/adapt/base.ts
+++ b/src/ts/adapt/base.ts
@@ -51,12 +51,18 @@ export const stripFragmentAndQuery = (url: string): string => {
  * Base URL relative to which URLs of resources are resolved.
  */
 export let baseURL = window.location.href;
+export function setBaseURL(value: string) {
+  baseURL = value;
+}
 
 /**
  * Base URL relative to which URLs of resources such as validation.txt and
  * user-agent.css are resolved.
  */
 export let resourceBaseURL = window.location.href;
+export function setResourceBaseURL(value: string) {
+  resourceBaseURL = value;
+}
 
 /**
  * @param relURL relative URL

--- a/src/ts/adapt/csscasc.ts
+++ b/src/ts/adapt/csscasc.ts
@@ -2728,7 +2728,10 @@ export enum ParseState {
 /**
  * Cascade for base User Agent stylesheet.
  */
-export let uaBaseCascade: Cascade = null;
+export var uaBaseCascade: Cascade = null;
+export function setUABaseCascade(value: Cascade) {
+  uaBaseCascade = value;
+}
 
 //------------- parsing ------------
 export class CascadeParserHandler extends

--- a/src/ts/adapt/epub.ts
+++ b/src/ts/adapt/epub.ts
@@ -1948,7 +1948,7 @@ export class OPFView implements CustomRendererFactory {
     }
   }
 
-  isTOCVisible(autohide): boolean {
+  isTOCVisible(): boolean {
     return this.tocView && this.tocView.isTOCVisible();
   }
 }

--- a/src/ts/adapt/epub.ts
+++ b/src/ts/adapt/epub.ts
@@ -61,7 +61,8 @@ export class EPUBDocStore extends ops.OPSDocStore {
   documents: {[key: string]: Result<xmldocs.XMLDocHolder>} = {};
 
   constructor() {
-    super(this.makeDeobfuscatorFactory());
+    super(null);
+    this.fontDeobfuscator = this.makeDeobfuscatorFactory();
     this.plainXMLStore = xmldocs.newXMLDocStore();
     this.jsonStore = net.newJSONStore();
   }
@@ -163,7 +164,7 @@ export class EPUBDocStore extends ops.OPSDocStore {
   }
 
   addDocument(url: string, doc: Document) {
-    const frame = task.newFrame('EPUBDocStore.load');
+    const frame = task.newFrame<xmldocs.XMLDocHolder>('EPUBDocStore.load');
     const docURL = base.stripFragment(url);
     const r = this.documents[docURL] = this.parseOPSResource({
       status: 200,
@@ -180,14 +181,14 @@ export class EPUBDocStore extends ops.OPSDocStore {
   /**
    * @override
    */
-  load(url) {
+  load(url: string)  {
     const docURL = base.stripFragment(url);
     let r = this.documents[docURL];
     if (r) {
       return r.isPending() ? r : task.newResult(r.get());
     } else {
-      const frame = task.newFrame('EPUBDocStore.load');
-      r = super(
+      const frame = task.newFrame<xmldocs.XMLDocHolder>('EPUBDocStore.load');
+      r = super.load(
           docURL, true,
           `Failed to fetch a source document from ${docURL}`);
       r.then((xmldoc: xmldocs.XMLDocHolder) => {
@@ -385,7 +386,7 @@ export const readMetadata = (mroot: xmldocs.NodeList, prefixes: string|null): JS
   let order = 1;
 
   // List of metadata items.
-  const rawItems = mroot.childElements().forEachNonNull((node) => {
+  const rawItems = mroot.childElements().forEachNonNull((node: Element) => {
     if (node.localName == 'meta') {
       const p = resolveProperty((node as Element).getAttribute('property'));
       if (p) {
@@ -416,9 +417,9 @@ export const readMetadata = (mroot: xmldocs.NodeList, prefixes: string|null): JS
   // Items grouped by their target id.
   const rawItemsByTarget =
       base.multiIndexArray(rawItems, (rawItem) => rawItem.refines);
-  const makeMetadata = (map) =>
-      base.mapObj(map, (rawItemArr, itemName) => {
-        const result = rawItemArr.map(rawItem => {
+  const makeMetadata = (map: {[key: string]: any[]}): {[key: string]: any[]} =>
+      base.mapObj(map, (rawItemArr, itemName) =>
+        rawItemArr.map(rawItem => {
           const entry = {'v': rawItem.value, 'o': rawItem.order};
           if (rawItem.schema) {
             entry['s'] = rawItem.scheme;
@@ -449,18 +450,17 @@ export const readMetadata = (mroot: xmldocs.NodeList, prefixes: string|null): JS
             }
           }
           return entry;
-        });
-        return result;
-      });
+        })
+      );
   const metadata = makeMetadata(base.multiIndexArray(
       rawItems, (rawItem) => rawItem.refines ? null : rawItem.name));
   let lang = null;
   if (metadata[metaTerms.language]) {
     lang = metadata[metaTerms.language][0]['v'];
   }
-  const sortMetadata = (metadata) => {
+  const sortMetadata = (metadata: {[key: string]: any[]}) => {
     for (const term in metadata) {
-      const arr = (metadata[term] as Array);
+      const arr = metadata[term];
       arr.sort(getMetadataComparator(term, lang));
       for (let i = 0; i < arr.length; i++) {
         const r = arr[i]['r'];
@@ -598,7 +598,7 @@ export class OPFDoc {
 
   initWithXMLDoc(
       opfXML: xmldocs.XMLDocHolder, encXML: xmldocs.XMLDocHolder,
-      zipMetadata: JSON, manifestURL: string): Result {
+      zipMetadata: JSON, manifestURL: string): Result<any> {
     const self = this;
     this.opfXML = opfXML;
     this.encXML = encXML;
@@ -938,7 +938,7 @@ export {OPFViewItem};
 
 export class OPFView implements CustomRendererFactory {
   spineItems: OPFViewItem[] = [];
-  spineItemLoadingContinuations: Continuation[][] = [];
+  spineItemLoadingContinuations: Continuation<any>[][] = [];
   pref: any;
   clientLayout: any;
   counterStore: any;
@@ -1006,8 +1006,8 @@ export class OPFView implements CustomRendererFactory {
    * too (calling `renderSinglePage` recursively).
    */
   private renderSinglePage(viewItem: OPFViewItem, pos: LayoutPosition):
-      Result<OPFView.RenderSinglePageResult> {
-    const frame: Frame<OPFView.RenderSinglePageResult> =
+      Result<RenderSinglePageResult> {
+    const frame: Frame<RenderSinglePageResult> =
         task.newFrame('renderSinglePage');
     let page = this.makePage(viewItem, pos);
     const self = this;
@@ -1641,7 +1641,7 @@ export class OPFView implements CustomRendererFactory {
           sb.append(srcParam);
           sb.append('&type=');
           sb.append(typeParam);
-          for (let c = srcElem.firstChild; c; c = c.nextSibling) {
+          for (let c: Node = srcElem.firstChild; c; c = c.nextSibling) {
             if (c.nodeType == 1) {
               const ce = (c as Element);
               if (ce.localName == 'param' &&

--- a/src/ts/adapt/layout.ts
+++ b/src/ts/adapt/layout.ts
@@ -2663,7 +2663,7 @@ export class Column extends vtree.Container {
                     return;
                   }
                 }
-                const viewTag = nodeContext.viewNode.localName;
+                const viewTag = (nodeContext.viewNode as Element).localName;
                 if (mediaTags[viewTag]) {
                   // elements that have inherent content
                   // check if a forced break must occur before the block.
@@ -2811,7 +2811,7 @@ export class Column extends vtree.Container {
                 // Leading edge
                 breakAtTheEdge = breaks.resolveEffectiveBreakValue(
                     breakAtTheEdge, nodeContext.breakBefore);
-                const viewTag = nodeContext.viewNode.localName;
+                const viewTag = (nodeContext.viewNode as Element).localName;
                 if (mediaTags[viewTag]) {
                   // elements that have inherent content
                   // check if a forced break must occur before the block.

--- a/src/ts/adapt/toc.ts
+++ b/src/ts/adapt/toc.ts
@@ -58,7 +58,7 @@ export class TOCView implements vgen.CustomRendererFactory {
     if (depth-- == 0) {
       return;
     }
-    for (let c = elem.firstChild; c; c = c.nextSibling) {
+    for (let c: Node = elem.firstChild; c; c = c.nextSibling) {
       if (c.nodeType == 1) {
         const e = (c as Element);
         if (base.getCSSProperty(e, 'height', 'auto') != 'auto') {
@@ -180,7 +180,7 @@ export const toggleNodeExpansion = (evt: Event) => {
   const open = elem.textContent == bulletClosed;
   elem.textContent = open ? bulletOpen : bulletClosed;
   const tocNodeElem = (elem.parentNode as Element);
-  let c = tocNodeElem.firstChild;
+  let c: Node = tocNodeElem.firstChild;
   while (c) {
     if (c.nodeType != 1) {
       c = c.nextSibling;

--- a/src/ts/vivliostyle/column.ts
+++ b/src/ts/vivliostyle/column.ts
@@ -61,10 +61,7 @@ function setBlockSize(container: Container, size) {
   }
 }
 
-/**
- * @abstract
- */
-export class ColumnBalancer {
+export abstract class ColumnBalancer {
   originalContainerBlockSize: any;
 
   constructor(
@@ -119,21 +116,11 @@ export class ColumnBalancer {
 
   protected preBalance(layoutResult: ColumnLayoutResult) {}
 
-  /**
-   * @abstract
-   */
-  protected calculatePenalty(layoutResult: ColumnLayoutResult): number {}
+  protected abstract calculatePenalty(layoutResult: ColumnLayoutResult): number;
 
-  /**
-   * @abstract
-   */
-  protected hasNextCandidate(candidates: ColumnBalancingTrialResult[]):
-      boolean {}
+  protected abstract hasNextCandidate(candidates: ColumnBalancingTrialResult[]): boolean;
 
-  /**
-   * @abstract
-   */
-  protected updateCondition(candidates: ColumnBalancingTrialResult[]) {}
+  protected abstract updateCondition(candidates: ColumnBalancingTrialResult[]): void;
 
   protected postBalance() {
     setBlockSize(this.layoutContainer, this.originalContainerBlockSize);

--- a/src/ts/vivliostyle/page.ts
+++ b/src/ts/vivliostyle/page.ts
@@ -668,7 +668,7 @@ export const marginBoxesKey: string = '_marginBoxes';
  * Represent a page master generated for @page rules
  * @param style Cascaded style for @page rules
  */
-export class PageRuleMaster extends pm.PageMaster {
+export class PageRuleMaster extends pm.PageMaster<PageRuleMasterInstance> {
   private bodyPartitionKey: any;
   private pageMarginBoxes: any =
       ({} as {[key: string]: PageMarginBoxPartition});
@@ -728,7 +728,7 @@ export class PageRuleMaster extends pm.PageMaster {
  * Represent a partition placed in a PageRuleMaster
  * @param style Cascaded style for @page rules
  */
-export class PageRulePartition extends pm.Partition {
+export class PageRulePartition extends pm.Partition<PageRulePartitionInstance> {
   constructor(
       scope: exprs.LexicalScope, parent: PageRuleMaster,
       style: csscasc.ElementStyle, public readonly pageSize: PageSize) {
@@ -760,7 +760,7 @@ export class PageRulePartition extends pm.Partition {
   /**
    * @override
    */
-  createInstance(parentInstance): PageRulePartitionInstance {
+  createInstance(parentInstance): pm.PageBoxInstance {
     return new PageRulePartitionInstance(parentInstance, this);
   }
 }
@@ -768,7 +768,7 @@ export class PageRulePartition extends pm.Partition {
 /**
  * Represent a partition for a page-margin box
  */
-export class PageMarginBoxPartition extends pm.Partition {
+export class PageMarginBoxPartition extends pm.Partition<PageMarginBoxPartitionInstance> {
   constructor(
       scope: exprs.LexicalScope, parent: PageRuleMaster,
       public readonly marginBoxName: string, style: csscasc.ElementStyle) {
@@ -806,7 +806,7 @@ export class PageMarginBoxPartition extends pm.Partition {
   /**
    * @override
    */
-  createInstance(parentInstance): PageMarginBoxPartitionInstance {
+  createInstance(parentInstance): pm.PageBoxInstance {
     return new PageMarginBoxPartitionInstance(parentInstance, this);
   }
 }
@@ -823,7 +823,7 @@ type PageAreaDimension = {
 
 export {PageAreaDimension};
 
-export class PageRuleMasterInstance extends pm.PageMasterInstance {
+export class PageRuleMasterInstance extends pm.PageMasterInstance<PageRuleMaster> {
   pageAreaDimension: PageAreaDimension|null = null;
   pageMarginBoxInstances: {[key: string]: PageMarginBoxPartitionInstance} = {};
 
@@ -1215,7 +1215,7 @@ interface MarginBoxSizingParam {
  */
 class SingleBoxMarginBoxSizingParam implements MarginBoxSizingParam {
   private hasAutoSize_: boolean;
-  private size: {[keykey in keyof sizing.Size]: number} | null = null;
+  private size: {[key in sizing.Size]: number} | null = null;
 
   constructor(
       protected readonly container: vtree.Container,
@@ -1382,7 +1382,7 @@ class FixedSizeMarginBoxSizingParam extends SingleBoxMarginBoxSizingParam {
   }
 };
 
-export class PageRulePartitionInstance extends pm.PartitionInstance {
+export class PageRulePartitionInstance extends pm.PartitionInstance<PageRulePartition> {
   borderBoxWidth: exprs.Val = null;
   borderBoxHeight: exprs.Val = null;
   marginTop: exprs.Val = null;
@@ -1537,7 +1537,7 @@ export class PageRulePartitionInstance extends pm.PartitionInstance {
   }
 }
 
-export class PageMarginBoxPartitionInstance extends pm.PartitionInstance {
+export class PageMarginBoxPartitionInstance extends pm.PartitionInstance<PageMarginBoxPartition> {
   boxInfo: PageMarginBoxInformation;
   suppressEmptyBoxGeneration: any = true;
 
@@ -1556,7 +1556,7 @@ export class PageMarginBoxPartitionInstance extends pm.PartitionInstance {
    */
   prepareContainer(context, container, page, docFaces, clientLayout) {
     this.applyVerticalAlign(context, container.element);
-    super(
+    super.prepareContainer(
         context, container, page, docFaces, clientLayout);
   }
 
@@ -1688,7 +1688,7 @@ export class PageMarginBoxPartitionInstance extends pm.PartitionInstance {
       [borderInsideWidth, paddingInside, paddingOutside, borderOutsideWidth]
           .forEach((x) => {
             if (x) {
-              borderAndPadding += x.evaluate(context);
+              borderAndPadding += x.evaluate(context) as number;
             }
           });
       if (result.marginInside === null || result.marginOutside === null) {
@@ -1795,7 +1795,7 @@ export class PageMarginBoxPartitionInstance extends pm.PartitionInstance {
    */
   finishContainer(
       context, container, page, column, columnCount, clientLayout, docFaces) {
-    super(
+    super.finishContainer(
         context, container, page, column, columnCount, clientLayout,
         docFaces);
 
@@ -1982,7 +1982,7 @@ export class PageManager {
       }
     });
     const pageMasterInstance =
-        newPageMaster.createInstance(this.rootPageBoxInstance);
+        newPageMaster.createInstance(this.rootPageBoxInstance) as pm.PageMasterInstance;
 
     // Do the same initialization as in adapt.ops.StyleInstance.prototype.init
     pageMasterInstance.applyCascadeAndInit(

--- a/src/ts/vivliostyle/viewerapp.ts
+++ b/src/ts/vivliostyle/viewerapp.ts
@@ -196,7 +196,7 @@ export const callback = (msg) => {
           'data-vivliostyle-page-progression', pageProgression);
       viewer.viewportElement.setAttribute(
           'data-vivliostyle-spread-view', viewer.pref.spreadView);
-      window.addEventListener('keydown', (keydown as Function), false);
+      window.addEventListener('keydown', keydown, false);
 
       //        window.addEventListener("touchstart", /** @type {Function} */
       //        (.touch), false);
@@ -207,12 +207,10 @@ export const callback = (msg) => {
       document.body.setAttribute('data-vivliostyle-viewer-status', 'complete');
       const leftButton =
           document.getElementById('vivliostyle-page-navigation-left');
-      leftButton.addEventListener(
-          'click', (navigateToLeftPage as Function), false);
+      leftButton.addEventListener('click', navigateToLeftPage, false);
       const rightButton =
           document.getElementById('vivliostyle-page-navigation-right');
-      rightButton.addEventListener(
-          'click', (navigateToRightPage as Function), false);
+      rightButton.addEventListener('click', navigateToRightPage, false);
       [leftButton, rightButton].forEach((button) => {
         button.setAttribute('data-vivliostyle-ui-state', 'attention');
         window.setTimeout(() => {

--- a/typings/lib.d.ts
+++ b/typings/lib.d.ts
@@ -1,0 +1,6 @@
+interface Element {
+  // `setAttribute` seems to allow non-string values.
+  // https://github.com/Microsoft/TypeScript/issues/15368
+  setAttribute(qualifiedName: string, value: number): void;
+  setAttribute(qualifiedName: string, value: boolean): void;
+}


### PR DESCRIPTION
## Issue

Close #482 
Close #483 
Close #484 
Close #485 
Close #486 
Close #487 
Close #488 
Close #489 

## Overview

This pull request fixes TypeScript compilation error for `adapt/pm.ts`, `vivliostyle/page.ts`, `adapt/ops.ts`, `vivliostyle/column.ts`, `adapt/toc.ts`, `adapt/epub.ts`, `adapt/viewer.ts` and `vivliostyle/viewerapp.ts`.

* This pull request adds `/typings/lib.d.ts` that defines overload functions of `Element#setAttribute`.
The definition of TypeScript doesn't allow non-string values and it may be strict unnecessarily. c.f. https://github.com/Microsoft/TypeScript/issues/15368
