### PR TITLE
fix: problems on pixel ratio emulation for thin border width

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -196,11 +196,10 @@ export class AdaptiveViewer {
     this.pageSizes = [];
 
     // Pixel ratio emulation on PDF output (PR #1079) does not work with
-    // non-Chromium browsers and has printing problem with Microsoft Edge
-    // (negative page margins used in this emulation causes pages disappeared).
-    this.pixelRatioLimit = /Chrome\/(?!.*Edg\/)/.test(navigator.userAgent)
-      ? 16 // max pixelRatio value on Chromium browsers except Edge
-      : 0; // disable pixelRatio emulation on non-Chromium browsers and Edge
+    // non-Chromium browsers.
+    this.pixelRatioLimit = /Chrome/.test(navigator.userAgent)
+      ? 16 // max pixelRatio value on Chromium browsers
+      : 0; // disable pixelRatio emulation on non-Chromium browsers
     this.pixelRatio = Math.min(8, this.pixelRatioLimit);
   }
 

--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -695,7 +695,16 @@ export class AdaptiveViewer {
     this.resized = false;
     const spreadViewChanged = this.pref.spreadView !== spreadView;
     this.updateSpreadView(spreadView);
+
+    // check if window.devicePixelRatio is changed
+    const scaleRatioChanged =
+      this.pixelRatio &&
+      this.opfView &&
+      this.pixelRatio / this.window.devicePixelRatio !==
+        this.opfView.clientLayout.scaleRatio;
+
     if (
+      scaleRatioChanged ||
       this.viewportSize ||
       !this.viewport ||
       this.viewport.fontSize != this.fontSize


### PR DESCRIPTION
This PR fix problems on pixel ratio emulation for thin border width.

## fix: very thin border on printing with Microsoft Edge

When the pixel ratio emulation for thin border width was implemented (PR #1079), it did not work well with Microsoft Edge on printing, so this feature was disabled for Microsoft Edge (PR #1085).

Now I tested it again with the latest Microsoft Edge (109.0.1518.61) and it works fine.

This feature is now enabled on all Chromium browsers including Microsoft Edge.

## fix: layout problem when devicePixelRatio is changed during rendering

The pixel ratio emulation for thin border width (PR #1079) causes layout problem when window.devicePixelRatio is changed during rendering,
For example, browser's zoom is changed or browser window is moved between displays with different resolutions (e.g., Retina and non-Retina).

