### PR TITLE
fix(core): spread break at beginning of a document does not work properly

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -842,10 +842,10 @@ export const UserAgentPageCss = `
 :root {
   hyphens: -epubx-expr(pref-hyphenate? "auto": "manual");
 }
-:root[data-vivliostyle-epub-spine-properties~="page-spread-left"] > html|body {
+:root[data-vivliostyle-epub-spine-properties~="page-spread-left"] {
   break-before: left;
 }
-:root[data-vivliostyle-epub-spine-properties~="page-spread-right"] > html|body {
+:root[data-vivliostyle-epub-spine-properties~="page-spread-right"] {
   break-before: right;
 }
 

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -2245,27 +2245,28 @@ export class PageManager {
    * Determine the page progression and define left/right/recto/verso pages.
    */
   private definePageProgression() {
-    // TODO If a page break is forced before the root element, recto/verso pages
+    // If a page break is forced before the root element, recto/verso pages
     // are no longer odd/even pages. left/right are reversed too.
     const scope = this.pageScope;
+    const styleInstance: any /* Ops.StyleInstance */ = this.context;
+    const isVersoFirstPage = styleInstance.isVersoFirstPage;
     const pageNumber = new Exprs.Named(scope, "page-number");
-    const isEvenPage = new Exprs.Eq(
+    const isVersoPage = new Exprs.Eq(
       scope,
       new Exprs.Modulo(scope, pageNumber, new Exprs.Const(scope, 2)),
-      scope.zero,
+      isVersoFirstPage ? scope.one : scope.zero,
     );
-    scope.defineName("recto-page", new Exprs.Not(scope, isEvenPage));
-    scope.defineName("verso-page", isEvenPage);
-    const styleInstance: any /* Ops.StyleInstance */ = this.context;
+    scope.defineName("recto-page", new Exprs.Not(scope, isVersoPage));
+    scope.defineName("verso-page", isVersoPage);
     const pageProgression =
       styleInstance.pageProgression ||
       resolvePageProgression(this.docElementStyle);
     if (pageProgression === Constants.PageProgression.LTR) {
-      scope.defineName("left-page", isEvenPage);
-      scope.defineName("right-page", new Exprs.Not(scope, isEvenPage));
+      scope.defineName("left-page", isVersoPage);
+      scope.defineName("right-page", new Exprs.Not(scope, isVersoPage));
     } else {
-      scope.defineName("left-page", new Exprs.Not(scope, isEvenPage));
-      scope.defineName("right-page", isEvenPage);
+      scope.defineName("left-page", new Exprs.Not(scope, isVersoPage));
+      scope.defineName("right-page", isVersoPage);
     }
   }
 

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -964,6 +964,14 @@ export class Styler implements AbstractStyler {
           );
         } else {
           box = this.boxStack.push(style, this.lastOffset, elem === this.root);
+
+          // For not ignoring break-before on :root (issue #666)
+          if (elem === this.xmldoc.body) {
+            box.breakBefore = Break.resolveEffectiveBreakValue(
+              box.flowChunk.breakBefore,
+              box.breakBefore,
+            );
+          }
         }
         const blockStartOffset = this.boxStack.nearestBlockStartOffset(box);
         this.registerForcedBreakOffset(

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2502,6 +2502,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
           viewportSize.height,
         );
       }
+      const isVersoFirstPage = this.spineItems[0]?.instance.isVersoFirstPage;
       const previousViewItem = this.spineItems[spineIndex - 1];
       let pageNumberOffset: number;
       if (item.startPage !== null) {
@@ -2514,8 +2515,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
           // When navigate to a new spine item skipping the previous items,
           // give up calculate pageNumberOffset and use epage (or spineIndex if epage is unset).
           pageNumberOffset = item.epage || spineIndex;
-          if (!this.opf.prePaginated && pageNumberOffset % 2 == 0) {
+          if (
+            !this.opf.prePaginated &&
+            pageNumberOffset % 2 == (isVersoFirstPage ? 1 : 0)
+          ) {
             // Force to odd number to avoid unpaired page. (This is 0 based and even number is recto)
+            // (odd and even are reversed if isVersoFirstPage is true)
             pageNumberOffset++;
           }
         } else {
@@ -2542,6 +2547,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         this.opf.documentURLTransformer,
         this.counterStore,
         this.opf.pageProgression,
+        isVersoFirstPage,
       );
       instance.pref = this.pref;
 


### PR DESCRIPTION
fixes #666

The spread break (break-before: left/right/recto/verso) at beginning of a document now works properly, as follows:

- break-before: left/right/recto/verso at the root (html) element works as well as at the body element.
- no blank page is generated at beginning of the first document, and the first page (normally recto) can be verso page.
- the blank page caused by a spread break between two documents should have no margin box content.