### PR TITLE
feat: Support named strings for running headers and footers

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -306,14 +306,16 @@ LIST_STYLE_TYPE = disc | circle | square | decimal | decimal-leading-zero | lowe
     hebrew | none;
 TYPE_OR_UNIT_IN_ATTR = string | color | url | integer | number | length | angle | time | frequency;
 ATTR = attr(SPACE(IDENT TYPE_OR_UNIT_IN_ATTR?) [ STRING | IDENT | COLOR | INT | NUM | PLENGTH | ANGLE | POS_TIME | FREQUENCY]?);
-CONTENT = normal | none |
-    [ STRING | URI | counter(IDENT LIST_STYLE_TYPE?) |
+CONTENT_LIST = [ STRING | URI | counter(IDENT LIST_STYLE_TYPE?) |
     counters(IDENT STRING LIST_STYLE_TYPE?) | ATTR |
     target-counter([ STRING | URI ] IDENT LIST_STYLE_TYPE?) |
     target-counter(ATTR IDENT LIST_STYLE_TYPE?) |
     target-counters([ STRING | URI ] IDENT STRING LIST_STYLE_TYPE?) |
     target-counters(ATTR IDENT STRING LIST_STYLE_TYPE?) |
-    open-quote | close-quote | no-open-quote | no-close-quote ]+;
+    open-quote | close-quote | no-open-quote | no-close-quote |
+    content([ text | before | after | first-letter ]?) |
+    string(IDENT [first | start | last | first-except]?) ]+;
+CONTENT = normal | none | CONTENT_LIST;
 content = CONTENT;
 COUNTER = [ IDENT INT? ]+ | none;
 counter-increment = COUNTER;
@@ -500,7 +502,7 @@ src = COMMA([SPACE(URI format(STRING+)?) | local(FAMILY)]+); /* for font-face */
 font-size-adjust = none | NNEG_NUM;
 [webkit]font-kerning = auto | normal | none;
 font-variant-east-asian = normal | [[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ] || [ full-width | proportional-width ] || ruby];
-font-feature-settings = COMMA( SPACE( STRING [ on | off | INT ]? )+ );
+font-feature-settings = COMMA( normal | SPACE( STRING [ on | off | INT ]? )+ );
 font-stretch = normal | wider | narrower | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded;
 
 /* CSS Images */
@@ -639,8 +641,10 @@ isolation = auto | isolate;
 background-blend-mode = COMMA( BLEND_MODE+ );
 
 /* CSS GCPM */
+string-set = COMMA( SPACE( IDENT CONTENT_LIST )+ | none );
 footnote-policy = auto | line;
 
+/* CSS Repeated Headers and Footers */
 [viv]repeat-on-break = auto | none | header | footer;
 
 DEFAULTS

--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -21,6 +21,16 @@
 import * as Logging from "./logging";
 import * as Asserts from "./asserts";
 
