### PR TITLE
fix: Vivliostyle crashes with "Error: Function xxx is undefined"

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4727,9 +4727,13 @@ export class CalcFilterVisitor extends Css.FilterVisitor {
       "",
     );
     if (exprVal instanceof Css.Expr) {
-      const exprResult = exprVal.expr.evaluate(this.context);
-      if (typeof exprResult === "number") {
-        value = new Css.Numeric(exprResult, "px");
+      try {
+        const exprResult = exprVal.expr.evaluate(this.context);
+        if (typeof exprResult === "number") {
+          value = new Css.Numeric(exprResult, "px");
+        }
+      } catch (err) {
+        Logging.logger.warn(err);
       }
     }
     return value;


### PR DESCRIPTION
This error happens when property value has calc() function with unsupported expression, e.g., `calc(attr(data-position) * 20mm)`.