### PR TITLE
Revert "fix: column-fill:balance on vertical writing mode causes columns left-aligned"

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1110,12 +1110,6 @@ export class StyleInstance
               layoutContainer.paddingLeft,
               layoutContainer.width,
             );
-            // Fix for issue #544
-            Base.setCSSProperty(
-              column.element,
-              "right",
-              `${layoutContainer.paddingRight}px`,
-            );
             column.setVerticalPosition(columnY, columnWidth);
           } else {
             const columnX =


### PR DESCRIPTION
Reverts vivliostyle/vivliostyle.js#784