### PR TITLE
feat(viewer): Configuration flags

### DIFF
--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html data-vivliostyle-paginated="true">
   <head>
-    <!-- Metadata -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="apple-mobile-web-app-capable" content="yes"/>
     <meta name="google" content="notranslate"/>
+    <title>Vivliostyle Viewer</title>
     
     <!-- WICG Visual Viewport -->
     <script src="https://wicg.github.io/visual-viewport/polyfill/visualViewport.js"></script>
@@ -14,30 +14,25 @@
     <script src="resources/mathjax-config.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
-    <!-- Core -->
+    <!-- Viewer -->
+    <script src="<%= viewerPath %>"></script>
     <link rel="icon" href="resources/vivliostyle-icon.png"/>
     <link rel="stylesheet" href="resources/vivliostyle-viewport.css"/>
     <link rel="stylesheet" href="resources/vivliostyle-viewport-screen.css" media="screen"/>
-
-    <!-- Viewer -->
-    <script src="<%= viewerPath %>"></script>
     <link rel="stylesheet" href="css/vivliostyle-viewer.css"/>
     <link rel="stylesheet" href="css/ui.arrows.css"/>
     <link rel="stylesheet" href="css/ui.menu-bar.css"/>
     <link rel="stylesheet" href="css/ui.message-dialog.css"/>
     <link rel="stylesheet" href="css/ui.loading-overlay.css"/>
-
     <style id="vivliostyle-page-rules"></style>
-
-    <title>Vivliostyle Viewer</title>
   </head>
   <body data-vivliostyle-viewer-status="loading" data-bind="event: {keydown: handleKey}, attr: {'data-vivliostyle-viewer-status': viewer.state.status, 'aria-busy': viewer.state.status()=='loading'}">
     <section id="vivliostyle-welcome" hidden data-bind="visible: !viewer.state.status(), attr: {hidden: !!viewer.state.status(), 'aria-hidden': viewer.state.status()?'true':'false'}, click: navigation.onclickViewport, swipePages: true">
       <h1>Vivliostyle Viewer <small>(version:&nbsp;<%= version %>)</small></h1>
       <input id="vivliostyle-input-url" type="text" placeholder="Input a document URL" data-bind="textInput: viewer.inputUrl"/>
       <div id="vivliostyle-input-options">
-        <label><input id="vivliostyle-book-mode" type="checkbox" data-bind="checked: settingsPanel.state.bookMode, disable: settingsPanel.isBookModeChangeDisabled" />&nbsp;<b>Book Mode</b></label>&emsp;
-        <label><input id="vivliostyle-render-all-pages" type="checkbox" data-bind="checked: settingsPanel.state.renderAllPages, disable: settingsPanel.isRenderAllPagesChangeDisabled" />&nbsp;<b>Render All Pages</b></label>&emsp;
+        <label data-bind="hidden: settingsPanel.isBookModeChangeDisabled"><input id="vivliostyle-book-mode" type="checkbox" data-bind="checked: settingsPanel.state.bookMode" />&nbsp;<b>Book Mode</b>&emsp;</label>
+        <label data-bind="hidden: settingsPanel.isRenderAllPagesChangeDisabled"><input id="vivliostyle-render-all-pages" type="checkbox" data-bind="checked: settingsPanel.state.renderAllPages" />&nbsp;<b>Render All Pages</b>&emsp;</label>
         <button id="vivliostyle-input-apply" type="button" data-bind="click: settingsPanel.apply, disable: !viewer.inputUrl()">Apply</button>
       </div>
       <p><strong>Supported document types:</strong></p>
@@ -120,13 +115,13 @@
                     <li><label><input type="radio" name="vivliostyle-settings_page-view-mode" value="spread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Spread</span></label></li>
                   </ul>
                 </fieldset>
-                <fieldset class="vivliostyle-menu-detail-group">
+                <fieldset class="vivliostyle-menu-detail-group" data-bind="hidden: settingsPanel.isBookModeChangeDisabled">
                   <div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-settings_book-mode" aria-keyshortcuts="B" data-bind="checked: settingsPanel.state.bookMode, disable: settingsPanel.isBookModeChangeDisabled" /> <span>Book Mode</span></label>
                   </div>
                   <div><small>On: for Book-like publications, with Table of Contents</small></div>
                   <div><small>Off: for single HTML documents</small></div>
                 </fieldset>
