### PR TITLE
fix: Browser "Back" button should work with internal link or TOC navigation

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -723,7 +723,9 @@ export class SimpleEventTarget {
     }
     const list = this.listeners[type];
     if (list) {
-      list.push(listener);
+      if (!list.includes(listener)) {
+        list.push(listener);
+      }
     } else {
       this.listeners[type] = [listener];
     }

--- a/packages/viewer/src/viewmodels/viewer.ts
+++ b/packages/viewer/src/viewmodels/viewer.ts
@@ -207,6 +207,9 @@ class Viewer {
     });
     this.coreViewer.addListener("hyperlink", (payload) => {
       if (payload.internal) {
+        // Ensure that the browser Back button works as expected.
+        window.history.pushState(null, null);
+
         this.navigateToInternalUrl(payload.href);
 
         // When navigate from TOC, TOC box may or may not become hidden by autohide.


### PR DESCRIPTION
Vivliostyle Viewerで閲覧中の文書内の内部リンクや目次でのナビゲーションでページを移動したあと、ブラウザの「戻る」ボタンで移動前に戻れるようにしました。
