### PR TITLE
fix: should generate single text node for pseudo elements if possible

### DIFF
--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -1314,6 +1314,10 @@ export class ContentPropertyHandler extends Css.Visitor {
 
   private visitStrInner(str: string, node?: Node | null) {
     if (!node) {
+      if (this.elem.lastChild instanceof Text) {
+        this.elem.lastChild.textContent += str;
+        return;
+      }
       node = this.elem.ownerDocument.createTextNode(str);
     }
     this.elem.appendChild(node);


### PR DESCRIPTION
- fix #863

Unnecesarily fragmented text nodes are problematic for text-combine-upright properly working, so we should generate single text node as much as possible.