### PR TITLE
fix: font-size with rem on root element causes wrong 1em size

### DIFF
--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -593,7 +593,7 @@ export class Styler implements AbstractStyler {
     if (!isBody) {
       const fontSize = elemStyle["font-size"];
       let isRelativeFontSize = true;
-      if (fontSize) {
+      if (fontSize && !Css.isDefaultingValue(fontSize.value)) {
         const val = fontSize.evaluate(this.context);
         let px = val.num;
         switch (val.unit) {

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -993,12 +993,20 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
     let val = this.style[name];
     if (!val && CssCascade.inheritedProps[name]) {
       // inherit from root style
-      const rootStyle = (
-        context as Exprs.Context & {
-          styler: { rootStyle: { [key: string]: CssCascade.CascadeValue } };
-        }
-      ).styler?.rootStyle;
-      val = rootStyle[name]?.value;
+      if (
+        name === "font-size" &&
+        context.isRelativeRootFontSize &&
+        context.rootFontSize
+      ) {
+        val = new Css.Numeric(context.rootFontSize, "px");
+      } else {
+        const rootStyle = (
+          context as Exprs.Context & {
+            styler: { rootStyle: { [key: string]: CssCascade.CascadeValue } };
+          }
+        ).styler?.rootStyle;
+        val = rootStyle[name]?.value;
+      }
     }
     if (val) {
       val = CssParser.evaluateCSSToCSS(context, val, name);


### PR DESCRIPTION
- fix #608