### PR TITLE
feat: Update CSS text-spacing-trim property to support the latest spec change

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1157,6 +1157,7 @@ html|kbd,
 html|samp {
   font-family: monospace;
   text-spacing: none;
+  hanging-punctuation: none;
 }
 html|pre {
   white-space: pre;

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -527,7 +527,7 @@ overflow-wrap = normal | break-word | anywhere;
 [moz]text-align-last = auto | start | end | left | right | center | justify;
 text-justify = auto | none | inter-word | inter-character;
 word-break = normal | keep-all | break-all | break-word;
-text-spacing-trim = auto | space-all | trim-auto |
+text-spacing-trim = auto | normal | space-all | trim-auto |
     [[ trim-start | space-start | space-first ] ||
      [ trim-end | space-end | allow-end ] ||
      [ trim-adjacent | space-adjacent ]];
@@ -720,7 +720,7 @@ padding-top: auto;
 text-autospace: normal;
 text-emphasis-color: currentColor;
 text-emphasis-style: none;
-text-spacing-trim: space-first;
+text-spacing-trim: normal;
 text-stroke-color: currentColor;
 text-stroke-width: 0;
 marker-start: none;

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -110,14 +110,14 @@ const SPACING_TRIM_NONE: SpacingTrim = {
 };
 
 /**
- * text-spacing-trim: space-first (normal)
- * space-first (normal) = space-first trim-end trim-adjacent
+ * text-spacing-trim: normal
+ * normal = space-start allow-end trim-adjacent
  */
 const SPACING_TRIM_NORMAL: SpacingTrim = {
-  trimStart: true,
-  spaceFirst: true,
+  trimStart: false,
+  spaceFirst: false,
   trimEnd: true,
-  allowEnd: false,
+  allowEnd: true,
   trimAdjacent: true,
 };
 
@@ -151,7 +151,7 @@ function spacingTrimFromPropertyValue(value: PropertyValue): SpacingTrim {
     return SPACING_TRIM_AUTO;
   }
   const values = cssval instanceof Css.SpaceList ? cssval.values : [cssval];
-  const textSpacing: SpacingTrim = Object.create(SPACING_TRIM_AUTO);
+  const textSpacing: SpacingTrim = Object.create(SPACING_TRIM_NORMAL);
 
   for (const val of values) {
     if (val instanceof Css.Ident) {

--- a/packages/core/test/files/text-spacing/hanging-punctuation-first-indent-ja.html
+++ b/packages/core/test/files/text-spacing/hanging-punctuation-first-indent-ja.html
@@ -1,53 +1,125 @@
 <!DOCTYPE html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <title>hanging-punctuation:first with text-indent (Japanese)</title>
-  <style>
-    @page {
-      @bottom-center {
-        content: "Page " counter(page);
+  <head>
+    <meta charset="UTF-8" />
+    <title>hanging-punctuation:first with text-indent (Japanese)</title>
+    <style>
+      @page {
+        @bottom-center {
+          content: "Page " counter(page);
+        }
       }
-    }
-    p {
-      margin: 0;
-      text-align: justify;
-    }
-    .indent p {
-      text-indent: 1em;
-    }
-    .hang-first p {
-      hanging-punctuation: first;
-    }
-    code {
-      background: lavender;
-      padding-block: 0.125em;
-      padding-inline: 0.25em;
-    }
-  </style>
-</head>
-<body>
-  <h1>日本語組版での段落字下げ</h1>
-  <section class="indent hang-first">
-    <h2>text-indent: 1em; hanging-punctuation: first;</h2>
-    <p>日本語組版では段落先頭を全角1字分字下げするのが標準的である。これはCSSの<code>text-indent: 1em</code>で実現される。この段落の先頭も、そのように字下げされているはず。</p>
-    <p>「開き括弧類」で段落がはじまる場合、全角幅の字下げをしないでそのまま全角幅の開き括弧類で始まる（あるいは半角幅だけ字下げして半角幅の開き括弧類で始まるともいえる）スタイルが書籍などでは一般的である。CSSではこれを<code>text-indent: 1em</code>での段落字下げと<code>hanging-punctuation: first</code>による段落先頭の開き括弧類の突き出しで実現する。</p>
-    <p>　しかし、これまでのCSSでhanging-punctuationプロパティが使えなかったため、日本語のEPUBコンテンツなどでは、段落字下げにtext-indentを使わないで、その代わりに、開き括弧類で開始する場合を除いて段落先頭に〈全角スペース〉（U+3000）を入れて段落字下げの形にしていることが多い。ためしに、この段落の先頭も〈全角スペース〉を入れている。このように〈全角スペース〉が使われているときCSSで<code>text-indent: 1em</code>を指定したら段落字下げの幅が2倍になってしまうのでは問題だ。そこで、<code>hanging-punctuation: first</code>では〈全角スペース〉も突き出しの対象とし、行頭に吸収されて<code>text-indent: 1em</code>での字下げだけが効果を持つようになっている。</p>
-    <p>　「この先頭のカギ括弧の前に〈全角スペース〉（U+3000）が入ってる」というような場合、<code>text-indent: 1em</code>と<code>hanging-punctuation: first</code>の指定があると、text-indentによる字下げのスペースに〈全角スペース〉が収まり、また〈全角スペース〉と全角開き括弧類はtext-spacingのデフォルト（normalの定義に含まれるtrim-adjacentの処理）によって半角幅だけ詰められるので、全角幅の字下げと半角幅の開き括弧類で段落が始まるように見えるはずである。</p>
-  </section>
-  <section class="indent">
-    <h2>text-indent: 1em; (no hanging-punctuation)</h2>
-    <p>日本語組版では段落先頭を全角1字分字下げするのが標準的である。これはCSSの<code>text-indent: 1em</code>で実現される。この段落の先頭も、そのように字下げされているはず。</p>
-    <p>「開き括弧類」で段落がはじまる場合、全角幅の字下げをしないでそのまま全角幅の開き括弧類で始まる（あるいは半角幅だけ字下げして半角幅の開き括弧類で始まるともいえる）スタイルが書籍などでは一般的である。CSSではこれを<code>text-indent: 1em</code>での段落字下げと<code>hanging-punctuation: first</code>による段落先頭の開き括弧類の突き出しで実現する。</p>
-    <p>　しかし、これまでのCSSでhanging-punctuationプロパティが使えなかったため、日本語のEPUBコンテンツなどでは、段落字下げにtext-indentを使わないで、その代わりに、開き括弧類で開始する場合を除いて段落先頭に〈全角スペース〉（U+3000）を入れて段落字下げの形にしていることが多い。ためしに、この段落の先頭も〈全角スペース〉を入れている。このように〈全角スペース〉が使われているときCSSで<code>text-indent: 1em</code>を指定したら段落字下げの幅が2倍になってしまうのでは問題だ。そこで、<code>hanging-punctuation: first</code>では〈全角スペース〉も突き出しの対象とし、行頭に吸収されて<code>text-indent: 1em</code>での字下げだけが効果を持つようになっている。</p>
-    <p>　「この先頭のカギ括弧の前に〈全角スペース〉（U+3000）が入ってる」というような場合、<code>text-indent: 1em</code>と<code>hanging-punctuation: first</code>の指定があると、text-indentによる字下げのスペースに〈全角スペース〉が収まり、また〈全角スペース〉と全角開き括弧類はtext-spacingのデフォルト（normalの定義に含まれるtrim-adjacentの処理）によって半角幅だけ詰められるので、全角幅の字下げと半角幅の開き括弧類で段落が始まるように見えるはずである。</p>
-  </section>
-  <section class="">
-    <h2>(no text-indent; no hanging-punctuation)</h2>
-    <p>日本語組版では段落先頭を全角1字分字下げするのが標準的である。これはCSSの<code>text-indent: 1em</code>で実現される。この段落の先頭も、そのように字下げされているはず。</p>
-    <p>「開き括弧類」で段落がはじまる場合、全角幅の字下げをしないでそのまま全角幅の開き括弧類で始まる（あるいは半角幅だけ字下げして半角幅の開き括弧類で始まるともいえる）スタイルが書籍などでは一般的である。CSSではこれを<code>text-indent: 1em</code>での段落字下げと<code>hanging-punctuation: first</code>による段落先頭の開き括弧類の突き出しで実現する。</p>
-    <p>　しかし、これまでのCSSでhanging-punctuationプロパティが使えなかったため、日本語のEPUBコンテンツなどでは、段落字下げにtext-indentを使わないで、その代わりに、開き括弧類で開始する場合を除いて段落先頭に〈全角スペース〉（U+3000）を入れて段落字下げの形にしていることが多い。ためしに、この段落の先頭も〈全角スペース〉を入れている。このように〈全角スペース〉が使われているときCSSで<code>text-indent: 1em</code>を指定したら段落字下げの幅が2倍になってしまうのでは問題だ。そこで、<code>hanging-punctuation: first</code>では〈全角スペース〉も突き出しの対象とし、行頭に吸収されて<code>text-indent: 1em</code>での字下げだけが効果を持つようになっている。</p>
-    <p>　「この先頭のカギ括弧の前に〈全角スペース〉（U+3000）が入ってる」というような場合、<code>text-indent: 1em</code>と<code>hanging-punctuation: first</code>の指定があると、text-indentによる字下げのスペースに〈全角スペース〉が収まり、また〈全角スペース〉と全角開き括弧類はtext-spacingのデフォルト（normalの定義に含まれるtrim-adjacentの処理）によって半角幅だけ詰められるので、全角幅の字下げと半角幅の開き括弧類で段落が始まるように見えるはずである。</p>
-  </section>
-</body>
+      p {
+        margin: 0;
+        text-align: justify;
+        text-spacing-trim: space-first;
+      }
+      .indent p {
+        text-indent: 1em;
+      }
+      .hang-first p {
+        hanging-punctuation: first;
+      }
+      code {
+        background: lavender;
+        padding-block: 0.125em;
+        padding-inline: 0.25em;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>日本語組版での段落字下げ</h1>
+    <p>
+      （以下のテストすべてで折り返し行頭約物を詰める<code
+        >text-spacing-trim: space-first</code
+      >の指定あり）
+    </p>
+    <section class="indent hang-first">
+      <h2>text-indent: 1em; hanging-punctuation: first;</h2>
+      <p>
+        日本語組版では段落先頭を全角1字分字下げするのが標準的である。これはCSSの<code
+          >text-indent: 1em</code
+        >で実現される。この段落の先頭も、そのように字下げされているはず。
+      </p>
+      <p>
+        「開き括弧類」で段落がはじまる場合、全角幅の字下げをしないでそのまま全角幅の開き括弧類で始まる（あるいは半角幅だけ字下げして半角幅の開き括弧類で始まるともいえる）スタイルが書籍などでは一般的である。CSSではこれを<code
+          >text-indent: 1em</code
+        >での段落字下げと<code>hanging-punctuation: first</code
+        >による段落先頭の開き括弧類の突き出しで実現する。
+      </p>
+      <p>
+        　しかし、これまでのCSSでhanging-punctuationプロパティが使えなかったため、日本語のEPUBコンテンツなどでは、段落字下げにtext-indentを使わないで、その代わりに、開き括弧類で開始する場合を除いて段落先頭に〈全角スペース〉（U+3000）を入れて段落字下げの形にしていることが多い。ためしに、この段落の先頭も〈全角スペース〉を入れている。このように〈全角スペース〉が使われているときCSSで<code
+          >text-indent: 1em</code
+        >を指定したら段落字下げの幅が2倍になってしまうのでは問題だ。そこで、<code
+          >hanging-punctuation: first</code
+        >では〈全角スペース〉も突き出しの対象とし、行頭に吸収されて<code
+          >text-indent: 1em</code
+        >での字下げだけが効果を持つようになっている。
+      </p>
+      <p>
+        　「この先頭のカギ括弧の前に〈全角スペース〉（U+3000）が入ってる」というような場合、<code
+          >text-indent: 1em</code
+        >と<code>hanging-punctuation: first</code
+        >の指定があると、text-indentによる字下げのスペースに〈全角スペース〉が収まり、また〈全角スペース〉と全角開き括弧類はtext-spacingのデフォルト（normalの定義に含まれるtrim-adjacentの処理）によって半角幅だけ詰められるので、全角幅の字下げと半角幅の開き括弧類で段落が始まるように見えるはずである。
+      </p>
+    </section>
+    <section class="indent">
+      <h2>text-indent: 1em; (no hanging-punctuation)</h2>
+      <p>
+        日本語組版では段落先頭を全角1字分字下げするのが標準的である。これはCSSの<code
+          >text-indent: 1em</code
+        >で実現される。この段落の先頭も、そのように字下げされているはず。
+      </p>
+      <p>
+        「開き括弧類」で段落がはじまる場合、全角幅の字下げをしないでそのまま全角幅の開き括弧類で始まる（あるいは半角幅だけ字下げして半角幅の開き括弧類で始まるともいえる）スタイルが書籍などでは一般的である。CSSではこれを<code
+          >text-indent: 1em</code
+        >での段落字下げと<code>hanging-punctuation: first</code
+        >による段落先頭の開き括弧類の突き出しで実現する。
+      </p>
+      <p>
+        　しかし、これまでのCSSでhanging-punctuationプロパティが使えなかったため、日本語のEPUBコンテンツなどでは、段落字下げにtext-indentを使わないで、その代わりに、開き括弧類で開始する場合を除いて段落先頭に〈全角スペース〉（U+3000）を入れて段落字下げの形にしていることが多い。ためしに、この段落の先頭も〈全角スペース〉を入れている。このように〈全角スペース〉が使われているときCSSで<code
+          >text-indent: 1em</code
+        >を指定したら段落字下げの幅が2倍になってしまうのでは問題だ。そこで、<code
+          >hanging-punctuation: first</code
+        >では〈全角スペース〉も突き出しの対象とし、行頭に吸収されて<code
+          >text-indent: 1em</code
+        >での字下げだけが効果を持つようになっている。
+      </p>
+      <p>
+        　「この先頭のカギ括弧の前に〈全角スペース〉（U+3000）が入ってる」というような場合、<code
+          >text-indent: 1em</code
+        >と<code>hanging-punctuation: first</code
+        >の指定があると、text-indentによる字下げのスペースに〈全角スペース〉が収まり、また〈全角スペース〉と全角開き括弧類はtext-spacingのデフォルト（normalの定義に含まれるtrim-adjacentの処理）によって半角幅だけ詰められるので、全角幅の字下げと半角幅の開き括弧類で段落が始まるように見えるはずである。
+      </p>
+    </section>
+    <section class="">
+      <h2>(no text-indent; no hanging-punctuation)</h2>
+      <p>
+        日本語組版では段落先頭を全角1字分字下げするのが標準的である。これはCSSの<code
+          >text-indent: 1em</code
+        >で実現される。この段落の先頭も、そのように字下げされているはず。
+      </p>
+      <p>
+        「開き括弧類」で段落がはじまる場合、全角幅の字下げをしないでそのまま全角幅の開き括弧類で始まる（あるいは半角幅だけ字下げして半角幅の開き括弧類で始まるともいえる）スタイルが書籍などでは一般的である。CSSではこれを<code
+          >text-indent: 1em</code
+        >での段落字下げと<code>hanging-punctuation: first</code
+        >による段落先頭の開き括弧類の突き出しで実現する。
+      </p>
+      <p>
+        　しかし、これまでのCSSでhanging-punctuationプロパティが使えなかったため、日本語のEPUBコンテンツなどでは、段落字下げにtext-indentを使わないで、その代わりに、開き括弧類で開始する場合を除いて段落先頭に〈全角スペース〉（U+3000）を入れて段落字下げの形にしていることが多い。ためしに、この段落の先頭も〈全角スペース〉を入れている。このように〈全角スペース〉が使われているときCSSで<code
+          >text-indent: 1em</code
+        >を指定したら段落字下げの幅が2倍になってしまうのでは問題だ。そこで、<code
+          >hanging-punctuation: first</code
+        >では〈全角スペース〉も突き出しの対象とし、行頭に吸収されて<code
+          >text-indent: 1em</code
+        >での字下げだけが効果を持つようになっている。
+      </p>
+      <p>
+        　「この先頭のカギ括弧の前に〈全角スペース〉（U+3000）が入ってる」というような場合、<code
+          >text-indent: 1em</code
+        >と<code>hanging-punctuation: first</code
+        >の指定があると、text-indentによる字下げのスペースに〈全角スペース〉が収まり、また〈全角スペース〉と全角開き括弧類はtext-spacingのデフォルト（normalの定義に含まれるtrim-adjacentの処理）によって半角幅だけ詰められるので、全角幅の字下げと半角幅の開き括弧類で段落が始まるように見えるはずである。
+      </p>
+    </section>
+  </body>
 </html>

--- a/packages/core/test/files/text-spacing/text-spacing-ja.html
+++ b/packages/core/test/files/text-spacing/text-spacing-ja.html
@@ -1,107 +1,143 @@
 <!DOCTYPE html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <title>text-spacingテスト</title>
-  <style>
-    p {
-      border: 1px solid silver;
-      text-align: justify;
-    }
-    b {
-      font-weight: bold;
-      color: maroon;
-    }
-    i {
-      font-style: normal;
-      font-size: 80%;
-      color: navy;
-    }
-    #test-ts-none {
-      text-spacing: none;
-    }
-    #test-ts-normal {
-      text-spacing: normal;
-    }
-    #test-ts-auto {
-      text-spacing: auto;
-    }
-    #test-ts-trim-auto {
-      text-spacing: trim-auto;
-    }
-    #test-ts-space-first {
-      text-spacing: space-first;
-    }
-    #test-ts-allow-end {
-      text-spacing: allow-end;
-    }
-    #test-ts-space-first-allow-end {
-      text-spacing: space-first allow-end;
-    }
-    #test-ts-space-all {
-      text-spacing: space-all;
-    }
-    #test-ts-ideograph-alpha {
-      text-spacing: ideograph-alpha;
-    }
-    #test-ts-ideograph-numeric {
-      text-spacing: ideograph-numeric;
-    }
-    #test-ts-no-autospace {
-      text-spacing: no-autospace;
-    }
-  </style>
-</head>
-<body>
-  <h1>文字組版用CSSプロパティ、「text-spacing」テスト</h1>
-  <section id="test-ts-default">
-    <h2>default</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-none">
-    <h2>text-spacing: none</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-normal">
-    <h2>text-spacing: normal</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-auto">
-    <h2>text-spacing: auto</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-trim-auto">
-    <h2>text-spacing: trim-auto</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-space-first">
-    <h2>text-spacing: space-first</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-allow-end">
-    <h2>text-spacing: allow-end</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-space-first-allow-end">
-    <h2>text-spacing: space-first allow-end</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-space-all">
-    <h2>text-spacing: space-all</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-ideograph-alpha">
-    <h2>text-spacing: ideograph-alpha</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-ideograph-numeric">
-    <h2>text-spacing: ideograph-numeric</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-  <section id="test-ts-no-autospace">
-    <h2>text-spacing: no-autospace</h2>
-    <p>〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b></p>
-  </section>
-
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>text-spacingテスト</title>
+    <style>
+      p {
+        border: 1px solid silver;
+        text-align: justify;
+      }
+      b {
+        font-weight: bold;
+        color: maroon;
+      }
+      i {
+        font-style: normal;
+        font-size: 80%;
+        color: navy;
+      }
+      #test-ts-none {
+        text-spacing: none;
+      }
+      #test-ts-normal {
+        text-spacing: normal;
+      }
+      #test-ts-auto {
+        text-spacing: auto;
+      }
+      #test-ts-trim-auto {
+        text-spacing: trim-auto;
+      }
+      #test-ts-trim-start {
+        text-spacing: trim-start;
+      }
+      #test-ts-space-first {
+        text-spacing: space-first;
+      }
+      #test-ts-space-all {
+        text-spacing: space-all;
+      }
+      #test-ts-ideograph-alpha {
+        text-spacing: ideograph-alpha;
+      }
+      #test-ts-ideograph-numeric {
+        text-spacing: ideograph-numeric;
+      }
+      #test-ts-no-autospace {
+        text-spacing: no-autospace;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>文字組版用CSSプロパティ、「text-spacing」テスト</h1>
+    <section id="test-ts-default">
+      <h2>default</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-none">
+      <h2>text-spacing: none</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-normal">
+      <h2>text-spacing: normal</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-auto">
+      <h2>text-spacing: auto</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-trim-auto">
+      <h2>text-spacing: trim-auto</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-trim-start">
+      <h2>text-spacing: trim-start</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-space-first">
+      <h2>text-spacing: space-first</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-space-all">
+      <h2>text-spacing: space-all</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-ideograph-alpha">
+      <h2>text-spacing: ideograph-alpha</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-ideograph-numeric">
+      <h2>text-spacing: ideograph-numeric</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-no-autospace">
+      <h2>text-spacing: no-autospace</h2>
+      <p>
+        〈約物〉は、〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123とか。」〈約物〉は、<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>とか。」</b
+        >
+      </p>
+    </section>
+  </body>
 </html>

