### PR TITLE
Core viewer: Allow processing of metadata, table of contents

### DIFF
--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -20,6 +20,7 @@
 import * as AdaptiveViewer from "./adaptive-viewer";
 import * as Base from "./base";
 import * as Constants from "./constants";
+import * as Epub from "./epub";
 import * as Profile from "./profile";
 import * as Toc from "./toc";
 
@@ -422,6 +423,24 @@ export class CoreViewer {
    */
   getTOC(): Toc.TOCItem[] {
     return this.adaptViewer_.opfView?.tocView?.getTOC();
+  }
+
+  /**
+   * Returns metadata for the publication. Metadata is
+   * organized as an object of fully-qualified IRI properties
+   * containing arrays of metadata entries. The first element
+   * in the array is primary and should be used by default. Other
+   * entries may overload or refine that metadata.
+   */
+  getMetadata(): Epub.Meta {
+    return this.adaptViewer_.opf.getMetadata();
+  }
+
+  /**
+   * Returns the cover for an EPUB publication, if specified.
+   */
+  getCover(): Epub.OPFItem | null {
+    return this.adaptViewer_.opf.cover;
   }
 }
 

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -21,6 +21,7 @@ import * as AdaptiveViewer from "./adaptive-viewer";
 import * as Base from "./base";
 import * as Constants from "./constants";
 import * as Profile from "./profile";
