### PR TITLE
fix: TypeError: Cannot read properties of null (reading 'readingProgression')

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -292,7 +292,11 @@ export class EPUBDocStore extends OPS.OPSDocStore {
               manifestLink.getAttribute("href"),
               url,
             );
-            this.loadAsJSON(manifestUrl).then((manifestObj) => {
+            this.loadAsJSON(
+              manifestUrl,
+              true,
+              `Failed to fetch Publication Manifest ${manifestUrl}`,
+            ).then((manifestObj) => {
               opf
                 .initWithWebPubManifest(manifestObj, doc, manifestUrl)
                 .then(() => {


### PR DESCRIPTION
This error occured when failed to fetch the specified publication manifest.
The error message for this failure should be "Failed to fetch Publication Manifest".

Fixes #796