--- a/packages/core/test/files/text-spacing/text-spacing-zh-hans.html
+++ b/packages/core/test/files/text-spacing/text-spacing-zh-hans.html
@@ -1,107 +1,143 @@
 <!DOCTYPE html>
 <html lang="zh-hans">
-<head>
-  <meta charset="UTF-8">
-  <title>text-spacing测试</title>
-  <style>
-    p {
-      border: 1px solid silver;
-      text-align: justify;
-    }
-    b {
-      font-weight: bold;
-      color: maroon;
-    }
-    i {
-      font-style: normal;
-      font-size: 80%;
-      color: navy;
-    }
-    #test-ts-none {
-      text-spacing: none;
-    }
-    #test-ts-normal {
-      text-spacing: normal;
-    }
-    #test-ts-auto {
-      text-spacing: auto;
-    }
-    #test-ts-trim-auto {
-      text-spacing: trim-auto;
-    }
-    #test-ts-space-first {
-      text-spacing: space-first;
-    }
-    #test-ts-allow-end {
-      text-spacing: allow-end;
-    }
-    #test-ts-space-first-allow-end {
-      text-spacing: space-first allow-end;
-    }
-    #test-ts-space-all {
-      text-spacing: space-all;
-    }
-    #test-ts-ideograph-alpha {
-      text-spacing: ideograph-alpha;
-    }
-    #test-ts-ideograph-numeric {
-      text-spacing: ideograph-numeric;
-    }
-    #test-ts-no-autospace {
-      text-spacing: no-autospace;
-    }
-  </style>
-</head>
-<body>
-  <h1>排版的CSS属性，「text-spacing」测试</h1>
-  <section id="test-ts-default">
-    <h2>default</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-none">
-    <h2>text-spacing: none</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-normal">
-    <h2>text-spacing: normal</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-auto">
-    <h2>text-spacing: auto</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-trim-auto">
-    <h2>text-spacing: trim-auto</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-space-first">
-    <h2>text-spacing: space-first</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-allow-end">
-    <h2>text-spacing: allow-end</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-space-first-allow-end">
-    <h2>text-spacing: space-first allow-end</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-space-all">
-    <h2>text-spacing: space-all</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-ideograph-alpha">
-    <h2>text-spacing: ideograph-alpha</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-ideograph-numeric">
-    <h2>text-spacing: ideograph-numeric</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-no-autospace">
-    <h2>text-spacing: no-autospace</h2>
-    <p>〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>text-spacing测试</title>
+    <style>
+      p {
+        border: 1px solid silver;
+        text-align: justify;
+      }
+      b {
+        font-weight: bold;
+        color: maroon;
+      }
+      i {
+        font-style: normal;
+        font-size: 80%;
+        color: navy;
+      }
+      #test-ts-none {
+        text-spacing: none;
+      }
+      #test-ts-normal {
+        text-spacing: normal;
+      }
+      #test-ts-auto {
+        text-spacing: auto;
+      }
+      #test-ts-trim-auto {
+        text-spacing: trim-auto;
+      }
+      #test-ts-trim-start {
+        text-spacing: trim-start;
+      }
+      #test-ts-space-first {
+        text-spacing: space-first;
+      }
+      #test-ts-space-all {
+        text-spacing: space-all;
+      }
+      #test-ts-ideograph-alpha {
+        text-spacing: ideograph-alpha;
+      }
+      #test-ts-ideograph-numeric {
+        text-spacing: ideograph-numeric;
+      }
+      #test-ts-no-autospace {
+        text-spacing: no-autospace;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>排版的CSS属性，「text-spacing」测试</h1>
+    <section id="test-ts-default">
+      <h2>default</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-none">
+      <h2>text-spacing: none</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-normal">
+      <h2>text-spacing: normal</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-auto">
+      <h2>text-spacing: auto</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-trim-auto">
+      <h2>text-spacing: trim-auto</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-trim-start">
+      <h2>text-spacing: trim-start</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-space-first">
+      <h2>text-spacing: space-first</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-space-all">
+      <h2>text-spacing: space-all</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-ideograph-alpha">
+      <h2>text-spacing: ideograph-alpha</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-ideograph-numeric">
+      <h2>text-spacing: ideograph-numeric</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-no-autospace">
+      <h2>text-spacing: no-autospace</h2>
+      <p>
+        〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+  </body>
 </html>

