### PR TITLE
Support CSS text-spacing and hanging-punctuation properties

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1430,7 +1430,7 @@ viv-ts-open:not(.viv-ts-trim,.viv-ts-space,.viv-hang-first)::before,
 viv-ts-close:not(.viv-ts-trim,.viv-ts-space,.viv-hang-last)::after {
   content: " ";
   font-family: Courier, monospace;
-  font-size: 83.3%;
+  font-size: 83%;
   line-height: 0;
   text-orientation: mixed;
   visibility: hidden;
@@ -1442,7 +1442,7 @@ viv-ts-close:not(.viv-ts-space,.viv-hang-last,.viv-hang-end:not(.viv-ts-trim)) >
   margin-inline-end: -0.5em;
 }
 viv-ts-close.viv-hang-end:not(.viv-ts-trim,.viv-hang-hw)::after {
-  font-size: 166.6%;
+  font-size: 166%;
 }
 viv-ts-close.viv-hang-end:not(.viv-ts-trim) > viv-ts-inner,
 viv-ts-close.viv-hang-last > viv-ts-inner {

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1444,7 +1444,12 @@ viv-ts-close:not(.viv-ts-space,.viv-hang-last,.viv-hang-end:not(.viv-ts-trim)) >
 viv-ts-close.viv-hang-end:not(.viv-ts-trim,.viv-hang-hw)::after {
   font-size: 166%;
 }
-viv-ts-close.viv-hang-end:not(.viv-ts-trim) > viv-ts-inner,
+viv-ts-close.viv-hang-end:not(.viv-ts-trim) > viv-ts-inner {
+  margin-inline-end: -1em;
+}
+viv-ts-close.viv-hang-end.viv-hang-hw > viv-ts-inner {
+  margin-inline-end: -0.5em;
+}
 viv-ts-close.viv-hang-last > viv-ts-inner {
   display: inline-block;
   inline-size: 0;

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1430,6 +1430,7 @@ viv-ts-close:not(.viv-ts-trim,.viv-ts-space)::after {
   content: " ";
   font-family: Courier, monospace;
   font-size: 83.3%;
+  line-height: 1;
   text-orientation: mixed;
   visibility: hidden;
 }
@@ -1443,6 +1444,7 @@ viv-ts-thin-sp::after {
   content: " ";
   font-family: Times, serif;
   font-size: 66.6%;
+  line-height: 1;
   text-orientation: mixed;
   visibility: hidden;
 }

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -535,6 +535,9 @@ overflow-wrap = normal | break-word | anywhere;
 [moz]text-align-last = auto | start | end | left | right | center | justify;
 text-justify = auto | none | inter-word | inter-character;
 word-break = normal | keep-all | break-all | break-word;
+text-spacing = normal | none | auto | [[ trim-start | space-start | space-first ] ||
+    [ trim-end | space-end | allow-end ] || [ trim-adjacent | space-adjacent ] ||
+    no-compress || ideograph-alpha || ideograph-numeric || punctuation];
 
 /* CSS Text Decoration */
 [webkit]text-decoration-color = COLOR;
@@ -1417,5 +1420,30 @@ ul[role="directory"],
 ul.toc,
 ul#toc {
   -adapt-behavior: toc-container;
+}
+`;
+
+// text-polyfill.css
+export const TextPolyfillCss = `
+viv-ts-open:not(.viv-ts-trim,.viv-ts-space)::before,
+viv-ts-close:not(.viv-ts-trim,.viv-ts-space)::after {
+  content: " ";
+  font-family: Courier, monospace;
+  font-size: 83.3%;
+  text-orientation: mixed;
+  visibility: hidden;
+}
+viv-ts-open:not(.viv-ts-space) > viv-ts-inner {
+  margin-inline-start: -0.5em;
+}
+viv-ts-close:not(.viv-ts-space) > viv-ts-inner {
+  margin-inline-end: -0.5em;
+}
+viv-ts-thin-sp::after {
+  content: " ";
+  font-family: Times, serif;
+  font-size: 66.6%;
+  text-orientation: mixed;
+  visibility: hidden;
 }
 `;

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -538,6 +538,7 @@ word-break = normal | keep-all | break-all | break-word;
 text-spacing = normal | none | auto | [[ trim-start | space-start | space-first ] ||
     [ trim-end | space-end | allow-end ] || [ trim-adjacent | space-adjacent ] ||
     no-compress || ideograph-alpha || ideograph-numeric || punctuation];
+hanging-punctuation = none | [ first || [ force-end | allow-end ] || last ];
 
 /* CSS Text Decoration */
 [webkit]text-decoration-color = COLOR;
@@ -1425,26 +1426,45 @@ ul#toc {
 
 // text-polyfill.css
 export const TextPolyfillCss = `
-viv-ts-open:not(.viv-ts-trim,.viv-ts-space)::before,
-viv-ts-close:not(.viv-ts-trim,.viv-ts-space)::after {
+viv-ts-open:not(.viv-ts-trim,.viv-ts-space,.viv-hang-first)::before,
+viv-ts-close:not(.viv-ts-trim,.viv-ts-space,.viv-hang-last)::after {
   content: " ";
   font-family: Courier, monospace;
   font-size: 83.3%;
-  line-height: 1;
+  line-height: 0;
   text-orientation: mixed;
   visibility: hidden;
 }
-viv-ts-open:not(.viv-ts-space) > viv-ts-inner {
+viv-ts-open:not(.viv-ts-space,.viv-hang-first) > viv-ts-inner {
   margin-inline-start: -0.5em;
 }
-viv-ts-close:not(.viv-ts-space) > viv-ts-inner {
+viv-ts-close:not(.viv-ts-space,.viv-hang-last,.viv-hang-end:not(.viv-ts-trim)) > viv-ts-inner {
   margin-inline-end: -0.5em;
+}
+viv-ts-close.viv-hang-end:not(.viv-ts-trim,.viv-hang-hw)::after {
+  font-size: 166.6%;
+}
+viv-ts-close.viv-hang-end:not(.viv-ts-trim) > viv-ts-inner,
+viv-ts-close.viv-hang-last > viv-ts-inner {
+  display: inline-block;
+  inline-size: 0;
+  text-indent: 0;
+  text-align: start;
+  text-align-last: start;
+}
+viv-ts-open.viv-hang-first > viv-ts-inner {
+  display: inline-block;
+  inline-size: 1em;
+  text-indent: 0;
+  text-align: end;
+  text-align-last: end;
+  margin-inline-start: -1em;
 }
 viv-ts-thin-sp::after {
   content: " ";
   font-family: Times, serif;
   font-size: 66.6%;
-  line-height: 1;
+  line-height: 0;
   text-orientation: mixed;
   visibility: hidden;
 }

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -61,6 +61,7 @@ export const inheritedProps = {
   "font-variant-east-asian": true,
   "font-weight": true,
   "glyph-orientation-vertical": true,
+  "hanging-punctuation": true,
   hyphens: true,
   "hyphenate-character": true,
   "hyphenate-limit-chars": true,

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -106,6 +106,7 @@ export const inheritedProps = {
   "text-justify": true,
   "text-rendering": true,
   "text-size-adjust": true,
+  "text-spacing": true,
   "text-transform": true,
   "text-underline-position": true,
   visibility: true,

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -177,10 +177,15 @@ export class BlockLayoutProcessor implements LayoutProcessor {
     ) {
       return;
     }
-    const parentNode = nodeContext.viewNode.parentNode;
-    LayoutHelper.removeFollowingSiblings(parentNode, nodeContext.viewNode);
+    let node = nodeContext.viewNode;
+    if (node.parentElement?.localName === "viv-ts-inner") {
+      // special element for text-spacing
+      node = node.parentElement.parentElement;
+    }
+    const parentNode = node.parentNode;
+    LayoutHelper.removeFollowingSiblings(parentNode, node);
     if (removeSelf) {
-      parentNode.removeChild(nodeContext.viewNode);
+      parentNode.removeChild(node);
     }
   }
 

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -21,6 +21,7 @@
  */
 import "./footnotes";
 import "./table";
+import "./text-polyfill";
 import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as Break from "./break";

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -232,7 +232,7 @@ class TextSpacingPolyfill {
     for (let node = nodeIter.nextNode(); node; node = nodeIter.nextNode()) {
       const textArr = node.textContent
         .replace(
-          /\p{P}\p{M}*(?=\P{M})|.(?=\p{P})|(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*(?=(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}])|(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}]\p{M}*(?=(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF])/gsu,
+          /[\p{Ps}\p{Pe}\p{Pf}\p{Pi}'"、。，．：；､｡]\p{M}*(?=\P{M})|.(?=[\p{Ps}\p{Pe}\p{Pf}\p{Pi}'"、。，．：；､｡])|(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*(?=(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}])|(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}]\p{M}*(?=(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF])/gsu,
           "$&\x00",
         )
         .split("\x00");
@@ -255,6 +255,7 @@ class TextSpacingPolyfill {
     checkPoints: Vtree.NodeContext[],
     column: Layout.Column,
   ): void {
+    const isFirstFragment = !nodeContext || nodeContext.fragmentIndex === 1;
     for (let i = 0; i < checkPoints.length; i++) {
       const p = checkPoints[i];
       if (
@@ -269,8 +270,8 @@ class TextSpacingPolyfill {
         const lang = normalizeLang(
           p.lang ??
             p.parent.lang ??
-            nodeContext.lang ??
-            nodeContext.parent?.lang,
+            nodeContext?.lang ??
+            nodeContext?.parent?.lang,
         );
         const textSpacing = textSpacingFromPropertyValue(
           p.inheritedProps["text-spacing"],
@@ -281,7 +282,7 @@ class TextSpacingPolyfill {
 
         let prevNode: Node = null;
         let nextNode: Node = null;
-        let isFirstInBlock = i === 0 && nodeContext.fragmentIndex === 1;
+        let isFirstInBlock = i === 0 && isFirstFragment;
         let isFirstAfterForcedLineBreak = false;
         let isLastInBlock = false;
 
@@ -330,7 +331,7 @@ class TextSpacingPolyfill {
           ) {
             break;
           }
-          if (prev === 0 && nodeContext.fragmentIndex === 1) {
+          if (prev === 0 && isFirstFragment) {
             isFirstInBlock = true;
             isFirstAfterForcedLineBreak = true;
           }
@@ -370,7 +371,6 @@ class TextSpacingPolyfill {
           lang,
           p.vertical,
         );
-        isFirstInBlock = false;
       }
     }
   }

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -1,0 +1,457 @@
+/**
+ * Copyright 2021 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @fileoverview TextPolyfill - CSS text-spacing etc. support.
+ */
+import * as Css from "./css";
+import * as Layout from "./layout";
+import * as Plugin from "./plugin";
+import * as Vtree from "./vtree";
+import { TextPolyfillCss } from "./assets";
+
+type TextSpacing = {
+  trimStart: boolean;
+  spaceFirst: boolean;
+  trimEnd: boolean;
+  allowEnd: boolean;
+  trimAdjacent: boolean;
+  ideographAlpha: boolean;
+  ideographNumeric: boolean;
+};
+
+/**
+ * text-spacing: none
+ * none = space-start space-end space-adjacent
+ */
+const TEXT_SPACING_NONE: TextSpacing = {
+  trimStart: false,
+  spaceFirst: false,
+  trimEnd: false,
+  allowEnd: false,
+  trimAdjacent: false,
+  ideographAlpha: false,
+  ideographNumeric: false,
+};
+
+/**
+ * text-spacing: normal
+ * normal = space-first trim-end trim-adjacent
+ */
+const TEXT_SPACING_NORMAL: TextSpacing = {
+  trimStart: true,
+  spaceFirst: true,
+  trimEnd: true,
+  allowEnd: false,
+  trimAdjacent: true,
+  ideographAlpha: false,
+  ideographNumeric: false,
+};
+/**
+ * text-spacing: auto
+ * auto = trim-start trim-end trim-adjacent ideograph-alpha ideograph-numeric
+ */
+const TEXT_SPACING_AUTO: TextSpacing = {
+  trimStart: true,
+  spaceFirst: false,
+  trimEnd: true,
+  allowEnd: false,
+  trimAdjacent: true,
+  ideographAlpha: true,
+  ideographNumeric: true,
+};
+
+function textSpacingFromPropertyValue(
+  value: string | number | Css.Val,
+): TextSpacing {
+  const cssval =
+    value instanceof Css.Val
+      ? value
+      : typeof value === "string"
+      ? Css.getName(value)
+      : Css.ident.normal;
+
+  if (cssval === Css.ident.normal) {
+    return TEXT_SPACING_NORMAL;
+  }
+  if (cssval === Css.ident.none) {
+    return TEXT_SPACING_NONE;
+  }
+  if (cssval === Css.ident.auto) {
+    return TEXT_SPACING_AUTO;
+  }
+  const values = cssval instanceof Css.SpaceList ? cssval.values : [cssval];
+  const textSpacing: TextSpacing = Object.create(TEXT_SPACING_NORMAL);
+
+  for (const val of values) {
+    if (val instanceof Css.Ident) {
+      switch (val.name) {
+        case "trim-start":
+          textSpacing.trimStart = true;
+          textSpacing.spaceFirst = false;
+          break;
+        case "space-start":
+          textSpacing.trimStart = false;
+          textSpacing.spaceFirst = false;
+          break;
+        case "space-first":
+          textSpacing.trimStart = true;
+          textSpacing.spaceFirst = true;
+          break;
+        case "trim-end":
+          textSpacing.trimEnd = true;
+          textSpacing.allowEnd = false;
+          break;
+        case "space-end":
+          textSpacing.trimEnd = false;
+          textSpacing.allowEnd = false;
+          break;
+        case "allow-end":
+          textSpacing.trimEnd = true;
+          textSpacing.allowEnd = true;
+          break;
+        case "trim-adjacent":
+          textSpacing.trimAdjacent = true;
+          break;
+        case "space-adjacent":
+          textSpacing.trimAdjacent = false;
+          break;
+        case "ideograph-alpha":
+          textSpacing.ideographAlpha = true;
+          break;
+        case "ideograph-numeric":
+          textSpacing.ideographNumeric = true;
+          break;
+      }
+    }
+  }
+
+  return textSpacing;
+}
+
+function normalizeLang(lang: string): string | null {
+  if (lang) {
+    // Normalize CJK lang
+    lang = lang.toLowerCase();
+    if (/^zh\b.*-(hant|tw|hk)\b/.test(lang)) {
+      return "zh-hant";
+    }
+    if (/^zh\b/.test(lang)) {
+      return "zh-hans";
+    }
+    if (/^ja\b/.test(lang)) {
+      return "ja";
+    }
+    if (/^ko\b/.test(lang)) {
+      return "ko";
+    }
+    return lang;
+  }
+  return null;
+}
+
+class TextSpacingPolyfill {
+  textSpacingProcessed = false;
+
+  getPolyfilledInheritedProps() {
+    return ["text-spacing"];
+  }
+
+  preprocessSingleDocument(document: Document): void {
+    // Split text nodes by punctuations and ideograph/non-ideograph boundary
+    const nodeIter = document.createNodeIterator(
+      document.body,
+      NodeFilter.SHOW_TEXT,
+    );
+    for (let node = nodeIter.nextNode(); node; node = nodeIter.nextNode()) {
+      const textArr = node.textContent
+        .replace(
+          /\p{P}\p{M}*(?!\p{M})|.(?=\p{P})|(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*(?=(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}])|(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}]\p{M}*(?=(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF])/gu,
+          "$&\x00",
+        )
+        .split("\x00");
+
+      if (textArr.length > 1) {
+        const lastIndex = textArr.length - 1;
+        for (let i = 0; i < lastIndex; i++) {
+          node.parentNode.insertBefore(
+            document.createTextNode(textArr[i]),
+            node,
+          );
+        }
+        node.textContent = textArr[lastIndex];
+      }
+    }
+  }
+
+  postLayoutBlock(
+    nodeContext: Vtree.NodeContext,
+    checkPoints: Vtree.NodeContext[],
+    column: Layout.Column,
+  ): void {
+    let isFirstInParagraph = nodeContext.fragmentIndex === 1;
+
+    for (let i = 0; i < checkPoints.length; i++) {
+      const p = checkPoints[i];
+      if (p.after) {
+        isFirstInParagraph = false;
+      } else if (
+        p.inline &&
+        !p.display &&
+        p.parent &&
+        p.viewNode.nodeType === Node.TEXT_NODE &&
+        p.viewNode.textContent.length > 0
+      ) {
+        const lang = normalizeLang(
+          p.lang ??
+            p.parent.lang ??
+            nodeContext.lang ??
+            nodeContext?.parent.lang,
+        );
+        const textSpacing = textSpacingFromPropertyValue(
+          p.inheritedProps["text-spacing"],
+        );
+
+        let prevNode: Node = null;
+        let nextNode: Node = null;
+
+        for (let prev = i - 1; prev >= 0; prev--) {
+          const prevP = checkPoints[prev];
+          if (
+            !prevP.display &&
+            prevP.viewNode.nodeType === Node.TEXT_NODE &&
+            prevP.viewNode.textContent.length > 0
+          ) {
+            prevNode = prevP.viewNode;
+            break;
+          }
+          if (
+            (prevP.display && prevP.display !== "inline") ||
+            (prevP.viewNode instanceof Element &&
+              Layout.mediaTags[prevP.viewNode.localName])
+          ) {
+            break;
+          }
+        }
+        for (let next = i + 1; next < checkPoints.length; next++) {
+          const nextP = checkPoints[next];
+          if (
+            nextP.viewNode !== p.viewNode &&
+            !nextP.display &&
+            nextP.viewNode.nodeType === Node.TEXT_NODE &&
+            nextP.viewNode.textContent.length > 0
+          ) {
+            nextNode = nextP.viewNode;
+            break;
+          }
+          if (
+            (nextP.display && nextP.display !== "inline") ||
+            (nextP.viewNode instanceof Element &&
+              Layout.mediaTags[nextP.viewNode.localName])
+          ) {
+            break;
+          }
+        }
+        this.processTextSpacing(
+          p.viewNode,
+          isFirstInParagraph,
+          prevNode,
+          nextNode,
+          textSpacing,
+          lang,
+          p.vertical,
+        );
+        isFirstInParagraph = false;
+      }
+    }
+  }
+
+  private processTextSpacing(
+    textNode: Node,
+    isFirstInParagraph: boolean,
+    prevNode: Node,
+    nextNode: Node,
+    textSpacing: TextSpacing,
+    lang: string,
+    vertical: boolean,
+  ): void {
+    const text = textNode.textContent;
+    const document = textNode.ownerDocument;
+
+    let trimPunctProcessing = false;
+    let tagName: string;
+
+    if (
+      (textSpacing.trimStart || textSpacing.trimAdjacent) &&
+      /^[‘“〝（［｛｟〈〈《「『【〔〖〘〚]\p{M}*$/u.test(text)
+    ) {
+      // fullwidth opening punctuation
+      tagName = "viv-ts-open";
+      trimPunctProcessing = true;
+    } else if (
+      (textSpacing.trimEnd || textSpacing.trimAdjacent) &&
+      (/^[’”〞〟）］｝｠〉〉》」』】〕〗〙〛]\p{M}*$/u.test(text) ||
+        (lang === "zh-hans" && /^[：；]\p{M}*$/u.test(text)) ||
+        (lang !== "zh-hant" && /^[、。，．]\p{M}*$/u.test(text)))
+    ) {
+      // fullwidth closing punctuation
+      tagName = "viv-ts-close";
+      trimPunctProcessing = true;
+    }
+
+    if (trimPunctProcessing) {
+      // Wrap the textNode as `<{tagName}><viv-ts-inner>{text}<viv-ts-inner></{tagName}>`
+      const outerElem = document.createElement(tagName);
+      const innerElem = document.createElement("viv-ts-inner");
+      outerElem.appendChild(innerElem);
+      textNode.parentNode.insertBefore(outerElem, textNode);
+      innerElem.appendChild(textNode);
+
+      // Check if the punctuation is really full width
+      const fullWidthElem = document.createElement("viv-ts-inner");
+      fullWidthElem.appendChild(document.createTextNode("水"));
+      outerElem.appendChild(fullWidthElem);
+      const isFullWidth = vertical
+        ? innerElem.offsetHeight >= fullWidthElem.offsetHeight * 0.9
+        : innerElem.offsetWidth >= fullWidthElem.offsetWidth * 0.9;
+      outerElem.removeChild(fullWidthElem);
+
+      if (isFullWidth) {
+        if (tagName === "viv-ts-open") {
+          if (
+            prevNode &&
+            /[\p{Ps}\p{Pi}\p{Pe}\p{Pf}\u00B7\u2027\u30FB\u3000：；、。，．]\p{M}*$/u.test(
+              prevNode.textContent,
+            )
+          ) {
+            if (textSpacing.trimAdjacent) {
+              outerElem.className = "viv-ts-trim";
+            }
+          } else if (isFirstInParagraph) {
+            outerElem.className =
+              textSpacing.spaceFirst || !textSpacing.trimStart
+                ? "viv-ts-first viv-ts-space"
+                : "viv-ts-first";
+          } else if (!textSpacing.trimStart) {
+            outerElem.className = "viv-ts-space";
+          }
+        } else if (tagName === "viv-ts-close") {
+          if (
+            nextNode &&
+            /^[\p{Pe}\p{Pf}\u00B7\u2027\u30FB\u3000：；、。，．]/u.test(
+              nextNode.textContent,
+            )
+          ) {
+            if (textSpacing.trimAdjacent) {
+              outerElem.className = "viv-ts-trim";
+            }
+          } else if (!textSpacing.trimEnd) {
+            outerElem.className = "viv-ts-space";
+          }
+        }
+      } else {
+        // Undo the processing
+        outerElem.parentNode.insertBefore(textNode, outerElem);
+        outerElem.parentNode.removeChild(outerElem);
+        trimPunctProcessing = false;
+      }
+    } else {
+      trimPunctProcessing = false;
+    }
+
+    let spaceIdeoAlnumProcessing = false;
+
+    function checkUpright(elem: Element): boolean {
+      if (!elem || !(elem instanceof HTMLElement)) {
+        return false;
+      }
+      if (elem.style.textOrientation === "upright") {
+        return true;
+      }
+      if (elem.style.textCombineUpright === "all") {
+        return true;
+      }
+      return checkUpright(elem.parentElement);
+    }
+
+    if (textSpacing.ideographAlpha || textSpacing.ideographNumeric) {
+      if (
+        prevNode &&
+        /^(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]/u.test(text) &&
+        ((textSpacing.ideographAlpha &&
+          /(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])\p{L}\p{M}*$/u.test(
+            prevNode.textContent,
+          )) ||
+          (textSpacing.ideographNumeric &&
+            /(?![\uFF01-\uFF60])\p{Nd}\p{M}*$/u.test(prevNode.textContent))) &&
+        !(vertical && checkUpright(prevNode.parentElement))
+      ) {
+        textNode.parentNode.insertBefore(
+          document.createElement("viv-ts-thin-sp"),
+          textNode,
+        );
+        spaceIdeoAlnumProcessing = true;
+      }
+      if (
+        nextNode &&
+        /(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*$/u.test(text) &&
+        ((textSpacing.ideographAlpha &&
+          /^(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])\p{L}/u.test(
+            nextNode.textContent,
+          )) ||
+          (textSpacing.ideographNumeric &&
+            /^(?![\uFF01-\uFF60])\p{Nd}/u.test(nextNode.textContent))) &&
+        !(vertical && checkUpright(nextNode.parentElement))
+      ) {
+        textNode.parentNode.insertBefore(
+          document.createElement("viv-ts-thin-sp"),
+          textNode.nextSibling,
+        );
+        spaceIdeoAlnumProcessing = true;
+      }
+    }
+
+    if (trimPunctProcessing || spaceIdeoAlnumProcessing) {
+      if (!this.textSpacingProcessed) {
+        this.initTextPolyfillCss(document.head);
+        this.textSpacingProcessed = true;
+      }
+    }
+  }
+
+  private initTextPolyfillCss(head: Element): void {
+    const style = head.ownerDocument.createElement("style");
+    style.textContent = TextPolyfillCss;
+    head.appendChild(style);
+  }
+
+  registerHooks() {
+    Plugin.registerHook(
+      Plugin.HOOKS.POLYFILLED_INHERITED_PROPS,
+      this.getPolyfilledInheritedProps.bind(this),
+    );
+    Plugin.registerHook(
+      Plugin.HOOKS.PREPROCESS_SINGLE_DOCUMENT,
+      this.preprocessSingleDocument.bind(this),
+    );
+    Plugin.registerHook(
+      Plugin.HOOKS.POST_LAYOUT_BLOCK,
+      this.postLayoutBlock.bind(this),
+    );
+  }
+}
+
+const textPolyfill = new TextSpacingPolyfill();
+textPolyfill.registerHooks();

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -178,7 +178,7 @@ class TextSpacingPolyfill {
     for (let node = nodeIter.nextNode(); node; node = nodeIter.nextNode()) {
       const textArr = node.textContent
         .replace(
-          /\p{P}\p{M}*(?!\p{M})|.(?=\p{P})|(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*(?=(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}])|(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}]\p{M}*(?=(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF])/gu,
+          /\p{P}\p{M}*(?=\P{M})|.(?=\p{P})|(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*(?=(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}])|(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}]\p{M}*(?=(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF])/gu,
           "$&\x00",
         )
         .split("\x00");
@@ -211,6 +211,7 @@ class TextSpacingPolyfill {
         p.inline &&
         !p.display &&
         p.parent &&
+        p.viewNode.parentNode &&
         p.viewNode.nodeType === Node.TEXT_NODE &&
         p.viewNode.textContent.length > 0
       ) {
@@ -218,7 +219,7 @@ class TextSpacingPolyfill {
           p.lang ??
             p.parent.lang ??
             nodeContext.lang ??
-            nodeContext?.parent.lang,
+            nodeContext.parent?.lang,
         );
         const textSpacing = textSpacingFromPropertyValue(
           p.inheritedProps["text-spacing"],

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -132,6 +132,23 @@ module.exports = [
     ],
   },
   {
+    category: "Text Spacing",
+    files: [
+      {
+        file: "text-spacing/text-spacing-ja.html",
+        title: "Text Spacing (Japanese)",
+      },
+      {
+        file: "text-spacing/text-spacing-zh-hans.html",
+        title: "Text Spacing (Chinese, Simplified)",
+      },
+      {
+        file: "text-spacing/text-spacing-zh-hant.html",
+        title: "Text Spacing (Chinese, Traditional)",
+      },
+    ],
+  },
+  {
     category: "Blank page selector",
     files: [
       {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -149,6 +149,15 @@ module.exports = [
     ],
   },
   {
+    category: "Hanging Punctuation",
+    files: [
+      {
+        file: "text-spacing/hanging-punctuation.html",
+        title: "Hanging Punctuation",
+      },
+    ],
+  },
+  {
     category: "Blank page selector",
     files: [
       {

--- a/packages/core/test/files/text-spacing/hanging-punctuation.html
+++ b/packages/core/test/files/text-spacing/hanging-punctuation.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Hanging-punctuation Test</title>
+  <style>
+    p {
+      border: 1px solid silver;
+      text-align: justify;
+      inline-size: 20em;
+      margin-inline-start: 1em;
+      margin-inline-end: 1em;
+    }
+    p:nth-of-type(n+2) {
+      inline-size: auto;
+    }
+    #test-hp-none p {
+      hanging-punctuation: none;
+    }
+    #test-hp-first p {
+      hanging-punctuation: first;
+    }
+    #test-hp-force-end p {
+      hanging-punctuation: force-end;
+    }
+    #test-hp-allow-end p {
+      hanging-punctuation: allow-end;
+    }
+    #test-hp-last p {
+      hanging-punctuation: last;
+      text-align: end;
+    }
+    #test-hp-first-last p {
+      hanging-punctuation: first last;
+      text-align-last: justify;
+    }
+    #test-hp-first-force-end-with-text-indent-and-ts-auto p {
+      hanging-punctuation: first force-end;
+      text-indent: 1em;
+      text-spacing: auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>Hanging-punctuation Test</h1>
+  <section id="test-hp-none">
+    <h2>hanging-punctuation: none</h2>
+    <p>『二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。一二三四五六七八九十。』</p>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-hp-force-end">
+    <h2>hanging-punctuation: force-end</h2>
+    <p>『二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。一二三四五六七八九十。』</p>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-hp-allow-end">
+    <h2>hanging-punctuation: allow-end</h2>
+    <p>『二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。一二三四五六七八九十。』</p>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-hp-first">
+    <h2>hanging-punctuation: first</h2>
+    <p>『二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。一二三四五六七八九十。』</p>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-hp-last">
+    <h2>hanging-punctuation: last;<br>text-align: end;</h2>
+    <p>『二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。一二三四五六七八九十。』</p>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-hp-first-last">
+    <h2>hanging-punctuation: first last;<br>text-align-last: justify;</h2>
+    <p>『二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。一二三四五六七八九十。』</p>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-hp-first-force-end-with-text-indent-and-ts-auto">
+    <h2>hanging-punctuation: first end;<br>text-indent: 1em;<br>text-spacing: auto;</h2>
+    <p>『二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。一二三四五六七八九十。』</p>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+
+</body>
+</html>

--- a/packages/core/test/files/text-spacing/text-spacing-ja.html
+++ b/packages/core/test/files/text-spacing/text-spacing-ja.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>text-spacingテスト</title>
+  <style>
+    p {
+      border: 1px solid silver;
+      text-align: justify;
+    }
+    b {
+      font-weight: bold;
+      color: maroon;
+    }
+    i {
+      font-style: normal;
+      font-size: 80%;
+      color: navy;
+    }
+    #test-ts-none {
+      text-spacing: none;
+    }
+    #test-ts-normal {
+      text-spacing: normal;
+    }
+    #test-ts-auto {
+      text-spacing: auto;
+    }
+    #test-ts-auto-equiv {
+      text-spacing: trim-start ideograph-alpha ideograph-numeric;
+    }
+    #test-ts-space-start {
+      text-spacing: space-start;
+    }
+    #test-ts-space-first {
+      text-spacing: space-first;
+    }
+    #test-ts-space-end {
+      text-spacing: space-end;
+    }
+    #test-ts-ideograph-alpha {
+      text-spacing: ideograph-alpha;
+    }
+    #test-ts-ideograph-numeric {
+      text-spacing: ideograph-numeric;
+    }
+  </style>
+</head>
+<body>
+  <h1>文字組版用CSSプロパティ、「text-spacing」テスト</h1>
+  <section id="test-ts-default">
+    <h2>default</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-none">
+    <h2>text-spacing: none</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-normal">
+    <h2>text-spacing: normal</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-auto">
+    <h2>text-spacing: auto</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-auto-equiv">
+    <h2>text-spacing: trim-start ideograph-alpha ideograph-numeric</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-space-start">
+    <h2>text-spacing: space-start</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-space-first">
+    <h2>text-spacing: space-first</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-space-end">
+    <h2>text-spacing: space-end</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-ideograph-alpha">
+    <h2>text-spacing: ideograph-alpha</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-ideograph-numeric">
+    <h2>text-spacing: ideograph-numeric</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+
+</body>
+</html>

