### PR TITLE
fix: remove workaround for old Chrome printing problem

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -204,13 +204,6 @@ export const VivliostyleViewportCss = `
     break-after: page;
   }
 
-  [data-vivliostyle-bleed-box] > div > div::before {
-    display: block;
-    content: "";
-    padding-top: 0.015625px;
-    margin-bottom: -0.015625px;
-  }
-
   /* Gecko-only hack, see https://bugzilla.mozilla.org/show_bug.cgi?id=267029#c17 */
   @-moz-document url-prefix()  {
     [data-vivliostyle-page-container]:nth-last-child(n + 2) {


### PR DESCRIPTION
Remove the workaround code (#514 and #394) for Chrome printing problem which was already fixed and no longer necessary.

After this change the following problem that was a side effect of the old workaround code will be resolved:

- fix #600