### PR TITLE
feat(viewer): improve the Settings menu: Custom Style, Crop Marks, Book Mode

### DIFF
--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -54,12 +54,12 @@
         <li><span>#<b>src</b>=&lt;document URL&gt;</span></li>
         <li><span>&amp;<b>bookMode</b>=[<b>true</b> | <b>false</b>]&emsp;(<b>Book Mode</b>)</span>
           <ul>
-            <li><b>true</b>: for Book-like publications, with Table of Contents.
+            <li><b>true</b> (default): for Book-like publications, with Table of Contents.
               <ul>
                 <li>When an HTML document URL is specified, a series of HTML documents linked from the publication manifest or Table of Contents (e.g., marked up with <code>&lt;nav role="doc-toc"&gt;</code>) are automatically loaded.</li>
               </ul>
             </li>
-            <li><b>false</b> (default): for single HTML documents</li>
+            <li><b>false</b>: for single HTML documents</li>
           </ul>
         </li>
         <li><span>&amp;<b>renderAllPages</b>=[<b>true</b> | <b>false</b>]&emsp;(<b>Render All Pages</b>)</span>

--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -27,7 +27,7 @@
   <body data-vivliostyle-viewer-status="loading" data-bind="event: {keydown: handleKey}, attr: {'data-vivliostyle-viewer-status': viewer.state.status, 'aria-busy': viewer.state.status()=='loading'}">
     <section id="vivliostyle-welcome" hidden data-bind="visible: !viewer.state.status(), attr: {hidden: viewer.state.status()?'':false, 'aria-hidden': viewer.state.status()?'true':'false'}, click: navigation.onclickViewport, swipePages: true">
       <h1>Vivliostyle Viewer <small>(version:&nbsp;<%= version %>)</small></h1>
-      <input id="vivliostyle-input-url" type="text" placeholder="Input a document URL" data-bind="textInput: viewer.inputUrl"/>
+      <input id="vivliostyle-input-url" type="text" placeholder="Input a document URL or HTML code" data-bind="textInput: viewer.inputUrl"/>
       <div id="vivliostyle-input-options">
         <label data-bind="hidden: settingsPanel.isBookModeChangeDisabled"><input id="vivliostyle-book-mode" type="checkbox" data-bind="checked: settingsPanel.state.bookMode" />&nbsp;<b>Book Mode</b>&emsp;</label>
         <label data-bind="hidden: settingsPanel.isRenderAllPagesChangeDisabled"><input id="vivliostyle-render-all-pages" type="checkbox" data-bind="checked: settingsPanel.state.renderAllPages" />&nbsp;<b>Render All Pages</b>&emsp;</label>
@@ -75,8 +75,8 @@
             <li><b>auto</b> (default): Auto spread view</li>
           </ul>
         </li>
-        <li><span>&amp;<b>style</b>=&lt;additional external style sheet URL&gt;</span></li>
-        <li><span>&amp;<b>userStyle</b>=&lt;user style sheet URL&gt;</span></li>
+        <li><span>&amp;<b>style</b>=&lt;additional (custom) stylesheet URL&gt;</span></li>
+        <li><span>&amp;<b>userStyle</b>=&lt;user stylesheet URL&gt;</span></li>
       </ul>
       <p>Options can also be set in the <a href="#" data-bind="click: settingsPanel.toggle"><img src="resources/vivliostyle-icon.png" width="16" height="16" alt="" />&nbsp;Settings</a> panel.</p>
       <p>For more details, see documentation:</p>
@@ -123,8 +123,8 @@
                   </div>
                 </fieldset>
               </details>
-              <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_user-style" open data-bind="hidden: settingsPanel.isPageStyleChangeDisabled">
-                <summary class="vivliostyle-menu-detail-group-heading" aria-keyshortcuts="U"><span>User Style Preferences</span></summary>
+              <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_custom-style" open data-bind="hidden: settingsPanel.isPageStyleChangeDisabled">
+                <summary class="vivliostyle-menu-detail-group-heading" aria-keyshortcuts="C"><span>Custom Style Settings</span></summary>
                 <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-size" aria-keyshortcuts="Z">
                   <legend class="vivliostyle-menu-detail-group-heading">Page Size</legend>
                   <ul class="vivliostyle-menu-detail-group">
@@ -151,12 +151,10 @@
                     </li>
                   </ul>
                 </fieldset>
-                <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_override-document-stylesheets">
-                  <div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-settings_override-document-stylesheets" aria-keyshortcuts="O" data-bind="checked: settingsPanel.state.pageStyle.allImportant, disable: settingsPanel.isOverrideDocumentStyleSheetDisabled" /> <span>Override Document Style Sheets</span></label></div>
+                <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_custom-style_more" data-bind="hidden: settingsPanel.isPageStyleChangeDisabled">
+                <summary class="vivliostyle-menu-detail-group-heading" aria-keyshortcuts="M"><span>More…</span></summary>
                 </fieldset>
