### PR TITLE
feat(viewer): new URL parameters

### DIFF
--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -35,11 +35,20 @@
     <section id="vivliostyle-welcome" hidden data-bind="visible: !viewer.state.status(), attr: {hidden: !!viewer.state.status(), 'aria-hidden': viewer.state.status()?'true':'false'}, click: navigation.onclickViewport, swipePages: true">
       <h1>Vivliostyle Viewer <small>(version:&nbsp;<%= version %>)</small></h1>
       <input id="vivliostyle-input-url" type="text" placeholder="Input a document URL" data-bind="textInput: viewer.inputUrl"/>
+      <div id="vivliostyle-input-options">
+        <label><input id="vivliostyle-book-mode" type="checkbox" data-bind="checked: settingsPanel.state.bookMode, disable: settingsPanel.isBookModeChangeDisabled" />&nbsp;<b>Book Mode</b></label>&emsp;
+        <label><input id="vivliostyle-render-all-pages" type="checkbox" data-bind="checked: settingsPanel.state.renderAllPages, disable: settingsPanel.isRenderAllPagesChangeDisabled" />&nbsp;<b>Render All Pages</b></label>&emsp;
+        <button id="vivliostyle-input-apply" type="button" data-bind="click: settingsPanel.apply, disable: !viewer.inputUrl()">Apply</button>
+      </div>
       <p><strong>Supported document types:</strong></p>
       <ul>
-        <li>(X)HTML document, with CSS for paged media</li>
-        <li>Web publication (a collection of HTML documents): specify URL of the primary entry page or manifest file.</li>
-        <li>Unzipped EPUB: specify URL of OPF file or top directory of the unzipped EPUB files.</li>
+        <li>HTML documents, with CSS for paged media</li>
+        <li>Book-like publications, with Table of Contents (<b>Book Mode</b>:&nbsp;On)</span>
+          <ul>
+            <li>Web publications (a collection of HTML documents): specify URL of the primary entry page or manifest file.</li>
+            <li>Unzipped EPUB: specify URL of OPF file or top directory of the unzipped EPUB files.</li>
+          </ul>
+        </li>
       </ul>
       <p>Notes:</p>
       <ul>
@@ -49,23 +58,28 @@
       </ul>
       <p><strong>URL parameter options:</strong></p>
       <ul>
-        <li><span>#<b>b</b>=&lt;document URL&gt;</span> or <span>#<b>x</b>=&lt;document URL&gt;</span>
+        <li><span>#<b>src</b>=&lt;document URL&gt;</span></li>
+        <li><span>&amp;<b>bookMode</b>=[<b>true</b> | <b>false</b>]&emsp;(<b>Book Mode</b>)</span>
           <ul>
-            <li>#<b>b</b>= Book view. When (X)HTML document URL is specified, the URL is treated as primary entry page’s, and a series of HTML documents linked from the manifest or TOC (Table of Contents, e.g. marked up with <code>&lt;nav role="doc-toc"&gt;</code>)  are automatically loaded.</li>
-            <li>#<b>x</b>= (X)HTML document is simply loaded. Multiple documents can be specified as #<b>x</b>=&lt;1st HTML&gt;&amp;<b>x</b>=&lt;2nd HTML&gt;...</li>
+            <li><b>true</b>: for Book-like publications, with Table of Contents.
+              <ul>
+                <li>When an HTML document URL is specified, a series of HTML documents linked from the publication manifest or Table of Contents (e.g., marked up with <code>&lt;nav role="doc-toc"&gt;</code>) are automatically loaded.</li>
+              </ul>
+            </li>
+            <li><b>false</b> (default): for single HTML documents</li>
           </ul>
         </li>
-        <li><span>&amp;<b>spread</b>=[<b>true</b> | <b>false</b> | <b>auto</b>]</span>
+        <li><span>&amp;<b>renderAllPages</b>=[<b>true</b> | <b>false</b>]&emsp;(<b>Render All Pages</b>)</span>
+          <ul>
+            <li><b>true</b> (default): for Print (all pages printable, page count works as expected)</li>
+            <li><b>false</b>: for Read (quick loading with rough page count)</li>
+          </ul>
+        </li>
+        <li><span>&amp;<b>spread</b>=[<b>true</b> | <b>false</b> | <b>auto</b>]&emsp;(<b>Page Spread View</b>)</span>
           <ul>
             <li><b>true</b>: Spread view</li>
             <li><b>false</b>: Single page view</li>
