### PR TITLE
fix: wrong cascading with CSS variables

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -240,7 +240,7 @@ export class DispatchParserHandler extends ParserHandler {
    * Called by a slave.
    */
   errorMsg(mnemonics: string, token: CssTokenizer.Token): void {
-    Logging.logger.warn(mnemonics, token.toString());
+    Logging.logger.warn(mnemonics, token?.toString() ?? "");
   }
 
   override startStylesheet(flavor: StylesheetFlavor): void {
@@ -853,15 +853,25 @@ export class Parser {
     count = valStack.length - (index + 1);
     if (v == "(") {
       if (sep != ")") {
-        this.handler.error("E_CSS_MISMATCHED_C_PAR", token);
-        this.actions = actionsErrorDecl;
-        // return null;
+        if (token.type !== CssTokenizer.TokenType.EOF) {
+          this.handler.error("E_CSS_MISMATCHED_C_PAR", token);
+          this.actions = actionsErrorDecl;
+        }
       }
       const func = new Css.Func(
         valStack[index - 1] as string,
         this.extractVals(",", index + 1),
       );
       valStack.splice(index - 1, count + 2, func);
+
+      // Check invalid var()
+      if (func.name === "var") {
+        const name = func.values[0] instanceof Css.Ident && func.values[0].name;
+        if (!Css.isCustomPropName(name) || name === this.propName) {
+          this.handler.error(`E_CSS_INVALID_VAR ${func.toString()}`, token);
+          this.actions = actionsErrorDecl;
+        }
+      }
       return func;
     }
     if (sep != ";" || index >= 0) {
@@ -1949,7 +1959,15 @@ export class Parser {
         case Action.VAL_FINISH:
           tokenizer.consume();
           tokenizer.unmark();
-          val = this.valStackReduce(";", token);
+
+          // for implicit closing parens, e.g. style="color: var(--a, var(--b"
+          while (valStack.length > 0) {
+            const len = valStack.length;
+            val = this.valStackReduce(";", token);
+            if (!val || valStack.length === len) {
+              break;
+            }
+          }
           if (parsingValue) {
             this.result = val;
             return true;
@@ -1957,11 +1975,7 @@ export class Parser {
           if (this.propName && val) {
             handler.property(this.propName as string, val, this.propImportant);
           }
-          if (parsingStyleAttr) {
-            return true;
-          }
-          this.exprError("E_CSS_SYNTAX", token);
-          continue;
+          return true;
         case Action.EXPR_IDENT:
           token1 = tokenizer.nthToken(1);
           if (token1.type == CssTokenizer.TokenType.CLASS) {
@@ -2456,9 +2470,6 @@ export class Parser {
           continue;
         case Action.ERROR_PUSH:
           // Open bracket while skipping error syntax
-          if (parsingValue || parsingStyleAttr) {
-            return true;
-          }
           this.errorBrackets.push(token.type + 1);
 
           // Expected closing bracket
@@ -2466,9 +2477,6 @@ export class Parser {
           continue;
         case Action.ERROR_POP_DECL:
           // Close bracket while skipping error syntax in declaration
-          if (parsingValue || parsingStyleAttr) {
-            return true;
-          }
           if (this.errorBrackets.length == 0) {
             this.actions = actionsBase;
 
@@ -2494,9 +2502,6 @@ export class Parser {
           tokenizer.consume();
           continue;
         case Action.ERROR_SEMICOL:
-          if (parsingValue || parsingStyleAttr) {
-            return true;
-          }
           if (this.errorBrackets.length == 0) {
             this.actions = actionsBase;
           }
@@ -2509,9 +2514,6 @@ export class Parser {
           }
           return true;
         default:
-          if (parsingValue || parsingStyleAttr) {
-            return true;
-          }
           if (parsingMediaQuery) {
             if (this.exprStackReduce(CssTokenizer.TokenType.C_PAR, token)) {
               this.result = valStack.pop() as Css.Val;
@@ -2540,7 +2542,7 @@ export class Parser {
           ) {
             if (token.type == CssTokenizer.TokenType.INVALID) {
               handler.error(token.text, token);
-            } else if (this.propName) {
+            } else if (this.actions === actionsPropVal) {
               // Do not stop parsing on invalid property syntax as long as brackets are balanced.
               switch (token.type) {
                 case CssTokenizer.TokenType.O_PAR:

--- a/packages/core/src/vivliostyle/css-tokenizer.ts
+++ b/packages/core/src/vivliostyle/css-tokenizer.ts
@@ -1585,20 +1585,15 @@ export class Tokenizer {
       const charCode = input.charCodeAt(position);
       switch (actions[charCode] || actions[65] /*A*/) {
         case Action.INVALID:
-          tokenType = TokenType.INVALID;
-          if (actions === actionsNumOrClass) {
-            // Fix for issue #597
-            tokenText = input.substring(tokenPosition, position);
-            actions = actionsNormal;
-            break;
-          }
+          tokenText = input.substring(tokenPosition, position);
           if (isNaN(charCode)) {
-            tokenText = "E_CSS_UNEXPECTED_EOF";
+            // unclosed comment `/***[EOF]`, unclosed string `"**[EOF]`
+            tokenType = TokenType.EOF;
           } else {
-            tokenText = "E_CSS_UNEXPECTED_CHAR";
+            // invalid, e.g, `.` in `:nth-child([.])` (Issue #597)
+            tokenType = TokenType.INVALID;
           }
           actions = actionsNormal;
-          position++;
           break;
         case Action.SPACE:
           position++;


### PR DESCRIPTION
- fix #979

CSS Variables were implemented in pr #967 (v2.17.0) but there were failed test cases. See the test results listed in
https://github.com/vivliostyle/vivliostyle.js/pull/967#issuecomment-1193224384:

> Tests: http://wpt.live/css/css-variables/ (GitHub: https://github.com/web-platform-tests/wpt/tree/master/css/css-variables)
> 
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/css-vars-custom-property-case-sensitive-001.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/css-vars-custom-property-inheritance.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-declaration-01.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-declaration-60.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-external-declaration-01.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-external-font-face-01.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-external-reference-01.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-external-supports-01.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-font-face-01.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-font-face-02.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-01.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-27.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-28.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-29.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-30.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-32.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-33.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-34.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-38.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-39.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-40.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-visited.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-reference-without-whitespace.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-01.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-17.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-18.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-19.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-20.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-21.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-22.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-23.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-24.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-25.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-29.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-30.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-31.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-49.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-50.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-51.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-52.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-53.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-54.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-55.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-63.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-64.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-65.html
>   .. https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/variable-supports-67.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/vars-background-shorthand-001.html
> - [ ] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/vars-font-shorthand-001.html
> - [x] https://github.com/web-platform-tests/wpt/blob/master/css/css-variables/wide-keyword-fallback.html

After this fix, it passes all these tests.
