### PR TITLE
fix: percentage units in color value changed, resulting in invalid colors

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -589,12 +589,6 @@ export class InheritanceVisitor extends Css.FilterVisitor {
         this.getFontSize(),
         this.context,
       );
-    } else if (numeric.unit == "%") {
-      if (this.propName === "line-height") {
-        return numeric;
-      }
-      const unit = this.propName.match(/height|^(top|bottom)$/) ? "vh" : "vw";
-      return new Css.Numeric(numeric.num, unit);
     }
     return numeric;
   }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -568,9 +568,11 @@ export class ViewFactory
               new Css.Numeric(this.context.rootFontSize, "px"),
               value.priority,
             );
-            continue;
+          } else if (Css.isCustomPropName(name)) {
+            props[name] = value;
+          } else {
+            props[name] = value.filterValue(inheritanceVisitor);
           }
-          props[name] = value.filterValue(inheritanceVisitor);
         }
       }
     }


### PR DESCRIPTION
- fix #1012

Fixes the bug that percentage units in color value are being changed to vw units when the color value is specified in :root.

Simplified examples:

```html
<style>
:root {
  color: rgb(0%, 50%, 0%);
}
</style>
<p>This text should be green.</p>
```

```html
<style>
:root {
  --color: rgb(0%, 50%, 0%);
  color: var(--color);
}
</style>
<p>This text should be green.</p>
```