--- a/packages/core/test/files/text-spacing/text-spacing-zh-hans.html
+++ b/packages/core/test/files/text-spacing/text-spacing-zh-hans.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="zh-hans">
+<head>
+  <meta charset="UTF-8">
+  <title>text-spacing测试</title>
+  <style>
+    p {
+      border: 1px solid silver;
+      text-align: justify;
+    }
+    b {
+      font-weight: bold;
+      color: maroon;
+    }
+    i {
+      font-style: normal;
+      font-size: 80%;
+      color: navy;
+    }
+    #test-ts-none {
+      text-spacing: none;
+    }
+    #test-ts-normal {
+      text-spacing: normal;
+    }
+    #test-ts-auto {
+      text-spacing: auto;
+    }
+    #test-ts-auto-equiv {
+      text-spacing: trim-start ideograph-alpha ideograph-numeric;
+    }
+    #test-ts-space-start {
+      text-spacing: space-start;
+    }
+    #test-ts-space-first {
+      text-spacing: space-first;
+    }
+    #test-ts-space-end {
+      text-spacing: space-end;
+    }
+    #test-ts-ideograph-alpha {
+      text-spacing: ideograph-alpha;
+    }
+    #test-ts-ideograph-numeric {
+      text-spacing: ideograph-numeric;
+    }
+  </style>
+</head>
+<body>
+  <h1>排版的CSS属性，「text-spacing」测试</h1>
+  <section id="test-ts-default">
+    <h2>default</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-none">
+    <h2>text-spacing: none</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-normal">
+    <h2>text-spacing: normal</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-auto">
+    <h2>text-spacing: auto</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-auto-equiv">
+    <h2>text-spacing: trim-start ideograph-alpha ideograph-numeric</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-space-start">
+    <h2>text-spacing: space-start</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-space-first">
+    <h2>text-spacing: space-first</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-space-end">
+    <h2>text-spacing: space-end</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-ideograph-alpha">
+    <h2>text-spacing: ideograph-alpha</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-ideograph-numeric">
+    <h2>text-spacing: ideograph-numeric</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+
+</body>
+</html>