-            <li><b>auto</b>: Auto spread view (default)</li>
-          </ul>
-        </li>
-        <li><span>&amp;<b>renderAllPages</b>=[<b>true</b> | <b>false</b>]</span>
-          <ul>
-            <li><b>true</b>: for Print (all pages printable, page count works as expected)</li>
-            <li><b>false</b>: for Read (quick loading with rough page count)</li>
+            <li><b>auto</b> (default): Auto spread view</li>
           </ul>
         </li>
         <li><span>&amp;<b>style</b>=&lt;additional external style sheet URL&gt;</span></li>
@@ -74,8 +88,8 @@
       <p>Options can also be set in the <a href="#" data-bind="click: settingsPanel.toggle">Settings</a> panel.</p>
       <p>For more details, see documentation on <a href="https://vivliostyle.org"><strong>Vivliostyle.org</strong></a>.</p>
       <ul>
-        <li><a href="https://vivliostyle.org/docs/user-guide">Vivliostyle Viewer User’s Guide</a></li>
-        <li><a href="https://vivliostyle.org/ja/docs/user-guide">Vivliostyle Viewer ユーザーガイド (日本語)</a></li>
+        <li><a href="https://docs.vivliostyle.org/#/user-guide">User Guide</a></li>
+        <li><a href="https://docs.vivliostyle.org/#/ja/user-guide">ユーザーガイド (日本語)</a></li>
       </ul>
     </section>
     <div id="vivliostyle-viewer-viewport" data-vivliostyle-viewer-viewport="true" role="main" tabindex="0" data-bind="attr: {'data-vivliostyle-page-progression': viewer.state.pageProgression}, click: navigation.onclickViewport, swipePages: true"></div>
@@ -101,6 +115,12 @@
                     <li><label><input type="radio" name="vivliostyle-settings_page-view-mode" value="singlePage" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Single page</span></label></li>
                     <li><label><input type="radio" name="vivliostyle-settings_page-view-mode" value="spread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Spread</span></label></li>
                   </ul>
+                </fieldset>
+                <fieldset class="vivliostyle-menu-detail-group">
+                  <div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-settings_book-mode" aria-keyshortcuts="B" data-bind="checked: settingsPanel.state.bookMode, disable: settingsPanel.isBookModeChangeDisabled" /> <span>Book Mode</span></label>
+                  </div>
+                  <div><small>On: for Book-like publications, with Table of Contents</small></div>
+                  <div><small>Off: for single HTML documents</small></div>
                 </fieldset>
                 <fieldset class="vivliostyle-menu-detail-group">
                   <div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-settings_render-all-pages" aria-keyshortcuts="A" data-bind="checked: settingsPanel.state.renderAllPages, disable: settingsPanel.isRenderAllPagesChangeDisabled" /> <span>Render All Pages</span></label>
@@ -152,7 +172,7 @@
                     <li><label><input type="checkbox" name="vivliostyle-settings_force-html-body-margin-zero" data-bind="checked: settingsPanel.state.pageStyle.forceHtmlBodyMarginZero" /> <span>Force html/body margin to 0</span><!--  <small>(avoid big page+body margin)</small> --></label>
                   </ul>
                 </fieldset>
-                <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-breaks" aria-keyshortcuts="B">
+                <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-breaks" aria-keyshortcuts="K">
                   <legend class="vivliostyle-menu-detail-group-heading">Page Breaks</legend>
                   <ul class="vivliostyle-menu-detail-group">
                     <li><label><input type="radio" name="vivliostyle-settings_widows-orphans" value="" required data-bind="checked: settingsPanel.state.pageStyle.widowsOrphans" /> <span>Default widows/orphans control</span></label></li>

--- a/packages/viewer/src/models/viewer-options.ts
+++ b/packages/viewer/src/models/viewer-options.ts
@@ -29,9 +29,9 @@ import PageViewMode, { PageViewModeInstance } from "./page-view-mode";
 import ZoomOptions, { FitToScreen } from "./zoom-options";
 
 type Options = {
-  renderAllPages: Observable<unknown>;
+  renderAllPages: Observable<boolean>;
   fontSize: Observable<number | string>;
-  profile: Observable<unknown>;
+  profile: Observable<boolean>;
   pageViewMode: Observable<PageViewModeInstance>;
   zoom: Observable<ZoomOptions>;
 };
