### PR TITLE
fix: remove ruby font-size workaround no longer necessary

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -44,12 +44,6 @@ export function calculateEdge(
 
   const element = node.nodeType === 1 ? (node as Element) : node.parentElement;
   if (element && element.namespaceURI === Base.NS.XHTML) {
-    if (element.localName === "rt" && (element as HTMLElement).style["zoom"]) {
-      // "zoom" is set in fixRubyTextFontSize() to fix the issue #673 for Chrome.
-      // when zoom is set, it is hard to get the edge value, so return NaN.
-      // (Fix for issues #804 and #808)
-      return NaN;
-    }
     if (
       /^([\d\.]|super|(text-)?top)/.test(
         (element as HTMLElement).style.verticalAlign,

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2230,12 +2230,6 @@ export class ViewFactory
         );
         continue;
       }
-      if (target.localName === "rt" && propName === "font-size") {
-        // Fix for Issue #673
-        if (this.fixRubyTextFontSize(target, value)) {
-          continue;
-        }
-      }
       if (
         isRoot &&
         this.page.pageAreaElement &&
@@ -2338,49 +2332,6 @@ export class ViewFactory
       }
     }
     return parentLineHeight;
-  }
-
-  /**
-   * Fix ruby text font size.
-   * Issue #673: Minimum font size setting in Chrome causes ruby font size problem
-   * @param target the rt element
-   * @param value the font-size value
-   * @returns true if the font-size fix is done
-   */
-  fixRubyTextFontSize(target: Element, value: Css.Val): boolean {
-    if (!/Chrome/.test(navigator.userAgent)) {
-      // Do nothing if the browser engine is not "Chrome"
-      return false;
-    }
-    if (!value.isNumeric()) {
-      return false;
-    }
-    const numeric = value as Css.Numeric;
-    let fontSizeInPx: number;
-    if (numeric.unit === "%" || numeric.unit === "em") {
-      const parentElem = this.nodeContext?.parent?.viewNode as Element;
-      const parentFontSize =
-        parentElem &&
-        parseFloat(this.viewport.window.getComputedStyle(parentElem).fontSize);
-      fontSizeInPx =
-        (parentFontSize * numeric.num) / (numeric.unit === "%" ? 100 : 1);
-    } else {
-      fontSizeInPx = Css.convertNumericToPx(numeric, this.context).num;
-    }
-    if (!fontSizeInPx) {
-      return false;
-    }
-    const minFontSizeInPx = 10; // Default minimum font size setting in Chrome
-    if (fontSizeInPx >= minFontSizeInPx) {
-      return false;
-    }
-    if ((target as HTMLElement).style?.["zoom"] === undefined) {
-      return false;
-    }
-    const zoom = fontSizeInPx / minFontSizeInPx;
-    Base.setCSSProperty(target, "font-size", `${minFontSizeInPx}px`);
-    Base.setCSSProperty(target, "zoom", `${zoom}`);
-    return true;
   }
 
   /** @override */


### PR DESCRIPTION
This hacky workaround (#710) using zoom property for the minimum font size problem is no longer necessary because the problem was fixed in Chrome 118.