### PR TITLE
fix: Rendering error with SVG images in EPUB (Regression in v2.23.0)

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -831,7 +831,7 @@ export class OPFDoc {
           const path = r[1] || baseURL;
           const fragment = decodeURIComponent(r[2]);
           if (path) {
-            if (self.items.some((item) => item.src === path)) {
+            if (self.spine.some((item) => item.src === path)) {
               return `#${this.transformFragment(fragment, path)}`;
             }
           }


### PR DESCRIPTION
The fix in PR #1139 for issue #1135 caused this problem.