### PR TITLE
fix: adjust TOC box width to account for scrollbar width

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2635,7 +2635,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       );
     }
     const viewport = this.viewport;
-    const tocWidth = Math.min(350, Math.round(0.67 * viewport.width) - 16);
+    const tocWidth = Math.min(344, Math.round(0.67 * viewport.width) - 16);
     const tocHeight = viewport.height - 6;
     const pageCont = viewport.document.createElement("div") as HTMLElement;
     viewport.root.appendChild(pageCont);
@@ -2645,7 +2645,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     }
     // pageCont.style.left = "3px";
     // pageCont.style.top = "3px";
-    pageCont.style.width = `${tocWidth + 10}px`;
+    pageCont.style.width = `${tocWidth + 16}px`;
     pageCont.style.maxHeight = `${tocHeight}px`;
     // pageCont.style.overflow = "scroll";
     // pageCont.style.overflowX = "hidden";


### PR DESCRIPTION
This adjusts TOC box width to account for scrollbar width. See screenshots:

Before this fix:

![Screenshot 2024-02-15 16 08 24](https://github.com/vivliostyle/vivliostyle.js/assets/3324737/399981e8-40a2-45e4-ac6f-342d305f5c32)

After this fix:

![Screenshot 2024-02-16 0 09 00](https://github.com/vivliostyle/vivliostyle.js/assets/3324737/7e2c1013-d8a0-4a7c-bc56-983fb69525d1)
