### PR TITLE
feat: support CSS text-spacing and hanging-punctuation in generated content

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1434,38 +1434,27 @@ viv-ts-open.viv-trim-start > viv-ts-inner {
 viv-ts-close.viv-trim-adj > viv-ts-inner {
   margin-inline-end: -0.5em;
 }
-viv-ts-close.viv-trim-end > viv-ts-inner {
-  display: inline-block;
-  inline-size: 0.5em;
-  text-indent: 0;
-  text-align: start;
-  text-align-last: start;
-}
-viv-ts-close.viv-hang-end > viv-ts-inner {
-  display: inline-block;
-  inline-size: 0;
-  text-indent: 0;
-  text-align: start;
-  text-align-last: start;
-}
-viv-ts-close.viv-trim-end::after,
-viv-ts-close.viv-hang-end::after {
-  content: " ";
-  font-family: Courier, monospace;
-  font-size: 83%;
-  line-height: 0;
-  text-orientation: mixed;
-  visibility: hidden;
-}
-viv-ts-close.viv-hang-end::after {
-  word-spacing: 0.6em;
-}
+viv-ts-close.viv-trim-end > viv-ts-inner,
+viv-ts-close.viv-hang-end > viv-ts-inner,
 viv-ts-close.viv-hang-last > viv-ts-inner {
   display: inline-block;
   inline-size: 0;
   text-indent: 0;
   text-align: start;
   text-align-last: start;
+}
+viv-ts-close.viv-trim-end > viv-ts-inner {
+  inline-size: 0.5em;
+}
+viv-ts-close.viv-trim-end::after,
+viv-ts-close.viv-hang-end::after {
+  content: " ";
+  text-orientation: mixed;
+  visibility: hidden;
+  word-spacing: 0.25em;
+}
+viv-ts-close.viv-hang-end::after {
+  word-spacing: 0.75em;
 }
 viv-ts-open.viv-hang-first > viv-ts-inner {
   display: inline-block;
@@ -1475,12 +1464,7 @@ viv-ts-open.viv-hang-first > viv-ts-inner {
   text-align-last: end;
   margin-inline-start: -1em;
 }
-viv-ts-thin-sp::after {
-  content: " ";
-  font-family: Times, serif;
-  font-size: 66.6%;
-  line-height: 0;
-  text-orientation: mixed;
-  visibility: hidden;
+viv-ts-thin-sp {
+  margin-inline-end: 0.166em;
 }
 `;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -105,6 +105,7 @@ export const inheritedProps = {
   "text-combine-upright": true,
   "text-indent": true,
   "text-justify": true,
+  "text-orientation": true,
   "text-rendering": true,
   "text-size-adjust": true,
   "text-spacing": true,

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -660,7 +660,7 @@ export const pageMarginBoxes: { [key: string]: PageMarginBoxInformation } = {
     isInTopRow: true,
     isInBottomRow: false,
     isInLeftColumn: true,
-    isInRightColumn: true,
+    isInRightColumn: false,
     positionAlongVariableDimension: null,
   },
   "top-left": {
@@ -1910,6 +1910,25 @@ export class PageMarginBoxPartitionInstance extends PageMaster.PartitionInstance
         this.vertical ? "row" : "column",
       );
       Base.setCSSProperty(element, "justify-content", flexAlign);
+      if (this.vertical) {
+        let align = "center";
+        if (this.boxInfo.isInTopRow || this.boxInfo.isInBottomRow) {
+          if (
+            this.boxInfo.isInLeftColumn ||
+            this.boxInfo.positionAlongVariableDimension ===
+              MarginBoxPositionAlongVariableDimension.END
+          ) {
+            align = "start";
+          } else if (
+            this.boxInfo.isInRightColumn ||
+            this.boxInfo.positionAlongVariableDimension ===
+              MarginBoxPositionAlongVariableDimension.START
+          ) {
+            align = "end";
+          }
+        }
+        Base.setCSSProperty(element, "align-items", align);
+      }
     }
   }
 

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -548,12 +548,15 @@ export class Styler implements AbstractStyler {
     elemStyle: CssCascade.ElementStyle,
     isBody: boolean,
   ): void {
-    ["writing-mode", "direction"].forEach((propName) => {
+    const rootInheritedProps = isBody
+      ? ["writing-mode", "direction"]
+      : Object.keys(CssCascade.inheritedProps);
+    for (const propName of rootInheritedProps) {
       if (elemStyle[propName] && !(isBody && this.rootStyle[propName])) {
         // Copy it over, but keep it at the root element as well.
         this.rootStyle[propName] = elemStyle[propName];
       }
-    });
+    }
     if (!this.rootBackgroundAssigned) {
       const backgroundColor = this.hasProp(
         elemStyle,

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -21,7 +21,6 @@
  */
 import "./footnotes";
 import "./table";
-import "./text-polyfill";
 import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as Break from "./break";
@@ -49,6 +48,7 @@ import * as PageMaster from "./page-master";
 import * as Scripts from "./scripts";
 import * as Task from "./task";
 import * as TaskUtil from "./task-util";
+import * as TextPolyfill from "./text-polyfill";
 import * as Vgen from "./vgen";
 import * as Vtree from "./vtree";
 import * as XmlDoc from "./xml-doc";
@@ -1521,6 +1521,16 @@ export class StyleInstance
           page,
           this.faces,
         );
+        if (innerContainerTag == "span") {
+          // text-spacing & hanging-punctuation on margin boxes
+          TextPolyfill.processGeneratedContent(
+            innerContainer,
+            boxInstance.getProp(this, "text-spacing"),
+            boxInstance.getProp(this, "hanging-punctuation"),
+            this.lang,
+            boxInstance.vertical,
+          );
+        }
       } else if (boxInstance.suppressEmptyBoxGeneration) {
         parentContainer.removeChild(boxContainer);
         removed = true;

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -991,6 +991,15 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
 
   getProp(context: Exprs.Context, name: string): Css.Val {
     let val = this.style[name];
+    if (!val && CssCascade.inheritedProps[name]) {
+      // inherit from root style
+      const rootStyle = (
+        context as Exprs.Context & {
+          styler: { rootStyle: { [key: string]: CssCascade.CascadeValue } };
+        }
+      ).styler?.rootStyle;
+      val = rootStyle[name]?.value;
+    }
     if (val) {
       val = CssParser.evaluateCSSToCSS(context, val, name);
     }

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1781,7 +1781,6 @@ export class PartitionInstance<
     docFaces: Font.DocumentFaces,
     clientLayout: Vtree.ClientLayout,
   ): void {
-    Base.setCSSProperty(container.element, "overflow", "hidden"); // default value
     super.prepareContainer(context, container, page, docFaces, clientLayout);
   }
 }

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1620,6 +1620,7 @@ export const passContentProperties = [
   "text-emphasis-color",
   "text-emphasis-position",
   "text-emphasis-style",
+  "text-orientation",
   "text-shadow",
   "text-underline-position",
 ];

--- a/packages/core/src/vivliostyle/pseudo-element.ts
+++ b/packages/core/src/vivliostyle/pseudo-element.ts
@@ -21,6 +21,7 @@ import * as Css from "./css";
 import * as CssCascade from "./css-cascade";
 import * as CssStyler from "./css-styler";
 import * as Exprs from "./exprs";
+import * as TextPolyfill from "./text-polyfill";
 import * as Vtree from "./vtree";
 import { PseudoElement } from "./types";
 
@@ -115,6 +116,8 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
               this.exprContentListener,
             ),
           );
+          // text-spacing & hanging-punctuation support
+          TextPolyfill.preprocessTextContent(element);
         }
       }
     }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -146,6 +146,14 @@ module.exports = [
         file: "text-spacing/text-spacing-zh-hant.html",
         title: "Text Spacing (Chinese, Traditional)",
       },
+      {
+        file: "text-spacing/ts-generated-content.html",
+        title: "Text-spacing on generated content",
+      },
+      {
+        file: "text-spacing/ts-generated-content-vertical.html",
+        title: "Text-spacing on generated content (vertical writing-mode)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/text-spacing/ts-generated-content-vertical.html
+++ b/packages/core/test/files/text-spacing/ts-generated-content-vertical.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Test text-spacing on generated content (vertical writing-mode)</title>
+  <style>
+    :root {
+      text-spacing: auto;
+      writing-mode: vertical-rl;
+    }
+
+    @page {
+      outline: dotted 1px;
+
+      @top-left {
+        content: "「日本語English（英語）」。";
+        color: navy;
+        writing-mode: horizontal-tb;
+      }
+
+      @top-right {
+        content: "「日本語English（英語）」。";
+        color: blue;
+        text-spacing: normal;
+        writing-mode: horizontal-tb;
+      }
+
+      @bottom-left {
+        content: "「日本語English（英語）」。";
+        color: gray;
+        text-spacing: none;
+        writing-mode: horizontal-tb;
+      }
+
+      @bottom-center {
+        content: "【第" counter(page, lower-roman) "頁（全" counter(pages) "頁）】";
+        text-spacing: ideograph-alpha ideograph-numeric;
+        color: maroon;
+        writing-mode: horizontal-tb;
+      }
+
+      @bottom-right {
+        content: "「日本語English（英語）」。";
+        color: teal;
+        hanging-punctuation: force-end;
+        writing-mode: horizontal-tb;
+      }
+
+      @left-top {
+        content: "「日本語English（英語）」。";
+        color: navy;
+      }
+
+      @left-bottom {
+        content: "「日本語English（英語）」。";
+        color: blue;
+        text-spacing: normal;
+      }
+
+      @right-top {
+        content: "「日本語English（英語）」。";
+        color: gray;
+        text-spacing: none;
+      }
+
+      @right-middle {
+        content: "【第" counter(page) "頁（全" counter(pages, cjk-ideographic) "頁）】";
+        text-spacing: ideograph-alpha ideograph-numeric;
+        color: maroon;
+        text-orientation: upright;
+      }
+
+      @right-bottom {
+        content: "「日本語English（英語）」。";
+        color: teal;
+        hanging-punctuation: force-end;
+      }
+    }
+
+    .test::before {
+      content: "「日本語English（英語）」。";
+      color: purple;
+    }
+
+    .test::after {
+      content: "「日本語English（英語）」。";
+      color: olive;
+    }
+
+    .right {
+      text-align: right;
+    }
+
+    .ts-none {
+      text-spacing: none;
+    }
+
+    .ts-normal {
+      text-spacing: normal;
+    }
+
+    .ts-auto {
+      /* text-spacing: auto (inherited from :root) */
+    }
+
+    .hp-force-end {
+      hanging-punctuation: force-end;
+    }
+  </style>
+</head>
+
+<body>
+  <section>
+    <h2>Margin boxes</h2>
+    <dl>
+      <dt style="color: navy">@top-left, @left-top</dt>
+      <dd>text-spacing: auto (inherited from :root)</dd>
+    </dl>
+    <dl>
+      <dt style="color: blue">@top-right, @left-bottom</dt>
+      <dd>text-spacing: normal</dd>
+    </dl>
+    <dl>
+      <dt style="color: gray">@bottom-left, @right-top</dt>
+      <dd>text-spacing: none</dd>
+    </dl>
+    <dl>
+      <dt style="color: teal">@bottom-right, @right-bottom</dt>
+      <dd>hanging-punctuation: force-end</dd>
+    </dl>
+    <dl>
+      <dt style="color: maroon">@right-middle, @bottom-center</dt>
+      <dd>text-spacing: ideograph-alpha ideograph-numeric</dd>
+    </dl>
+  </section>
+
+  <section>
+    <h2><span style="color: purple">::before</span>/<span
+        style="color: olive">::after</span> pseudo elements</h2>
+    <section class="ts-auto">
+      <h3>text-spacing: auto (inherited from :root)</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+    <section class="ts-normal">
+      <h3>text-spacing: normal</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+    <section class="ts-none">
+      <h3>text-spacing: none</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+    <section class="hp-force-end">
+      <h3>hanging-punctuation: force-end</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+  </section>
+</body>
+
+</html>

--- a/packages/core/test/files/text-spacing/ts-generated-content.html
+++ b/packages/core/test/files/text-spacing/ts-generated-content.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Test text-spacing on generated content</title>
+  <style>
+    :root {
+      text-spacing: auto;
+    }
+
+    @page {
+      outline: dotted 1px;
+
+      @top-left {
+        content: "「日本語English（英語）」。";
+        color: navy;
+      }
+
+      @top-right {
+        content: "「日本語English（英語）」。";
+        color: blue;
+        text-spacing: normal;
+      }
+
+      @bottom-left {
+        content: "「日本語English（英語）」。";
+        color: gray;
+        text-spacing: none;
+      }
+
+      @bottom-right {
+        content: "「日本語English（英語）」。";
+        color: teal;
+        hanging-punctuation: force-end;
+      }
+    }
+
+    .test::before {
+      content: "「日本語English（英語）」。";
+      color: purple;
+    }
+
+    .test::after {
+      content: "「日本語English（英語）」。";
+      color: olive;
+    }
+
+    .right {
+      text-align: right;
+    }
+
+    .ts-none {
+      text-spacing: none;
+    }
+
+    .ts-normal {
+      text-spacing: normal;
+    }
+
+    .ts-auto {
+      /* text-spacing: auto (inherited from :root) */
+    }
+
+    .hp-force-end {
+      hanging-punctuation: force-end;
+    }
+  </style>
+</head>
+
+<body>
+  <section>
+    <h2>Margin boxes</h2>
+    <dl>
+      <dt style="color: navy">@top-left</dt>
+      <dd>text-spacing: auto (inherited from :root)</dd>
+    </dl>
+    <dl>
+      <dt style="color: blue">@top-right</dt>
+      <dd>text-spacing: normal</dd>
+    </dl>
+    <dl>
+      <dt style="color: gray">@bottom-left</dt>
+      <dd>text-spacing: none</dd>
+    </dl>
+    <dl>
+      <dt style="color: teal">@bottom-right</dt>
+      <dd>hanging-punctuation: force-end</dd>
+    </dl>
+  </section>
+
+  <section>
+    <h2><span style="color: purple">::before</span>/<span
+        style="color: olive">::after</span> pseudo elements</h2>
+    <section class="ts-auto">
+      <h3>text-spacing: auto (inherited from :root)</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+    <section class="ts-normal">
+      <h3>text-spacing: normal</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+    <section class="ts-none">
+      <h3>text-spacing: none</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+    <section class="hp-force-end">
+      <h3>hanging-punctuation: force-end</h3>
+      <p>「日本語English（英語）」。</p>
+      <p class="test">「日本語English（英語）」。</p>
+      <p class="right">「日本語English（英語）」。</p>
+      <p class="test right">「日本語English（英語）」。</p>
+    </section>
+  </section>
+</body>
+
+</html>


### PR DESCRIPTION
CSS text-spacing and hanging-punctuation properties have been supported since v2.12, but with the limitation that they do not work in generated content, i.e., page margin boxes and ::before/::after pseudo elements. Now this issue is resolved.

- Resolve #820
