### PR TITLE
fix: TypeError occurs on repeating_elements/nesting test

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2844,6 +2844,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               // (Issue #611)
               if (
                 !nodeContext.inline &&
+                !nodeContext.repeatOnBreak &&
                 (lastAfterNodeContext
                   ? LayoutHelper.findAncestorSpecialInlineNodeContext(
                       lastAfterNodeContext,


### PR DESCRIPTION
This fixes the bug that causes "TypeError: Cannot read properties of null" with the repeating_elements/nesting test https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/test/files/repeating_elements/nesting.html