### PR TITLE
followup fix for #1079: add pixelRatioLimit

### DIFF
--- a/packages/core/test/files/border-width-test.html
+++ b/packages/core/test/files/border-width-test.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>border-width test</title>
+  <style>
+    body {
+      font: 10pt/13pt "Arial", sans-serif;
+    }
+    .test>div>div {
+      box-sizing: border-box;
+      border-style: solid;
+      height: 20pt;
+      margin-bottom: 5pt;
+      text-align: center;
+    }
+  </style>
+  </head>
+<body>
+<h1>Test: border-width</h1>
+<div class="test">
+  <div class="px">
+    <div style="border-width: 0.0625px">0.0625px</div>
+    <div style="border-width: 0.125px">0.125px</div>
+    <div style="border-width: 0.25px">0.25px</div>
+    <div style="border-width: 0.50px">0.50px</div>
+    <div style="border-width: 0.75px">0.75px</div>
+    <div style="border-width: 1.00px">1.00px</div>
+    <div style="border-width: 1.25px">1.25px</div>
+    <div style="border-width: 1.50px">1.50px</div>
+    <div style="border-width: 1.75px">1.75px</div>
+    <div style="border-width: 2.00px">2.00px</div>
+    <div style="border-width: 2.25px">2.25px</div>
+    <div style="border-width: 2.50px">2.50px</div>
+    <div style="border-width: 2.75px">2.75px</div>
+    <div style="border-width: 3.00px">3.00px</div>
+    <div style="border-width: 3.25px">3.25px</div>
+    <div style="border-width: 3.50px">3.50px</div>
+    <div style="border-width: 3.75px">3.75px</div>
+    <div style="border-width: 4.00px">4.00px</div>
+  </div>
+  <div class="pt">
+    <div style="border-width: 0.0625pt">0.0625pt</div>
+    <div style="border-width: 0.125pt">0.125pt</div>
+    <div style="border-width: 0.25pt">0.25pt</div>
+    <div style="border-width: 0.50pt">0.50pt</div>
+    <div style="border-width: 0.75pt">0.75pt</div>
+    <div style="border-width: 1.00pt">1.00pt</div>
+    <div style="border-width: 1.25pt">1.25pt</div>
+    <div style="border-width: 1.50pt">1.50pt</div>
+    <div style="border-width: 1.75pt">1.75pt</div>
+    <div style="border-width: 2.00pt">2.00pt</div>
+    <div style="border-width: 2.25pt">2.25pt</div>
+    <div style="border-width: 2.50pt">2.50pt</div>
+    <div style="border-width: 2.75pt">2.75pt</div>
+    <div style="border-width: 3.00pt">3.00pt</div>
+    <div style="border-width: 3.25pt">3.25pt</div>
+    <div style="border-width: 3.50pt">3.50pt</div>
+    <div style="border-width: 3.75pt">3.75pt</div>
+    <div style="border-width: 4.00pt">4.00pt</div>
+  </div>
+  <div class="mm">
+    <div style="border-width: 0.025mm">0.025mm</div>
+    <div style="border-width: 0.05mm">0.05mm</div>
+    <div style="border-width: 0.1mm">0.1mm</div>
+    <div style="border-width: 0.2mm">0.2mm</div>
+    <div style="border-width: 0.3mm">0.3mm</div>
+    <div style="border-width: 0.4mm">0.4mm</div>
+    <div style="border-width: 0.5mm">0.5mm</div>
+    <div style="border-width: 0.6mm">0.6mm</div>
+    <div style="border-width: 0.7mm">0.7mm</div>
+    <div style="border-width: 0.8mm">0.8mm</div>
+    <div style="border-width: 0.9mm">0.9mm</div>
+    <div style="border-width: 1.0mm">1.0mm</div>
+    <div style="border-width: 1.1mm">1.1mm</div>
+    <div style="border-width: 1.2mm">1.2mm</div>
+    <div style="border-width: 1.3mm">1.3mm</div>
+    <div style="border-width: 1.4mm">1.4mm</div>
+    <div style="border-width: 1.5mm">1.5mm</div>
+    <div style="border-width: 1.6mm">1.6mm</div>
+  </div>
+</div>
+</body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -143,7 +143,11 @@ module.exports = [
       {
         file: "margin-break.html",
         title: "margin-break property",
-      }
+      },
+      {
+        file: "border-width-test.html",
+        title: "border-width test",
+      },
     ],
   },
   {


### PR DESCRIPTION
Pixel ratio emulation on PDF output (PR #1079) does not work with
non-Chromium browsers ~~and has printing problem with Microsoft Edge
(negative page margins used in this emulation causes pages disappeared)~~.

So limit this feature for Chromium browsers ~~except Microsoft Edge~~.
Sets the max pixelRatio value pixelRatioLimit to 16 for Chromium browsers ~~except Microsoft Edge~~,
and 0 (disabled) for non-Chromium browsers ~~and Microsoft Edge~~.
(The defualt value of pixelRatio is 8, if not disabled)

Also, add a test file border-width-test.html

----

- **Update 2023-01-23** PR #1101:
    > Now I tested it again with the latest Microsoft Edge (109.0.1518.61) and it works fine.
    > This feature is now enabled on all Chromium browsers including Microsoft Edge.