-                <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_user-style_advanced" data-bind="hidden: settingsPanel.isPageStyleChangeDisabled">
-                <summary class="vivliostyle-menu-detail-group-heading" aria-keyshortcuts="D"><span>Advanced</span></summary>
-                <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-margin" aria-keyshortcuts="M">
+                <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-margin" aria-keyshortcuts="G">
                   <legend class="vivliostyle-menu-detail-group-heading">Page Margins</legend>
                   <ul class="vivliostyle-menu-detail-group">
                     <li><label><input type="radio" name="vivliostyle-settings_page-margin" value="" required data-bind="checked: settingsPanel.state.pageStyle.pageMarginMode" /> <span>Default</span> <small>(=10% unless specified elsewhere)</small></label></li>
@@ -217,24 +215,31 @@
                     </li>
                   </ul>
                 </fieldset>
-                <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_css-details">
-                  <summary class="vivliostyle-menu-detail-group-heading"><span>CSS Details</span></summary>
-                  <div><small>Don't edit between /*&lt;viewer&gt;*/ and /*&lt;/viewer&gt;*/.</small></div>
-                  <textarea name="vivliostyle-settings_css-details" autocomplete="off" aria-keyshortcuts="C" rows="10" data-bind="value: settingsPanel.state.pageStyle.cssText"></textarea>
+                <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_priority" aria-keyshortcuts="Y">
+                  <legend class="vivliostyle-menu-detail-group-heading">Custom Style Priority</legend>
+                  <ul class="vivliostyle-menu-detail-group">
+                    <li><label><input type="checkbox" name="vivliostyle-settings_set-as-custom-style" data-bind="checked: settingsPanel.state.pageStyle.customStyleAsUserStyle" /> <span>Set as user stylesheet</span> <small>(lower priority unless !important)</small></label></li>
+                    <li><label><input type="checkbox" name="vivliostyle-settings_override-document-stylesheets" data-bind="checked: settingsPanel.state.pageStyle.allImportant" /> <span>Force override document style</span> <small>(!important)</small></label></li>
+                  </ul>
+                </fieldset>
                 </details>
-                <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_reset-user-style">
-                  <summary class="vivliostyle-menu-detail-group-heading"><span>Reset User Style</span></summary>
+                <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_edit-css">
+                  <summary class="vivliostyle-menu-detail-group-heading"><span>Edit CSS</span></summary>
+                  <div><small>Don't edit between /*&lt;viewer&gt;*/ and /*&lt;/viewer&gt;*/.</small></div>
+                  <textarea name="vivliostyle-settings_edit-css" autocomplete="off" aria-keyshortcuts="E" rows="10" data-bind="value: settingsPanel.state.pageStyle.cssText"></textarea>
+                </details>
+                <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_reset-custom-style">
+                  <summary class="vivliostyle-menu-detail-group-heading"><span>Reset Custom Style</span></summary>
                   <ul class="vivliostyle-menu-detail-group">
                     <li>
-                      <label><input type="checkbox" name="vivliostyle-settings_reset-user-style" aria-keyshortcuts="R" data-bind="click: settingsPanel.resetUserStyle" /> <span>Reset all to default</span></label>
+                      <label><input type="checkbox" name="vivliostyle-settings_reset-custom-style" aria-keyshortcuts="R" data-bind="checked: settingsPanel.resetCustomStyle" /> <span>Reset all to default</span></label>
                     </li>
                   </ul>
                 </details>
               </details>
-              </details>
-              <div class="vivliostyle-menu-detail-group vivliostyle-menu-detail-group-buttons vivliostyle-menu-detail-group-inline">
+              <div class="vivliostyle-menu-detail-group vivliostyle-menu-detail-group-buttons vivliostyle-menu-detail-group-inline" id="vivliostyle-settings_apply-or-cancel">
                 <div><button type="button" class="vivliostyle-menu-button vivliostyle-menu-button-positive" id="vivliostyle-menu-button_apply" aria-keyshortcuts="Enter" data-bind="menuButton: true, click: settingsPanel.apply">Apply</button></div>
-                <div><button type="button" class="vivliostyle-menu-button vivliostyle-menu-button-negative" id="vivliostyle-menu-button_reset" aria-keyshortcuts="Escape" data-bind="menuButton: true, click: settingsPanel.cancel">Cancel</button></div>
+                <div><button type="button" class="vivliostyle-menu-button vivliostyle-menu-button-negative" id="vivliostyle-menu-button_cancel" aria-keyshortcuts="Escape" data-bind="menuButton: true, click: settingsPanel.cancel">Cancel</button></div>
               </div>
             </div>
             <aside class="vivliostyle-menu-detail-aside">

--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -153,6 +153,26 @@
                 </fieldset>
                 <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_custom-style_more" data-bind="hidden: settingsPanel.isPageStyleChangeDisabled">
                 <summary class="vivliostyle-menu-detail-group-heading" aria-keyshortcuts="M"><span>More…</span></summary>
