### PR TITLE
fix: Modify the conditional expression to determine if it is EPUB

### DIFF
--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -98,8 +98,6 @@ export const Renderer = ({
 
   function loadSource() {
     const instance = instanceRef.current!;
-    const isPublication = source.endsWith(".json");
-
     const documentOptions = {
       ...(userStyleSheet
         ? {
@@ -123,7 +121,7 @@ export const Renderer = ({
         : null),
     };
 
-    if (isPublication || bookMode) {
+    if (bookMode) {
       instance.loadPublication(source, documentOptions);
     } else {
       instance.loadDocument({ url: source }, documentOptions, {

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -60,7 +60,7 @@ export const Renderer = ({
   source,
   page = 1,
   zoom = 1,
-  bookMode = false,
+  bookMode = true,
   fontSize = 16,
   background = "#ececec",
   renderAllPages = true,
@@ -98,6 +98,8 @@ export const Renderer = ({
 
   function loadSource() {
     const instance = instanceRef.current!;
+    const isPublication = source.endsWith(".json");
+
     const documentOptions = {
       ...(userStyleSheet
         ? {
@@ -121,7 +123,7 @@ export const Renderer = ({
         : null),
     };
 
-    if (bookMode) {
+    if (isPublication || bookMode) {
       instance.loadPublication(source, documentOptions);
     } else {
       instance.loadDocument({ url: source }, documentOptions, {

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -32,6 +32,7 @@ interface RendererProps {
   source: string;
   page?: number;
   zoom?: number;
+  bookMode?: boolean;
   renderAllPages?: boolean;
   autoResize?: boolean;
   pageViewMode?: PageViewMode;
@@ -59,6 +60,7 @@ export const Renderer = ({
   source,
   page = 1,
   zoom = 1,
+  bookMode = false,
   fontSize = 16,
   background = "#ececec",
   renderAllPages = true,
@@ -96,7 +98,6 @@ export const Renderer = ({
 
   function loadSource() {
     const instance = instanceRef.current!;
-    const isPublication = source.endsWith(".json");
     const documentOptions = {
       ...(userStyleSheet
         ? {
@@ -120,7 +121,7 @@ export const Renderer = ({
         : null),
     };
 
-    if (isPublication) {
+    if (bookMode) {
       instance.loadPublication(source, documentOptions);
     } else {
       instance.loadDocument({ url: source }, documentOptions, {

--- a/packages/react/src/stories/Renderer.stories.js
+++ b/packages/react/src/stories/Renderer.stories.js
@@ -12,6 +12,7 @@ export default {
 const SOURCES = [
   "https://vivliostyle.github.io/vivliostyle_doc/samples/gon/index.html",
   "https://vivliostyle.github.io/vivliostyle_doc/samples/gutenberg/Alice.html",
+  "https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol4/artifacts/content/",
   "https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3",
 ];
 
@@ -20,7 +21,7 @@ export const Basic = () => (
     source={select("Source", SOURCES, SOURCES[0])}
     page={number("Page", 1)}
     zoom={number("Zoom", 1)}
-    bookMode={boolean("Book Mode", false)}
+    bookMode={boolean("Book Mode", true)}
     fontSize={number("Font Size", 16)}
     background={color("Background", "#ececec")}
     renderAllPages={boolean("Render All Pages", true)}
@@ -67,7 +68,7 @@ export const Narrowed = () => (
         source={select("Source", SOURCES, SOURCES[0])}
         page={number("Page", 1)}
         zoom={number("Zoom", 1)}
-        bookMode={boolean("Book Mode", false)}
+        bookMode={boolean("Book Mode", true)}
         fontSize={number("Font Size", 16)}
         background={color("Background", "#ececec")}
         renderAllPages={boolean("Render All Pages", true)}

--- a/packages/react/src/stories/Renderer.stories.js
+++ b/packages/react/src/stories/Renderer.stories.js
@@ -12,6 +12,7 @@ export default {
 const SOURCES = [
   "https://vivliostyle.github.io/vivliostyle_doc/samples/gon/index.html",
   "https://vivliostyle.github.io/vivliostyle_doc/samples/gutenberg/Alice.html",
+  "https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3",
 ];
 
 export const Basic = () => (
@@ -19,6 +20,7 @@ export const Basic = () => (
     source={select("Source", SOURCES, SOURCES[0])}
     page={number("Page", 1)}
     zoom={number("Zoom", 1)}
+    bookMode={boolean("Book Mode", false)}
     fontSize={number("Font Size", 16)}
     background={color("Background", "#ececec")}
     renderAllPages={boolean("Render All Pages", true)}
@@ -65,6 +67,7 @@ export const Narrowed = () => (
         source={select("Source", SOURCES, SOURCES[0])}
         page={number("Page", 1)}
         zoom={number("Zoom", 1)}
+        bookMode={boolean("Book Mode", false)}
         fontSize={number("Font Size", 16)}
         background={color("Background", "#ececec")}
         renderAllPages={boolean("Render All Pages", true)}


### PR DESCRIPTION
**Describe the bug**
EPUB cannot be read in `vivliostyle/react`.

**Reproduce operation**
Load EPUB with `yarn storybook.

**Expected behavior**
EPUB is displayed.

**Additional context**

I think the conditional expression "EPUB" is wrong if it is a JSON extension.

The documentation says that "EPUB (decompressed) typesetting display" is enabled if "bookMode" is true.
I changed it to use the loadPublication function if bookMode is passed as true in props.
https://vivliostyle.org/ja/faq/#book-mode-%E3%81%A8%E3%81%AF

Please check with us.

---

**不具合の内容**
vivliostyle/react で EPUB が読み込めない。

**動作を再現**
`yarn storybook`で EPUB を読み込む。

**期待される動作**
EPUBが表示される。

**補足説明**

JSON拡張子であればEPUBである、という条件式は誤りだと思います。

ドキュメントには「bookModeが真」であるときに「EPUB（ZIP解凍済み）の組版表示」が有効化される、
とありましたのでpropsでbookModeにtrueが渡されたらloadPublication関数を使用するように変更しました。
https://vivliostyle.org/ja/faq/#book-mode-%E3%81%A8%E3%81%AF

ご確認していただけますようお願いいたします。