### PR TITLE
fix: Viewer page navigation hangs with EPUB/webpub with undetermined page-progression-direction

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2542,6 +2542,11 @@ export class OPFView implements Vgen.CustomRendererFactory {
       instance.docTitle = item.title || "";
 
       instance.init().then(() => {
+        if (!this.opf.pageProgression && instance.pageProgression) {
+          // Use the first instance's page progression as the global page progression.
+          // (Fix for issue #1260)
+          this.opf.pageProgression = instance.pageProgression;
+        }
         viewItem = {
           item,
           xmldoc,


### PR DESCRIPTION
Vivliostyle Viewer cannot handle mixed page progression direction, so if it is not specified in EPUB OPF or pub-manifest, it has to be determined by the root writing mode of the first document of the publication.

- fix #1260