### PR TITLE
fix: set overflow property of `@-epubx-partition` to hidden by default

### DIFF
--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -1857,8 +1857,8 @@ export class PageRulePartitionInstance extends PageMaster.PartitionInstance<Page
     docFaces: Font.DocumentFaces,
     clientLayout: Vtree.ClientLayout,
   ): void {
-    super.prepareContainer(context, container, page, docFaces, clientLayout);
     page.pageAreaElement = container.element as HTMLElement;
+    super.prepareContainer(context, container, page, docFaces, clientLayout);
 
     // Set page area size for vw/vh unit calculation
     context.pageAreaWidth = parseFloat(page.pageAreaElement.style.width);

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1808,6 +1808,10 @@ export class PartitionInstance<
     docFaces: Font.DocumentFaces,
     clientLayout: Vtree.ClientLayout,
   ): void {
+    if (!page.pageAreaElement) {
+      // The overflow property of a `@-epubx-partition` is set by default to hidden.
+      Base.setCSSProperty(container.element, "overflow", "hidden");
+    }
     super.prepareContainer(context, container, page, docFaces, clientLayout);
   }
 }


### PR DESCRIPTION
The spec https://idpf.org/epub/pgt/#s3.4.4 says "The overflow property of a partition is set by default to hidden."

However this implementation was changed in v2.14.0 commit cf25ad5cf "fix: overflow:hidden should not be default in page margin boxes"

That change was good for page margin boxes (CSS Paged Media model) but not good for page partitions (EPUB Adaptive Layout model).