--- a/packages/core/test/files/text-spacing/text-spacing-zh-hant.html
+++ b/packages/core/test/files/text-spacing/text-spacing-zh-hant.html
@@ -1,107 +1,143 @@
 <!DOCTYPE html>
 <html lang="zh-hant">
-<head>
-  <meta charset="UTF-8">
-  <title>text-spacing測試</title>
-  <style>
-    p {
-      border: 1px solid silver;
-      text-align: justify;
-    }
-    b {
-      font-weight: bold;
-      color: maroon;
-    }
-    i {
-      font-style: normal;
-      font-size: 80%;
-      color: navy;
-    }
-    #test-ts-none {
-      text-spacing: none;
-    }
-    #test-ts-normal {
-      text-spacing: normal;
-    }
-    #test-ts-auto {
-      text-spacing: auto;
-    }
-    #test-ts-trim-auto {
-      text-spacing: trim-auto;
-    }
-    #test-ts-space-first {
-      text-spacing: space-first;
-    }
-    #test-ts-allow-end {
-      text-spacing: allow-end;
-    }
-    #test-ts-space-first-allow-end {
-      text-spacing: space-first allow-end;
-    }
-    #test-ts-space-all {
-      text-spacing: space-all;
-    }
-    #test-ts-ideograph-alpha {
-      text-spacing: ideograph-alpha;
-    }
-    #test-ts-ideograph-numeric {
-      text-spacing: ideograph-numeric;
-    }
-    #test-ts-no-autospace {
-      text-spacing: no-autospace;
-    }
-  </style>
-</head>
-<body>
-  <h1>排版的CSS属性，「text-spacing」測試</h1>
-  <section id="test-ts-default">
-    <h2>default</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-none">
-    <h2>text-spacing: none</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-normal">
-    <h2>text-spacing: normal</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-auto">
-    <h2>text-spacing: auto</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-trim-auto">
-    <h2>text-spacing: trim-auto</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-space-first">
-    <h2>text-spacing: space-first</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-allow-end">
-    <h2>text-spacing: allow-end</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-space-first-allow-end">
-    <h2>text-spacing: space-first allow-end</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-space-all">
-    <h2>text-spacing: space-all</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-ideograph-alpha">
-    <h2>text-spacing: ideograph-alpha</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-ideograph-numeric">
-    <h2>text-spacing: ideograph-numeric</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-  <section id="test-ts-no-autospace">
-    <h2>text-spacing: no-autospace</h2>
-    <p>〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b>「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b></p>
-  </section>
-
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>text-spacing測試</title>
+    <style>
+      p {
+        border: 1px solid silver;
+        text-align: justify;
+      }
+      b {
+        font-weight: bold;
+        color: maroon;
+      }
+      i {
+        font-style: normal;
+        font-size: 80%;
+        color: navy;
+      }
+      #test-ts-none {
+        text-spacing: none;
+      }
+      #test-ts-normal {
+        text-spacing: normal;
+      }
+      #test-ts-auto {
+        text-spacing: auto;
+      }
+      #test-ts-trim-auto {
+        text-spacing: trim-auto;
+      }
+      #test-ts-trim-start {
+        text-spacing: trim-start;
+      }
+      #test-ts-space-first {
+        text-spacing: space-first;
+      }
+      #test-ts-space-all {
+        text-spacing: space-all;
+      }
+      #test-ts-ideograph-alpha {
+        text-spacing: ideograph-alpha;
+      }
+      #test-ts-ideograph-numeric {
+        text-spacing: ideograph-numeric;
+      }
+      #test-ts-no-autospace {
+        text-spacing: no-autospace;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>排版的CSS属性，「text-spacing」測試</h1>
+    <section id="test-ts-default">
+      <h2>default</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-none">
+      <h2>text-spacing: none</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-normal">
+      <h2>text-spacing: normal</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-auto">
+      <h2>text-spacing: auto</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-trim-auto">
+      <h2>text-spacing: trim-auto</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-trim-start">
+      <h2>text-spacing: trim-start</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-space-first">
+      <h2>text-spacing: space-first</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-space-all">
+      <h2>text-spacing: space-all</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-ideograph-alpha">
+      <h2>text-spacing: ideograph-alpha</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-ideograph-numeric">
+      <h2>text-spacing: ideograph-numeric</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+    <section id="test-ts-no-autospace">
+      <h2>text-spacing: no-autospace</h2>
+      <p>
+        〈標點符號〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈標點符號〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+          >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+        >
+      </p>
+    </section>
+  </body>
 </html>