@@ -64,6 +64,8 @@ function getViewerOptionsFromURL(): ViewerOptionsType {
         ? true
         : renderAllPages === "false"
         ? false
+        : urlParameters.hasParameter("b")
+        ? false
         : null,
     fontSize,
     profile: urlParameters.getParameter("profile")[0] === "true",
@@ -75,9 +77,8 @@ function getViewerOptionsFromURL(): ViewerOptionsType {
 }
 
 function getDefaultValues(): ViewerOptionsType {
-  const isNotBook = urlParameters.hasParameter("x");
   return {
-    renderAllPages: isNotBook,
+    renderAllPages: true,
     fontSize: 16,
     profile: false,
     pageViewMode: PageViewMode.defaultMode(),
@@ -86,9 +87,9 @@ function getDefaultValues(): ViewerOptionsType {
 }
 
 class ViewerOptions {
-  renderAllPages: Observable<unknown>;
+  renderAllPages: Observable<boolean>;
   fontSize: Observable<number | string>;
-  profile: Observable<unknown>;
+  profile: Observable<boolean>;
   pageViewMode: Observable<PageViewModeInstance>;
   zoom: Observable<ZoomOptions>;
 
@@ -96,7 +97,7 @@ class ViewerOptions {
     renderAllPages: boolean;
     fontSize: number;
     profile: boolean;
-    pageViewMode: unknown;
+    pageViewMode: PageViewModeInstance;
     zoom: FitToScreen;
   };
 

--- a/packages/viewer/src/scss/vivliostyle-viewer.scss
+++ b/packages/viewer/src/scss/vivliostyle-viewer.scss
@@ -59,6 +59,7 @@ html[data-vivliostyle-paginated] {
   z-index: 1;
   overflow: auto;
   box-sizing: border-box;
+  max-width: 60rem;
   padding: 4px 16px;
   margin-top: $menu-icon-height;
   background: #f0f0f0;
@@ -80,7 +81,7 @@ html[data-vivliostyle-paginated] {
     }
   }
 
-  > input {
+  > #vivliostyle-input-url {
     font-size: 1rem;
     background: white;
     display: block;
@@ -89,7 +90,20 @@ html[data-vivliostyle-paginated] {
     padding: 4px;
     border: 2px solid #808080;
     border-radius: 6px;
-    margin: 1em 0;
+  }
+
+  > #vivliostyle-input-options {
+    line-height: 2;
+    margin: 0.5em 0 1em;
+
+    > button {
+      margin: 0 2px;
+      padding: 5px 7px;
+      line-height: 1em;
+      font-size: 12px;
+      font-weight: bold;
+      cursor: pointer;
+    }
   }
 
   p {
@@ -111,5 +125,10 @@ html[data-vivliostyle-paginated] {
       font-size: 1.25em;
       font-weight: 400;
     }
+  }
+
+  b {
+    font-weight: bold;
+    white-space: nowrap;
   }
 }

--- a/packages/viewer/src/stores/url-parameters.ts
+++ b/packages/viewer/src/stores/url-parameters.ts
@@ -81,6 +81,10 @@ class URLParameterStore {
       updated = `${url +
         (url.match(/[#&]$/) ? "" : url.match(/#/) ? "&" : "#") +
         name}=${value}`;
+      if (name === "src") {
+        // "src" should be the first parameter
+        updated = updated.replace(/#(?!src)(.*?)&(src=[^&]*)/, "#$2&$1");
+      }
     }
     if (this.history !== null && this.history.replaceState) {
       this.history.replaceState(null, "", updated);

--- a/packages/viewer/src/viewmodels/viewer.ts
+++ b/packages/viewer/src/viewmodels/viewer.ts
@@ -218,18 +218,20 @@ class Viewer {
     }
     this.documentOptions_ = documentOptions;
 
-    if (documentOptions.xUrl()) {
-      this.coreViewer_.loadDocument(
-        documentOptions.xUrl(),
-        documentOptions.toObject(),
-        this.viewerOptions_.toObject(),
-      );
-    } else if (documentOptions.bookUrl()) {
-      this.coreViewer_.loadPublication(
-        documentOptions.bookUrl(),
-        documentOptions.toObject(),
-        this.viewerOptions_.toObject(),
-      );
+    if (documentOptions.srcUrls()) {
+      if (!documentOptions.bookMode()) {
+        this.coreViewer_.loadDocument(
+          documentOptions.srcUrls(),
+          documentOptions.toObject(),
+          this.viewerOptions_.toObject(),
+        );
+      } else {
+        this.coreViewer_.loadPublication(
+          documentOptions.srcUrls()[0],
+          documentOptions.toObject(),
+          this.viewerOptions_.toObject(),
+        );
+      }
     } else {
       // No document specified, show welcome page
       this.state_.status.value("");


### PR DESCRIPTION
fixes #628

- the old `x` and `b` parameters are changed to the new `src` and `bookMode` parameters
    - `#x=<url>` is converted to `#src=<url>` (with default `bookMode=false` and `renderAllPages=true`)
    - `#b=<url>` is converted to `#src=<url>&bookMode=true&renderAllPages=false`
- add `Book Mode` and `Render All Pages` check boxes and Apply button in the start page
- update the description in the start page