### PR TITLE
Support the `@supports` CSS at-rule

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -324,7 +324,12 @@ export class ConditionalCascadeValue extends CascadeValue {
   }
 
   isEnabled(context: Exprs.Context): boolean {
-    return !!this.condition.evaluate(context);
+    try {
+      return !!this.condition.evaluate(context);
+    } catch (err) {
+      Logging.logger.warn(err);
+    }
+    return false;
   }
 }
 

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -524,6 +524,10 @@ export class Context {
     return false;
   }
 
+  evalSupportsTest(name: string, value: string, isFunc: boolean): boolean {
+    return false;
+  }
+
   queryVal(scope: LexicalScope, key: string): Result | undefined {
     const s = this.scopes[scope.scopeKey];
     return s ? s[key] : undefined;
@@ -818,6 +822,19 @@ export class Not extends Prefix {
   }
 }
 
+export class NotMedia extends Not {
+  constructor(scope: LexicalScope, val: Val) {
+    super(scope, val);
+  }
+
+  /**
+   * @override
+   */
+  getOp(): string {
+    return "not ";
+  }
+}
+
 export class Negate extends Prefix {
   constructor(scope: LexicalScope, val: Val) {
     super(scope, val);
@@ -891,7 +908,7 @@ export class Or extends Logical {
   }
 }
 
-export class OrMedia extends Or {
+export class Comma extends Or {
   constructor(scope: LexicalScope, lhs: Val, rhs: Val) {
     super(scope, lhs, rhs);
   }
@@ -901,6 +918,19 @@ export class OrMedia extends Or {
    */
   getOp(): string {
     return ", ";
+  }
+}
+
+export class OrMedia extends Or {
+  constructor(scope: LexicalScope, lhs: Val, rhs: Val) {
+    super(scope, lhs, rhs);
+  }
+
+  /**
+   * @override
+   */
+  getOp(): string {
+    return " or ";
   }
 }
 
@@ -1515,6 +1545,40 @@ export class MediaTest extends Val {
     }
     const r = new MediaTest(this.scope, this.name, value);
     return r;
+  }
+}
+
+export class SupportsTest extends Val {
+  constructor(
+    scope: LexicalScope,
+    public name: string,
+    public value: string,
+    public isFunc: boolean,
+  ) {
+    super(scope);
+  }
+
+  /**
+   * @override
+   */
+  appendTo(buf: Base.StringBuffer, priority: number): void {
+    if (this.isFunc) {
+      buf.append(this.name);
+    }
+    buf.append("(");
+    if (!this.isFunc && this.name) {
+      buf.append(this.name);
+      buf.append(":");
+    }
+    buf.append(this.value);
+    buf.append(")");
+  }
+
+  /**
+   * @override
+   */
+  evaluateCore(context: Context): Result {
+    return context.evalSupportsTest(this.name, this.value, this.isFunc);
   }
 }
 

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -1195,10 +1195,6 @@ export class Named extends Val {
  * Named value.
  */
 export class MediaName extends Val {
-  // FIXME: This property is added to reduce TypeScript error on `dependCore`
-  // but it is never initialized. Is it really correct code?
-  value: Val;
-
   constructor(scope: LexicalScope, public not: boolean, public name: string) {
     super(scope);
   }
@@ -1218,19 +1214,6 @@ export class MediaName extends Val {
    */
   evaluateCore(context: Context): Result {
     return context.evalMediaName(this.name, this.not);
-  }
-
-  /**
-   * @override
-   */
-  dependCore(
-    other: Val,
-    context: Context,
-    dependencyCache: DependencyCache,
-  ): boolean {
-    return (
-      other === this || this.value.dependOuter(other, context, dependencyCache)
-    );
   }
 
   /**


### PR DESCRIPTION
Spec: CSS Conditional Rules Module Level 3 https://www.w3.org/TR/css-conditional-3/

Tests: https://github.com/web-platform-tests/wpt/tree/master/css/css-conditional

Now it passes all non-javascript tests in https://github.com/web-platform-tests/wpt/tree/master/css/css-conditional
except "at-supports-040.html" that is for the Level 4 `selector(...)` not supported yet
and "css-supports-042.xht" that is an edge case that Chromium also fails.

resolves #730