-                <fieldset class="vivliostyle-menu-detail-group">
+                <fieldset class="vivliostyle-menu-detail-group" data-bind="hidden: settingsPanel.isRenderAllPagesChangeDisabled">
                   <div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-settings_render-all-pages" aria-keyshortcuts="A" data-bind="checked: settingsPanel.state.renderAllPages, disable: settingsPanel.isRenderAllPagesChangeDisabled" /> <span>Render All Pages</span></label>
                   </div>
                   <div><small>On: for Print (all pages printable, page count works)</small></div>
@@ -239,31 +234,6 @@
                   </ul>
                 </details>
               </details>
-              <!--
-              <fieldset class="vivliostyle-menu-detail-group">
-                <div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-settings_override-xxxx" /> <span>Menu-Detail Item</span> <small>(Sample)</small></label></div>
-                <ul class="vivliostyle-menu-detail-group">
-                  <li><label><input type="radio" name="vivliostyle-settings_page-yyyy" value="vivliostyle-settings_page-yyyy-a" /> <span>Sample A</span> <small>(Abc De Fg.)</small></label></li>
-                  <li class="vivliostyle-menu-disabled"><label><input type="radio" name="vivliostyle-settings_page-yyyy" value="vivliostyle-settings_page-yyyy-b" disabled /> <span>Sample B</span></label>
-                    <ul class="vivliostyle-menu-detail-group">
-                      <li><label><input type="radio" name="vivliostyle-settings_page-yyyy" value="vivliostyle-settings_page-yyyy-c" disabled /> <span>Sample C</span></label></li>
-                    </ul>
-                  </li>
-                </ul>
-              </fieldset>
-              <fieldset class="vivliostyle-menu-detail-group">
-                <legend class="vivliostyle-menu-detail-group-heading">Menu-Detail Item <small>(Sample)</small></legend>
-                <ul class="vivliostyle-menu-detail-group vivliostyle-menu-disabled">
-                  <li><label><input type="radio" name="vivliostyle-settings_page-yyyy" value="vivliostyle-settings_page-yyyy-d" disabled /> <span>Sample D</span> <small>(Abc De Fg.)</small></label></li>
-                </ul>
-              </fieldset>
-              <fieldset class="vivliostyle-menu-detail-group">
-                <div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-settings_paginate" /> <span>Paginate</span></label></div>
-                <div class="vivliostyle-menu-detail-group vivliostyle-menu-disabled">
-                  <div><label><input type="checkbox" name="vivliostyle-settings_spread-view" disabled /> <span>Spread View</span></label></div>
-                </div>
-              </fieldset>
-              -->
               <div class="vivliostyle-menu-detail-group vivliostyle-menu-detail-group-buttons vivliostyle-menu-detail-group-inline">
                 <div><button type="button" class="vivliostyle-menu-button vivliostyle-menu-button-positive" id="vivliostyle-menu-button_apply" aria-keyshortcuts="Enter" data-bind="menuButton: true, click: settingsPanel.apply">Apply</button></div>
                 <div><button type="button" class="vivliostyle-menu-button vivliostyle-menu-button-negative" id="vivliostyle-menu-button_reset" aria-keyshortcuts="Escape" data-bind="menuButton: true, click: settingsPanel.cancel">Cancel</button></div>

