### PR TITLE
fix: Page content is not painted in the bleed area (Regression in v2.23.1)

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -151,6 +151,7 @@ export const VivliostyleViewportCss = `
 [data-vivliostyle-bleed-box] {
   position: absolute;
   overflow: hidden;
+  background-origin: content-box !important;
   box-sizing: border-box;
 }
 

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1943,9 +1943,7 @@ export class StyleInstance
     page.bleedBox.style.right = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
     page.bleedBox.style.top = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
     page.bleedBox.style.bottom = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
-    // Use transparent border (not padding) for bleed area to position page background image correctly.
-    // (Fix for issue #644)
-    page.bleedBox.style.border = `${evaluatedPageSizeAndBleed.bleed}px solid transparent`;
+    page.bleedBox.style.padding = `${evaluatedPageSizeAndBleed.bleed}px`;
   }
 }
 


### PR DESCRIPTION
This is a followup fix to PR #1145 for issue #644.