### PR TITLE
fix(viewer): [Regression v2.22.4] Viewer TOC item indent too large

### DIFF
--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -122,6 +122,9 @@ export class TOCView implements Vgen.CustomRendererFactory {
             computedStyle["color"] = Css.ident.inherit;
             computedStyle["text-decoration"] = Css.ident.none;
             break;
+          case "toc-container":
+            computedStyle["padding"] = Css.numericZero;
+            break;
         }
       }
       if (


### PR DESCRIPTION
- fix #1133