--- a/packages/viewer/src/utils/key-util.ts
+++ b/packages/viewer/src/utils/key-util.ts
@@ -35,10 +35,11 @@ const Keys = {
 
 // CAUTION: This function covers only part of common keys on a keyboard. Keys not covered by the implementation are identified as KeyboardEvent.key, KeyboardEvent.keyIdentifier, or "Unidentified".
 function identifyKeyFromEvent(
-  event: KeyboardEvent & { keyIdentifier: string }, // TODO: remove keyIdentifier
+  event: KeyboardEvent,
 ): typeof Keys[keyof typeof Keys] {
   const key = event.key;
-  const keyIdentifier = event.keyIdentifier;
+  const keyIdentifier = (event as KeyboardEvent & { keyIdentifier: string })
+    .keyIdentifier;
   const location = event.location;
   if (key === Keys.ArrowDown || key === "Down" || keyIdentifier === "Down") {
     if (event.metaKey) {

--- a/packages/viewer/src/viewmodels/viewer-app.ts
+++ b/packages/viewer/src/viewmodels/viewer-app.ts
@@ -42,6 +42,53 @@ class ViewerApp {
   navigation: Navigation;
 
   constructor() {
+    const flags =
+      (document.documentElement.getAttribute("data-vivliostyle-viewer-flags") ||
+        "") + (urlParameters.getParameter("flags")[0] || "");
+    const disableSettings = flags.includes("s");
+    const settingsPanelOptions = {
+      disablePageStyleChange: disableSettings || flags.includes("g"),
+      disablePageViewModeChange: disableSettings || flags.includes("v"),
+      disableBookModeChange: disableSettings || flags.includes("b"),
+      disableRenderAllPagesChange: disableSettings || flags.includes("a"),
+    };
+    const navigationOptions = {
+      disableTOCNavigation: flags.includes("t"),
+      disablePageNavigation: flags.includes("n"),
+      disableZoom: flags.includes("z"),
+      disableFontSizeChange: flags.includes("f"),
+    };
+    const disableContextMenu = flags.includes("c");
+    const disablePrint = flags.includes("p");
+
+    if (disableSettings) {
+      const welcome: HTMLElement = document.getElementById(
+        "vivliostyle-welcome",
+      );
+      if (welcome) {
+        welcome.remove();
+      }
+      const menuDetail: HTMLElement = document.querySelector(
+        ".vivliostyle-menu-detail",
+      );
+      const menuDetailMain: HTMLElement = document.querySelector(
+        ".vivliostyle-menu-detail-main",
+      );
+      if (menuDetail && menuDetailMain) {
+        menuDetailMain.style.visibility = "hidden";
+        menuDetail.style.height = "auto";
+      }
+    }
+    if (disableContextMenu) {
+      document.oncontextmenu = (): boolean => false;
+    }
+    if (disablePrint) {
+      const printStyle = document.createElement("style");
+      printStyle.setAttribute("media", "print");
+      printStyle.textContent = "*{display:none}";
+      document.head.appendChild(printStyle);
+    }
+
     this.documentOptions = new DocumentOptions();
     this.viewerOptions = new ViewerOptions();
 
@@ -86,6 +133,7 @@ class ViewerApp {
     urlParameters.removeParameter("fontSize", true);
     urlParameters.removeParameter("profile", true);
     urlParameters.removeParameter("debug", true);
+    urlParameters.removeParameter("flags", true);
 
     this.viewer = new Viewer(this.viewerSettings, this.viewerOptions);
 
@@ -113,13 +161,6 @@ class ViewerApp {
 
     this.messageDialog = new MessageDialog(messageQueue);
 
-    const settingsPanelOptions = {
-      disablePageStyleChange: false,
-      disablePageViewModeChange: false,
-      disableBookModeChange: false,
-      disableRenderAllPagesChange: false,
-    };
-
     this.settingsPanel = new SettingsPanel(
       this.viewerOptions,
       this.documentOptions,
@@ -127,13 +168,6 @@ class ViewerApp {
       this.messageDialog,
       settingsPanelOptions,
     );
-
-    const navigationOptions = {
-      disableTOCNavigation: false,
-      disablePageNavigation: false,
-      disableZoom: false,
-      disableFontSizeChange: false,
-    };
 
     this.navigation = new Navigation(
       this.viewerOptions,

--- a/packages/viewer/src/viewmodels/viewer.ts
+++ b/packages/viewer/src/viewmodels/viewer.ts
@@ -216,7 +216,7 @@ class Viewer {
 
   loadDocument(
     documentOptions: DocumentOptions,
-    viewerOptions: ViewerOptions,
+    viewerOptions?: ViewerOptions,
   ): void {
     this.state_.status.value(ReadyState.LOADING);
     if (viewerOptions) {


### PR DESCRIPTION
Configuration flags can be specified with the `data-vivliostyle-viewer-flags`
attribute on the vivliostyle-viewer root element or the `flags` URL parameter.
e.g.,
```
<html data-vivliostyle-viewer-flags="szf" data-vivliostyle-paginated="true">
```
or
```
https://vivliostyle.org/viewer/#src=https://example.com/&flags=bap
```

Flags:  (update: https://github.com/vivliostyle/vivliostyle.js/pull/693)
> * "S": disableSettings
>   * "P": disablePageStyleChange
>   * "V": disablePageViewModeChange
>   * "B": disableBookModeChange
>   * "A": disableRenderAllPagesChange
> * "T": disableTOCNavigation
> * "N": disablePageNavigation
> * "Z": disableZoom
> * "F": disableFontSizeChange
> * "s": disablePageSlider
> * "c": disableContextMenu
> * "p": disablePrint
> * "b": defaultBookMode
> * "a": undefaultRenderAllPages