+                <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_crop-marks" aria-keyshortcuts="O">
+                  <legend class="vivliostyle-menu-detail-group-heading">Crop Marks</legend>
+                  <ul class="vivliostyle-menu-detail-group">
+                    <li><label><input type="checkbox" name="vivliostyle-settings_crop-marks" data-bind="checked: settingsPanel.state.pageStyle.cropMarks" /> <span>Print crop marks</span></label>
+                      <ul class="vivliostyle-menu-detail-group">
+                        <li>
+                          <div>
+                            <label><input type="checkbox" name="vivliostyle-settings_bleed-specified" data-bind="checked: settingsPanel.state.pageStyle.bleedSpecified" /> <span>Bleed:</span></label>
+                            <span class="vivliostyle-menu-disabled" data-bind="css: {'vivliostyle-menu-disabled': !settingsPanel.state.pageStyle.bleedSpecified()}, click: ()=>{settingsPanel.state.pageStyle.bleedSpecified(true);return true;}"><input type="text" autocomplete="off" name="vivliostyle-settings_bleed" data-bind="value: settingsPanel.state.pageStyle.bleed, attr: {tabindex: settingsPanel.state.pageStyle.bleedSpecified()?0:-1}" /></span>
+                          </div>
+                        </li>
+                        <li>
+                          <div>
+                            <label><input type="checkbox" name="vivliostyle-settings_crop-offset-specified" data-bind="checked: settingsPanel.state.pageStyle.cropOffsetSpecified" /> <span>Crop offset:</span></label>
+                            <span class="vivliostyle-menu-disabled" data-bind="css: {'vivliostyle-menu-disabled': !settingsPanel.state.pageStyle.cropOffsetSpecified()}, click: ()=>{settingsPanel.state.pageStyle.cropOffsetSpecified(true);return true;}"><input type="text" autocomplete="off" name="vivliostyle-settings_crop-offset" data-bind="value: settingsPanel.state.pageStyle.cropOffset, attr: {tabindex: settingsPanel.state.pageStyle.cropOffsetSpecified()?0:-1}" /></span>
+                          </div>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
                 </fieldset>
                 <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-margin" aria-keyshortcuts="G">
                   <legend class="vivliostyle-menu-detail-group-heading">Page Margins</legend>

