### PR TITLE
chore: fix typo in base-spec.js

### DIFF
--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -65,7 +65,7 @@ describe("base", function () {
       );
     });
 
-    it("unescape a string containing 4-digit hex codes with '\\u' prefix to the orignal string when prefix is not specified", function () {
+    it("unescape a string containing 4-digit hex codes with '\\u' prefix to the original string when prefix is not specified", function () {
       expect(
         module.unescapeStrFromHex("abc-_\\u003a\\u0025\\u002f\\u005c"),
       ).toBe("abc-_:%/\\");


### PR DESCRIPTION
orignal -> original