### PR TITLE
fix(react): init core-viewer once even if source is updated

### DIFF
--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -212,10 +212,13 @@ export const Renderer: React.FC<RendererProps> = ({
   useEffect(() => {
     initInstance();
     setViewerOptions();
-    loadSource();
 
     const cleanup = registerEventHandlers();
     return cleanup;
+  }, []);
+
+  useEffect(() => {
+    loadSource();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source, authorStyleSheet, userStyleSheet]);
 


### PR DESCRIPTION
# before
`Renderer` component initializes core-viewer every time `source` prop is changed.

# after
Just run `loadSource()` when only `source` prop is changed.