### PR TITLE
fix: text-spacing not working depending on fonts

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1455,7 +1455,7 @@ viv-ts-close.viv-hang-end::after {
   visibility: hidden;
 }
 viv-ts-close.viv-hang-end::after {
-  word-spacing: 0.9em;
+  word-spacing: 0.6em;
 }
 viv-ts-open.viv-hang-first > viv-ts-inner {
   display: inline-block;

--- a/packages/core/test/files/text-spacing/text-spacing-ja.html
+++ b/packages/core/test/files/text-spacing/text-spacing-ja.html
@@ -38,6 +38,9 @@
     #test-ts-space-end {
       text-spacing: space-end;
     }
+    #test-ts-allow-end {
+      text-spacing: allow-end;
+    }
     #test-ts-ideograph-alpha {
       text-spacing: ideograph-alpha;
     }
@@ -78,6 +81,10 @@
   </section>
   <section id="test-ts-space-end">
     <h2>text-spacing: space-end</h2>
+    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
+  </section>
+  <section id="test-ts-allow-end">
+    <h2>text-spacing: allow-end</h2>
     <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
   </section>
   <section id="test-ts-ideograph-alpha">

--- a/packages/core/test/files/text-spacing/text-spacing-zh-hans.html
+++ b/packages/core/test/files/text-spacing/text-spacing-zh-hans.html
@@ -38,6 +38,9 @@
     #test-ts-space-end {
       text-spacing: space-end;
     }
+    #test-ts-allow-end {
+      text-spacing: allow-end;
+    }
     #test-ts-ideograph-alpha {
       text-spacing: ideograph-alpha;
     }
@@ -78,6 +81,10 @@
   </section>
   <section id="test-ts-space-end">
     <h2>text-spacing: space-end</h2>
+    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-allow-end">
+    <h2>text-spacing: allow-end</h2>
     <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
   </section>
   <section id="test-ts-ideograph-alpha">

--- a/packages/core/test/files/text-spacing/text-spacing-zh-hant.html
+++ b/packages/core/test/files/text-spacing/text-spacing-zh-hant.html
@@ -38,6 +38,9 @@
     #test-ts-space-end {
       text-spacing: space-end;
     }
+    #test-ts-allow-end {
+      text-spacing: allow-end;
+    }
     #test-ts-ideograph-alpha {
       text-spacing: ideograph-alpha;
     }
@@ -78,6 +81,10 @@
   </section>
   <section id="test-ts-space-end">
     <h2>text-spacing: space-end</h2>
+    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
+  </section>
+  <section id="test-ts-allow-end">
+    <h2>text-spacing: allow-end</h2>
     <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
   </section>
   <section id="test-ts-ideograph-alpha">


### PR DESCRIPTION
- fix https://github.com/vivliostyle/vivliostyle.js/issues/858
  - it was a regression caused by https://github.com/vivliostyle/vivliostyle.js/pull/855
- minor tweaks
- add `text-spacing: allow-end` tests to text-spacing-*.html test files