### PR TITLE
fix: text-combine-upright with text-indent does not work properly

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -463,17 +463,29 @@ export function setCSSProperty(
     if (!prefixedPropertyNames) {
       return;
     }
+    const elemStyle = (elem as HTMLElement)?.style;
+    if (!elemStyle) {
+      return;
+    }
     prefixedPropertyNames.forEach((prefixed) => {
-      if (prefixed === "-webkit-text-combine") {
-        switch (value) {
-          case "all":
-            value = "horizontal";
-            break;
-        }
+      switch (prefixed) {
+        case "-webkit-text-combine": // for Safari
+          switch (value) {
+            case "all":
+              value = "horizontal";
+              break;
+          }
+          break;
+        case "text-combine-upright":
+          switch (value) {
+            case "all":
+              // workaround for Chrome 93 bug https://crbug.com/1242755
+              elemStyle.setProperty("text-indent", "0");
+              break;
+          }
+          break;
       }
-      if (elem && (elem as HTMLElement).style) {
-        (elem as HTMLElement).style.setProperty(prefixed, value);
-      }
+      elemStyle.setProperty(prefixed, value);
     });
   } catch (err) {
     Logging.logger.warn(err);


### PR DESCRIPTION
This problem happens with Chrome 93-94 due to the Chrome bug (fixed in Chrome 95):
https://crbug.com/1242755 - text-combine-upright with text-indent does not work properly

This fix is a workaround for the problem necessary for Chrome (Chromium) 93-94 users.