### PR TITLE
fix: Text disappears at page break when footnote or page float is given on before pseudo element

### DIFF
--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -170,6 +170,13 @@ export class BlockLayoutProcessor implements LayoutProcessor {
     if (!nodeContext.viewNode.parentNode) {
       return;
     }
+    // Fix for issue #740
+    if (
+      nodeContext.shadowType === Vtree.ShadowType.ROOTLESS &&
+      LayoutHelper.isSpecialNodeContext(nodeContext)
+    ) {
+      return;
+    }
     const parentNode = nodeContext.viewNode.parentNode;
     LayoutHelper.removeFollowingSiblings(parentNode, nodeContext.viewNode);
     if (removeSelf) {


### PR DESCRIPTION
Fix #740