### PR TITLE
feat: Improve page auto spread view mode

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -409,6 +409,37 @@ export class EPUBDocStore extends OPS.OPSDocStore {
       return frame.result();
     }
   }
+
+  override processViewportMeta(meta: Element): string {
+    let content = meta.getAttribute("content");
+    if (!content) {
+      return "";
+    }
+    const vals = {};
+    let r: RegExpMatchArray;
+    while (
+      (r = content.match(
+        /^,?\s*([-A-Za-z_.][-A-Za-z_0-9.]*)\s*=\s*([-+A-Za-z_0-9.]*)\s*/,
+      )) != null
+    ) {
+      content = content.substr(r[0].length);
+      vals[r[1]] = r[2];
+    }
+    const width = vals["width"] - 0;
+    const height = vals["height"] - 0;
+    if (width && height) {
+      const prePaginated = !!Object.values(this.primaryOPFByEPubURL).find(
+        (opf) => opf.prePaginated,
+      );
+      return (
+        `@-epubx-viewport{width:${width}px;height:${height}px;}` +
+        (prePaginated
+          ? `@page{size:${width}px ${height}px;margin:0;}`
+          : `@page{margin:0;}`)
+      );
+    }
+    return "";
+  }
 }
 
 export type OPFItemParam = {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -2115,30 +2115,6 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
   }
 }
 
-// override, so we don't register an error
-export function processViewportMeta(meta: Element): string {
-  let content = meta.getAttribute("content");
-  if (!content) {
-    return "";
-  }
-  const vals = {};
-  let r: RegExpMatchArray;
-  while (
-    (r = content.match(
-      /^,?\s*([-A-Za-z_.][-A-Za-z_0-9.]*)\s*=\s*([-+A-Za-z_0-9.]*)\s*/,
-    )) != null
-  ) {
-    content = content.substr(r[0].length);
-    vals[r[1]] = r[2];
-  }
-  const width = vals["width"] - 0;
-  const height = vals["height"] - 0;
-  if (width && height) {
-    return `@-epubx-viewport{width:${width}px;height:${height}px;}`;
-  }
-  return "";
-}
-
 export class StyleParserHandler extends CssParser.DispatchParserHandler {
   rootScope: Exprs.LexicalScope;
   pageScope: Exprs.LexicalScope;
@@ -2363,7 +2339,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
               ) {
                 sources.push({
                   url,
-                  text: processViewportMeta(elem),
+                  text: this.processViewportMeta(elem),
                   flavor: CssParser.StylesheetFlavor.AUTHOR,
                   classes: null,
                   media: null,
@@ -2451,5 +2427,9 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
       },
     );
     return frame.result();
+  }
+
+  processViewportMeta(meta: Element): string {
+    return "";
   }
 }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2829,12 +2829,8 @@ export class Viewport {
     this.outerZoomBox = outerZoomBox as HTMLElement;
     this.contentContainer = contentContainer as HTMLElement;
     this.layoutBox = layoutBox as HTMLElement;
-    const clientLayout = new DefaultClientLayout(this);
-    const computedStyle = clientLayout.getElementComputedStyle(this.root);
-    this.width =
-      opt_width || parseFloat(computedStyle["width"]) || window.innerWidth;
-    this.height =
-      opt_height || parseFloat(computedStyle["height"]) || window.innerHeight;
+    this.width = opt_width || this.root.offsetWidth || window.innerWidth;
+    this.height = opt_height || this.root.offsetHeight || window.innerHeight;
 
     // Use the fallbackPageSize if window size is 0 or browser is in headless mode.
     const fallbackPageSize = {


### PR DESCRIPTION
- For non-auto page sizes, the aspect ratio is used to determine to resolve auto spread view mode
  - Resolves the problem that landscape pages, such as slides, are often become spread view unwantedly
- Set default page margin to 0 when `<meta name="viewport" content="width=…, height=…"/>` tag is given in document (for fixed layout EPUBs)