### PR TITLE
fix(viewer): tweak viewer UI for mobile devices

### DIFF
--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -325,7 +325,7 @@
         </li>
         <li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_find-toggle" data-bind="css: {'vivliostyle-menu-disabled': navigation.isFindBoxDisabled, 'on': findBox.opened}, visible: !navigation.hideFind"><span role="button" class="vivliostyle-menu-icon-button" aria-keyshortcuts="Ctrl+F Meta+F" data-bind="click: findBox.toggle, menuButton: true, attr: {'aria-disabled': navigation.isFindBoxDisabled, 'aria-pressed': findBox.opened()?'true':'false', 'tabindex': !navigation.isFindBoxDisabled()?'0':false, title: t('TIP_Find')}"></span>
           <div id="vivliostyle-menu-find-box" aria-hidden="true" data-bind="attr: {'aria-hidden': !findBox.opened()?'true':'false'}">
-            <input id="vivliostyle-find-box" data-bind="textInput: findBox.text, attr: {'aria-disabled': navigation.isFindBoxDisabled, placeholder: t('Find')}" type="text"/>
+            <input id="vivliostyle-find-box" data-bind="textInput: findBox.text, attr: {'aria-disabled': navigation.isFindBoxDisabled, placeholder: t('Find')}" type="text" size="6"/>
             <span id="vivliostyle-find-status" data-bind="text: findBox.status"></span>
             <span id="vivliostyle-find-previous" role="button" aria-keyshortcuts="Shift+Enter" data-bind="menuButton: true, click: findBox.findPrevious, attr: {title: t('TIP_Find_Previous')}"></span>
             <span id="vivliostyle-find-next" role="button" aria-keyshortcuts="Enter" data-bind="menuButton: true, click: findBox.findNext, attr: {title: t('TIP_Find_Next')}"></span>

--- a/packages/viewer/src/scss/ui.menu-bar.scss
+++ b/packages/viewer/src/scss/ui.menu-bar.scss
@@ -91,6 +91,10 @@
       float: right;
       margin-left: -7px;
       padding-right: 0;
+      z-index: 11;
+    }
+    &#vivliostyle-menu_toc-find {
+      z-index: 12;
     }
     > li.vivliostyle-menu-item {
       display: table-cell;
@@ -404,7 +408,7 @@
         }
       }
       &#vivliostyle-menu-item_text-size-default {
-        @media screen and (max-width: ($menu-icon-width * 11 - 3px - 2px)) {
+        @media screen and (max-width: ($menu-icon-width * 11 - 3px)) {
           display: none;
         }
       }
@@ -761,6 +765,9 @@
   width: $menu-icon-width * 10;
   @media screen and (max-width: 450px) {
     width: 80vw;
+  }
+  @media screen and (max-width: 376px) {
+    width: calc(100vw - $menu-icon-offset-x - 2 * $menu-icon-width);
   }
 
   #vivliostyle-find-box {

--- a/packages/viewer/src/viewmodels/find-box.ts
+++ b/packages/viewer/src/viewmodels/find-box.ts
@@ -208,11 +208,8 @@ class FindBox {
     findBoxElem.style.visibility = "";
 
     if (found) {
-      if (
-        selection.anchorNode?.parentElement?.closest(
-          "[data-vivliostyle-page-container]",
-        )
-      ) {
+      // Check if the found range is in the page content excluding generated page margin box content.
+      if (selection.anchorNode?.parentElement?.closest("[data-adapt-eloff]")) {
         this.foundRange = selection.getRangeAt(0);
         this.fixHighlight();
         return true;

--- a/packages/viewer/src/viewmodels/navigation.ts
+++ b/packages/viewer/src/viewmodels/navigation.ts
@@ -339,7 +339,9 @@ class Navigation {
       const pageNumber = Number(this.pageNumber());
       if (this.viewer.lastPage()) {
         totalPages = pageNumber;
-      } else if (pageNumber >= totalPages) {
+      } else if (pageNumber > totalPages) {
+        totalPages = pageNumber;
+      } else if (pageNumber == totalPages) {
         totalPages++;
       }
       return totalPages;
@@ -347,7 +349,14 @@ class Navigation {
 
     this.pageSlider = ko.pureComputed({
       read() {
-        return this.pageNumber();
+        const pageNumber = Number(this.pageNumber());
+        const pageSliderElem = document.getElementById(
+          "vivliostyle-page-slider",
+        ) as HTMLInputElement;
+        if (Number(pageSliderElem.max) < pageNumber) {
+          pageSliderElem.max = String(pageNumber);
+        }
+        return pageNumber;
       },
       write(pageNumberText: number | string) {
         if (this.viewerOptions.renderAllPages()) {


### PR DESCRIPTION
Resolves the following problems:

- Page slider knob position may be incorrect when reloaded.
- Menu bar icons and the logo icon (settings button) may overlap in small screen.
- The find box may overflow the screen when "Not Found".
- Text Find should exclude generated page margin box content