### PR TITLE
Fix internal link fragment bugs

### DIFF
--- a/packages/core/src/vivliostyle/cfi.ts
+++ b/packages/core/src/vivliostyle/cfi.ts
@@ -31,7 +31,7 @@ export type Position = {
 export function getId(node: Node): string | null {
   if (node.nodeType == 1) {
     const idtxt = (node as Element).getAttribute("id");
-    if (idtxt && idtxt.match(/^[-a-zA-Z_0-9.\u007F-\uFFFF]+$/)) {
+    if (idtxt) {
       return idtxt;
     }
   }
@@ -240,7 +240,7 @@ export class Fragment {
     if (!r) {
       throw new Error("E_CFI_NOT_CFI");
     }
-    const str = r[1];
+    const str = decodeURIComponent(r[1]);
     let i = 0;
     const steps = [];
     while (true) {
@@ -252,9 +252,7 @@ export class Fragment {
           i++;
           r = str
             .substr(i)
-            .match(
-              /^(0|[1-9][0-9]*)(\[([-a-zA-Z_0-9.\u007F-\uFFFF]+)(;([^\]]|\^\])*)?\])?/,
-            );
+            .match(/^(0|[1-9][0-9]*)(\[(.*?)(;([^\]]|\^\])*)?\])?/);
           if (!r) {
             throw new Error("E_CFI_NUMBER_EXPECTED");
           }
@@ -429,6 +427,6 @@ export class Fragment {
       this.steps[i].appendTo(sb);
     }
     sb.append(")");
-    return sb.toString();
+    return sb.toString().replace(/%/g, "%25");
   }
 }

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -102,7 +102,7 @@ class CounterListener implements CssCascade.CounterListener {
    */
   countersOfId(id: string, counters: CssCascade.CounterValues) {
     id = this.counterStore.documentURLTransformer.transformFragment(
-      id,
+      encodeURIComponent(id),
       this.baseURL,
     );
     this.counterStore.countersById[id] = counters;

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -763,7 +763,9 @@ export class OPFDoc {
        */
       transformFragment(fragment: string, baseURL: string): string {
         const url = baseURL + (fragment ? `#${fragment}` : "");
-        return transformedIdPrefix + Base.escapeNameStrToHex(url, ":");
+        return (
+          transformedIdPrefix + Base.escapeNameStrToHex(decodeURI(url), ":")
+        );
       }
 
       /**

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1148,7 +1148,7 @@ export class ViewFactory extends Base.SimpleEventTarget
                   // (only first time).
                   if (firstTime) {
                     attributeValue = self.documentURLTransformer.transformFragment(
-                      attributeValue,
+                      encodeURIComponent(attributeValue),
                       self.xmldoc.url,
                     );
                     result.setAttribute(attributeName, attributeValue);

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -254,7 +254,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
         node = next;
         lastGood = node;
         nodeOffset += (next.textContent as string).length;
-        if (nodeOffset > offset) {
+        if (nodeOffset > offset && !/^\s*$/.test(next.textContent)) {
           break;
         }
       } else {
@@ -264,6 +264,10 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
         }
       }
       next = node.nextSibling;
+    }
+    if (next && lastGood && /^\s*$/.test(lastGood.textContent)) {
+      // skip white-space text node
+      lastGood = next;
     }
     return lastGood || element;
   }
@@ -315,7 +319,7 @@ export enum DOMParserSupportedType {
   TEXT_HTML = "text/html",
   TEXT_XML = "text/xml",
   APPLICATION_XML = "application/xml",
-  APPLICATION_XHTML_XML = "application/xhtml_xml",
+  APPLICATION_XHTML_XML = "application/xhtml+xml",
   IMAGE_SVG_XML = "image/svg+xml",
 }
 
@@ -331,7 +335,7 @@ export function parseAndReturnNullIfError(
   const parser = opt_parser || new DOMParser();
   let doc: Document;
   try {
-    doc = parser.parseFromString(str, type as SupportedType);
+    doc = parser.parseFromString(str, type as DOMParserSupportedType);
   } catch (e) {}
   if (!doc) {
     return null;


### PR DESCRIPTION
Resolves the following issues:
- Internal links not working when the URL fragment has %-encoded characters #649
- EPUBCFI with %-encoded characters not working #650
- Reloading causes unexpected move to the previous page #651
