### PR TITLE
fix: DOMException error caused by wrong `instanceof Element` usage

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -81,15 +81,23 @@ export function calculateEdge(
   if (!node) {
     return NaN;
   }
-  const element = node instanceof Element ? node : node.parentElement;
-  if (element && element instanceof HTMLElement) {
-    if (element.localName === "rt" && element.style["zoom"]) {
+
+  // NOTE: Do not replace `node.nodeType === 1` with `node instanceof Element`,
+  // which does not work when the node is inside iframe. (Issue #1000)
+
+  const element = node.nodeType === 1 ? (node as Element) : node.parentElement;
+  if (element && element.namespaceURI === Base.NS.XHTML) {
+    if (element.localName === "rt" && (element as HTMLElement).style["zoom"]) {
       // "zoom" is set in fixRubyTextFontSize() to fix the issue #673 for Chrome.
       // when zoom is set, it is hard to get the edge value, so return NaN.
       // (Fix for issues #804 and #808)
       return NaN;
     }
-    if (/^([\d\.]|super|(text-)?top)/.test(element.style.verticalAlign)) {
+    if (
+      /^([\d\.]|super|(text-)?top)/.test(
+        (element as HTMLElement).style.verticalAlign,
+      )
+    ) {
       // (Fix for issue #811)
       return NaN;
     }
@@ -206,7 +214,7 @@ export function isSpecial(e: Element): boolean {
 
 export function isSpecialNodeContext(nodeContext: Vtree.NodeContext): boolean {
   const viewNode = nodeContext?.viewNode;
-  return viewNode instanceof Element && isSpecial(viewNode);
+  return viewNode?.nodeType === 1 && isSpecial(viewNode as Element);
 }
 
 export function isSpecialInlineDisplay(display: string): boolean {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -582,8 +582,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         let firstLetterLength = r ? r[0].length : 0;
         if (
           !r &&
-          position.sourceNode instanceof Text &&
-          position.sourceNode.nextSibling instanceof Text &&
+          position.sourceNode?.nodeType === 3 &&
+          position.sourceNode.nextSibling?.nodeType === 3 &&
           text === position.sourceNode.textContent
         ) {
           // The text '“Foo' may be split to '“' and 'Foo'
@@ -2151,7 +2151,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             endNotReached = false;
           }
         }
-        if (!(node instanceof Element)) {
+        const element = node.nodeType === 1 ? (node as Element) : null;
+        if (!element) {
           if (!haveStart) {
             if (node.parentNode == null) {
               endNotReached = false;
@@ -2163,19 +2164,19 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           lastGood = node;
         } else if (wentUp) {
           wentUp = false;
-        } else if (LayoutHelper.isSpecial(node)) {
+        } else if (LayoutHelper.isSpecial(element)) {
           // Skip special
           seekRange = !haveStart;
         } else if (
-          /^r(uby|[bt]c?)$/.test(node.localName) ||
+          /^r(uby|[bt]c?)$/.test(element.localName) ||
           LayoutHelper.isSpecialInlineDisplay(
-            this.clientLayout.getElementComputedStyle(node).display,
+            this.clientLayout.getElementComputedStyle(element).display,
           )
         ) {
           // ruby, inline-block, etc.
           seekRange = !haveStart;
           if (seekRange) {
-            if (node.localName === "ruby" && node.firstChild) {
+            if (element.localName === "ruby" && node.firstChild) {
               // Fix for issue #985
               node = node.firstChild;
             }
@@ -2291,7 +2292,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let clonedPaddingBorder = 0;
     nodeContext.walkUpBlocks((block) => {
       if (block.inheritedProps["box-decoration-break"] === "clone") {
-        Asserts.assert(block.viewNode instanceof Element);
+        Asserts.assert(block.viewNode?.nodeType === 1);
         const paddingBorders = this.getComputedPaddingBorder(
           block.viewNode as Element,
         );

--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -77,7 +77,7 @@ export function ajax(
           response.contentType = (request.responseXML as any).contentType;
         } else if (
           (!opt_type || opt_type === XMLHttpRequestResponseType.DOCUMENT) &&
-          request.response instanceof HTMLDocument
+          request.response instanceof Document
         ) {
           response.responseXML = request.response;
           response.contentType = (request.response as any).contentType;

--- a/packages/core/src/vivliostyle/scripts.ts
+++ b/packages/core/src/vivliostyle/scripts.ts
@@ -186,8 +186,8 @@ function getAllFontFamilyList(
   }
   // Find all font-family values in inline style.
   for (const elem of srcDocument.querySelectorAll("[style]")) {
-    if (elem instanceof HTMLElement && elem.style.fontFamily) {
-      fontFamilySet[elem.style.fontFamily] = true;
+    if ((elem as HTMLElement).style?.fontFamily) {
+      fontFamilySet[(elem as HTMLElement).style.fontFamily] = true;
     }
   }
   return Object.keys(fontFamilySet).join(",");

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -369,7 +369,7 @@ class TextSpacingPolyfill {
         prevNode = p.sourceNode?.previousSibling;
         if (prevNode) {
           if (
-            prevNode instanceof Text &&
+            prevNode.nodeType === 3 &&
             /^\s*$/.test(prevNode.textContent) &&
             p.whitespace !== Vtree.Whitespace.PRESERVE
           ) {
@@ -383,11 +383,11 @@ class TextSpacingPolyfill {
       }
 
       while (prevNode) {
-        if (prevNode instanceof Element) {
-          if (prevNode.localName === "br") {
+        if (prevNode.nodeType === 1) {
+          if ((prevNode as Element).localName === "br") {
             return true;
           }
-        } else if (prevNode instanceof Text) {
+        } else if (prevNode.nodeType === 3) {
           if (p.whitespace === Vtree.Whitespace.PRESERVE) {
             if (/\n$/.test(prevNode.textContent)) {
               return true;
@@ -448,10 +448,10 @@ class TextSpacingPolyfill {
         function checkIfFirstAfterForcedLineBreak(
           prevP: Vtree.NodeContext,
         ): boolean {
-          if (prevP.viewNode instanceof Element) {
-            return prevP.viewNode.localName === "br";
+          if (prevP.viewNode?.nodeType === 1) {
+            return (prevP.viewNode as Element).localName === "br";
           }
-          if (prevP.viewNode instanceof Text) {
+          if (prevP.viewNode?.nodeType === 3) {
             if (prevP.whitespace === Vtree.Whitespace.PRESERVE) {
               if (/\n$/.test(prevP.viewNode.textContent)) {
                 return true;
@@ -461,7 +461,10 @@ class TextSpacingPolyfill {
                 return true;
               }
             }
-            if (prevP.viewNode.previousElementSibling?.localName === "br") {
+            if (
+              (prevP.viewNode as Element).previousElementSibling?.localName ===
+              "br"
+            ) {
               return Vtree.canIgnore(prevP.viewNode, prevP.whitespace);
             }
           }
@@ -471,10 +474,10 @@ class TextSpacingPolyfill {
         function checkIfLastBeforeForcedLineBreak(
           nextP: Vtree.NodeContext,
         ): boolean {
-          if (nextP.viewNode instanceof Element) {
-            return nextP.viewNode.localName === "br";
+          if (nextP.viewNode?.nodeType === 1) {
+            return (nextP.viewNode as Element).localName === "br";
           }
-          if (nextP.viewNode instanceof Text) {
+          if (nextP.viewNode?.nodeType === 3) {
             if (nextP.whitespace === Vtree.Whitespace.PRESERVE) {
               if (/^\n/.test(nextP.viewNode.textContent)) {
                 return true;
@@ -484,7 +487,9 @@ class TextSpacingPolyfill {
                 return true;
               }
             }
-            if (nextP.viewNode.nextElementSibling?.localName === "br") {
+            if (
+              (nextP.viewNode as Element).nextElementSibling?.localName === "br"
+            ) {
               return Vtree.canIgnore(nextP.viewNode, nextP.whitespace);
             }
           }
@@ -507,9 +512,9 @@ class TextSpacingPolyfill {
           }
           if (
             (prevP.display && !/^(inline|ruby)\b/.test(prevP.display)) ||
-            (prevP.viewNode instanceof Element &&
-              (prevP.viewNode.localName === "br" ||
-                embeddedContentTags[prevP.viewNode.localName]))
+            (prevP.viewNode?.nodeType === 1 &&
+              ((prevP.viewNode as Element).localName === "br" ||
+                embeddedContentTags[(prevP.viewNode as Element).localName]))
           ) {
             break;
           }
@@ -535,9 +540,9 @@ class TextSpacingPolyfill {
           }
           if (
             (nextP.display && !/^(inline|ruby)\b/.test(nextP.display)) ||
-            (nextP.viewNode instanceof Element &&
-              (nextP.viewNode.localName === "br" ||
-                embeddedContentTags[nextP.viewNode.localName]))
+            (nextP.viewNode?.nodeType === 1 &&
+              ((nextP.viewNode as Element).localName === "br" ||
+                embeddedContentTags[(nextP.viewNode as Element).localName]))
           ) {
             break;
           }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -737,8 +737,15 @@ export class ViewFactory
       frame.finish(false);
       return frame.result();
     }
-    if (Scripts.allowScripts && element instanceof HTMLScriptElement) {
-      Scripts.loadScript(element, this.viewport.window).thenFinish(frame);
+    if (
+      Scripts.allowScripts &&
+      element.localName === "script" &&
+      element.namespaceURI === Base.NS.XHTML
+    ) {
+      Scripts.loadScript(
+        element as HTMLScriptElement,
+        this.viewport.window,
+      ).thenFinish(frame);
       return frame.result();
     }
     let display = computedStyle["display"] as Css.Ident;
@@ -2146,7 +2153,7 @@ export class ViewFactory
     if (fontSizeInPx >= minFontSizeInPx) {
       return false;
     }
-    if (!(target instanceof HTMLElement && "zoom" in target.style)) {
+    if ((target as HTMLElement).style?.["zoom"] === undefined) {
       return false;
     }
     const zoom = fontSizeInPx / minFontSizeInPx;
@@ -2301,7 +2308,7 @@ export class ViewFactory
         const boxDecorationBreak = block.inheritedProps["box-decoration-break"];
         if (!boxDecorationBreak || boxDecorationBreak === "slice") {
           const elem = block.viewNode as Element;
-          Asserts.assert(elem instanceof Element);
+          Asserts.assert(elem.nodeType === 1);
           if (block.vertical) {
             Base.setCSSProperty(elem, "padding-left", "0");
             Base.setCSSProperty(elem, "border-left", "none");

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -1301,7 +1301,7 @@ export class ContentPropertyHandler extends Css.Visitor {
 
   private visitStrInner(str: string, node?: Node | null) {
     if (!node) {
-      if (this.elem.lastChild instanceof Text) {
+      if (this.elem.lastChild?.nodeType === 3) {
         this.elem.lastChild.textContent += str;
         return;
       }


### PR DESCRIPTION
- fix #1000

`node instanceof Element`, `node instanceof Text`, etc. are not worked as expeced when the node is inside `<iframe>`. So we have to use `node.nodeType` for such DOM nodes (viewNode).