### PR TITLE
Support import system both browser and ESModules

### DIFF
--- a/src/ts/vivliostyle.ts
+++ b/src/ts/vivliostyle.ts
@@ -21,7 +21,6 @@ import { plugin } from "./vivliostyle/plugin";
 import { profile } from "./vivliostyle/profile";
 import { viewer } from "./vivliostyle/viewer";
 import { viewerapp } from "./vivliostyle/viewerapp";
-export { constants, plugin, profile, viewer, viewerapp };
 export default { constants, plugin, profile, viewer, viewerapp };
 
 import { registerPlugins } from "./plugins";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,8 @@ module.exports = {
         ? "vivliostyle.min.js"
         : "vivliostyle.dev.js",
     library: "vivliostyle",
-    libraryTarget: "umd"
+    libraryTarget: "umd",
+    libraryExport: "default"
   },
   resolve: {
     extensions: [".js", ".ts"]


### PR DESCRIPTION
## Overview

This pull request enables us to import Vivliostyle through browser module and ESModules.

### from browser

```html
<script src="vivliostyle.js"></script>
<script>
  const { viewer, constants, proifle } = window.vivliostyle;
</script>
```

### from ESModules

```js
import { viewer, constants, profile } from 'vivliostyle';
```