+import * as Toc from "./toc";
 
 export interface Payload {
   type: string;
@@ -413,6 +414,14 @@ export class CoreViewer {
 
   getPageSizes(): { width: number; height: number }[] {
     return this.adaptViewer_.pageSizes;
+  }
+
+  /**
+   * Returns the current structure of the TOC once it has
+   * been shown, or the empty array if there is no TOC.
+   */
+  getTOC(): Toc.TOCItem[] {
+    return this.adaptViewer_.opfView?.tocView?.getTOC();
   }
 }
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -504,17 +504,17 @@ export function getMetadataComparator(
     const r1 = item1["r"] || empty;
     const r2 = item2["r"] || empty;
     if (term == metaTerms.title) {
-      m1 = r1[metaTerms.titleType] == "main";
-      m2 = r2[metaTerms.titleType] == "main";
+      m1 = r1[metaTerms.titleType]?.[0].v == "main";
+      m2 = r2[metaTerms.titleType]?.[0].v == "main";
       if (m1 != m2) {
         return m1 ? -1 : 1;
       }
     }
-    let i1 = parseInt(r1[metaTerms.displaySeq], 10);
+    let i1 = parseInt(r1[metaTerms.displaySeq]?.[0].v, 10);
     if (isNaN(i1)) {
       i1 = Number.MAX_VALUE;
     }
-    let i2 = parseInt(r2[metaTerms.displaySeq], 10);
+    let i2 = parseInt(r2[metaTerms.displaySeq]?.[0].v, 10);
     if (isNaN(i2)) {
       i2 = Number.MAX_VALUE;
     }
@@ -522,8 +522,12 @@ export function getMetadataComparator(
       return i1 - i2;
     }
     if (term != metaTerms.language && lang) {
-      m1 = (r1[metaTerms.language] || r1[metaTerms.alternateScript]) == lang;
-      m2 = (r2[metaTerms.language] || r2[metaTerms.alternateScript]) == lang;
+      m1 =
+        (r1[metaTerms.language] || r1[metaTerms.alternateScript])?.[0].v ==
+        lang;
+      m2 =
+        (r2[metaTerms.language] || r2[metaTerms.alternateScript])?.[0].v ==
+        lang;
       if (m1 != m2) {
         return m1 ? -1 : 1;
       }
@@ -612,11 +616,11 @@ export function readMetadata(
     Base.mapObj(map, (rawItemArr, itemName) =>
       rawItemArr.map((rawItem) => {
         const entry = { v: rawItem.value, o: rawItem.order };
-        if (rawItem.schema) {
+        if (rawItem.scheme) {
           entry["s"] = rawItem.scheme;
         }
         if (rawItem.id || rawItem.lang) {
-          let refs = rawItemsByTarget[rawItem.id];
+          let refs = rawItemsByTarget[`#${rawItem.id}`];
           if (refs || rawItem.lang) {
             if (rawItem.lang) {
               // Special handling for xml:lang

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -16,10 +16,11 @@
  */
 
 import * as adapt_epub from "../../../src/vivliostyle/epub";
+import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
 
-describe("epub", function() {
-  describe("OPFDoc", function() {
-    describe("OPFDocumentURLTransformer", function() {
+describe("epub", function () {
+  describe("OPFDoc", function () {
+    describe("OPFDocumentURLTransformer", function () {
       var opfDoc = new adapt_epub.OPFDoc(null, null);
       opfDoc.items = [
         { src: "http://example.com:8000/foo/bar1.html" },
@@ -29,17 +30,17 @@ describe("epub", function() {
 
       var illegalCharRegexp = /[^-a-zA-Z0-9_:]/;
 
-      describe("transformFragment / restoreURL", function() {
+      describe("transformFragment / restoreURL", function () {
         var baseURL = "http://base.org:9000/baz.html";
         var fragment = "some-fragment";
         var transformed = transformer.transformFragment(fragment, baseURL);
 
-        it("transforms a pair of a fragment and a base URL into an XML ID string", function() {
+        it("transforms a pair of a fragment and a base URL into an XML ID string", function () {
           expect(transformed).not.toMatch(illegalCharRegexp);
           expect(transformed.indexOf(adapt_epub.transformedIdPrefix)).toBe(0);
         });
 
-        it("restores a pair of the original base URL and the original fragment", function() {
+        it("restores a pair of the original base URL and the original fragment", function () {
           var restored = transformer.restoreURL(transformed);
           expect(restored).toEqual([baseURL, fragment]);
 
@@ -48,10 +49,10 @@ describe("epub", function() {
         });
       });
 
-      describe("transformURL", function() {
+      describe("transformURL", function () {
         var fragment = "some-fragment";
 
-        it("transforms a URL internal to the document into an XML ID string", function() {
+        it("transforms a URL internal to the document into an XML ID string", function () {
           var baseURL = opfDoc.items[1].src;
 
           var transformed = transformer.transformURL("#" + fragment, baseURL);
@@ -66,7 +67,7 @@ describe("epub", function() {
           expect(restored).toEqual([baseURL, fragment]);
         });
 
-        it("does not transform an external URL", function() {
+        it("does not transform an external URL", function () {
           var baseURL = "http://base.org:9000/baz.html";
 
           var transformed = transformer.transformURL("#" + fragment, baseURL);
@@ -76,6 +77,136 @@ describe("epub", function() {
           expect(transformed).toBe(baseURL + "#" + fragment);
         });
       });
+    });
+  });
+
+  describe("readMetadata", function () {
+    var url = "foobar";
+
+    it("parses DC11 terms in order", function () {
+      var doc = new DOMParser().parseFromString(
+        `
+      <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>
+        <dc:title>Norwegian Wood</dc:title>
+        <dc:language>en</dc:language>
+      </metadata>`,
+        "text/xml",
+      );
+      var holder = new adapt_xmldoc.XMLDocHolder(null, url, doc);
+      var items = holder.doc().childElements();
+      var metadata = adapt_epub.readMetadata(items);
+
+      expect(metadata["http://purl.org/dc/terms/identifier"]).toEqual([
+        { v: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809", o: 1 },
+      ]);
+
+      expect(metadata["http://purl.org/dc/terms/title"]).toEqual([
+        { v: "Norwegian Wood", o: 2 },
+      ]);
+
+      expect(metadata["http://purl.org/dc/terms/language"]).toEqual([
+        { v: "en", o: 3 },
+      ]);
+    });
+
+    it("parses DCTERMS properties in order", function () {
+      var doc = new DOMParser().parseFromString(
+        `
+      <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <meta property="dcterms:modified">2011-01-01T12:00:00Z</meta>
+      </metadata>`,
+        "text/xml",
+      );
+      var holder = new adapt_xmldoc.XMLDocHolder(null, url, doc);
+      var items = holder.doc().childElements();
+      var metadata = adapt_epub.readMetadata(items);
+
+      expect(metadata["http://purl.org/dc/terms/modified"]).toEqual([
+        { v: "2011-01-01T12:00:00Z", o: 1 },
+      ]);
+    });
+
+    it("parses refinement properties", function () {
+      var doc = new DOMParser().parseFromString(
+        `
+      <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:creator id="creator">Haruki Murakami</dc:creator>
+        <meta refines="#creator" property="role" scheme="marc:relators" id="role">aut</meta>
+        <meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹</meta>
+        <meta refines="#creator" property="file-as">Murakami, Haruki</meta>
+      </metadata>`,
+        "text/xml",
+      );
+      var holder = new adapt_xmldoc.XMLDocHolder(null, url, doc);
+      var items = holder.doc().childElements();
+      var metadata = adapt_epub.readMetadata(items);
+
+      expect(metadata["http://purl.org/dc/terms/creator"]).toEqual([
+        {
+          v: "Haruki Murakami",
+          o: 1,
+          r: {
+            "http://idpf.org/epub/vocab/package/meta/#role": [
+              { v: "aut", o: 2, s: "http://id.loc.gov/vocabulary/relators" },
+            ],
+            "http://idpf.org/epub/vocab/package/meta/#alternate-script": [
+              { v: "村上 春樹", o: 3 },
+            ],
+            "http://idpf.org/epub/vocab/package/meta/#file-as": [
+              { v: "Murakami, Haruki", o: 4 },
+            ],
+          },
+        },
+      ]);
+    });
+
+    it("parses role properties", function () {
+      var doc = new DOMParser().parseFromString(
+        `
+      <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+        <dc:creator opf:role="aut">Harkaitz Cano</dc:creator>
+        <dc:creator opf:role="trl">Roberta Gozzi</dc:creator>
+        <dc:contributor opf:role="bkp">calibre (3.12.0) [https://calibre-ebook.com]</dc:contributor>
+      </metadata>`,
+        "text/xml",
+      );
+      var holder = new adapt_xmldoc.XMLDocHolder(null, url, doc);
+      var items = holder.doc().childElements();
+      var metadata = adapt_epub.readMetadata(items);
+
+      expect(metadata["http://purl.org/dc/terms/creator"]).toEqual([
+        {
+          v: "Harkaitz Cano",
+          o: 1,
+          r: {
+            "http://idpf.org/epub/vocab/package/meta/#role": [
+              { v: "aut", o: 1 },
+            ],
+          },
+        },
+        {
+          v: "Roberta Gozzi",
+          o: 2,
+          r: {
+            "http://idpf.org/epub/vocab/package/meta/#role": [
+              { v: "trl", o: 2 },
+            ],
+          },
+        },
+      ]);
+
+      expect(metadata["http://purl.org/dc/terms/contributor"]).toEqual([
+        {
+          v: "calibre (3.12.0) [https://calibre-ebook.com]",
+          o: 3,
+          r: {
+            "http://idpf.org/epub/vocab/package/meta/#role": [
+              { v: "bkp", o: 3 },
+            ],
+          },
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
Adds methods for client of the core and adaptive viewers to process the metadata and table of contents from the source document.

This PR supports the functionality added in vivliostyle/vivliostyle-cli#47.

Exporting the TOC requires the TOC to have been shown; this was done to not require a rewrite of the DOM-based TOC parsing code, which vivliostyle-cli needs anyway.

This PR also makes changes in metadata processing:
- Sorting based on `title-type`, `display-seq`, and `alternate-script` now works correctly. Previously, it was comparing metadata items themselves, not their contents.
- ID-based `refines` works correctly. Previously, refinement targets were keyed by the ID alone, even though the `refines` attribute requires a `#` prefix.
- Converts metadata properties `role` attribute to a refinement attribute, like `xml:lang`. This allows a parser to correctly distinguish multiple`contributor` items.