### PR TITLE
fix: Unnecessary aria-hidden attributes caused tagged PDF output broken

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -495,7 +495,6 @@ export class AdaptiveViewer {
     this.removePageListeners();
     this.forCurrentPages((page) => {
       Base.setCSSProperty(page.container, "display", "none");
-      page.container.setAttribute("aria-hidden", "true");
     });
     this.currentPage = null;
     this.currentSpread = null;
@@ -506,7 +505,6 @@ export class AdaptiveViewer {
     page.addEventListener("replaced", this.pageReplacedListener, false);
     Base.setCSSProperty(page.container, "visibility", "visible");
     Base.setCSSProperty(page.container, "display", "block");
-    page.container.setAttribute("aria-hidden", "false");
   }
 
   private showPage(page: Vtree.Page): void {

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2252,7 +2252,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
     if (!Constants.isDebug) {
       pageCont.style.visibility = "hidden";
-      pageCont.setAttribute("aria-hidden", "true");
     }
     viewport.layoutBox.appendChild(pageCont);
     const bleedBox = viewport.document.createElement("div") as HTMLElement;


### PR DESCRIPTION
Before this fix, aria-hidden="true" was set on generated pages that were hidden (display: none) in viewer. This behavior caused problem on printing to PDF, because Chromium generates tagged PDF but not generating tags for elements with aria-hidden="true".

Removing aria-hidden attributes on hidden pages in viewer would be no problem because screen readers skip display:none elements regardless of aria-hidden.