### PR TITLE
followup fix to PR #1149

### DIFF
--- a/packages/viewer/src/viewmodels/viewer.ts
+++ b/packages/viewer/src/viewmodels/viewer.ts
@@ -207,9 +207,6 @@ class Viewer {
     });
     this.coreViewer.addListener("hyperlink", (payload) => {
       if (payload.internal) {
-        // Ensure that the browser Back button works as expected.
-        window.history.pushState(null, null);
-
         this.navigateToInternalUrl(payload.href);
 
         // When navigate from TOC, TOC box may or may not become hidden by autohide.
@@ -279,18 +276,24 @@ class Viewer {
   }
 
   navigateToFirst(): void {
+    window.history.pushState(null, null);
     this.coreViewer.navigateToPage(Navigation.FIRST);
   }
 
   navigateToLast(): void {
+    window.history.pushState(null, null);
     this.coreViewer.navigateToPage(Navigation.LAST);
   }
 
   navigateToEPage(epage: number): void {
+    if (Math.abs(epage - this.epage()) > 1) {
+      window.history.pushState(null, null);
+    }
     this.coreViewer.navigateToPage(Navigation.EPAGE, epage);
   }
 
   navigateToInternalUrl(href: string): void {
+    window.history.pushState(null, null);
     this.coreViewer.navigateToInternalUrl(href);
   }
 


### PR DESCRIPTION
Back button should work not only with internal link navigation but also to-first/last and to-page navigation.

Note: it excludes to-prevous/next and to-page where page is previous or next of current page, so that too many locations do not remain in the browser history.