### PR TITLE
Fix error on logical border shorthand properties

### DIFF
--- a/src/resources/validation.txt
+++ b/src/resources/validation.txt
@@ -513,6 +513,19 @@ marker-start: none;
 marker-mid: none;
 marker-end: none;
 
+/* css-logical */
+border-block-start-color: currentColor;
+border-block-end-color: currentColor;
+border-inline-start-color: currentColor;
+border-inline-end-color: currentColor;
+border-block-start-style: none;
+border-block-end-style: none;
+border-inline-start-style: none;
+border-inline-end-style: none;
+border-block-start-width: 3px;
+border-block-end-width: 3px;
+border-inline-start-width: 3px;
+border-inline-end-width: 3px;
 
 SHORTHANDS
 


### PR DESCRIPTION
**Problem:**

"TypeError: Cannot read property 'visit' of undefined" occurs when logical border shorthand property is used.
e.g. `border-inline-start: 1px solid` causes this error.

When none of `<border-width>`, `<border-style>`, `<border-color>` is omitted,
e.g. `border-inline-start: 1px solid blue`, this error does not happen.

This error happens because default value definition of logical border properties is missing in src/resources/validation.txt.
The problem existed since PR #443 "Support CSS Logical Properties".