### PR TITLE
fix: TypeError: Cannot read properties of null

### DIFF
--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -407,7 +407,7 @@ class TextSpacingPolyfill {
     }
 
     this.isTextPolyfillCssReady =
-      !!nodeContext.viewNode.ownerDocument.getElementById(
+      !!checkPoints[0]?.viewNode?.ownerDocument.getElementById(
         "vivliostyle-text-polyfill-css",
       );
 


### PR DESCRIPTION
Fix the problem that the error "TypeError: Cannot read properties of null (reading 'ownerDocument')" may occur, I found it with sample: https://vivliostyle.org/viewer/#src=https://vivliostyle.github.io/vivliostyle_doc/samples/news/index.html&spread=false&bookMode=true