### PR TITLE
fix: Wrong cascading with shorthand property text-decoration and its longhand

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -314,7 +314,6 @@ quotes = [STRING STRING]+ | none | auto;
 right = APLENGTH;
 table-layout = auto | fixed;
 text-align = left | right | center | justify | start | end;
-text-decoration = none | [ underline || overline || line-through || blink ];
 text-indent = PLENGTH;
 text-transform = capitalize | uppercase | lowercase | none;
 top = APLENGTH;
@@ -493,6 +492,7 @@ hanging-punctuation = none | [ first || [ force-end | allow-end ] || last ];
 [webkit]text-decoration-line = none | [ underline || overline || line-through || blink ];
 [webkit]text-decoration-skip = none | [ objects || spaces || ink || edges || box-decoration ];
 [webkit]text-decoration-style = solid | double | dotted | dashed | wavy;
+[webkit]text-decoration-thickness = from-font | APLENGTH;
 [epub,webkit]text-emphasis-color = COLOR;
 [webkit]text-emphasis-position = [ over | under ] [ right | left ];
 [epub,webkit]text-emphasis-style = none | [[ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]] | STRING;
@@ -721,6 +721,7 @@ font-variant = font-variant-ligatures font-variant-caps font-variant-numeric fon
 [epub,webkit]text-emphasis = text-emphasis-style text-emphasis-color;
 marker = INSETS marker-start marker-mid marker-end;
 [webkit]text-stroke = text-stroke-width text-stroke-color;
+text-decoration = text-decoration-line text-decoration-color text-decoration-style text-decoration-thickness;
 
 /* css-logical */
 margin-block = INSETS margin-block-start margin-block-end;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3134,8 +3134,9 @@ export class CascadeInstance {
                 if (!shorthand.error) {
                   for (const nameLH of shorthand.propList) {
                     const avLH = new CascadeValue(
-                      shorthand.values[nameLH] ||
-                        validatorSet.defaultValues[nameLH],
+                      shorthand.values[nameLH] ??
+                        validatorSet.defaultValues[nameLH] ??
+                        Css.ident.initial,
                       cascVal.priority,
                     );
                     const tvLH = getProp(elementStyle, nameLH);

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -999,7 +999,9 @@ export class ShorthandValidator extends Css.Visitor {
       for (const name of this.propList) {
         receiver.simpleProperty(
           name,
-          this.values[name] || this.validatorSet.defaultValues[name],
+          this.values[name] ??
+            this.validatorSet.defaultValues[name] ??
+            Css.ident.initial,
           important,
         );
       }
@@ -1179,7 +1181,10 @@ export class CommaShorthandValidator extends SimpleShorthandValidator {
 
   mergeIn(acc: { [key: string]: Css.Val[] }, values: ValueMap) {
     for (const name of this.propList) {
-      const val = values[name] || this.validatorSet.defaultValues[name];
+      const val =
+        values[name] ??
+        this.validatorSet.defaultValues[name] ??
+        Css.ident.initial;
       let arr = acc[name];
       if (!arr) {
         arr = [];
@@ -2021,12 +2026,7 @@ export class ValidatorSet {
       const shorthand = this.shorthands[prop];
       const list = shorthand ? shorthand.propList : [prop];
       for (const pname of list) {
-        const pval = this.defaultValues[pname];
-        if (!pval) {
-          Logging.logger.warn("Unknown property in makePropSet:", pname);
-        } else {
-          map[pname] = pval;
-        }
+        map[pname] = this.defaultValues[pname] ?? Css.ident.initial;
       }
     }
     return map;


### PR DESCRIPTION
- fix #1054

Notes:
- This commit fixes the problem that the text-decoration property was not defined as a shorthand property in the ValidationTxt in assets.ts.
- There are still such CSS shorthand properties that not defined as shorthand in the ValidationTxt, not fixed in this commit: animation, contain-intrinsic-size, flex, gap, grid, grid-area, grid-column, grid-row, grid-template, mask, offset, overflow, place-content, place-items, place-self, scroll-margin, scroll-padding, scroll-timeline, and transition.
  - The wrong cascading problem still exists on these shorthand properties.