### PR TITLE
feat(core): Support the :nth() page selector

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1687,6 +1687,7 @@ export class Parser {
                 case "nth-of-type":
                 case "nth-last-child":
                 case "nth-last-of-type":
+                case "nth":
                   params = this.readNthPseudoParams();
                   if (!params) {
                     break pseudoclassType;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -212,7 +212,7 @@ export class StyleInstance
   pageBreaks: { [key: string]: boolean } = {};
   pageProgression: Constants.PageProgression | null = null;
   isVersoFirstPage: boolean = false;
-  needBlankPage: boolean = false;
+  blankPageAtStart: boolean = false;
   pageSheetSize: { [key: string]: { width: number; height: number } } = {};
   pageSheetHeight: number = 0;
   pageSheetWidth: number = 0;
@@ -297,7 +297,7 @@ export class StyleInstance
       if (this.pageNumberOffset === 0) {
         this.isVersoFirstPage = true;
       } else {
-        this.needBlankPage = true;
+        this.blankPageAtStart = true;
       }
     }
 
@@ -624,10 +624,9 @@ export class StyleInstance
 
         // The blank page caused by a spread break between two documents
         // should have no margin box content (issue #666)
-        if (this.needBlankPage) {
+        if (cp.page === 1 && this.blankPageAtStart) {
           pageMaster.style = {}; // clear root background-color/image
           cascadedPageStyle = {}; // clear margin boxes
-          this.needBlankPage = false;
           // TODO: support the :blank page selector
         }
 

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -132,6 +132,22 @@ module.exports = [
     ],
   },
   {
+    category: "Nth page selector",
+    files: [
+      {
+        file: ["nth-page/nth-page.html", "nth-page/nth-page.html"],
+        title: "nth() page selector & blank page between two docs",
+      },
+      {
+        file: [
+          "nth-page/nth-page-counter-reset.html",
+          "nth-page/nth-page-counter-reset.html",
+        ],
+        title: "nth() page selector & page counter reset",
+      },
+    ],
+  },
+  {
     category: "Named Strings",
     files: [
       {

--- a/packages/core/test/files/nth-page/nth-page-counter-reset.html
+++ b/packages/core/test/files/nth-page/nth-page-counter-reset.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nth() page selector &amp; page counter reset</title>
+    <style>
+      @page {
+        size: 12cm 10cm;
+        margin: 1.5cm;
+
+        @bottom-right {
+          content: "Page " counter(page);
+        }
+      }
+      @page :first {
+        @top-left {
+          content: ":first";
+        }
+      }
+      @page :nth(1) {
+        counter-reset: page 0;
+        @top-center {
+          content: ":nth(1)";
+        }
+      }
+      @page :nth(2) {
+        @top-center {
+          content: ":nth(2)";
+        }
+      }
+      @page :nth(3n) {
+        @top-center {
+          content: ":nth(3n)";
+        }
+      }
+      @page :nth(3n+2) {
+        @top-center {
+          content: ":nth(3n+2)";
+        }
+      }
+      @page :nth(7) {
+        counter-increment: page 2;
+        @top-center {
+          content: ":nth(7)";
+        }
+      }
+      @page :nth(9) {
+        counter-reset: page 100;
+        @top-center {
+          content: ":nth(9)";
+        }
+      }
+      @page :nth(odd) {
+        @top-right {
+          content: ":nth(odd)";
+        }
+      }
+      @page :nth(even) {
+        @top-right {
+          content: ":nth(even)";
+        }
+      }
+      @page :nth(-n+3) {
+        @bottom-left {
+          content: ":nth(-n+3)";
+        }
+      }
+      @page :nth(n+5) {
+        @bottom-left {
+          content: ":nth(n+5)";
+        }
+      }
+      @page :nth(3n-1) {
+        @bottom-center {
+          content: ":nth(3n-1)";
+        }
+      }
+
+      .test {
+        break-after: page;
+      }
+      .test table {
+        width: 80%;
+        margin: auto;
+        table-layout: fixed;
+      }
+      code {
+        font-size: smaller;
+      }
+      h1 {
+        font-size: large;
+      }
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Nth() page selector &amp; page counter reset</h1>
+    <div class="test">
+      <p>The 1st page header/footer should be:</p>
+      <table>
+        <tr>
+          <td>:first*</td>
+          <td>:nth(1)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(-n+3)</td>
+          <td></td>
+          <td>Page 1</td>
+        </tr>
+      </table>
+      <p>* If this is not the first doc, “:first” will not appear.</p>
+      <p>
+        Page counter is reset by <code>counter-reset: page 0</code> (incremented
+        to 1).
+      </p>
+    </div>
+    <div class="test">
+      <p>The 2nd page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n+2)</td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td>:nth(-n+3)</td>
+          <td>:nth(3n-1)</td>
+          <td>Page 2</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 3rd page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(-n+3)</td>
+          <td></td>
+          <td>Page 3</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 4th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td></td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td>Page 4</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 5th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n+2)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td>:nth(3n-1)</td>
+          <td>Page 5</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 6th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n)</td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td></td>
+          <td>Page 6</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 7th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(7)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td></td>
+          <td>Page 8</td>
+        </tr>
+      </table>
+      <p>
+        Page counter is incremented by
+        <code>counter-increment: page 2</code> resulting in 8.
+      </p>
+    </div>
+    <div class="test">
+      <p>The 8th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n+2)</td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td>:nth(3n-1)</td>
+          <td>Page 9</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 9th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(9)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td></td>
+          <td>Page 101</td>
+        </tr>
+      </table>
+      <p>
+        Page counter is reset by
+        <code>counter-reset: page 100</code> (incremented to 101).
+      </p>
+    </div>
+  </body>
+</html>

