### PR TITLE
feat: Add support for CSS running elements

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -304,7 +304,8 @@ CONTENT_LIST = [ STRING | URI | counter(IDENT LIST_STYLE_TYPE?) |
     leader([ dotted | solid | space ] | STRING ) |
     open-quote | close-quote | no-open-quote | no-close-quote |
     content([ text | before | after | first-letter ]?) |
-    string(IDENT [first | start | last | first-except]?) ]+;
+    string(IDENT [first | start | last | first-except]?) |
+    element(IDENT [first | start | last | first-except]?) ]+;
 CONTENT = normal | none | CONTENT_LIST;
 content = CONTENT;
 COUNTER = [ IDENT INT? ]+ | none;
@@ -356,7 +357,7 @@ PAGE_BREAK = auto | always | avoid | left | right | recto | verso;
 page-break-after = PAGE_BREAK;
 page-break-before = PAGE_BREAK;
 page-break-inside = avoid | auto;
-position = static | relative | absolute | fixed;
+position = static | relative | absolute | fixed | running(IDENT);
 quotes = [STRING STRING]+ | none | auto;
 right = APLENGTH;
 table-layout = auto | fixed;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2016,12 +2016,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     let stringValue = "";
     switch (pseudoName) {
       case "text":
-      case "first-letter":
         stringValue = this.element.textContent;
-        if (pseudoName === "first-letter") {
-          const r = stringValue.match(Base.firstLetterPattern);
-          stringValue = r ? r[0] : "";
-        }
         break;
       case "before":
       case "after":
@@ -2030,6 +2025,22 @@ export class ContentPropVisitor extends Css.FilterVisitor {
           const val = (pseudos?.[pseudoName]?.["content"] as CascadeValue)
             ?.value;
           stringValue = getStringValueFromCssContentVal(val);
+        }
+        break;
+      case "first-letter":
+        {
+          // Respect ::before/after pseudo-elements (Issue #1174)
+          const pseudos = getStyleMap(this.cascade.currentStyle, "_pseudos");
+          const r = (
+            getStringValueFromCssContentVal(
+              (pseudos?.["before"]?.["content"] as CascadeValue)?.value,
+            ) ||
+            this.element.textContent ||
+            getStringValueFromCssContentVal(
+              (pseudos?.["after"]?.["content"] as CascadeValue)?.value,
+            )
+          ).match(Base.firstLetterPattern);
+          stringValue = r ? r[0] : "";
         }
         break;
     }

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -1890,6 +1890,11 @@ export class PageMarginBoxPartitionInstance extends PageMaster.PartitionInstance
 
   private applyVerticalAlign(context: Exprs.Context, element: Element) {
     Base.setCSSProperty(element, "display", "flex");
+    Base.setCSSProperty(
+      element,
+      "flex-flow",
+      this.vertical ? (this.rtl ? "row-reverse" : "row") : "column",
+    );
     const verticalAlign: Css.Val = this.getProp(context, "vertical-align");
     let flexAlign: string | null = null;
     if (verticalAlign === Css.getName("middle")) {
@@ -1900,31 +1905,33 @@ export class PageMarginBoxPartitionInstance extends PageMaster.PartitionInstance
       flexAlign = "flex-end";
     }
     if (flexAlign) {
-      Base.setCSSProperty(
-        element,
-        "flex-flow",
-        this.vertical ? "row" : "column",
-      );
       Base.setCSSProperty(element, "justify-content", flexAlign);
-      if (this.vertical) {
-        let align = "center";
-        if (this.boxInfo.isInTopRow || this.boxInfo.isInBottomRow) {
-          if (
-            this.boxInfo.isInLeftColumn ||
-            this.boxInfo.positionAlongVariableDimension ===
-              MarginBoxPositionAlongVariableDimension.END
-          ) {
-            align = "start";
-          } else if (
-            this.boxInfo.isInRightColumn ||
-            this.boxInfo.positionAlongVariableDimension ===
-              MarginBoxPositionAlongVariableDimension.START
-          ) {
-            align = "end";
-          }
+    }
+    const content: Css.Val = this.getProp(context, "content");
+    if (
+      this.vertical ||
+      content instanceof Css.URL ||
+      (content instanceof Css.Expr &&
+        content.expr instanceof Exprs.Native &&
+        content.expr.str.startsWith("running-element-"))
+    ) {
+      let align = "center";
+      if (this.boxInfo.isInTopRow || this.boxInfo.isInBottomRow) {
+        if (
+          this.boxInfo.isInLeftColumn ||
+          this.boxInfo.positionAlongVariableDimension ===
+            MarginBoxPositionAlongVariableDimension.END
+        ) {
+          align = this.vertical || this.rtl ? "start" : "end";
+        } else if (
+          this.boxInfo.isInRightColumn ||
+          this.boxInfo.positionAlongVariableDimension ===
+            MarginBoxPositionAlongVariableDimension.START
+        ) {
+          align = this.vertical || this.rtl ? "end" : "start";
         }
-        Base.setCSSProperty(element, "align-items", align);
       }
+      Base.setCSSProperty(element, "align-items", align);
     }
   }
 

--- a/packages/core/src/vivliostyle/display.ts
+++ b/packages/core/src/vivliostyle/display.ts
@@ -64,8 +64,16 @@ export function blockify(display: Css.Ident): Css.Ident {
 /**
  * Judge if the generated box is absolutely positioned.
  */
-export function isAbsolutelyPositioned(position: Css.Ident): boolean {
+export function isAbsolutelyPositioned(position: Css.Val): boolean {
   return position === Css.ident.absolute || position === Css.ident.fixed;
+}
+
+/**
+ * Check if the position value is 'running()'.
+ * https://drafts.csswg.org/css-gcpm/#running-elements
+ */
+export function isRunning(position: Css.Val): boolean {
+  return position instanceof Css.Func && position.name === "running";
 }
 
 /**
@@ -73,7 +81,7 @@ export function isAbsolutelyPositioned(position: Css.Ident): boolean {
  * cf. https://drafts.csswg.org/css-display/#transformations
  *     https://drafts.csswg.org/css2/visuren.html#dis-pos-flo
  */
-export function getComputedDislayValue(
+export function getComputedDisplayValue(
   display: Css.Ident,
   position: Css.Ident,
   float: Css.Ident,
@@ -103,7 +111,7 @@ export function isBlock(
   isRoot: boolean,
 ): boolean {
   return (
-    getComputedDislayValue(display, position, float, isRoot).display ===
+    getComputedDisplayValue(display, position, float, isRoot).display ===
     Css.ident.block
   );
 }

--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -166,6 +166,14 @@ export function isSpecial(e: Element): boolean {
   return !!e.getAttribute(VtreeImpl.SPECIAL_ATTR);
 }
 
+export function isOutOfFlow(node: Node): boolean {
+  if (!(node?.nodeType === 1)) return false;
+  const e = node as HTMLElement;
+  if (isSpecial(e)) return true;
+  const position = e.style?.position;
+  return position === "absolute" || position === "fixed";
+}
+
 export function isSpecialNodeContext(nodeContext: Vtree.NodeContext): boolean {
   const viewNode = nodeContext?.viewNode;
   return viewNode?.nodeType === 1 && isSpecial(viewNode as Element);

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1574,7 +1574,7 @@ export class StyleInstance
         );
         boxContainer.appendChild(innerContainer);
         if (innerContainerTag == "img") {
-          boxInstance.transferSinglUriContentProps(
+          boxInstance.transferSingleUriContentProps(
             this,
             innerContainer,
             this.faces,

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1543,7 +1543,21 @@ export class StyleInstance
     let removed = false;
     if (!flowName || !flowName.isIdent()) {
       const contentVal = boxInstance.getProp(this, "content");
-      if (contentVal && Vtree.nonTrivialContent(contentVal)) {
+      if (
+        contentVal instanceof Css.Expr &&
+        contentVal.expr instanceof Exprs.Native &&
+        contentVal.expr.str.startsWith("running-element-")
+      ) {
+        // Single running element
+        contentVal.visit(
+          new Vtree.ContentPropertyHandler(
+            boxContainer,
+            this,
+            contentVal,
+            this.counterStore.getExprContentListener(),
+          ),
+        );
+      } else if (contentVal && Vtree.nonTrivialContent(contentVal)) {
         let innerContainerTag = "span";
         if ((contentVal as any).url) {
           innerContainerTag = "img";

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1327,18 +1327,45 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
     }
   }
 
-  transferSinglUriContentProps(
+  transferSingleUriContentProps(
     context: Exprs.Context,
     element: Element,
     docFaces: Font.DocumentFaces,
   ): void {
-    for (let i = 0; i < passSingleUriContentProperties.length; i++) {
-      this.propagatePropertyToElement(
-        context,
-        element,
-        passSingleUriContentProperties[i],
-        docFaces,
+    const hasWidth = (): boolean => {
+      const width = (
+        (this.cascaded["width"] ??
+          this.cascaded[
+            this.vertical ? "block-size" : "inline-size"
+          ]) as CssCascade.CascadeValue
+      )?.value;
+      return (
+        !!width && width !== Css.ident.auto && !Css.isDefaultingValue(width)
       );
+    };
+    const hasHeight = (): boolean => {
+      const height = (
+        (this.cascaded["height"] ??
+          this.cascaded[
+            this.vertical ? "inline-size" : "block-size"
+          ]) as CssCascade.CascadeValue
+      )?.value;
+      return (
+        !!height && height !== Css.ident.auto && !Css.isDefaultingValue(height)
+      );
+    };
+
+    for (let i = 0; i < passSingleUriContentProperties.length; i++) {
+      const name = passSingleUriContentProperties[i];
+      if (
+        (name === "width" && !hasWidth()) ||
+        (name === "height" && !hasHeight())
+      ) {
+        // Don't propagate width/height to the img element if it's not specified.
+        // (Issue #1177)
+        continue;
+      }
+      this.propagatePropertyToElement(context, element, name, docFaces);
     }
   }
 

--- a/packages/core/src/vivliostyle/sizing.ts
+++ b/packages/core/src/vivliostyle/sizing.ts
@@ -193,6 +193,16 @@ export function getSize(
         r = isVertical ? getFitContentInline() : getIdealBlock();
         break;
     }
+    // Workaround for the case that the element has an image that is
+    // not loaded yet. Use 1px instead of 0px to avoid wrong layout.
+    if (
+      r === "0px" &&
+      element.childNodes.length === 1 &&
+      element.firstElementChild?.localName === "img" &&
+      !(element.firstElementChild as HTMLImageElement).complete
+    ) {
+      r = "1px";
+    }
     result[size] = parseFloat(r);
     Base.setCSSProperty(element, "position", original.position);
     Base.setCSSProperty(element, "display", original.display);

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1396,7 +1396,24 @@ export class ViewFactory
           if (image !== result) {
             (result as HTMLImageElement).src = delayedSrc;
           }
-          if (!hasAutoWidth && !hasAutoHeight) {
+          const isInsideRunningElement = (): boolean => {
+            // Check if the image is inside a position:fixed or running element
+            // which is converted to position:fixed.
+            if (computedStyle["position"] === Css.ident.fixed) {
+              return true;
+            }
+            for (
+              let p = this.nodeContext.parent?.viewNode as HTMLElement;
+              p && p !== this.viewRoot;
+              p = p.parentElement
+            ) {
+              if (p.style?.["position"] === "fixed") {
+                return true;
+              }
+            }
+            return false;
+          };
+          if (!hasAutoWidth && !hasAutoHeight && !isInsideRunningElement()) {
             // No need to wait for the image, does not affect layout
             this.page.fetchers.push(imageFetcher);
           } else {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -272,6 +272,19 @@ module.exports = [
     ],
   },
   {
+    category: "Running Elements",
+    files: [
+      {
+        file: "running-elements/running-elements.html",
+        title: "Running Elements - running() and element() functions",
+      },
+      {
+        file: "running-elements/page-margin-boxes.html",
+        title: "Page Margin Boxes",
+      },
+    ],
+  },
+  {
     category: "Page breaks",
     files: [
       {

--- a/packages/core/test/files/named-strings/string-set-content.html
+++ b/packages/core/test/files/named-strings/string-set-content.html
@@ -35,9 +35,9 @@
   <body>
     <h1>Test</h1>
     <p>The top-center page header output must be "Chapter 1: Test~"</p>
-    <p>The top-right page header output must be "First Letter: T"</p>
+    <p>The top-right page header output must be "First Letter: C"</p>
     <h1>More test</h1>
     <p>The top-center page header output must be "Chapter 2: More test~"</p>
-    <p>The top-right page header output must be "First Letter: M"</p>
+    <p>The top-right page header output must be "First Letter: C"</p>
   </body>
 </html>

--- a/packages/core/test/files/running-elements/page-margin-boxes.html
+++ b/packages/core/test/files/running-elements/page-margin-boxes.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page Margin Boxes</title>
+    <style>
+
+@page {
+  size: A4;
+  margin: 60mm 42mm;
+  @top-left-corner {
+    border: 1px solid silver;
+  }
+  @top-left {
+    border: 1px solid silver;
+  }
+  @top-center {
+    border: 1px solid silver;
+  }
+  @top-right {
+    border: 1px solid silver;
+  }
+  @top-right-corner {
+    border: 1px solid silver;
+  }
+  @left-top {
+    border: 1px solid silver;
+  }
+  @left-middle {
+    border: 1px solid silver;
+  }
+  @left-bottom {
+    border: 1px solid silver;
+  }
+  @right-top {
+    border: 1px solid silver;
+  }
+  @right-middle {
+    border: 1px solid silver;
+  }
+  @right-bottom {
+    border: 1px solid silver;
+  }
+  @bottom-left-corner {
+    border: 1px solid silver;
+  }
+  @bottom-left {
+    border: 1px solid silver;
+  }
+  @bottom-center {
+    border: 1px solid silver;
+  }
+  @bottom-right {
+    border: 1px solid silver;
+  }
+  @bottom-right-corner {
+    border: 1px solid silver;
+  }
+}
+
+@page :first {
+  @top-left-corner {
+    content: "top-left-corner";
+  }
+  @top-left {
+    content: "top-left";
+  }
+  @top-center {
+    content: "top-center";
+  }
+  @top-right {
+    content: "top-right";
+  }
+  @top-right-corner {
+    content: "top-right-corner";
+  }
+  @left-top {
+    content: "left-top";
+  }
+  @left-middle {
+    content: "left-middle";
+  }
+  @left-bottom {
+    content: "left-bottom";
+  }
+  @right-top {
+    content: "right-top";
+  }
+  @right-middle {
+    content: "right-middle";
+  }
+  @right-bottom {
+    content: "right-bottom";
+  }
+  @bottom-left-corner {
+    content: "bottom-left-corner";
+  }
+  @bottom-left {
+    content: "bottom-left";
+  }
+  @bottom-center {
+    content: "bottom-center";
+  }
+  @bottom-right {
+    content: "bottom-right";
+  }
+  @bottom-right-corner {
+    content: "bottom-right-corner";
+  }
+}
+
+@page single-image {
+  @top-left-corner {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-left {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-center {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-right {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-right-corner {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @left-top {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @left-middle {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @left-bottom {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @right-top {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @right-middle {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @right-bottom {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-left-corner {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-left {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-center {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-right {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-right-corner {
+    content: url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+}
+
+@page text-and-image {
+  @top-left-corner {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-left {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-center {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-right {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @top-right-corner {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @left-top {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @left-middle {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @left-bottom {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @right-top {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @right-middle {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @right-bottom {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-left-corner {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-left {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-center {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-right {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+  @bottom-right-corner {
+    content: "Text and " url(https://vivliostyle.org/assets/vivliostyle-icon.png);
+  }
+}
+
+@page single-running-element {
+  @top-left-corner {
+    content: element(RunningImage);
+  }
+  @top-left {
+    content: element(RunningImage);
+  }
+  @top-center {
+    content: element(RunningImage);
+  }
+  @top-right {
+    content: element(RunningImage);
+  }
+  @top-right-corner {
+    content: element(RunningImage);
+  }
+  @left-top {
+    content: element(RunningImage);
+  }
+  @left-middle {
+    content: element(RunningImage);
+  }
+  @left-bottom {
+    content: element(RunningImage);
+  }
+  @right-top {
+    content: element(RunningImage);
+  }
+  @right-middle {
+    content: element(RunningImage);
+  }
+  @right-bottom {
+    content: element(RunningImage);
+  }
+  @bottom-left-corner {
+    content: element(RunningImage);
+  }
+  @bottom-left {
+    content: element(RunningImage);
+  }
+  @bottom-center {
+    content: element(RunningImage);
+  }
+  @bottom-right {
+    content: element(RunningImage);
+  }
+  @bottom-right-corner {
+    content: element(RunningImage);
+  }
+}
+
+@page text-and-running-element {
+  @top-left-corner {
+    content: "Text and " element(RunningImage);
+  }
+  @top-left {
+    content: "Text and " element(RunningImage);
+  }
+  @top-center {
+    content: "Text and " element(RunningImage);
+  }
+  @top-right {
+    content: "Text and " element(RunningImage);
+  }
+  @top-right-corner {
+    content: "Text and " element(RunningImage);
+  }
+  @left-top {
+    content: "Text and " element(RunningImage);
+  }
+  @left-middle {
+    content: "Text and " element(RunningImage);
+  }
+  @left-bottom {
+    content: "Text and " element(RunningImage);
+  }
+  @right-top {
+    content: "Text and " element(RunningImage);
+  }
+  @right-middle {
+    content: "Text and " element(RunningImage);
+  }
+  @right-bottom {
+    content: "Text and " element(RunningImage);
+  }
+  @bottom-left-corner {
+    content: "Text and " element(RunningImage);
+  }
+  @bottom-left {
+    content: "Text and " element(RunningImage);
+  }
+  @bottom-center {
+    content: "Text and " element(RunningImage);
+  }
+  @bottom-right {
+    content: "Text and " element(RunningImage);
+  }
+  @bottom-right-corner {
+    content: "Text and " element(RunningImage);
+  }
+}
+
+.single-image {
+  page: single-image;
+}
+
+.text-and-image {
+  page: text-and-image;
+}
+
+img.running {
+  position: running(RunningImage);
+  background: cyan;
+}
+
+img.block {
+  display: block;
+  background: orange;
+}
+
+.single-running-element {
+  page: single-running-element;
+}
+
+.text-and-running-element {
+  page: text-and-running-element;
+}
+
+pre {
+  white-space: pre-wrap;
+}
+
+    </style>
+  </head>
+  <body>
+    <h1>Page Margin Boxes</h1>
+    <section class="single-image">
+      <h2>Single Image</h2>
+      <pre>content: url(Image.png);</pre>
+    </section>
+    <section class="text-and-image">
+      <h2>Text and Image</h2>
+      <pre>content: "Text and " url(Image.png);</pre>
+    </section>
+    <section class="single-running-element">
+      <img class="running" src="https://vivliostyle.org/assets/vivliostyle-icon.png" alt="Image"/>
+      <h2>Single Running Element (image)</h2>
+      <pre>content: element(RunningImage);</pre>
+    </section>
+    <section class="text-and-running-element">
+      <h2>Text and Running Element (image)</h2>
+      <pre>content: "Text and " element(RunningImage);</pre>
+    </section>
+    <section class="single-running-element">
+      <img class="running block" src="https://vivliostyle.org/assets/vivliostyle-icon.png" alt="Image"/>
+      <h2>Single Running Element (block-level image)</h2>
+      <pre>content: element(RunningImage);</pre>
+    </section>
+    <section class="text-and-running-element">
+      <h2>Text and Running Element (block-level image)</h2>
+      <pre>content: "Text and " element(RunningImage);</pre>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/running-elements/running-elements.html
+++ b/packages/core/test/files/running-elements/running-elements.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Running elements - running() and element() functions</title>
+    <style>
+      @page {
+        size: 15cm 10cm;
+        margin: 1.5cm;
+        font-size: 80%;
+
+        @top-left {
+          content: "first: " element(heading, first);
+        }
+        @top-center {
+          content: "start: " element(heading, start);
+        }
+        @top-right {
+          content: "last: " element(heading, last);
+        }
+        @bottom-left {
+          content: "first-except: " element(heading, first-except);
+        }
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+        @bottom-right {
+          content: element(heading);
+        }
+      }
+
+      body {
+        margin: 0;
+      }
+
+      h2 {
+        color: navy;
+      }
+      em {
+        color: maroon;
+      }
+      h2.RE {
+        font-size: 1.2em;
+        display: inline;
+        position: running(heading);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Using Running Elements</h1>
+    <h2 class="RE">Heading <em>A</em></h2><h2>Heading <em>A</em></h2>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestias in,
+      provident quasi doloremque blanditiis itaque esse placeat maiores eveniet
+      ipsa dolores, harum alias expedita distinctio neque asperiores
+      accusantium, pariatur laboriosam. Deserunt accusamus corporis esse ex,
+      sunt sint voluptatibus asperiores iusto voluptas repellat molestiae quis
+      obcaecati?
+    </p>
+    <h2 class="RE">Heading <em>B</em></h2><h2>Heading <em>B</em></h2>
+    <p>
+      Quod distinctio iste dignissimos ullam perspiciatis numquam neque
+      recusandae corrupti, similique voluptatem dolore nulla itaque eveniet?
+      Delectus optio aliquam necessitatibus officiis eius!
+    </p>
+    <h2 class="RE">Heading <em>C</em></h2><h2>Heading <em>C</em></h2>
+    <p>
+      Autem perferendis voluptatibus, explicabo corporis doloremque ducimus
+      illum cupiditate quibusdam voluptatem totam optio debitis ipsam quaerat
+      consectetur dolores cum odio repellendus expedita! Quia et quo voluptate
+      obcaecati necessitatibus inventore aspernatur nesciunt minima.
+      Consectetur, voluptatem? Quam, doloribus animi porro veniam laudantium
+      numquam accusantium quos enim. Rerum aliquid aliquam perferendis
+      architecto autem laborum?
+    </p>
+    <h2 class="RE">Heading <em>D</em></h2><h2>Heading <em>D</em></h2>
+    <p>
+      A dignissimos asperiores fugiat, fugit dolore, harum dolorem deleniti
+      nulla nam, molestias dolorum error quos sapiente corrupti quidem! Nostrum
+      voluptatum sed blanditiis? Delectus, totam? Maxime qui perspiciatis
+      explicabo vel error distinctio sed doloremque rem vero dolorum, iure
+      itaque quia, dolor dignissimos.
+    </p>
+    <p>
+      Dolores, deleniti impedit! Atque autem omnis doloremque exercitationem.
+      Facilis nobis dolorum quia aut doloremque voluptate excepturi fuga hic
+      eius. Recusandae voluptates laboriosam exercitationem rem voluptatum?
+      Obcaecati distinctio doloribus impedit dignissimos porro quia, reiciendis
+      voluptatum ad eos. Id voluptatum soluta illo saepe repudiandae accusantium
+      voluptatibus ratione veniam molestiae?
+    </p>
+    <p>
+      Magnam perferendis tempora fuga molestiae quas, numquam cumque id porro
+      iure fugiat ipsum in enim facilis? Nobis, repellat. Facilis, consequatur
+      consectetur. Suscipit!
+    </p>
+    <p>
+      Autem porro maxime quod facilis numquam ducimus repellendus officiis
+      expedita dolore! Ipsam temporibus molestiae dolore assumenda beatae illo
+      dolorem quidem praesentium doloribus.
+    </p>
+    <p>
+      Lorem ipsum dolor sit amet consectetur, adipisicing elit. Amet accusamus
+      dolore libero, voluptas ullam ratione doloremque eius sunt iusto nam
+      perferendis ut? Ducimus facilis magnam hic ut cupiditate numquam ea.
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit. Rerum expedita
+      magnam, id vitae exercitationem enim voluptatibus quam quis aperiam
+      delectus non nobis fugiat quod earum ea. Fugit vero nulla magni?
+    </p>
+    <h2 class="RE">Heading <em>E</em></h2><h2>Heading <em>E</em></h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+    <h2 class="RE">Heading <em>F</em></h2><h2>Heading <em>F</em></h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+    <h2 class="RE">Heading <em>G</em></h2><h2>Heading <em>G</em></h2>
+    <h2 class="RE">Heading <em>H</em></h2><h2>Heading <em>H</em></h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+    <h2 class="RE">Heading <em>I</em></h2><h2>Heading <em>I</em></h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+    <h2 class="RE">Heading <em>J</em></h2><h2>Heading <em>J</em></h2>
+    <p>
+      Lorem ipsum dolor sit amet consectetur, adipisicing elit. Veniam
+      repellendus eum recusandae, nostrum, distinctio voluptates atque commodi
+      laboriosam fugiat, iure nobis laudantium ad iusto eveniet impedit. Iure
+      repellat voluptatem itaque!
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Spec: CSS Generated Content for Paged Media (GCPM) / §1.2 Running elements

- Working Draft: https://www.w3.org/TR/css-gcpm-3/#running-elements
- Editor's Draft: https://drafts.csswg.org/css-gcpm-3/#running-elements

resolves #424

----

This PR also contains fixes for related issues:

- #1174 
- #1176 
- #1177 

----

Added test files:

- [running-elements/running-elements.html: Running Elements - running() and element() functions](https://github.com/vivliostyle/vivliostyle.js/blob/d1926543904279f0d5277b108c9659d1b88686ad/packages/core/test/files/running-elements/running-elements.html)
- [running-elements/page-margin-boxes.html: Page Margin Boxes](https://github.com/vivliostyle/vivliostyle.js/blob/d1926543904279f0d5277b108c9659d1b88686ad/packages/core/test/files/running-elements/page-margin-boxes.html)