### PR TITLE
fix: Footnote may disappear on Adaptive Layout

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -768,6 +768,15 @@ export class StyleInstance
     const checkPageFloatForLaterPage = (
       float: PageFloats.PageFloat,
     ): boolean => {
+      // FIXME: This check is incomplete when float-reference is other than "page".
+      // so give up for now to prevent another problem (Issue #962).
+      if (
+        !this.pageAreaWidth &&
+        !this.pageAreaHeight &&
+        float.floatReference !== PageFloats.FloatReference.PAGE
+      ) {
+        return false;
+      }
       const pageStartPos = this.layoutPositionAtPageStart.flowPositions.body;
       const pageStartOffset =
         pageStartPos && this.getConsumedOffset(pageStartPos);


### PR DESCRIPTION
- fix issue #962

This fix is a workaround for the problem footnotes or float with region or column float-reference may disappear due to the problem on `checkPageFloatForLaterPage()`.
See the code comment.