--- a/packages/core/test/files/nth-page/nth-page.html
+++ b/packages/core/test/files/nth-page/nth-page.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nth() Page Selector</title>
+    <style>
+      @page {
+        size: 12cm 10cm;
+        margin: 1.5cm;
+
+        @bottom-right {
+          content: "Page " counter(page);
+        }
+      }
+      @page :first {
+        @top-left {
+          content: ":first";
+        }
+      }
+      @page :nth(1) {
+        @top-center {
+          content: ":nth(1)";
+        }
+      }
+      @page :nth(2) {
+        @top-center {
+          content: ":nth(2)";
+        }
+      }
+      @page :nth(3n) {
+        @top-center {
+          content: ":nth(3n)";
+        }
+      }
+      @page :nth(3n+2) {
+        @top-center {
+          content: ":nth(3n+2)";
+        }
+      }
+      @page :nth(odd) {
+        @top-right {
+          content: ":nth(odd)";
+        }
+      }
+      @page :nth(even) {
+        @top-right {
+          content: ":nth(even)";
+        }
+      }
+      @page :nth(-n+3) {
+        @bottom-left {
+          content: ":nth(-n+3)";
+        }
+      }
+      @page :nth(n+5) {
+        @bottom-left {
+          content: ":nth(n+5)";
+        }
+      }
+      @page :nth(3n-1) {
+        @bottom-center {
+          content: ":nth(3n-1)";
+        }
+      }
+
+      :root {
+        break-before: recto;
+      }
+      .test {
+        break-after: page;
+      }
+      .test table {
+        width: 80%;
+        margin: auto;
+        table-layout: fixed;
+      }
+      code {
+        font-size: smaller;
+      }
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Nth() Page Selector</h1>
+    <div class="test">
+      <p>The 1st page header/footer should be:</p>
+      <table>
+        <tr>
+          <td>:first*</td>
+          <td>:nth(1)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(-n+3)</td>
+          <td></td>
+          <td>Page 1*</td>
+        </tr>
+      </table>
+      <p>
+        * If this is not the first doc, “:first” will not appear, and the Page
+        numbering will be consecutive from the previous doc. A blank page is
+        inserted by <code>:root { break-before: recto; }</code>.
+      </p>
+    </div>
+    <div class="test">
+      <p>The 2nd page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n+2)</td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td>:nth(-n+3)</td>
+          <td>:nth(3n-1)</td>
+          <td>Page 2*</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 3rd page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(-n+3)</td>
+          <td></td>
+          <td>Page 3*</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 4th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td></td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td>Page 4*</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 5th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n+2)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td>:nth(3n-1)</td>
+          <td>Page 5*</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 6th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n)</td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td></td>
+          <td>Page 6*</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 7th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td></td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td></td>
+          <td>Page 7*</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 8th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n+2)</td>
+          <td>:nth(even)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td>:nth(3n-1)</td>
+          <td>Page 8*</td>
+        </tr>
+      </table>
+    </div>
+    <div class="test">
+      <p>The 9th page header/footer should be:</p>
+      <table>
+        <tr>
+          <td></td>
+          <td>:nth(3n)</td>
+          <td>:nth(odd)</td>
+        </tr>
+        <tr>
+          <td>:nth(n+5)</td>
+          <td></td>
+          <td>Page 9*</td>
+        </tr>
+      </table>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Spec: https://drafts.csswg.org/css-gcpm-3/#document-page-selectors

Notes:
- The `:nth(An+B)` syntax is supported but the `:nth(An+B of <custom-ident>)` is not
  because the named pages are not yet supported.
- In multi-document publications, the `:nth(1)` matches the first page of each document,
  but the `:first` matches only the first page of the first document.
  (see: https://github.com/vivliostyle/vivliostyle.js/issues/667#issuecomment-738020563 )

Test files:
https://raw.githack.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/#Nth_page_selector
- packages/core/test/files/nth-page/nth-page.html
- packages/core/test/files/nth-page/nth-page-counter-reset.html

Fixes #667