--- a/packages/core/test/files/text-spacing/text-spacing-zh-hant.html
+++ b/packages/core/test/files/text-spacing/text-spacing-zh-hant.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="zh-hant">
+<head>
+  <meta charset="UTF-8">
+  <title>text-spacing測試</title>
+  <style>
+    p {
+      border: 1px solid silver;
+      text-align: justify;
+    }
+    b {
+      font-weight: bold;
+      color: maroon;
+    }
+    i {
+      font-style: normal;
+      font-size: 80%;
+      color: navy;
+    }
+    #test-ts-none {
+      text-spacing: none;
+    }
+    #test-ts-normal {
+      text-spacing: normal;
+    }
+    #test-ts-auto {
+      text-spacing: auto;
+    }
+    #test-ts-auto-equiv {
+      text-spacing: trim-start ideograph-alpha ideograph-numeric;
+    }
+    #test-ts-space-start {
+      text-spacing: space-start;
+    }
+    #test-ts-space-first {
+      text-spacing: space-first;
+    }
+    #test-ts-space-end {
+      text-spacing: space-end;
+    }
+    #test-ts-ideograph-alpha {
+      text-spacing: ideograph-alpha;
+    }
+    #test-ts-ideograph-numeric {
+      text-spacing: ideograph-numeric;
+    }
+  </style>
+</head>
+<body>
+  <h1>排版的CSS属性，「text-spacing」測試</h1>
+  <section id="test-ts-default">
+    <h2>default</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-none">
+    <h2>text-spacing: none</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-normal">
+    <h2>text-spacing: normal</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-auto">
+    <h2>text-spacing: auto</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-auto-equiv">
+    <h2>text-spacing: trim-start ideograph-alpha ideograph-numeric</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-space-start">
+    <h2>text-spacing: space-start</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-space-first">
+    <h2>text-spacing: space-first</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-space-end">
+    <h2>text-spacing: space-end</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-ideograph-alpha">
+    <h2>text-spacing: ideograph-alpha</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-ideograph-numeric">
+    <h2>text-spacing: ideograph-numeric</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+
+</body>
+</html>


