### PR TITLE
fix(react): Add react-dom to peer deps

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,8 @@
     "@vivliostyle/core": "^2.4.1"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.0.21",


### PR DESCRIPTION
Add `react-dom` to `peerDependencies`.

# why?

microbundle bundles `devDependencies` that imported from application code [(doc)](https://github.com/developit/microbundle/wiki/How-Microbundle-decides-which-dependencies-to-bundle), so `@vivliostyle/react`'s bundle includes react code. This will cause [multiple react instance problem](https://reactjs.org/warnings/invalid-hook-call-warning.html).