### PR TITLE
fix: "TypeError: Cannot read property '1' of null" occurred in getTOC()

### DIFF
--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -310,7 +310,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
 
     function exportLink(tag): TOCItem {
       const url = new URL(tag.href);
-      const [, id] = url.hash.match(/^#(.*)$/);
+      const [, id] = url.hash.match(/^#?(.*)$/);
 
       const title = tag.innerText;
 


### PR DESCRIPTION
Fixes the problem that when the table of contents in html has dead links,
the error "TypeError: Cannot read property '1' of null" occurred in
the getTOC() function called from Vivliostyle CLI when generating PDF
with bookmarks using the TOC data.