### PR TITLE
fix: Viewer page position should be kept after the heading ID changed

### DIFF
--- a/packages/core/src/vivliostyle/cfi.ts
+++ b/packages/core/src/vivliostyle/cfi.ts
@@ -19,6 +19,7 @@
  * @fileoverview Cfi - Support for EPUB Canonical Fragment Identifiers.
  */
 import * as Base from "./base";
+import * as Logging from "./logging";
 
 export type Position = {
   node: Node;
@@ -157,7 +158,12 @@ export class ChildStep implements Step {
       pos.node = child;
     }
     if (this.id && (pos.after || this.id != getId(pos.node))) {
-      throw new Error("E_CFI_ID_MISMATCH");
+      const movedNode = elem.ownerDocument.getElementById(this.id);
+      if (movedNode) {
+        pos.node = movedNode;
+      } else {
+        Logging.logger.warn("E_CFI_ID_MISMATCH:", this.id);
+      }
     }
     pos.sideBias = this.sideBias;
     return true;


### PR DESCRIPTION
Fixes #826

Now the EPUBCFI handling is improved and can track viewing position even if the document structure or the element id is modified.