### PR TITLE
fix: tweak TOC detection for VFM v2 change

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1360,9 +1360,10 @@ epub|case[required-namespace::supported] ~ epub|case {
 epub|case[required-namespace::supported] ~ epub|default {
   display: none;
 }
+`;
 
-/*--------------- ncx and toc ----------------------*/
-
+/** user-agent-toc.css */
+export const UserAgentTocCss = `
 @namespace ncx "http://www.daisy.org/z3986/2005/ncx/";
 
 ncx|ncx {
@@ -1384,6 +1385,7 @@ body > * {
 nav,
 .toc,
 #toc,
+section:has(>:first-child:is(h1,h2,h3,h4,h5,h6):is(.toc,#toc)),
 #table-of-contents,
 #contents {
   -adapt-behavior: toc-root;
@@ -1394,6 +1396,7 @@ nav,
 nav a,
 .toc a,
 #toc a,
+section:has(>:first-child:is(h1,h2,h3,h4,h5,h6):is(.toc,#toc)) a,
 ncx|navLabel {
   -adapt-behavior: toc-node-anchor;
 }
@@ -1403,6 +1406,7 @@ ncx|navLabel {
 nav li,
 .toc li,
 #toc li,
+section:has(>:first-child:is(h1,h2,h3,h4,h5,h6):is(.toc,#toc)) li,
 ncx|navPoint {
   -adapt-behavior: toc-node;
 }
@@ -1411,7 +1415,8 @@ ncx|navPoint {
 [role="directory"] li > *:first-child,
 nav li > *:first-child,
 .toc li > *:first-child,
-#toc li > *:first-child {
+#toc li > *:first-child,
+section:has(>:first-child:is(h1,h2,h3,h4,h5,h6):is(.toc,#toc)) li > *:first-child {
   -adapt-behavior: toc-node-first-child;
 }
 
@@ -1432,7 +1437,8 @@ ol#toc,
 ul[role="doc-toc"],
 ul[role="directory"],
 ul.toc,
-ul#toc {
+ul#toc/*,
+section:has(>:first-child:is(h1,h2,h3,h4,h5,h6):is(.toc,#toc)) :is(ol,ul)*/ {
   -adapt-behavior: toc-container;
 }
 `;

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1232,7 +1232,8 @@ export class OPFDoc {
         "[role=directory] a[href]," +
         "nav li a[href]," +
         ".toc a[href]," +
-        "#toc a[href]";
+        "#toc a[href]," +
+        "section:has(>:first-child:is(h1,h2,h3,h4,h5,h6):is(.toc,#toc)) a[href]";
       for (const anchorElem of doc.querySelectorAll(selector)) {
         const href = anchorElem.getAttribute("href");
         if (/^(https?:)?\/\//.test(href)) {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -53,7 +53,7 @@ import * as Vgen from "./vgen";
 import * as Vtree from "./vtree";
 import * as XmlDoc from "./xml-doc";
 import { Layout as LayoutType } from "./types";
-import { UserAgentBaseCss, UserAgentPageCss } from "./assets";
+import { UserAgentBaseCss, UserAgentPageCss, UserAgentTocCss } from "./assets";
 
 export const uaStylesheetBaseFetcher: TaskUtil.Fetcher<boolean> =
   new TaskUtil.Fetcher(() => {
@@ -2280,18 +2280,22 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
         }
         this.triggersByDocURL[url] = triggers;
         const sources = [] as StyleSource[];
-        const userAgentURL = Base.resolveURL(
-          "user-agent-page.css",
-          Base.resourceBaseURL,
-        );
         sources.push({
-          url: userAgentURL,
+          url: Base.resolveURL("user-agent-page.css", Base.resourceBaseURL),
           text: UserAgentPageCss,
           flavor: CssParser.StylesheetFlavor.USER_AGENT,
           classes: null,
           media: null,
         });
-        if (!isTocBox) {
+        if (isTocBox) {
+          sources.push({
+            url: Base.resolveURL("user-agent-toc.css", Base.resourceBaseURL),
+            text: UserAgentTocCss,
+            flavor: CssParser.StylesheetFlavor.USER_AGENT,
+            classes: null,
+            media: null,
+          });
+        } else {
           const elemList =
             xmldoc.document.querySelectorAll("style, link, meta");
           for (const elem of elemList) {


### PR DESCRIPTION
This resolves the problem on VFM v2 change:

- https://github.com/vivliostyle/vfm/pull/157

With the following Markdown,

```md
 # Table of Contents {.toc}

- [One](one.html)
- [Two](two.html)
```

VFM v1 generates the following HTML:

```html
    <section class="level1 toc" id="table-of-contents">
      <h1 class="toc">Table of Contents</h1>
      <ul>
        <li><a href="one.html">One</a></li>
        <li><a href="two.html">Two</a></li>
      </ul>
    </section>
```

Vivliostyle.js recognizes the section as TOC because "toc" class is found in the section element.

This is changed in VFM v2. It generates the following HTML:

```html
    <section class="level1" aria-labelledby="table-of-contents">
      <h1 class="toc" id="table-of-contents">Table of Contents</h1>
      <ul>
        <li><a href="one.html">One</a></li>
        <li><a href="two.html">Two</a></li>
      </ul>
    </section>
```

The "toc" class (or id) is not found on the `<section>` element, so the TOC detection has to be tweaked using the selector, `section:has(>:first-child:is(h1,h2,h3,h4,h5,h6):is(.toc,#toc))`.

Note: the stylesheet for TOC that was a part of UserAgentBaseCSS is now a separate stylesheet UserAgentTocCSS. This change is necessary because uaStylesheetBaseFetcher cannot handle the `:has()` selector.