### PR TITLE
feat(viewer): Add UI Language in settings panel

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "@vivliostyle/core": "^2.23.2",
-    "i18next": "^22.0.6",
-    "i18next-browser-languagedetector": "^7.0.1",
+    "i18next-ko": "^3.0.1",
     "knockout": "^3.5.0"
   },
   "devDependencies": {

--- a/packages/viewer/src/bindings/i18n.ts
+++ b/packages/viewer/src/bindings/i18n.ts
@@ -15,13 +15,14 @@
  * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { use } from "i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
+import i18nextko from "i18next-ko";
+import ko from "knockout";
 
 const translations = {
   en: {
     translation: {
       UI_LNG: "en",
+      TIP_UI_Language: "Language of UI",
       CONFIRM_DELETE: "Do you really want to delete it?",
       CONFIRM_REMOVE: "Do you really want to remove it?",
       CONFIRM_REMOVE_ALL: "Do you really want to remove all?",
@@ -158,6 +159,7 @@ const translations = {
   ja: {
     translation: {
       UI_LNG: "ja",
+      TIP_UI_Language: "UI表示言語 (L)",
       CONFIRM_DELETE: "本当に削除しますか？",
       CONFIRM_REMOVE: "本当に削除しますか？",
       CONFIRM_REMOVE_ALL: "本当にすべて削除しますか？",
@@ -293,7 +295,35 @@ const translations = {
   },
 };
 
-use(LanguageDetector).init({
-  fallbackLng: "en",
-  resources: translations,
-});
+/**
+ * simple language detector alternative to i18next-browser-languageDetector
+ * @returns {string} language code
+ */
+function detectLanguage(): string {
+  try {
+    // Detect from URL parameter: "?lng=xx", "&lng=xx" or "#lng=xx"
+    let lng = /[?&#]lng=([^?&#]+)/.exec(window.location.href)?.[1];
+    if (!lng) {
+      // Detect from localStorage
+      lng = window.localStorage.getItem("i18nextLng");
+      if (!lng) {
+        // Detect from browser
+        lng = navigator.language;
+      }
+    }
+    if (lng) {
+      // "en-US" -> "en"
+      // FIXME: need fix for "zh-CN", "zh-TW", or "zh-Hant-HK" etc. when we support them
+      lng = lng.toLowerCase().replace(/-.*/, "");
+      if (lng in translations) {
+        return lng;
+      }
+    }
+  } catch (e) {
+    // ignore
+  }
+  // fallback
+  return "en";
+}
+
+i18nextko.init(translations, detectLanguage(), ko);

--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -127,6 +127,11 @@
           <!-- MENU DETAIL -->
           <div role="dialog" aria-label="Settings Panel" class="vivliostyle-menu-detail" tabindex="0" aria-hidden="true" data-bind="attr: {'aria-hidden': !settingsPanel.opened()?'true':'false'}">
             <div class="vivliostyle-menu-detail-main">
+              <div class="vivliostyle-menu-detail-group" id="vivliostyle-settings_ui-language" data-bind="hidden: settingsPanel.isUILanguageChangeDisabled, attr: {title: t('TIP_UI_Language')}">
+                <select name="vivliostyle-settings_ui-language" aria-keyshortcuts="L" data-bind="foreach: Object.keys(i18n.options.resources), value: settingsPanel.uiLanguage">
+                  <option data-bind="value: $data, text: $parent.t('UI_LNG', {lng: $data})">&nbsp;</option>
+                </select>
+              </div>
               <details class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-view-and-rendering" open data-bind="hidden: settingsPanel.isPageViewModeChangeDisabled">
                 <summary class="vivliostyle-menu-detail-group-heading" aria-keyshortcuts="P"><span data-bind="text: t('Page_View_Mode')"></span></summary>
                 <fieldset class="vivliostyle-menu-detail-group" id="vivliostyle-settings_page-view-mode" aria-keyshortcuts="V">

--- a/packages/viewer/src/scss/ui.menu-bar.scss
+++ b/packages/viewer/src/scss/ui.menu-bar.scss
@@ -436,6 +436,7 @@
         max-width: -moz-min-content;
         max-width: min-content; // make it resizable with CSS Details textarea
         height: calc(100% - #{$menu-icon-height});
+        min-height: 54px;
         line-height: 1;
         color: $menu-fg-color;
         .vivliostyle-menu-disabled {
@@ -520,12 +521,31 @@
           font-size: 0.9em;
         }
         > .vivliostyle-menu-detail-main {
+          position: relative;
           overflow-y: auto;
           height: calc(100% - 56px);
           font-size: 14px;
           -webkit-overflow-scrolling: touch;
           @media screen and (min-width: 320px) {
             min-width: 316px; // make it resizable with CSS Details textarea
+          }
+          #vivliostyle-settings_ui-language {
+            position: absolute;
+            top: 0px;
+            right: 0px;
+            z-index: 1;
+            font-size: 14px;
+            &::before {
+              @include font-icon("FontAwesome");
+              content: fa-content($fa-var-globe);
+              color: #555;
+            }
+            select {
+              font-size: inherit;
+            }
+          }
+          summary {
+            width: fit-content;
           }
           .vivliostyle-menu-detail-group {
             position: relative;

--- a/packages/viewer/src/viewmodels/marks-store.ts
+++ b/packages/viewer/src/viewmodels/marks-store.ts
@@ -15,7 +15,7 @@
  * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { t } from "i18next";
+import { t } from "i18next-ko";
 import ko, { Computed, Observable, ObservableArray } from "knockout";
 import ViewerOptions from "../models/viewer-options";
 import Viewer from "./viewer";

--- a/packages/viewer/src/viewmodels/viewer-app.ts
+++ b/packages/viewer/src/viewmodels/viewer-app.ts
@@ -18,7 +18,7 @@
  * along with Vivliostyle UI.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { t } from "i18next";
+import i18nextko from "i18next-ko";
 import Vivliostyle from "../vivliostyle";
 import DocumentOptions from "../models/document-options";
 import ViewerOptions from "../models/viewer-options";
@@ -53,7 +53,8 @@ class ViewerApp {
   marksStore: MarksStoreFacade;
   marksMenuStatus: MarksMenuStatus;
   marksBox: MarksBox;
-  t = t;
+  t = i18nextko.t;
+  i18n = i18nextko.i18n;
 
   constructor() {
     // Configuration flags
@@ -72,6 +73,7 @@ class ViewerApp {
       disableBookModeChange: disableSettings || flags.includes("B"),
       disableRenderAllPagesChange: disableSettings || flags.includes("A"),
       disableRestoreViewChange: disableSettings || flags.includes("R"),
+      disableUILanguageChange: disableSettings || flags.includes("L"),
     };
     const navigationOptions = {
       disableTOCNavigation: flags.includes("T"),
@@ -190,6 +192,7 @@ class ViewerApp {
     urlParameters.removeParameter("debug", true);
     urlParameters.removeParameter("pixelRatio", true);
     urlParameters.removeParameter("restoreView", true);
+    urlParameters.removeParameter("lng", true);
 
     this.viewer = new Viewer(this.viewerSettings, this.viewerOptions);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,13 +1318,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.17.2", "@babel/runtime@^7.19.4":
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
-  integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@babel/template@^7.12.7", "@babel/template@^7.18.10", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -11978,19 +11971,17 @@ husky@^4.2.3:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-i18next-browser-languagedetector@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.0.1.tgz#ead34592edc96c6c3a618a51cb57ad027c5b5d87"
-  integrity sha512-Pa5kFwaczXJAeHE56CHG2aWzFBMJNUNghf0Pm4SwSrEMps/PTKqW90EYWlIvhuYStf3Sn1K0vw+gH3+TLdkH1g==
+i18next-ko@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-ko/-/i18next-ko-3.0.1.tgz#b5ee2a4fc6767064e3b27d7b5683a527bf2bbc5d"
+  integrity sha512-Z0HMTiJHU1zP+Lgp8H8iZYmOZHrUVu6LaAWAmm5cMuP4y/VFAghEfs9kDuQ86+S+g45TCKzX76MqyNGemlJuMA==
   dependencies:
-    "@babel/runtime" "^7.19.4"
+    i18next "^3.4.3"
 
-i18next@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-22.0.6.tgz#d7029912f8aa74ff295c0d9afd1b7dea45859b49"
-  integrity sha512-RlreNGoPIdDP4QG+qSA9PxZKGwlzmcozbI9ObI6+OyUa/Rp0EjZZA9ubyBjw887zVNZsC+7FI3sXX8oiTzAfig==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
+i18next@^3.4.3:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-3.5.2.tgz#930390d5c318ceaa4858b52dd0e40e6b203f9f41"
+  integrity sha512-42eGG1b56O5NR01Gudod1R3LzPugN6tZ3ZmYtAqOJSmx4V3vD07hLtkkFrv/qu1mRecW1woezyXFZBFnNAgRXw==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -18918,11 +18909,6 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"


### PR DESCRIPTION
- Add UI Language in settings panel
- New configuration flag "L": disable UI Language change in the setting panel

When Viewer is open, the UI language is determined with the following priority order:

1. Check URL parameter (in query or fragment): "?lng=xx", "&lng=xx" or "#lng=xx"
2. Check LocalStorage with "i18nextLng" key
3. browser navigator.language value

When the UI language is changed in the settings panel, it is saved to the LocalStorage with "i18nextLng" key.

Currently, only two languages, "en" and "ja", are available. English (en) is used as the fallback language.

----

Related previous commit:
- [feat(viewer): Multilingual user interface (en/ja)](https://github.com/vivliostyle/vivliostyle.js/pull/1152/commits/aa2f27bf561267e3eca47da3edb8df9f6139526e)