### PR TITLE
fix: output page size slightly bigger than the specified

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -724,12 +724,7 @@ export class AdaptiveViewer {
       const widthMax = Math.max(...this.pageSizes.map((p) => p.width));
       const heightMax = Math.max(...this.pageSizes.map((p) => p.height));
 
-      // Adjustment to prevent unwanted blank pages due to the rounded
-      // page size problem of Chromium print output.
-      const width = widthMax + 2;
-      const height = heightMax + 2;
-
-      const styleText = `@page {margin:0;size:${width}px ${height}px;}`;
+      const styleText = `@page {margin:0;size:${widthMax}px ${heightMax}px;}`;
       this.pageRuleStyleElement.textContent = styleText;
       this.pageSheetSizeAlreadySet = true;
     }

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -150,6 +150,7 @@ export const VivliostyleViewportCss = `
 
   [data-vivliostyle-page-container] {
     display: block !important;
+    max-height: 100vh;
     break-after: page;
   }
 


### PR DESCRIPTION
Vivliostyle.js v2.15.0 has problem on output page size that is about 0.5mm bigger than the specified page size.

This is due to a workaround for a problem that occurred when mixed page sizes were supported:

In packages/core/src/vivliostyle/adaptive-viewer.ts:
```
      // Adjustment to prevent unwanted blank pages due to the rounded
      // page size problem of Chromium print output.
      const width = widthMax + 2;
      const height = heightMax + 2;

      const styleText = `@page {margin:0;size:${width}px ${height}px;}`;
```

This adjustment is not so bad when used with Vivliostyle CLI v4.12.0 that sets the exact page size in the postprocess.

However, this may be a big problem when using Vivliostyle.js without Vivliostyle CLI.

I found a better workaround: Setting `max-height: 100vh` on the page container can prevent unwanted blank pages.