### PR TITLE
fix: Layout problem with Chrome>=102

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -175,6 +175,16 @@ export const VivliostyleViewportCss = `
     }
   }
 }
+/* Workaround for Chromium problem (issue #758, #793, #896). */
+/* Force Chromium legacy layout */
+/* (Remove this when https://crbug.com/1121942 is resolved) */
+[data-vivliostyle-page-container] {
+  column-count: 1;
+  height: 99999999px;
+}
+[data-vivliostyle-bleed-box] {
+  display: table;
+}
 `;
 
 // validation.txt

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2261,15 +2261,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
     pageCont.style.top = "0";
     pageCont.style.left = "0";
 
-    // Workaround for Chromium problem (issues #758 and #793).
-    // Chromium currently uses legacy engine for multicol and print
-    // and uses new engine (LayoutNG) for non-multicol screen,
-    // so need to use multicol to match screen and print layouts.
-    // This will be unnecessary when the Chromium issue is resolved:
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=829028
-    pageCont.style.columnCount = "1";
-    pageCont.style.height = "99999999px";
-
     if (!Constants.isDebug) {
       pageCont.style.visibility = "hidden";
     }


### PR DESCRIPTION
- Fix #896

This is a workaround for the Chromium problem that printing uses legacy layout and causes inconsistent results between viewing and printing. This forces always Chromium legacy layout by using table in multicolumn layout.

```css
[data-vivliostyle-page-container] {
  column-count: 1;
  height: 99999999px;
}
[data-vivliostyle-bleed-box] {
  display: table;
}
```

This workaround will be unnecessary when the Chromium issue is resolved:
- [Chromium bugs - Issue 1121942: [LayoutNG] Implement printing](https://bugs.chromium.org/p/chromium/issues/detail?id=1121942) 