--- a/packages/core/test/files/text-spacing/ts-hp-allow-force-end.html
+++ b/packages/core/test/files/text-spacing/ts-hp-allow-force-end.html
@@ -1,76 +1,93 @@
 <!DOCTYPE html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <title>Text-spacing &amp; hanging-punctuation allow/force-end test</title>
-  <style>
-    h2 {
-      margin: 0;
-    }
-    p {
-      border: 1px solid silver;
-      text-align: justify;
-      inline-size: 20em;
-      margin-inline-start: 1em;
-      margin-inline-end: 1em;
-    }
-    .ts-none {
-      text-spacing: none;
-    }
-    .ts-allow-end {
-      text-spacing: allow-end;
-    }
-    .ts-trim-end {
-      text-spacing: trim-end;
-    }
-    .hp-none {
-      hanging-punctuation: none;
-    }
-    .hp-allow-end {
-      hanging-punctuation: allow-end;
-    }
-    .hp-force-end {
-      hanging-punctuation: force-end;
-    }
-  </style>
-</head>
-<body>
-  <section class="ts-none hp-none">
-    <h2>text-spacing: none; hanging-punctuation: none</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-none hp-allow-end">
-    <h2>text-spacing: none; hanging-punctuation: allow-end</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-none hp-force-end">
-    <h2>text-spacing: none; hanging-punctuation: force-end</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-allow-end hp-none">
-    <h2>text-spacing: allow-end; hanging-punctuation: none</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-allow-end hp-allow-end">
-    <h2>text-spacing: allow-end; hanging-punctuation: allow-end</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-allow-end hp-force-end">
-    <h2>text-spacing: allow-end; hanging-punctuation: force-end</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-trim-end hp-none">
-    <h2>text-spacing: trim-end; hanging-punctuation: none</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-trim-end hp-allow-end">
-    <h2>text-spacing: trim-end; hanging-punctuation: allow-end</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-  <section class="ts-trim-end hp-force-end">
-    <h2>text-spacing: trim-end; hanging-punctuation: force-end</h2>
-    <p>一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br>一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。</p>
-  </section>
-
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Text-spacing &amp; hanging-punctuation allow/force-end test</title>
+    <style>
+      h2 {
+        margin: 0;
+      }
+      p {
+        border: 1px solid silver;
+        text-align: justify;
+        inline-size: 20em;
+        margin-inline-start: 1em;
+        margin-inline-end: 1em;
+      }
+      .ts-none {
+        text-spacing: none;
+      }
+      .ts-allow-end {
+        text-spacing: normal;
+      }
+      .ts-trim-end {
+        text-spacing: trim-auto;
+      }
+      .hp-none {
+        hanging-punctuation: none;
+      }
+      .hp-allow-end {
+        hanging-punctuation: allow-end;
+      }
+      .hp-force-end {
+        hanging-punctuation: force-end;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="ts-none hp-none">
+      <h2>text-spacing: none; hanging-punctuation: none</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-none hp-allow-end">
+      <h2>text-spacing: none; hanging-punctuation: allow-end</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-none hp-force-end">
+      <h2>text-spacing: none; hanging-punctuation: force-end</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-allow-end hp-none">
+      <h2>text-spacing: normal; hanging-punctuation: none</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-allow-end hp-allow-end">
+      <h2>text-spacing: normal; hanging-punctuation: allow-end</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-allow-end hp-force-end">
+      <h2>text-spacing: normal; hanging-punctuation: force-end</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-trim-end hp-none">
+      <h2>text-spacing: trim-auto; hanging-punctuation: none</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-trim-end hp-allow-end">
+      <h2>text-spacing: trim-auto; hanging-punctuation: allow-end</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+    <section class="ts-trim-end hp-force-end">
+      <h2>text-spacing: trim-auto; hanging-punctuation: force-end</h2>
+      <p>
+        一二三四五六七八九十一二三四五六七八九、一二三四五六七八九十一二三四五六七八九十。<br />一二三四五六七八九十一二三四五六七八九!、一二三四五六七八九十。
+      </p>
+    </section>
+  </body>
 </html>


### PR DESCRIPTION
supports the latest CSS text-spacing-trim property spec. https://drafts.csswg.org/css-text-4/#text-spacing-trim-property (except the `trim-all` value)

- resolves #1244 
  See this issue for details.

- also fixes #1251

