### PR TITLE
feat: Enable very thin border width on PDF output

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -43,7 +43,6 @@ export const VivliostyleViewportScreenCss = `
   }
 
   [data-vivliostyle-viewer-viewport] [data-vivliostyle-spread-container] {
-    display: -webkit-flex;
     display: flex;
     flex: none;
     justify-content: center;
@@ -97,6 +96,7 @@ export const VivliostyleViewportCss = `
   bottom: 0;
   overflow: hidden;
   z-index: -1;
+  transform-origin: left top;
 }
 
 [data-vivliostyle-debug] [data-vivliostyle-layout-box] {
@@ -106,6 +106,43 @@ export const VivliostyleViewportCss = `
   z-index: auto;
 }
 
+[data-vivliostyle-spread-container] {
+  transform: scale(var(--viv-outputScale,1));
+  transform-origin: left top;
+}
+
+/* Emulate high pixel ratio using zoom & transform:scale() */
+@supports (zoom: 8) {
+  [data-vivliostyle-layout-box] {
+    zoom: calc(var(--viv-outputPixelRatio,1) / var(--viv-devicePixelRatio,1));
+    transform: scale(calc(var(--viv-devicePixelRatio,1) / var(--viv-outputPixelRatio,1)));
+  }
+  [data-vivliostyle-spread-container] {
+    zoom: calc(var(--viv-outputPixelRatio,1) / var(--viv-devicePixelRatio,1));
+    transform: scale(calc(var(--viv-outputScale,1) * var(--viv-devicePixelRatio,1) / var(--viv-outputPixelRatio,1)));
+  }
+  /* Workaround for Chromium's default border etc. widths not zoomed but scaled down */
+  [data-vivliostyle-spread-container] :where([style*=border],[style*=outline],[style*=rule]) {
+    border-width: medium;
+    outline-width: medium;
+    column-rule-width: medium;
+  }
+  [data-vivliostyle-spread-container] ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  [data-vivliostyle-spread-container] ::-webkit-scrollbar-track {
+    background-color: #f4f4f4;
+  }
+  [data-vivliostyle-spread-container] ::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background: #c7c7c7;
+  }
+  [data-vivliostyle-spread-container] ::-webkit-scrollbar-thumb:hover {
+    background: #7d7d7d;
+  }
+}
+
 [data-vivliostyle-page-container] {
   position: relative;
   overflow: hidden;
@@ -113,7 +150,7 @@ export const VivliostyleViewportCss = `
 
 [data-vivliostyle-bleed-box] {
   position: absolute;
-  /* overflow: hidden; ** removed to fix issue #945 */
+  overflow: hidden;
   box-sizing: border-box;
 }
 
@@ -143,10 +180,19 @@ export const VivliostyleViewportCss = `
     height: 100% !important;
   }
 
-  [data-vivliostyle-spread-container],
+  [data-vivliostyle-spread-container] {
+    --viv-outputScale: 1 !important;
+    --viv-devicePixelRatio: 1 !important;
+  }
+
+  /* for Safari */
+  ::-webkit-full-page-media, [data-vivliostyle-spread-container] {
+    zoom: normal !important;
+    transform: none !important;
+  }
+
   [data-vivliostyle-page-container] {
     transform: none !important;
-    zoom: normal !important;
   }
 
   [data-vivliostyle-page-container] {
@@ -174,7 +220,7 @@ export const VivliostyleViewportCss = `
     }
     /* Workaround Gecko problem on page break */
     [data-vivliostyle-page-container] {
-      break-after: auto;
+      break-after: auto !important;
       height: 100% !important;
     }
   }

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -69,6 +69,10 @@ export type CoreViewerSettings = {
  * - defaultPaperSize: Default paper size in px. Effective when `@page` size
  *   is set to auto. default: undefined (means the windows size is used as
  *   paper size).
+ * - allowScripts: Allow JavaScript in documents. default: true
+ * - pixelRatio: Set output pixel ratio. Enables very thin border width and
+ *   improves layout precision, emulating high pixel ratio.
+ *   default: 8. Set 0 to disable pixel ratio emulation.
  */
 export type CoreViewerOptions = {
   autoResize?: boolean;
@@ -80,6 +84,7 @@ export type CoreViewerOptions = {
   fitToScreen?: boolean;
   defaultPaperSize?: { width: number; height: number };
   allowScripts?: boolean;
+  pixelRatio?: number;
 };
 
 function getDefaultViewerOptions(): CoreViewerOptions {
@@ -93,6 +98,7 @@ function getDefaultViewerOptions(): CoreViewerOptions {
     fitToScreen: false,
     defaultPaperSize: undefined,
     allowScripts: true,
+    pixelRatio: 8,
   };
 }
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2528,6 +2528,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         viewport = new Vgen.Viewport(
           viewport.window,
           viewportSize.fontSize,
+          viewport.pixelRatio,
           viewport.root,
           viewportSize.width,
           viewportSize.height,

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -672,11 +672,11 @@ class TextSpacingPolyfill {
       }
       return vertical
         ? rect.top < prevRect.top + prevRect.height - rect.width ||
-            rect.left + rect.width < prevRect.left + 1 ||
-            rect.left > prevRect.left + prevRect.width - 1
+            rect.left + rect.width < prevRect.left + rect.width / 10 ||
+            rect.left > prevRect.left + prevRect.width - rect.width / 10
         : rect.left < prevRect.left + prevRect.width - rect.height ||
-            rect.top > prevRect.top + prevRect.height - 1 ||
-            rect.top + rect.height < prevRect.top + 1;
+            rect.top > prevRect.top + prevRect.height - rect.height / 10 ||
+            rect.top + rect.height < prevRect.top + rect.height / 10;
     }
 
     function isAtEndOfLine(): boolean {
@@ -698,11 +698,11 @@ class TextSpacingPolyfill {
       }
       return vertical
         ? rect.top + rect.height > nextRect.top + rect.width ||
-            rect.left > nextRect.left + nextRect.width - 1 ||
-            rect.left + rect.width < nextRect.left + 1
+            rect.left > nextRect.left + nextRect.width - rect.width / 10 ||
+            rect.left + rect.width < nextRect.left + rect.width / 10
         : rect.left + rect.width > nextRect.left + rect.height ||
-            rect.top + rect.height < nextRect.top + 1 ||
-            rect.top > nextRect.top + nextRect.height - 1;
+            rect.top + rect.height < nextRect.top + rect.height / 10 ||
+            rect.top > nextRect.top + nextRect.height - rect.height / 10;
     }
 
     let punctProcessing = false;

--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -244,6 +244,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
       viewport = new Vgen.Viewport(
         viewport.window,
         viewportSize.fontSize,
+        0,
         viewport.root,
         viewportSize.width,
         viewportSize.height,

--- a/packages/viewer/src/models/viewer-options.ts
+++ b/packages/viewer/src/models/viewer-options.ts
@@ -28,6 +28,10 @@ import urlParameters from "../stores/url-parameters";
 import PageViewMode, { PageViewModeInstance } from "./page-view-mode";
 import ZoomOptions from "./zoom-options";
 
+/**
+ * Viewer Options
+ * See CoreViewerOptions in core/src/vivliostyle/core-viewer.ts
+ */
 interface ViewerOptionsType {
   allowScripts: boolean;
   renderAllPages: boolean;
@@ -35,6 +39,7 @@ interface ViewerOptionsType {
   profile: boolean;
   pageViewMode: CorePageViewMode;
   zoom: ZoomOptions;
+  pixelRatio: number;
 }
 
 function getViewerOptionsFromURL(): ViewerOptionsType {
@@ -54,6 +59,9 @@ function getViewerOptionsFromURL(): ViewerOptionsType {
   }
   const zoomStr = urlParameters.getParameter("zoom")[0];
   const zoomFactor = parseFloat(zoomStr);
+
+  const pixelRatioStr = urlParameters.getParameter("pixelRatio")[0];
+  const pixelRatio = pixelRatioStr && parseFloat(pixelRatioStr);
 
   return {
     allowScripts:
@@ -75,6 +83,7 @@ function getViewerOptionsFromURL(): ViewerOptionsType {
       zoomFactor > 0
         ? ZoomOptions.createFromZoomFactor(zoomFactor)
         : ZoomOptions.createDefaultOptions(),
+    pixelRatio,
   };
 }
 
@@ -86,6 +95,7 @@ function getDefaultValues(): ViewerOptionsType {
     profile: false,
     pageViewMode: PageViewMode.defaultMode(),
     zoom: ZoomOptions.createDefaultOptions(),
+    pixelRatio: 8,
   };
 }
 
@@ -100,6 +110,7 @@ class ViewerOptions {
   profile: Observable<boolean>;
   pageViewMode: Observable<CorePageViewMode>;
   zoom: Observable<ZoomOptions>;
+  pixelRatio: Observable<number>;
 
   static getDefaultValues: () => {
     allowScripts: boolean;
@@ -108,6 +119,7 @@ class ViewerOptions {
     profile: boolean;
     pageViewMode: CorePageViewMode;
     zoom: ZoomOptions;
+    pixelRatio: number;
   };
 
   constructor(defaultRenderAllPages: boolean);
@@ -124,6 +136,7 @@ class ViewerOptions {
     this.profile = ko.observable();
     this.pageViewMode = ko.observable();
     this.zoom = ko.observable();
+    this.pixelRatio = ko.observable();
 
     if (options) {
       this.copyFrom(options);
@@ -136,6 +149,7 @@ class ViewerOptions {
       this.profile(urlOptions.profile || defaultValues.profile);
       this.pageViewMode(urlOptions.pageViewMode || defaultValues.pageViewMode);
       this.zoom(urlOptions.zoom || defaultValues.zoom);
+      this.pixelRatio(urlOptions.pixelRatio ?? defaultValues.pixelRatio);
 
       // write spread parameter back to URL when updated
       this.pageViewMode.subscribe((pageViewMode) => {
@@ -193,6 +207,7 @@ class ViewerOptions {
     this.profile(other.profile());
     this.pageViewMode(other.pageViewMode());
     this.zoom(other.zoom());
+    this.pixelRatio(other.pixelRatio());
   }
 
   toObject(): CoreViewerOptions {
@@ -203,6 +218,7 @@ class ViewerOptions {
       pageViewMode: this.pageViewMode().toString() as CorePageViewMode,
       fitToScreen: this.zoom().fitToScreen,
       zoom: this.zoom().zoom,
+      pixelRatio: this.pixelRatio(),
     };
   }
 }

--- a/packages/viewer/src/viewmodels/viewer-app.ts
+++ b/packages/viewer/src/viewmodels/viewer-app.ts
@@ -154,6 +154,7 @@ class ViewerApp {
     urlParameters.removeParameter("find", true);
     urlParameters.removeParameter("profile", true);
     urlParameters.removeParameter("debug", true);
+    urlParameters.removeParameter("pixelRatio", true);
 
     this.viewer = new Viewer(this.viewerSettings, this.viewerOptions);
 


### PR DESCRIPTION
Enables very thin border width by emulating high pixel ratio.

- fixes #419
- also improves on #1076

### About `pixelRatio` viewer option

The output pixel ratio is configurable by setting `pixelRatio=<number>` in [Vivliostyle Viewer options](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/viewer/src/models/viewer-options.ts), or in the [CoreViewerOptions](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/src/vivliostyle/core-viewer.ts#L73). The default setting is `pixelRatio=8`, which means that the minimum border width is 1/8 px = 0.125px (about 0.09pt, or 0.033mm).

The pixelRatio value can be any number (max value is 16 -- updated in #1085) but recommended values are 1, 2, 4, **8** (default), or 16. Note:
- Values other than powers of 2 may cause layout problems.
- Large value may cause problem in browser.
- If 0 is specified, the pixel ratio emulation is turned off. Note that this is not same as `pixelRatio=1` when your display device pixel ratio is not 1, i.e., with HiDPI display such as "Retina" display whose device pixel ratio is 2.

### Limitation

This high pixel ratio emulation on PDF output works only with Chromium (Chrome) browser, because it uses the `zoom` non-standard CSS property that Firefox does not support and negative page margins in the page rule that both Firefox and Safari do not support.
