### PR TITLE
feat: Add support for CSS shorthand property 'all'

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -686,6 +686,7 @@ border-inline-end-width: 3px;
 
 SHORTHANDS
 
+all = ALL;
 background = COMMA background-image [background-position [ / background-size ]] background-repeat
      background-attachment [background-origin background-clip] background-color; /* background-color is a special case, see the code */
 border-top = border-top-width border-top-style border-top-color;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -121,7 +121,7 @@ export const inheritedProps = {
 
 export const polyfilledInheritedProps = [
   "box-decoration-break",
-  // TODO: box-decoration-block should not be inherited.
+  // TODO: box-decoration-break should not be inherited.
   // https://github.com/vivliostyle/vivliostyle.js/issues/259
   "image-resolution",
   "orphans",
@@ -3323,7 +3323,9 @@ export class CascadeParserHandler
     if (!name && !ns) {
       return;
     }
-    this.specificity += 1;
+    if (name) {
+      this.specificity += 1;
+    }
     if (name && ns) {
       this.chain.push(new CheckNSTagAction(ns, name.toLowerCase()));
     } else if (name) {

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -231,7 +231,7 @@ export class Box {
 
   styleValue(name: string, defaultValue?: Css.Val): Css.Val | null {
     if (!(name in this.styleValues)) {
-      const cv = this.style[name];
+      const cv: CssCascade.CascadeValue = this.style[name];
       this.styleValues[name] = cv
         ? cv.evaluate(this.context, name)
         : defaultValue || null;
@@ -374,8 +374,7 @@ export class BoxStack {
         .styleValue("white-space", Css.ident.normal)
         .toString();
       const whitespace = Vtree.whitespaceFromPropertyValue(whitespaceValue);
-      Asserts.assert(whitespace !== null);
-      if (!Vtree.canIgnore(node, whitespace)) {
+      if (whitespace && !Vtree.canIgnore(node, whitespace)) {
         this.atBlockStart = false;
         this.atFlowStart = false;
       }
@@ -987,7 +986,11 @@ export class Styler implements AbstractStyler {
 
         if (blockStartOffset === 0) {
           // Named page type at first page
-          const pageType = style["page"]?.value.toString();
+          const pageCV: CssCascade.CascadeValue = style["page"];
+          const pageType =
+            pageCV &&
+            !Css.isDefaultingValue(pageCV.value) &&
+            pageCV.value.toString();
           if (pageType && pageType.toLowerCase() !== "auto") {
             this.cascade.firstPageType = pageType;
           }

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1483,6 +1483,104 @@ export class FontShorthandValidator extends SimpleShorthandValidator {
   }
 }
 
+const propsExcludedFromAll = [
+  "unicode-bidi",
+  "direction",
+
+  // excludes css-logical
+  "margin-block-start",
+  "margin-block-end",
+  "margin-inline-start",
+  "margin-inline-end",
+  "padding-block-start",
+  "padding-block-end",
+  "padding-inline-start",
+  "padding-inline-end",
+  "border-block-start-color",
+  "border-block-end-color",
+  "border-inline-start-color",
+  "border-inline-end-color",
+  "border-block-start-style",
+  "border-block-end-style",
+  "border-inline-start-style",
+  "border-inline-end-style",
+  "border-block-start-width",
+  "border-block-end-width",
+  "border-inline-start-width",
+  "border-inline-end-width",
+  "block-start",
+  "block-end",
+  "inline-start",
+  "inline-end",
+  "block-size",
+  "inline-size",
+  "max-block-size",
+  "max-inline-size",
+  "min-block-size",
+  "min-inline-size",
+
+  // excludes non-standards and special
+  "behavior",
+  "bleed",
+  "conflicting-partitions",
+  "crop-offset",
+  "enabled",
+  "flow-consume",
+  "flow-from",
+  "flow-into",
+  "flow-linger",
+  "flow-options",
+  "flow-priority",
+  "font-display",
+  "font-size-adjust",
+  "font-stretch_css3",
+  "font-variant_css2",
+  "glyph-orientation-vertical",
+  "marks",
+  "min-page-height",
+  "min-page-width",
+  "repeat-on-break",
+  "required",
+  "required-partitions",
+  "ruby-align",
+  "shape-inside",
+  "snap-height",
+  "snap-width",
+  "template",
+  "text-decoration-skip",
+  "text-justify",
+  "text-zoom",
+  "unicode-range",
+  "utilization",
+  "wrap-flow",
+];
+
+export class AllShorthandValidator extends SimpleShorthandValidator {
+  constructor() {
+    super();
+  }
+
+  /**
+   * @override
+   */
+  init(syntax: ShorthandSyntaxNode[], propList: string[]): void {
+    super.init(syntax, propList);
+    for (const name in this.validatorSet.validators) {
+      if (!propsExcludedFromAll.includes(name)) {
+        this.propList.push(name);
+      }
+    }
+  }
+
+  /**
+   * @override
+   */
+  validateList(list: Css.Val[]): number {
+    this.error = true;
+    return 0;
+  }
+}
+
 export const shorthandValidators: {
   [key: string]: typeof ShorthandValidator;
 } = {
@@ -1491,6 +1589,7 @@ export const shorthandValidators: {
   INSETS_SLASH: InsetsSlashShorthandValidator,
   COMMA: CommaShorthandValidator,
   FONT: FontShorthandValidator,
+  ALL: AllShorthandValidator,
 };
 
 //---- validation grammar parser and public property validator

--- a/packages/core/src/vivliostyle/display.ts
+++ b/packages/core/src/vivliostyle/display.ts
@@ -84,7 +84,10 @@ export function getComputedDislayValue(
   } else if (isAbsolutelyPositioned(position)) {
     float = Css.ident.none;
     display = blockify(display);
-  } else if ((float && float !== Css.ident.none) || isRoot) {
+  } else if (
+    (float && float !== Css.ident.none && !Css.isDefaultingValue(float)) ||
+    isRoot
+  ) {
     display = blockify(display);
   }
   return { display, position, float };

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -320,7 +320,7 @@ export function toExprIdent(
   val: Css.Val,
   def: string,
 ): Exprs.Val {
-  if (!val) {
+  if (!val || Css.isDefaultingValue(val)) {
     return new Exprs.Const(scope, def);
   }
   return val.toExpr(scope, scope.zero);
@@ -331,7 +331,7 @@ export function toExprAuto(
   val: Css.Val,
   ref: Exprs.Val,
 ): Exprs.Val {
-  if (!val || val === Css.ident.auto) {
+  if (!val || val === Css.ident.auto || Css.isDefaultingValue(val)) {
     return null;
   }
   return val.toExpr(scope, ref);
@@ -342,7 +342,7 @@ export function toExprNormal(
   val: Css.Val,
   ref: Exprs.Val,
 ): Exprs.Val {
-  if (!val || val === Css.ident.normal) {
+  if (!val || val === Css.ident.normal || Css.isDefaultingValue(val)) {
     return null;
   }
   return val.toExpr(scope, ref);
@@ -353,7 +353,7 @@ export function toExprZero(
   val: Css.Val,
   ref: Exprs.Val,
 ): Exprs.Val {
-  if (!val || val === Css.ident.auto) {
+  if (!val || val === Css.ident.auto || Css.isDefaultingValue(val)) {
     return scope.zero;
   }
   return val.toExpr(scope, ref);
@@ -369,7 +369,7 @@ export function toExprZeroAuto(
   val: Css.Val,
   ref: Exprs.Val,
 ): Exprs.Val {
-  if (!val) {
+  if (!val || Css.isDefaultingValue(val)) {
     return scope.zero;
   } else if (val === Css.ident.auto) {
     return null;
@@ -384,7 +384,7 @@ export function toExprZeroBorder(
   styleVal: Css.Val,
   ref: Exprs.Val,
 ): Exprs.Val {
-  if (!val || styleVal === Css.ident.none) {
+  if (!val || styleVal === Css.ident.none || Css.isDefaultingValue(val)) {
     return scope.zero;
   }
   return val.toExpr(scope, ref);
@@ -395,7 +395,7 @@ export function toExprBool(
   val: Css.Val,
   def: Exprs.Val,
 ): Exprs.Val {
-  if (!val) {
+  if (!val || Css.isDefaultingValue(val)) {
     return def;
   }
   if (val === Css.ident._true) {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -679,11 +679,12 @@ export class ViewFactory
       elementStyle = inheritedValues.elementStyle;
       this.nodeContext.lang = inheritedValues.lang;
     }
+    const floatReferenceCV: CssCascade.CascadeValue =
+      elementStyle["float-reference"];
     const floatReference =
-      elementStyle["float-reference"] &&
-      PageFloats.floatReferenceOf(
-        elementStyle["float-reference"].value.toString(),
-      );
+      floatReferenceCV &&
+      !Css.isDefaultingValue(floatReferenceCV.value) &&
+      PageFloats.floatReferenceOf(floatReferenceCV.value.toString());
     if (
       this.nodeContext.parent &&
       floatReference &&
@@ -846,8 +847,11 @@ export class ViewFactory
       this.nodeContext.floatSide = floating ? floatSide.toString() : null;
       this.nodeContext.floatReference =
         floatReference || PageFloats.FloatReference.INLINE;
+      const floatMinWrapBlock = computedStyle["float-min-wrap-block"];
       this.nodeContext.floatMinWrapBlock =
-        computedStyle["float-min-wrap-block"] || null;
+        floatMinWrapBlock && !Css.isDefaultingValue(floatMinWrapBlock)
+          ? floatMinWrapBlock
+          : null;
       this.nodeContext.columnSpan = computedStyle["column-span"];
       if (!this.nodeContext.inline) {
         const breakAfter = computedStyle["break-after"];
@@ -859,7 +863,9 @@ export class ViewFactory
           this.nodeContext.breakBefore = breakBefore.toString();
         }
         // Named page type
-        let pageType = computedStyle["page"]?.toString() || null;
+        const pageVal: Css.Val = computedStyle["page"];
+        let pageType =
+          pageVal && !Css.isDefaultingValue(pageVal) && pageVal.toString();
         if (!pageType || pageType.toLowerCase() === "auto") {
           pageType = this.nodeContext.pageType;
         } else {


### PR DESCRIPTION
spec: https://www.w3.org/TR/css-cascade-4/#all-shorthand

Tested:
https://github.com/web-platform-tests/wpt/blob/master/css/css-cascade/all-prop-001.html
https://github.com/web-platform-tests/wpt/blob/master/css/css-cascade/all-prop-002.html
https://github.com/web-platform-tests/wpt/blob/master/css/css-cascade/all-prop-inherit-color.html
https://github.com/web-platform-tests/wpt/blob/master/css/css-cascade/all-prop-initial-color.html
https://github.com/web-platform-tests/wpt/blob/master/css/css-cascade/all-prop-revert-color.html
https://github.com/web-platform-tests/wpt/blob/master/css/css-cascade/all-prop-unset-color.html
