### PR TITLE
fix(viewer): marker edit menu closes unexpectedly when editing memo

### DIFF
--- a/packages/viewer/src/bindings/textSelection.ts
+++ b/packages/viewer/src/bindings/textSelection.ts
@@ -62,6 +62,13 @@ ko.bindingHandlers.textSelection = {
           return;
         }
         const range = selection.getRangeAt(0);
+        if (
+          !range.commonAncestorContainer.parentElement.closest(
+            "[data-vivliostyle-spread-container]",
+          )
+        ) {
+          return;
+        }
         const pageArea = range.commonAncestorContainer.parentElement.closest(
           "[data-vivliostyle-page-box] > div",
         ) as HTMLElement;


### PR DESCRIPTION
Fix the problem that marker edit menu closes unexpectedly with text selecting in memo text.

マーカー編集ボックスが編集中のメモのテキストを選択したとき（日本語入力での漢字変換でも）閉じてしまう不具合があったのを修正した。
