### PR TITLE
fix(viewer): selection highlighting problems on iOS

### DIFF
--- a/packages/viewer/src/viewmodels/marks-store.ts
+++ b/packages/viewer/src/viewmodels/marks-store.ts
@@ -195,8 +195,8 @@ const highlight = (
       div.style.position = "absolute";
       div.style.margin = "0";
       div.style.padding = "0";
-      div.style.top = `${rect.top + window.scrollY}px`;
-      div.style.left = `${rect.left + window.scrollX}px`;
+      div.style.top = `${rect.top}px`;
+      div.style.left = `${rect.left}px`;
       div.style.width = `${rect.width}px`;
       div.style.height = `${rect.height}px`;
       applyStyle(div, style);


### PR DESCRIPTION
This fixes the followintg problems that only occur on iOS (iPhone and iPad).

- marker highlighting position is wrongly shifted.
- highlighting of found text is not shown. This is due to the [WebKit Bug 199211 - Selection highlight not shown on programmatic focus after initial load](https://bugs.webkit.org/show_bug.cgi?id=199211)
- Find Next/Previous button clears the previous found position and cannot continue same text searching