### PR TITLE
fix: Incorrect behavior of ::first-letter and ::first-line selectors

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -367,6 +367,7 @@ export function getPrefixedPropertyNames(prop: string): string[] | null {
   switch (prop) {
     case "behavior":
     case "ua-list-item-count":
+    case "x-first-pseudo":
       propNameMap[prop] = null;
       return null;
     case "text-combine-upright":

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -628,6 +628,7 @@ export const OP_MEDIA_NOT: number = CssTokenizer.TokenType.LAST + 3;
   actionsBase[CssTokenizer.TokenType.CLASS] = Action.SELECTOR_START;
   actionsBase[CssTokenizer.TokenType.O_BRK] = Action.SELECTOR_START;
   actionsBase[CssTokenizer.TokenType.COLON] = Action.SELECTOR_START;
+  actionsBase[CssTokenizer.TokenType.COL_COL] = Action.SELECTOR_START;
   actionsBase[CssTokenizer.TokenType.AT] = Action.AT;
   actionsBase[CssTokenizer.TokenType.C_BRC] = Action.RULE_END;
   actionsBase[CssTokenizer.TokenType.EOF] = Action.DONE;
@@ -640,6 +641,8 @@ export const OP_MEDIA_NOT: number = CssTokenizer.TokenType.LAST + 3;
   actionsSelectorStart[CssTokenizer.TokenType.O_BRK] = Action.SELECTOR_ATTR;
   actionsSelectorStart[CssTokenizer.TokenType.COLON] =
     Action.SELECTOR_PSEUDOCLASS;
+  actionsSelectorStart[CssTokenizer.TokenType.COL_COL] =
+    Action.SELECTOR_PSEUDOELEM;
 
   actionsSelector[CssTokenizer.TokenType.GT] = Action.SELECTOR_CHILD;
   actionsSelector[CssTokenizer.TokenType.PLUS] = Action.SELECTOR_SIBLING;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -221,6 +221,19 @@ export class ViewFactory
           if (!display || display === Css.ident.inline) {
             continue;
           }
+          const child = element.firstElementChild;
+          if (child && !child.previousSibling?.textContent.trim()) {
+            const childStyle = styler.getStyle(child, false);
+            if (childStyle) {
+              const childDisplay = CssCascade.getProp(childStyle, "display");
+              if (
+                childDisplay?.value &&
+                childDisplay.value !== Css.ident.inline
+              ) {
+                continue;
+              }
+            }
+          }
         }
         if (name === "before" || name === "after") {
           const content = pseudoMap[name]["content"] as CssCascade.CascadeValue;


### PR DESCRIPTION
- fix #566
- fix #586

This commit also fixes the following related problems:
- Selector starting with `::` (without `*`) causes CSS parser error
- Useless warning message "Property not supported by the browser:  x-first-pseudo"