+/**
+ * RegExp pattern for ::first-letter pseudo element:
+ * https://drafts.csswg.org/css-pseudo-4/#first-letter-pseudo
+ */
+export const firstLetterPattern = /^[\p{Zs}\p{P}\p{Mn}]*[\p{L}\p{N}]\p{Mn}*(?:\p{Zs}*\p{P}\p{Mn}*)*/u;
+/**
+ * Indicates the offset position of an element in a document
+ */
+export const ELEMENT_OFFSET_ATTR = "data-adapt-eloff";
+
 export let emptyObj = {};
 
 export type JSON = any;

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -977,7 +977,7 @@ export class Parser {
   extractVals(sep: string, index: number): Css.Val[] {
     const arr: Css.Val[] = [];
     const valStack = this.valStack;
-    while (true) {
+    while (index < valStack.length) {
       arr.push(valStack[index++] as Css.Val);
       if (index == valStack.length) {
         break;

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -568,10 +568,12 @@ export function appendList(
   toString: boolean,
 ): void {
   const length = values.length;
-  values[0].appendTo(buf, toString);
-  for (let i = 1; i < length; i++) {
-    buf.append(separator);
-    values[i].appendTo(buf, toString);
+  if (length > 0) {
+    values[0].appendTo(buf, toString);
+    for (let i = 1; i < length; i++) {
+      buf.append(separator);
+      values[i].appendTo(buf, toString);
+    }
   }
 }
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -593,8 +593,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       // first char
       if (position.viewNode.nodeType != 1) {
         const text = position.viewNode.textContent;
-        const r = text.match(firstCharPattern);
-        return this.layoutContext.peelOff(position, r[0].length);
+        const r = text.match(Base.firstLetterPattern);
+        return this.layoutContext.peelOff(position, r ? r[0].length : 0);
       }
     }
     return Task.newResult(position) as Task.Result<Vtree.NodeContext>;
@@ -3753,8 +3753,6 @@ export class PseudoColumn {
     return this.column;
   }
 }
-
-export const firstCharPattern = /^[^A-Za-z0-9_\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]*([A-Za-z0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527][^A-Za-z0-9_\u009E\u009F\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02AF\u037B-\u037D\u0386\u0388-\u0482\u048A-\u0527]*)?/;
 
 export type SinglePageFloatLayoutResult = Layout.SinglePageFloatLayoutResult;
 

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -26,8 +26,6 @@ import { XmlDoc } from "./types";
 
 export type XMLDocStore = XmlDoc.XMLDocStore;
 
-export const ELEMENT_OFFSET_ATTR = "data-adapt-eloff";
-
 export class XMLDocHolder implements XmlDoc.XMLDocHolder {
   lang: string | null = null;
   totalOffset: number = -1;
@@ -72,7 +70,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
     this.body = body as Element;
     this.head = head as Element;
     this.last = this.root;
-    this.last.setAttribute(ELEMENT_OFFSET_ATTR, "0");
+    this.last.setAttribute(Base.ELEMENT_OFFSET_ATTR, "0");
   }
 
   doc(): XmlDoc.NodeList {
@@ -80,7 +78,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
   }
 
   getElementOffset(element: Element): number {
-    const offsetStr = element.getAttribute(ELEMENT_OFFSET_ATTR);
+    const offsetStr = element.getAttribute(Base.ELEMENT_OFFSET_ATTR);
     if (offsetStr) {
       return parseInt(offsetStr, 10);
     }
@@ -103,7 +101,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
       last = next;
       if (next.nodeType == 1) {
         const nextElement = next as Element;
-        nextElement.setAttribute(ELEMENT_OFFSET_ATTR, offset.toString());
+        nextElement.setAttribute(Base.ELEMENT_OFFSET_ATTR, offset.toString());
         ++offset;
       } else {
         offset += (next.textContent as string).length;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -128,6 +128,23 @@ module.exports = [
     ],
   },
   {
+    category: "Named Strings",
+    files: [
+      {
+        file: "named-strings/named-strings.html",
+        title: "Named strings - string() function",
+      },
+      {
+        file: "named-strings/string-set-content.html",
+        title: "string-set with content() function",
+      },
+      {
+        file: "named-strings/string-set-attr.html",
+        title: "string-set with attr() function",
+      },
+    ],
+  },
+  {
     category: "Page breaks",
     files: [
       {

--- a/packages/core/test/files/named-strings/named-strings.html
+++ b/packages/core/test/files/named-strings/named-strings.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Named strings - string() function</title>
+    <style>
+      @page {
+        size: 15cm 10cm;
+        margin: 1.5cm;
+
+        @top-left {
+          content: "first: " string(heading, first);
+        }
+        @top-center {
+          content: "start: " string(heading, start);
+        }
+        @top-right {
+          content: "last: " string(heading, last);
+        }
+        @bottom-left {
+          content: "first-except: " string(heading, first-except);
+        }
+        @bottom-right {
+          content: "Page " counter(page);
+        }
+      }
+
+      body {
+        margin: 0;
+      }
+
+      h2 {
+        string-set: heading content();
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Using String-set</h1>
+    <h2>Heading A</h2>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestias in,
+      provident quasi doloremque blanditiis itaque esse placeat maiores eveniet
+      ipsa dolores, harum alias expedita distinctio neque asperiores
+      accusantium, pariatur laboriosam. Deserunt accusamus corporis esse ex,
+      sunt sint voluptatibus asperiores iusto voluptas repellat molestiae quis
+      obcaecati?
+    </p>
+    <h2>Heading B</h2>
+    <p>
+      Quod distinctio iste dignissimos ullam perspiciatis numquam neque
+      recusandae corrupti, similique voluptatem dolore nulla itaque eveniet?
+      Delectus optio aliquam necessitatibus officiis eius!
+    </p>
+    <h2>Heading C</h2>
+    <p>
+      Autem perferendis voluptatibus, explicabo corporis doloremque ducimus
+      illum cupiditate quibusdam voluptatem totam optio debitis ipsam quaerat
+      consectetur dolores cum odio repellendus expedita! Quia et quo voluptate
+      obcaecati necessitatibus inventore aspernatur nesciunt minima.
+      Consectetur, voluptatem? Quam, doloribus animi porro veniam laudantium
+      numquam accusantium quos enim. Rerum aliquid aliquam perferendis
+      architecto autem laborum?
+    </p>
+    <h2>Heading D</h2>
+    <p>
+      A dignissimos asperiores fugiat, fugit dolore, harum dolorem deleniti
+      nulla nam, molestias dolorum error quos sapiente corrupti quidem! Nostrum
+      voluptatum sed blanditiis? Delectus, totam? Maxime qui perspiciatis
+      explicabo vel error distinctio sed doloremque rem vero dolorum, iure
+      itaque quia, dolor dignissimos.
+    </p>
+    <p>
+      Dolores, deleniti impedit! Atque autem omnis doloremque exercitationem.
+      Facilis nobis dolorum quia aut doloremque voluptate excepturi fuga hic
+      eius. Recusandae voluptates laboriosam exercitationem rem voluptatum?
+      Obcaecati distinctio doloribus impedit dignissimos porro quia, reiciendis
+      voluptatum ad eos. Id voluptatum soluta illo saepe repudiandae accusantium
+      voluptatibus ratione veniam molestiae?
+    </p>
+    <p>
+      Magnam perferendis tempora fuga molestiae quas, numquam cumque id porro
+      iure fugiat ipsum in enim facilis? Nobis, repellat. Facilis, consequatur
+      consectetur. Suscipit!
+    </p>
+    <p>
+      Autem porro maxime quod facilis numquam ducimus repellendus officiis
+      expedita dolore! Ipsam temporibus molestiae dolore assumenda beatae illo
+      dolorem quidem praesentium doloribus.
+    </p>
+    <p>
+      Lorem ipsum dolor sit amet consectetur, adipisicing elit. Amet accusamus
+      dolore libero, voluptas ullam ratione doloremque eius sunt iusto nam
+      perferendis ut? Ducimus facilis magnam hic ut cupiditate numquam ea.
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit. Rerum expedita
+      magnam, id vitae exercitationem enim voluptatibus quam quis aperiam
+      delectus non nobis fugiat quod earum ea. Fugit vero nulla magni?
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/named-strings/string-set-attr.html
+++ b/packages/core/test/files/named-strings/string-set-attr.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Test String-set with Attr</title>
+    <meta name="author" content="Test Author">
+    <style>
+      meta[name="author"] {
+        string-set: author attr(content);
+      }
+      title {
+        string-set: title content(text);
+      }
+      section {
+        string-set: section attr(title);
+        break-after: page;
+      }
+      @page {
+        @top-left {
+          content: string(title);
+        }
+        @top-center {
+          content: string(author);
+        }
+        @top-right {
+          content:  string(section);
+        }
+        @bottom-center {
+          content: "- " counter(page) " -";
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <p>The top-left page header output must be "Test String-set with Attr", retrieved from the "title" element: 
+      <code>&lt;title&gt;Test String-set with Attr&lt;/title&gt;</code></p>
+    <p>The top-center page header output must be "Test Author", retrieved from the "content" attribute of the meta tag: 
+      <code>&lt;meta name="author" content="Test Author"&gt;</code></p>
+    
+    <section title="Section One">
+      <h1>Test Section 1</h1>
+      <p>The top-right page header output must be "Section One", retrieved from the "title" attribute of the section start tag:
+        <code>&lt;section title="Section One"&gt;</section></code></p>
+    </section>
+    <section title="Section Two">
+      <h1>Test Section 2</h1>
+      <p>The top-right page header output must be "Section Two", retrieved from the "title" attribute of the section start tag
+        <code>&lt;section title="Section Two"&gt;</section></code></p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/named-strings/string-set-content.html
+++ b/packages/core/test/files/named-strings/string-set-content.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>string-set with content() function</title>
+    <style>
+      body {
+        counter-reset: chapter;
+      }
+      h1 {
+        counter-increment: chapter;
+        string-set: header content(before) ": " content(text) content(after), FirstLetter content(first-letter);
+        break-before: page;
+      }
+      h1::before {
+        content: "Chapter " counter(chapter);
+        display: block;
+      }
+      h1::after {
+        content: "~";
+      }
+      @page {
+        @top-center {
+          content: string(header);
+        }
+        @top-right {
+          content: "First Letter: " string(FirstLetter);
+        }
+        @bottom-center {
+          content: "- " counter(page) " -";
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Test</h1>
+    <p>The top-center page header output must be "Chapter 1: Test~"</p>
+    <p>The top-right page header output must be "First Letter: T"</p>
+    <h1>More test</h1>
+    <p>The top-center page header output must be "Chapter 2: More test~"</p>
+    <p>The top-right page header output must be "First Letter: M"</p>
+  </body>
+</html>


### PR DESCRIPTION
Spec: https://drafts.csswg.org/css-gcpm/#named-strings

Implements the named strings feature in CSS Generated Content for Paged Media Module.
- `string-set` property
- `content()` function
- `string()` function

Tests:
https://raw.githack.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/#Named_Strings
- packages/core/test/files/named-strings/named-strings.html
- packages/core/test/files/named-strings/string-set-attr.html
- packages/core/test/files/named-strings/string-set-content.html

Closes #545