### PR TITLE
fix(viewer): tweak viewer UI style for mobile devices

### DIFF
--- a/packages/viewer/src/scss/ui.menu-bar.scss
+++ b/packages/viewer/src/scss/ui.menu-bar.scss
@@ -91,7 +91,6 @@
       float: right;
       margin-left: -7px;
       padding-right: 0;
-      z-index: 11;
     }
     > li.vivliostyle-menu-item {
       display: table-cell;
@@ -767,7 +766,7 @@
   #vivliostyle-find-box {
     flex: auto;
     background: white;
-    font-size: 14px;
+    font-size: 16px;
     line-height: 1;
     padding: 2px;
   }

--- a/packages/viewer/src/scss/ui.text-selection-menu.scss
+++ b/packages/viewer/src/scss/ui.text-selection-menu.scss
@@ -34,6 +34,9 @@
   textarea {
     font: inherit;
   }
+  textarea {
+    font-size: 16px;
+  }
   .viv-marker-color {
     box-sizing: content-box;
     padding: 2px;


### PR DESCRIPTION
Resolves the following problems:
- input box (esp. in text-selection-edit-menu and find-box) with font-size smaller than 16px causes problem on iPhone that it enlarges screen content when the input box gets focus.
- z-index on the settings menu botton should not be larger than find-box's z-index, because the ". . ." part of the settings menu button obstructs the find next button on small screen.