### PR TITLE
fix: use appropriate fallback page size when window size is not available

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -356,6 +356,9 @@ export class StyleInstance
 
     // Determine page sheet sizes corresponding to page selectors
     const pageProps = this.style.pageProps;
+    if (!pageProps[""]) {
+      pageProps[""] = {};
+    }
     Object.keys(pageProps).forEach((selector) => {
       const pageSizeAndBleed = CssPage.evaluatePageSizeAndBleed(
         CssPage.resolvePageSizeAndBleed(pageProps[selector] as any),

--- a/packages/core/src/vivliostyle/print.ts
+++ b/packages/core/src/vivliostyle/print.ts
@@ -107,12 +107,6 @@ class VivliostylePrint {
           window: this.iframeWin,
           debug: true,
         },
-        {
-          defaultPaperSize: {
-            width: 794, // These numbers give weird output, but not setting them crashes the browser when there is no CSS.
-            height: 1122,
-          },
-        },
       );
     return new Promise<void>((resolve) => {
       Viewer.addListener("readystatechange", () => {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2473,6 +2473,20 @@ export class Viewport {
       opt_width || parseFloat(computedStyle["width"]) || window.innerWidth;
     this.height =
       opt_height || parseFloat(computedStyle["height"]) || window.innerHeight;
+
+    // Use the fallbackPageSize if window size is 0 or browser is in headless mode.
+    const fallbackPageSize = {
+      // compromise between A4 (210mm 297mm) and letter (8.5in 11in)
+      width: 794, // 210mm (8.27in)
+      height: 1056, // 279.4mm (11in)
+    };
+    const isHeadlessBrowser = !window.outerWidth && !window.outerHeight;
+    if (!this.width || (!opt_width && isHeadlessBrowser)) {
+      this.width = fallbackPageSize.width;
+    }
+    if (!this.height || (!opt_height && isHeadlessBrowser)) {
+      this.height = fallbackPageSize.height;
+    }
   }
 
   /**

--- a/packages/viewer/src/models/document-options.ts
+++ b/packages/viewer/src/models/document-options.ts
@@ -133,17 +133,12 @@ class DocumentOptions {
         url,
       }));
     }
-    const userStyleSheetArray = convertStyleSheetArray(this.userStyleSheet());
-    if (this.pageStyle.pageSizeMode() == PageStyle.Mode.Default) {
-      // Put default page size auto. This is needed to output auto size PDF.
-      userStyleSheetArray.unshift({ text: "@page{size:auto}" });
-    }
     // Do not include url
     // (url is a required argument to Viewer.loadDocument, separated from other options)
     return {
       fragment: this.fragment(),
       authorStyleSheet: convertStyleSheetArray(this.authorStyleSheet()),
-      userStyleSheet: userStyleSheetArray,
+      userStyleSheet: convertStyleSheetArray(this.userStyleSheet()),
     };
   }
 


### PR DESCRIPTION
When page size is not specified or `auto`, Vivliostyle uses the window size to determine the page size.
The problem here is when the window size is not available, i.e., window size is 0 or browser is in headless mode.

To solve the problem, now we use the fallbackPageSize:

```ts
    const fallbackPageSize = {
      // compromise between A4 (210mm 297mm) and letter (8.5in 11in)
      width: 794, // 210mm (8.27in)
      height: 1056, // 279.4mm (11in)
    };
```