### PR TITLE
fix: Remove workaround for Chromium legacy layout engine

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -175,16 +175,6 @@ export const VivliostyleViewportCss = `
     }
   }
 }
-/* Workaround for Chromium problem (issue #758, #793, #896). */
-/* Force Chromium legacy layout */
-/* (Remove this when https://crbug.com/1121942 is resolved) */
-[data-vivliostyle-page-container] {
-  column-count: 1;
-  height: 99999999px;
-}
-[data-vivliostyle-bleed-box] {
-  display: table;
-}
 `;
 
 // validation.txt


### PR DESCRIPTION
This change removes the workaround code for the Chromium's problem of inconsistent layout between viewing (new LayoutNG) and printing (legacy layout engine).

That workaround, that forces Chromium legacy layout, is no longer necessary when Chromium LayoutNG supports printing,
that will be around Chrome 108 according to the Chromium issue comment https://bugs.chromium.org/p/chromium/issues/detail?id=1121942#c79.

For now we can use LayoutNG for printing by specifying option --enable-blink-features=LayoutNGPrinting to Chromium.

If Vivliostyle CLI sets that option to Chromium, the problem of inconsistent layout between viewing and printing is resolved. Related pull request:

- https://github.com/vivliostyle/vivliostyle-cli/pull/307

Chromium's new LayoutNG will solve the following issue:

- https://github.com/vivliostyle/vivliostyle.js/issues/806

However, the problem of inconsistent layout between viewing and printing remains when printing not using the Vivliostyle CLI until Chromium LayoutNG officially supports printing.