### PR TITLE
fix: The :not() selector not working when the argument has ID selector

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -831,6 +831,10 @@ export const OP_MEDIA_NOT: number = CssTokenizer.TokenType.LAST + 3;
   actionsSelector[CssTokenizer.TokenType.COLON] = Action.SELECTOR_PSEUDOCLASS_1;
   actionsSelector[CssTokenizer.TokenType.COL_COL] = Action.SELECTOR_PSEUDOELEM;
   actionsSelector[CssTokenizer.TokenType.COMMA] = Action.SELECTOR_NEXT;
+  actionsSelectorInFunc[CssTokenizer.TokenType.GT] = Action.SELECTOR_CHILD;
+  actionsSelectorInFunc[CssTokenizer.TokenType.PLUS] = Action.SELECTOR_SIBLING;
+  actionsSelectorInFunc[CssTokenizer.TokenType.TILDE] =
+    Action.SELECTOR_FOLLOWING_SIBLING;
   actionsSelectorInFunc[CssTokenizer.TokenType.IDENT] = Action.SELECTOR_NAME_1;
   actionsSelectorInFunc[CssTokenizer.TokenType.STAR] = Action.SELECTOR_ANY_1;
   actionsSelectorInFunc[CssTokenizer.TokenType.HASH] = Action.SELECTOR_ID_1;
@@ -1985,8 +1989,15 @@ export class Parser {
           try {
             valStack.push(colorFromHash(token.text));
           } catch (err) {
-            handler.error("E_CSS_COLOR", token);
-            this.actions = actionsError;
+            if (this.actions === actionsPropVal && tokenizer.hasMark()) {
+              tokenizer.reset();
+              this.actions = actionsSelectorStart;
+              handler.startSelectorRule();
+              continue;
+            } else {
+              handler.error("E_CSS_COLOR", token);
+              this.actions = actionsError;
+            }
           }
           tokenizer.consume();
           continue;

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1994,10 +1994,9 @@ export class Parser {
               this.actions = actionsSelectorStart;
               handler.startSelectorRule();
               continue;
-            } else {
-              handler.error("E_CSS_COLOR", token);
-              this.actions = actionsError;
             }
+            handler.error("E_CSS_COLOR", token);
+            this.actions = actionsError;
           }
           tokenizer.consume();
           continue;

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -597,6 +597,13 @@ describe("css-parser", function () {
             expect(handler.endFuncWithSelector).toHaveBeenCalled();
           });
         });
+        it("can take adjacent selector", function (done) {
+          parse(done, ":not(div + .foo) {}", function () {
+            expect(handler.error).not.toHaveBeenCalled();
+            expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
+            expect(handler.endFuncWithSelector).toHaveBeenCalled();
+          });
+        });
         it("error if selector is invalid", function (done) {
           parse(done, ":not(.) {}", function () {
             expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
@@ -606,13 +613,6 @@ describe("css-parser", function () {
         });
         it("error if multiple selectors", function (done) {
           parse(done, ":not(div, .foo) {}", function () {
-            expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
-            expect(handler.error).toHaveBeenCalled();
-            expect(handler.endFuncWithSelector).not.toHaveBeenCalled();
-          });
-        });
-        it("error if adjacent selector is specified", function (done) {
-          parse(done, ":not(div + .foo) {}", function () {
             expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
             expect(handler.error).toHaveBeenCalled();
             expect(handler.endFuncWithSelector).not.toHaveBeenCalled();


### PR DESCRIPTION
Fixes the bug that the :not() selector causes CSS parser error when the argument has
ID selector (#myid), child combinator (>), next-sibling combinator (+), or
subsequent-sibling combinator (~).

Fixes #769