### PR TITLE
fix: break-before:column on single column causes printed page content disappear

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -151,6 +151,9 @@ export const VivliostyleViewportCss = `
   [data-vivliostyle-page-container] {
     display: block !important;
     max-height: 100vh;
+  }
+
+  [data-vivliostyle-page-container]:not(:last-child) {
     break-after: page;
   }
 


### PR DESCRIPTION
- fix #1067

This commit also fixes the following problems
- An unnecessary blank page is always added to the last on print (This fix is not complete. The problem still sometimes happens. This is a chromium problem)
- break-before/after:column is not worked properly in non-root/body multi-column element