### PR TITLE
feat: Add support for CSS lh and rlh units

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -581,9 +581,11 @@ export class InheritanceVisitor extends Css.FilterVisitor {
     if (this.propName === "font-size") {
       return convertFontSizeToPx(numeric, this.getFontSize(), this.context);
     } else if (
-      numeric.unit == "em" ||
-      numeric.unit == "ex" ||
-      numeric.unit == "rem"
+      numeric.unit === "em" ||
+      numeric.unit === "ex" ||
+      numeric.unit === "rem" ||
+      numeric.unit === "lh" ||
+      numeric.unit === "rlh"
     ) {
       return convertFontRelativeLengthToPx(
         numeric,
@@ -615,6 +617,8 @@ export function convertFontRelativeLengthToPx(
     return new Css.Numeric(num * ratio * baseFontSize, "px");
   } else if (unit === "rem") {
     return new Css.Numeric(num * context.fontSize(), "px");
+  } else if (unit === "rlh") {
+    return new Css.Numeric(num * context.rootLineHeight, "px");
   } else {
     return numeric;
   }

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1577,6 +1577,8 @@ export class ValidatorSet {
         ex: Css.empty,
         ch: Css.empty,
         rem: Css.empty,
+        lh: Css.empty,
+        rlh: Css.empty,
         vw: Css.empty,
         vh: Css.empty,
         vi: Css.empty,

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -695,7 +695,8 @@ export const fullURange: URange = new URange("U+0-10FFFF");
 
 export const processingOrder = {
   "font-size": 1,
-  color: 2,
+  "line-height": 2,
+  color: 3,
 };
 
 export function isDefaultingValue(value: Val): boolean {

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -259,6 +259,8 @@ export function isFontRelativeLengthUnit(unit: string): boolean {
     case "em":
     case "ex":
     case "rem":
+    case "lh":
+    case "rlh":
       return true;
     default:
       return false;
@@ -276,6 +278,8 @@ export const defaultUnitSizes: { [key: string]: number } = {
   em: 16,
   rem: 16,
   ex: 8,
+  lh: 20,
+  rlh: 20,
   // <resolution>
   dppx: 1,
   dpi: 1 / 96,
@@ -289,7 +293,10 @@ export function needUnitConversion(unit: string): boolean {
   switch (unit) {
     case "q":
       return !CSS.supports("font-size", "1q");
+    case "lh":
+      return !CSS.supports("line-height", "1lh");
     case "rem":
+    case "rlh":
       return true;
     default:
       return false;
@@ -312,6 +319,7 @@ export class Context {
   rootFontSize: number | null = null;
   isRelativeRootFontSize: boolean | null = null;
   fontSize: () => number;
+  rootLineHeight: number | null = null;
   pref: Preferences;
   scopes: { [key: string]: ScopeContext } = {};
   pageAreaWidth: number | null = null;
@@ -413,6 +421,11 @@ export class Context {
         defaultUnitSizes["em"]
       );
     }
+    if (unit == "lh" || unit == "rlh") {
+      // FIXME: "lh" unit is incorrect, treated same as "rlh"
+      return this.rootLineHeight;
+    }
+
     return defaultUnitSizes[unit];
   }
 


### PR DESCRIPTION
- resolves #1035

Now lh and rlh units are available even if not supported by browser.

However, this implementation is not very complete and has the following limitations:
(These limitations will be solved with Chrome >= 109, in whch lh unit is supported natively.)

- when line-height is not specified (= `line-height: normal`, depends on font metrics), the lh/rlh unit size is inaccurate, because using 1.25em for 'normal' line-height unit calculation and not using font metrics.
- the lh unit is not worked in calc() expression.