### PR TITLE
Fix SVG rendering broken

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1149,6 +1149,10 @@ export class ViewFactory
                   );
                 if (
                   Scripts.allowScripts &&
+                  !(
+                    result.namespaceURI === Base.NS.SVG &&
+                    result.localName !== "svg"
+                  ) &&
                   !result.ownerDocument.getElementById(attributeValue)
                 ) {
                   // Keep original id value so that JavaScript can manipulate it


### PR DESCRIPTION
Fixes the problem caused by the change for allowScripts (#824)
that SVG elements are not rendered correctly when the SVG elements
have id attributes that are referenced by SVG elements attribute value
"url(#idref)".