### PR TITLE
fix: Fallback page size not applied on HeadlessChrome on Linux or Windows

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2487,7 +2487,9 @@ export class Viewport {
       width: 794, // 210mm (8.27in)
       height: 1056, // 279.4mm (11in)
     };
-    const isHeadlessBrowser = !window.outerWidth && !window.outerHeight;
+    const isHeadlessBrowser =
+      (!window.outerWidth && !window.outerHeight) ||
+      /Headless/.test(navigator.userAgent);
     if (!this.width || (!opt_width && isHeadlessBrowser)) {
       this.width = fallbackPageSize.width;
     }


### PR DESCRIPTION
- fix #905