### PR DESCRIPTION
## text-spacing

Spec: CSS Text Module Level 4 / §10.2 Character Class Spacing: the text-spacing property

- Working Draft: https://www.w3.org/TR/css-text-4/#text-spacing-property
- Editor' Draft: https://drafts.csswg.org/css-text-4/#text-spacing-property

```
Name:   text-spacing
Value:  normal | none | auto | [[ trim-start | space-start | space-first ] ||
    [ trim-end | space-end | allow-end ] || [ trim-adjacent | space-adjacent ] ||
    no-compress || ideograph-alpha || ideograph-numeric || punctuation];
Initial:   normal
Inherited: yes
```

- (**Update** on 2023-01-06: the description in this PR is outdated; the draft spec and our implementation have been changed. See PR #1084)

### Limitations and differences from the current CSS draft spec

- `normal` is equivalent to `space-first trim-end trim-adjacent`
  **Note:** it was `space-start allow-end trim-adjacent` in the draft spec
- `auto` is equivalent to `trim-start trim-end trim-adjacent ideograph-alpha ideograph-numeric`
  **Note:** `auto` is defined in the editor's draft as
  "The user agent chooses a set of typographically high quality spacing value."
- `ideograph-alpha` and `ideograph-numeric` create 1/6em space.
  **Note:** the 1/4em space in the draft is considered too wide in many cases.
- ~~`allow-end` is treated as `trim-end`~~ **(update: fixed in #818)**
- `no-compress` and `punctuation` are ignored

## hanging-punctuation

Spec: CSS Text Module Level 3 / §8.2.1 Hanging Punctuation: the hanging-punctuation property

- Working Draft: https://www.w3.org/TR/css-text-3/#hanging-punctuation-property
- Editor' Draft: https://drafts.csswg.org/css-text-3/#hanging-punctuation-property

```
Name:   hanging-punctuation
Value:  none | [ first || [ force-end | allow-end ] || last ]
Initial:   none
Inherited: yes
```

### Limitations and differences from the current CSS draft spec

- ~~`allow-end` is treated as `force-end`~~ **(update: fixed in #818)**
- Stops and commas allowed to hang are limited to U+3001, U+3002, U+FF0C, U+FF0E, U+FF61, U+FF64 [、。，．､｡]
  - Not include ASCII comma and full stop, Arabic comma adn full stop, Small comma, etc. that are included in the draft spec.