--- a/packages/viewer/src/models/document-options.ts
+++ b/packages/viewer/src/models/document-options.ts
@@ -28,7 +28,7 @@ import stringUtil from "../utils/string-util";
 function getDocumentOptionsFromURL(): DocumentOptionsType {
   const srcUrls = urlParameters.getParameter("src");
   const bUrls = urlParameters.getParameter("b"); // (deprecated) => src & bookMode=true
-  const xUrls = urlParameters.getParameter("x"); // (deprecated) => src
+  const xUrls = urlParameters.getParameter("x"); // (deprecated) => src & bookMode=false
   const bookMode = urlParameters.getParameter("bookMode")[0];
   const fragment = urlParameters.getParameter("f")[0];
   const style = urlParameters.getParameter("style");
@@ -48,6 +48,10 @@ function getDocumentOptionsFromURL(): DocumentOptionsType {
         ? false
         : bUrls.length
         ? true
+        : xUrls.length
+        ? false
+        : srcUrls.length > 1
+        ? false // multiple srcUrls cannot be bookMode
         : null,
     fragment: fragment || null,
     authorStyleSheet: style.length ? style : [],

--- a/packages/viewer/src/models/page-style.ts
+++ b/packages/viewer/src/models/page-style.ts
@@ -29,6 +29,8 @@ type Constants = {
   baseLineHeight: string;
   baseFontFamily: string;
   viewerFontSize: number;
+  bleed: string;
+  cropOffset: string;
 };
 
 enum Mode {
@@ -97,6 +99,8 @@ const CONSTANTS: Constants = {
   baseLineHeight: "1.2",
   baseFontFamily: "serif",
   viewerFontSize: 16,
+  bleed: "3mm",
+  cropOffset: "9mm",
 };
 
 class PageStyle {
@@ -127,6 +131,14 @@ class PageStyle {
   baseFontFamily: Observable<string>;
   baseFontFamilySpecified: Observable<boolean>;
   baseFontFamilyImportant: Observable<boolean>;
+  cropMarks: Observable<boolean>;
+  cropMarksImportant: Observable<boolean>;
+  bleed: Observable<string>;
+  bleedSpecified: Observable<boolean>;
+  bleedImportant: Observable<boolean>;
+  cropOffset: Observable<string>;
+  cropOffsetSpecified: Observable<boolean>;
+  cropOffsetImportant: Observable<boolean>;
   customStyleAsUserStyle: Observable<boolean>;
   allImportant: Observable<boolean>;
   pageOtherStyle: Observable<string>;
@@ -176,6 +188,14 @@ class PageStyle {
     this.baseFontFamily = ko.observable(CONSTANTS.baseFontFamily);
     this.baseFontFamilySpecified = ko.observable(false);
     this.baseFontFamilyImportant = ko.observable(false);
+    this.cropMarks = ko.observable(false);
+    this.cropMarksImportant = ko.observable(false);
+    this.bleed = ko.observable(CONSTANTS.bleed);
+    this.bleedSpecified = ko.observable(false);
+    this.bleedImportant = ko.observable(false);
+    this.cropOffset = ko.observable(CONSTANTS.cropOffset);
+    this.cropOffsetSpecified = ko.observable(false);
+    this.cropOffsetImportant = ko.observable(false);
     this.customStyleAsUserStyle = ko.observable(false);
     this.allImportant = ko.observable(false);
     this.pageOtherStyle = ko.observable("");
@@ -247,6 +267,21 @@ class PageStyle {
       this.baseFontSizeImportant(allImportant);
       this.baseLineHeightImportant(allImportant);
       this.baseFontFamilyImportant(allImportant);
+      this.cropMarksImportant(allImportant);
+      this.bleedImportant(allImportant);
+      this.cropOffsetImportant(allImportant);
+    });
+
+    this.cropMarks.subscribe((cropMarks) => {
+      if (cropMarks) {
+        // when marks is specified, bleed should also be specified
+        // because the CSS default bleed 6pt is not very good.
+        this.bleedSpecified(true);
+      } else {
+        // when marks is turned off, bleed and cropOffset should also be turned off.
+        this.bleedSpecified(false);
+        this.cropOffsetSpecified(false);
+      }
     });
 
     this.pageStyleRegExp = new RegExp(
@@ -256,21 +291,27 @@ class PageStyle {
         "(?:size:\\s*([^\\s!;{}]+)(?:\\s+([^\\s!;{}]+))?\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?" +
         // 5. pageMargin, pageMarginImportant,
         "(?:margin:\\s*([^\\s!;{}]+(?:\\s+[^\\s!;{}]+)?(?:\\s+[^\\s!;{}]+)?(?:\\s+[^\\s!;{}]+)?)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?" +
-        // 7. pageOtherStyle,
+        // 7. cropMarks, cropMarksImportant
+        "(?:marks:\\s*(crop\\s+cross)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?" +
+        // 9. bleed, bleedImportant
+        "(?:bleed:\\s*([^\\s!;{}]+)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?" +
+        // 11. cropOffset, cropOffsetImportant
+        "(?:crop-offset:\\s*([^\\s!;{}]+)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?" +
+        // 13. pageOtherStyle,
         "((?:[^{}]+|\\{[^{}]*\\})*)\\}\\s*)?" +
-        // 8. firstPageMarginZero, firstPageMarginZeroImportant, firstPageOtherStyle,
+        // 14. firstPageMarginZero, firstPageMarginZeroImportant, firstPageOtherStyle,
         "(?:@page\\s*:first\\s*\\{\\s*(margin:\\s*0(?:\\w+|%)?\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?((?:[^{}]+|\\{[^{}]*\\})*)\\}\\s*)?" +
-        // 11. forceHtmlBodyMarginZero,
+        // 17. forceHtmlBodyMarginZero,
         "((?:html|:root),\\s*body\\s*\\{\\s*margin:\\s*0(?:\\w+|%)?\\s*!important(?:;|(?=[\\s{}]))\\s*\\}\\s*)?" +
-        // 12. baseFontSize, baseFontSizeImportant, baseLineHeight, baseLineHeightImportant, baseFontFamily, baseFontFamilyImportant, rootOtherStyle,
+        // 18. baseFontSize, baseFontSizeImportant, baseLineHeight, baseLineHeightImportant, baseFontFamily, baseFontFamilyImportant, rootOtherStyle,
         "(?:(?:html|:root)\\s*\\{\\s*(?:font-size:\\s*(calc\\([^()]+\\)|[^\\s!;{}]+)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?(?:line-height:\\s*([^\\s!;{}]+)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?(?:font-family:\\s*([^!;{}]+)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?([^{}]*)\\}\\s*)?" +
         // body {font-size: inherit !important;} etc.
         "(?:body\\s*\\{\\s*(?:[-\\w]+:\\s*inherit\\s*!important(?:;|(?=[\\s{}]))\\s*)+\\}\\s*)?" +
-        // 19. widowsOrphans, widowsOrphansImportant,
+        // 25. widowsOrphans, widowsOrphansImportant,
         "(?:\\*\\s*\\{\\s*widows:\\s*(1|999)\\s*(!important)?(?:;|(?=[\\s{}]))\\s*orphans:\\s*\\19\\s*\\20(?:;|(?=[\\s{}]))\\s*\\}\\s*)?" +
-        // 21. imageMaxSizeToFitPage, imageMaxSizeToFitPageImportant, imageKeepAspectRatio, imageKeepAspectRatioImportant,
+        // 27. imageMaxSizeToFitPage, imageMaxSizeToFitPageImportant, imageKeepAspectRatio, imageKeepAspectRatioImportant,
         "(?:img,\\s*svg\\s*\\{\\s*(max-inline-size:\\s*100%\\s*(!important)?(?:;|(?=[\\s{}]))\\s*max-block-size:\\s*100vb\\s*\\22(?:;|(?=[\\s{}]))\\s*)?(object-fit:\\s*contain\\s*(!important)?(?:;|(?=[\\s{}]))\\s*)?\\}\\s*)?" +
-        // 25. afterOtherStyle
+        // 31. afterOtherStyle
         "((?:\\n|.)*)$",
     );
 
@@ -330,6 +371,12 @@ class PageStyle {
         sizeImportant,
         pageMargin,
         pageMarginImportant,
+        cropMarks,
+        cropMarksImportant,
+        bleed,
+        bleedImportant,
+        cropOffset,
+        cropOffsetImportant,
         pageOtherStyle_,
         firstPageMarginZero,
         firstPageMarginZeroImportant,
@@ -414,6 +461,32 @@ class PageStyle {
         else countNotImportant++;
       } else {
         this.pageMarginMode(Mode.Default);
+      }
+      if (cropMarks != null) {
+        this.cropMarks(true);
+        this.cropMarksImportant(!!cropMarksImportant);
+        if (cropMarksImportant) countImportant++;
+        else countNotImportant++;
+      } else {
+        this.cropMarks(false);
+      }
+      if (bleed != null) {
+        this.bleedSpecified(true);
+        this.bleed(bleed);
+        this.bleedImportant(!!bleedImportant);
+        if (bleedImportant) countImportant++;
+        else countNotImportant++;
+      } else {
+        this.bleedSpecified(false);
+      }
+      if (cropOffset != null) {
+        this.cropOffsetSpecified(true);
+        this.cropOffset(cropOffset);
+        this.cropOffsetImportant(!!cropOffsetImportant);
+        if (cropOffsetImportant) countImportant++;
+        else countNotImportant++;
+      } else {
+        this.cropOffsetSpecified(false);
       }
       pageOtherStyle = pageOtherStyle || "";
       this.pageOtherStyle(pageOtherStyle);
@@ -521,6 +594,9 @@ class PageStyle {
     if (
       this.pageSizeMode() != Mode.Default ||
       this.pageMarginMode() != Mode.Default ||
+      this.cropMarks() ||
+      this.bleedSpecified() ||
+      this.cropOffsetSpecified() ||
       this.pageOtherStyle()
     ) {
       cssText += "@page { ";
@@ -562,6 +638,17 @@ class PageStyle {
             throw new Error(`Unknown pageMarginMode ${this.pageMarginMode()}`);
         }
         cssText += `${imp(this.pageMarginImportant())}; `;
+      }
+      if (this.cropMarks()) {
+        cssText += `marks: crop cross${imp(this.cropMarksImportant())}; `;
+      }
+      if (this.bleedSpecified()) {
+        cssText += `bleed: ${this.bleed()}${imp(this.bleedImportant())}; `;
+      }
+      if (this.cropOffsetSpecified()) {
+        cssText += `crop-offset: ${this.cropOffset()}${imp(
+          this.cropOffsetImportant(),
+        )}; `;
       }
       cssText += this.pageOtherStyle();
       cssText += "}\n";
@@ -702,6 +789,14 @@ class PageStyle {
     this.baseFontFamily(other.baseFontFamily());
     this.baseFontFamilySpecified(other.baseFontFamilySpecified());
     this.baseFontFamilyImportant(other.baseFontFamilyImportant());
+    this.cropMarks(other.cropMarks());
+    this.cropMarksImportant(other.cropMarksImportant());
+    this.bleed(other.bleed());
+    this.bleedSpecified(other.bleedSpecified());
+    this.bleedImportant(other.bleedImportant());
+    this.cropOffset(other.cropOffset());
+    this.cropOffsetSpecified(other.cropOffsetSpecified());
+    this.cropOffsetImportant(other.cropOffsetImportant());
     this.customStyleAsUserStyle(other.customStyleAsUserStyle());
     this.allImportant(other.allImportant());
     this.pageOtherStyle(other.pageOtherStyle());
@@ -802,6 +897,17 @@ class PageStyle {
     )
       return false;
     if (this.baseFontFamilyImportant() !== other.baseFontFamilyImportant())
+      return false;
+
+    if (this.cropMarks() !== other.cropMarks()) return false;
+    if (this.cropMarksImportant() !== other.cropMarksImportant()) return false;
+    if (this.bleed() !== other.bleed()) return false;
+    if (this.bleedSpecified() !== other.bleedSpecified()) return false;
+    if (this.bleedImportant() !== other.bleedImportant()) return false;
+    if (this.cropOffset() !== other.cropOffset()) return false;
+    if (this.cropOffsetSpecified() !== other.cropOffsetSpecified())
+      return false;
+    if (this.cropOffsetImportant() !== other.cropOffsetImportant())
       return false;
 
     if (this.customStyleAsUserStyle() !== other.customStyleAsUserStyle())

--- a/packages/viewer/src/models/page-style.ts
+++ b/packages/viewer/src/models/page-style.ts
@@ -127,6 +127,7 @@ class PageStyle {
   baseFontFamily: Observable<string>;
   baseFontFamilySpecified: Observable<boolean>;
   baseFontFamilyImportant: Observable<boolean>;
+  customStyleAsUserStyle: Observable<boolean>;
   allImportant: Observable<boolean>;
   pageOtherStyle: Observable<string>;
   firstPageOtherStyle: Observable<string>;
@@ -175,6 +176,7 @@ class PageStyle {
     this.baseFontFamily = ko.observable(CONSTANTS.baseFontFamily);
     this.baseFontFamilySpecified = ko.observable(false);
     this.baseFontFamilyImportant = ko.observable(false);
+    this.customStyleAsUserStyle = ko.observable(false);
     this.allImportant = ko.observable(false);
     this.pageOtherStyle = ko.observable("");
     this.firstPageOtherStyle = ko.observable("");
@@ -700,6 +702,7 @@ class PageStyle {
     this.baseFontFamily(other.baseFontFamily());
     this.baseFontFamilySpecified(other.baseFontFamilySpecified());
     this.baseFontFamilyImportant(other.baseFontFamilyImportant());
+    this.customStyleAsUserStyle(other.customStyleAsUserStyle());
     this.allImportant(other.allImportant());
     this.pageOtherStyle(other.pageOtherStyle());
     this.firstPageOtherStyle(other.firstPageOtherStyle());
@@ -801,6 +804,8 @@ class PageStyle {
     if (this.baseFontFamilyImportant() !== other.baseFontFamilyImportant())
       return false;
 
+    if (this.customStyleAsUserStyle() !== other.customStyleAsUserStyle())
+      return false;
     if (this.allImportant() !== other.allImportant()) return false;
     if (this.pageOtherStyle() !== other.pageOtherStyle()) return false;
     if (this.firstPageOtherStyle() !== other.firstPageOtherStyle())

--- a/packages/viewer/src/scss/ui.menu-bar.scss
+++ b/packages/viewer/src/scss/ui.menu-bar.scss
@@ -636,25 +636,8 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
               font-size: 0.9em;
               padding-left: 1.1em;
             }
-            > #vivliostyle-settings_user-style_advanced {
-              padding-left: 0;
-              > .vivliostyle-menu-detail-group {
-                padding-left: 1.1em;
-                > textarea {
-                  display: block;
-                  line-height: 1.3;
-                  font-size: 1em;
-                  font-family: monospace;
-                  margin: 0.5em 0;
-                  padding: 2px;
-                  box-sizing: border-box;
-                  width: 100%;
-                }
-              }
-            }
             ul.vivliostyle-menu-detail-group {
               margin-top: 0;
-              padding-bottom: 0.1em;
               &:before {
                 content: "";
                 display: block;
@@ -687,6 +670,39 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
                   }
                 }
               }
+            }
+            > #vivliostyle-settings_custom-style_more,
+            > #vivliostyle-settings_edit-css,
+            > #vivliostyle-settings_reset-custom-style {
+              padding-left: 0.5em;
+              > .vivliostyle-menu-detail-group {
+                padding-left: 0.6em;
+              }
+              > ul.vivliostyle-menu-detail-group {
+                padding-left: 1.9em;
+                &::before {
+                  left: 1em;
+                }
+              }
+              > textarea {
+                display: block;
+                line-height: 1.3;
+                font-size: 1em;
+                font-family: monospace;
+                margin: 0.5em 0;
+                padding: 2px;
+                box-sizing: border-box;
+                width: 100%;
+              }
+            }
+            > #vivliostyle-settings_reset-custom-style {
+              max-height: 2em;
+            }
+            > #vivliostyle-settings_apply-or-cancel {
+              position: sticky;
+              bottom: 0;
+              background: $menu-bg-color;
+              padding: 4px;
             }
           }
         }

--- a/packages/viewer/src/viewmodels/navigation.ts
+++ b/packages/viewer/src/viewmodels/navigation.ts
@@ -543,8 +543,8 @@ class Navigation {
     );
 
     if (this.viewer.documentOptions.pageStyle.baseFontSizeSpecified()) {
-      // Update userStylesheet when base font-size is specified
-      this.viewer.documentOptions.updateUserStyleSheetFromCSSText();
+      // Update custom style when base font-size is specified
+      this.viewer.documentOptions.updateCustomStyleSheetFromCSSText();
       this.viewer.loadDocument(this.viewer.documentOptions, this.viewerOptions);
     }
   }

--- a/packages/viewer/src/viewmodels/settings-panel.ts
+++ b/packages/viewer/src/viewmodels/settings-panel.ts
@@ -326,6 +326,15 @@ class SettingsPanel {
           return false;
         }
         return true;
+      case "o":
+      case "O":
+        if (isHotKeyEnabled) {
+          this.focusToFirstItem(
+            document.getElementById("vivliostyle-settings_crop-marks"),
+          );
+          return false;
+        }
+        return true;
       case "g":
       case "G":
         if (isHotKeyEnabled) {

--- a/packages/viewer/src/viewmodels/settings-panel.ts
+++ b/packages/viewer/src/viewmodels/settings-panel.ts
@@ -40,7 +40,6 @@ const { Keys } = keyUtil;
 
 class SettingsPanel {
   isPageStyleChangeDisabled: boolean;
-  isOverrideDocumentStyleSheetDisabled: boolean;
   isPageViewModeChangeDisabled: boolean;
   isBookModeChangeDisabled: boolean;
   isRenderAllPagesChangeDisabled: boolean;
@@ -49,6 +48,7 @@ class SettingsPanel {
   state: State;
   opened: Observable<boolean>;
   pinned: Observable<boolean>;
+  resetCustomStyle: PureComputed<boolean>;
   defaultPageStyle: PageStyle;
 
   constructor(
@@ -65,7 +65,6 @@ class SettingsPanel {
   ) {
     this.isPageStyleChangeDisabled =
       !!settingsPanelOptions.disablePageStyleChange;
-    this.isOverrideDocumentStyleSheetDisabled = this.isPageStyleChangeDisabled;
     this.isPageViewModeChangeDisabled =
       !!settingsPanelOptions.disablePageViewModeChange;
     this.isBookModeChangeDisabled =
@@ -80,7 +79,6 @@ class SettingsPanel {
 
     this.opened = ko.observable(false);
     this.pinned = ko.observable(false);
-
     this.state = {
       viewerOptions: new ViewerOptions(viewerOptions),
       pageStyle: new PageStyle(documentOptions.pageStyle),
@@ -108,13 +106,11 @@ class SettingsPanel {
     );
 
     this.defaultPageStyle = new PageStyle();
+    this.defaultPageStyle.setViewerFontSizeObservable(ko.observable(16));
 
-    ["close", "toggle", "apply", "cancel", "resetUserStyle"].forEach(function (
-      methodName,
-    ) {
+    ["close", "toggle", "apply", "cancel"].forEach(function (methodName) {
       this[methodName] = this[methodName].bind(this);
-    },
-    this);
+    }, this);
 
     messageDialog.visible.subscribe(function (visible) {
       if (visible) this.close();
@@ -125,6 +121,21 @@ class SettingsPanel {
     });
     this.state.renderAllPages.subscribe((renderAllPages) => {
       viewerOptions.renderAllPages(renderAllPages);
+    });
+
+    this.resetCustomStyle = ko.pureComputed({
+      read() {
+        return this.state.pageStyle.equivalentTo(this.defaultPageStyle);
+      },
+      write(resetCustomStyle) {
+        if (resetCustomStyle) {
+          this.state.pageStyle.copyFrom(this.defaultPageStyle);
+          this.state.viewerOptions.fontSize(
+            ViewerOptions.getDefaultValues().fontSize,
+          );
+        }
+      },
+      owner: this,
     });
   }
 
@@ -171,10 +182,16 @@ class SettingsPanel {
   }
 
   apply(): void {
+    const customStyleAsUserStyleChanged =
+      this.documentOptions.pageStyle.customStyleAsUserStyle() !==
+      this.state.pageStyle.customStyleAsUserStyle();
     this.documentOptions.pageStyle.copyFrom(this.state.pageStyle);
+    if (customStyleAsUserStyleChanged) {
+      this.documentOptions.switchCustomStyleUserOrAuthorStyleSheets();
+    }
     if (this.documentOptions.pageStyle.baseFontSizeSpecified()) {
-      // Update userStylesheet when base font-size is specified
-      this.documentOptions.updateUserStyleSheetFromCSSText();
+      // Update custom style when base font-size is specified
+      this.documentOptions.updateCustomStyleSheetFromCSSText();
     }
     this.viewer.loadDocument(this.documentOptions, this.state.viewerOptions);
     if (this.pinned()) {
@@ -188,20 +205,6 @@ class SettingsPanel {
     this.state.viewerOptions.copyFrom(this.viewerOptions);
     this.state.pageStyle.copyFrom(this.documentOptions.pageStyle);
     this.close();
-  }
-
-  resetUserStyle(): boolean {
-    this.state.pageStyle.copyFrom(this.defaultPageStyle);
-    this.state.viewerOptions.fontSize(
-      ViewerOptions.getDefaultValues().fontSize,
-    );
-    window.setTimeout(() => {
-      const elem = document.getElementsByName(
-        "vivliostyle-settings_reset-user-style",
-      )[0] as HTMLInputElement;
-      elem.checked = false;
-    }, 200);
-    return true;
   }
 
   focusToFirstItem(outerElemParam?: Element): void {
@@ -294,21 +297,21 @@ class SettingsPanel {
           return false;
         }
         return true;
-      case "u":
-      case "U":
+      case "c":
+      case "C":
         if (isHotKeyEnabled) {
           this.focusToFirstItem(
-            document.getElementById("vivliostyle-settings_user-style")
+            document.getElementById("vivliostyle-settings_custom-style")
               .firstElementChild,
           );
           return false;
         }
         return true;
-      case "d":
-      case "D":
+      case "m":
+      case "M":
         if (isHotKeyEnabled) {
           this.focusToFirstItem(
-            document.getElementById("vivliostyle-settings_user-style_advanced")
+            document.getElementById("vivliostyle-settings_custom-style_more")
               .firstElementChild,
           );
           return false;
@@ -323,8 +326,8 @@ class SettingsPanel {
           return false;
         }
         return true;
-      case "m":
-      case "M":
+      case "g":
+      case "G":
         if (isHotKeyEnabled) {
           this.focusToFirstItem(
             document.getElementById("vivliostyle-settings_page-margin"),
@@ -359,22 +362,20 @@ class SettingsPanel {
           return false;
         }
         return true;
-      case "o":
-      case "O":
+      case "y":
+      case "Y":
         if (isHotKeyEnabled) {
           this.focusToFirstItem(
-            document.getElementsByName(
-              "vivliostyle-settings_override-document-stylesheets",
-            )[0],
+            document.getElementById("vivliostyle-settings_priority"),
           );
           return false;
         }
         return true;
-      case "c":
-      case "C":
+      case "e":
+      case "E":
         if (isHotKeyEnabled) {
           this.focusToFirstItem(
-            document.getElementsByName("vivliostyle-settings_css-details")[0],
+            document.getElementsByName("vivliostyle-settings_edit-css")[0],
           );
           return false;
         }
@@ -384,7 +385,7 @@ class SettingsPanel {
         if (isHotKeyEnabled) {
           this.focusToFirstItem(
             document.getElementsByName(
-              "vivliostyle-settings_reset-user-style",
+              "vivliostyle-settings_reset-custom-style",
             )[0],
           );
           return false;
@@ -395,7 +396,7 @@ class SettingsPanel {
           isInInput ||
           (isHotKeyEnabled &&
             document.activeElement.id !== "vivliostyle-menu-button_apply" &&
-            document.activeElement.id !== "vivliostyle-menu-button_reset")
+            document.activeElement.id !== "vivliostyle-menu-button_cancel")
         ) {
           document.getElementById("vivliostyle-menu-button_apply").focus();
           return false;

--- a/packages/viewer/src/viewmodels/viewer-app.ts
+++ b/packages/viewer/src/viewmodels/viewer-app.ts
@@ -70,7 +70,9 @@ class ViewerApp {
       disablePrint: flags.includes("p"),
     };
     const disableContextMenu = flags.includes("c");
-    const defaultBookMode = flags.includes("b");
+    // const defaultBookMode = flags.includes("b");
+    // Changed to default true (Issue #992)
+    const defaultBookMode = !flags.includes("k");
     const defaultRenderAllPages = !flags.includes("a");
     const disableScripts = flags.includes("d");
 
@@ -120,11 +122,13 @@ class ViewerApp {
     // Replace deprecated "b" and "x" to "src" & "bookMode"
     const srcUrls = urlParameters.getParameter("src");
     const bUrls = urlParameters.getParameter("b"); // (deprecated) => src & bookMode=true & renderAllPages=false
-    const xUrls = urlParameters.getParameter("x"); // (deprecated) => src
+    const xUrls = urlParameters.getParameter("x"); // (deprecated) => src & bookMode=false
     if (!srcUrls.length) {
       if (bUrls.length) {
         urlParameters.setParameter("src", bUrls[0]);
-        urlParameters.setParameter("bookMode", "true");
+        if (!urlParameters.hasParameter("bookMode")) {
+          urlParameters.setParameter("bookMode", "true");
+        }
         if (!urlParameters.hasParameter("renderAllPages")) {
           urlParameters.setParameter("renderAllPages", "false");
         }
@@ -132,6 +136,9 @@ class ViewerApp {
         xUrls.forEach((x, i) => {
           urlParameters.setParameter("src", x, i);
         });
+        if (!urlParameters.hasParameter("bookMode")) {
+          urlParameters.setParameter("bookMode", "false");
+        }
       }
     }
     // Remove redundant or ineffective URL parameters


### PR DESCRIPTION
- resolves #991

  Changed menu item names and keyshortcuts
  - User Style Preferences (U) → Custom Style Settings (C)
  - Advanced (D) → More... (M)
  - Page Margins (M) → Page Margins (G)
  - CSS Details (C) → Edit CSS (E)
  - Reset User Style (R) → Reset Custom Style (R)
  - Override Document Style Sheets (O) → Custom Style Priority (Y) / Force override document style

  Added menu item:
  - Custom Style Priority (Y) / Set as user stylesheet

  Now, custom style settings (changed from "user style preferences") are set as an author stylesheet by default and can be changed to user stylesheet.

- resolves #993

  Added menu items:
  - Crop Marks (O)
    - Print crop marks
      - Bleed
      - Crop offset

- resolves #992

  Now bookMode=true is default.
