### PR TITLE
Add Content MathML extension in mathjax-config.js

### DIFF
--- a/packages/viewer/resources/mathjax-config.js
+++ b/packages/viewer/resources/mathjax-config.js
@@ -17,6 +17,9 @@
  */
 
 window.MathJax = {
+  MathML: {
+    extensions: ["content-mathml.js"],
+  },
   showProcessingMessages: false,
   messageStyle: "none",
   skipStartupTypeset: true,


### PR DESCRIPTION
To support [MathML Content Markup](https://www.w3.org/TR/MathML3/chapter4.html), the "content-mathml" extension needed to be added to the mathjax-config.js.

**Note:**

The `content-mathml` extension is available for MathJax v2.7 which is used in Vivliostyle Viewer. However, the latest version of MathJax does not support it. See MathJax v2.7 document https://docs.mathjax.org/en/v2.7-latest/mathml.html#content-mathml and the latest MathJax document https://docs.mathjax.org/en/latest/input/mathml.html#content-mathml saying "The version 2 `content-mathml` extension is not yet available in version 3."

