### PR TITLE
fix: remove old EPUB NCX handling

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1359,17 +1359,6 @@ epub|case[required-namespace::supported] ~ epub|default {
 /** user-agent-toc.css */
 export const UserAgentTocCss = `
 @namespace "http://www.w3.org/1999/xhtml";
-@namespace ncx "http://www.daisy.org/z3986/2005/ncx/";
-
-ncx|ncx {
-  display: block;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
-ncx|content {
-  display: none;
-}
 
 *:not([data-vivliostyle-role=doc-toc],
   [data-vivliostyle-role=doc-toc] *,
@@ -1382,13 +1371,11 @@ ncx|content {
   display: revert;
 }
 
-[data-vivliostyle-role=doc-toc] li a,
-ncx|navLabel {
+[data-vivliostyle-role=doc-toc] li a {
   -adapt-behavior: toc-node-anchor;
 }
 
-[data-vivliostyle-role=doc-toc] li,
-ncx|navPoint {
+[data-vivliostyle-role=doc-toc] li {
   -adapt-behavior: toc-node;
 }
 

--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -211,7 +211,6 @@ export enum NS {
   SHADOW = "http://www.pyroxy.com/ns/shadow",
   SVG = "http://www.w3.org/2000/svg",
   DC = "http://purl.org/dc/elements/1.1/",
-  NCX = "http://www.daisy.org/z3986/2005/ncx/",
 }
 
 /**

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -409,8 +409,7 @@ export class CoreViewer {
     if (
       this.adaptViewer_.opfView &&
       this.adaptViewer_.opfView.opf &&
-      (this.adaptViewer_.opfView.opf.xhtmlToc ||
-        this.adaptViewer_.opfView.opf.ncxToc)
+      this.adaptViewer_.opfView.opf.toc
     ) {
       return !!this.adaptViewer_.opfView.isTOCVisible();
     } else {

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -280,11 +280,11 @@ export class EPUBDocStore extends OPS.OPSDocStore {
         } else {
           // No manifest
           opf.initWithWebPubManifest({}, doc).then(() => {
-            if (opf.xhtmlToc && opf.xhtmlToc.src === xmldoc.url) {
-              // xhtmlToc is the primary entry (X)HTML
+            if (opf.toc && opf.toc.src === xmldoc.url) {
+              // toc is the primary entry (X)HTML
               if (Toc.findTocElements(doc).length === 0) {
                 // TOC is not found in the primary entry (X)HTML
-                opf.xhtmlToc = null;
+                opf.toc = null;
               }
             }
             frame.finish(opf);
@@ -768,8 +768,7 @@ export class OPFDoc {
   epageIsRenderedPage: boolean = true;
   epageCountCallback: (p1: number) => void | null = null;
   metadata: Meta = {};
-  ncxToc: OPFItem = null;
-  xhtmlToc: OPFItem = null;
+  toc: OPFItem = null;
   cover: OPFItem = null;
   fallbackMap: { [key: string]: string } = {};
   pageProgression: Constants.PageProgression | null = null;
@@ -886,8 +885,8 @@ export class OPFDoc {
         if (fallback && !supportedMediaTypes[item.mediaType]) {
           srcToFallbackId[item.src] = fallback;
         }
-        if (!this.xhtmlToc && item.itemProperties["nav"]) {
-          this.xhtmlToc = item;
+        if (!this.toc && item.itemProperties["nav"]) {
+          this.toc = item;
         }
         if (!this.cover && item.itemProperties["cover-image"]) {
           this.cover = item;
@@ -929,10 +928,6 @@ export class OPFDoc {
         }
         return item;
       });
-    const tocAttr = pkg.child("spine").attribute("toc")[0];
-    if (tocAttr) {
-      this.ncxToc = this.itemMap[tocAttr];
-    }
     const pageProgressionAttr = pkg
       .child("spine")
       .attribute("page-progression-direction")[0];
@@ -1217,11 +1212,11 @@ export class OPFDoc {
     const frame: Task.Frame<boolean> = Task.newFrame("initWithWebPubManifest");
     this.initWithChapters(params).then(() => {
       if (tocFound !== -1) {
-        this.xhtmlToc = this.items[tocFound];
+        this.toc = this.items[tocFound];
       }
 
-      if (!this.xhtmlToc) {
-        this.xhtmlToc = manifestUrl
+      if (!this.toc) {
+        this.toc = manifestUrl
           ? this.items?.[0]
           : this.itemMapByPath[primaryEntryPath];
       }
@@ -2616,7 +2611,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
   showTOC(autohide: boolean): Task.Result<Vtree.Page> {
     const opf = this.opf;
-    const toc = opf.xhtmlToc || opf.ncxToc;
+    const toc = opf.toc;
     this.tocAutohide = autohide;
     if (!toc) {
       return Task.newResult(null as Vtree.Page);

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1181,40 +1181,6 @@ export class ViewFactory
       } else if (ns == Base.NS.epub) {
         tag = "span";
         ns = Base.NS.XHTML;
-      } else if (ns == Base.NS.NCX) {
-        ns = Base.NS.XHTML;
-        if (tag == "ncx" || tag == "navPoint") {
-          tag = "div";
-        } else if (tag == "navLabel") {
-          // Cheat here. Translate source to HTML, so it will plug
-          // in into the rest of the pipeline.
-          tag = "span";
-          const navParent = element.parentNode;
-          if (navParent) {
-            // find the content element
-            let href: string | null = null;
-            for (let c: Node = navParent.firstChild; c; c = c.nextSibling) {
-              if (c.nodeType != 1) {
-                continue;
-              }
-              const childElement = c as Element;
-              if (
-                childElement.namespaceURI == Base.NS.NCX &&
-                childElement.localName == "content"
-              ) {
-                href = childElement.getAttribute("src");
-                break;
-              }
-            }
-            if (href) {
-              tag = "a";
-              element = element.ownerDocument.createElementNS(ns, "a");
-              element.setAttribute("href", href);
-            }
-          }
-        } else {
-          tag = "span";
-        }
       } else if (ns == Base.NS.SHADOW) {
         ns = Base.NS.XHTML;
         tag = this.nodeContext.inline ? "span" : "div";


### PR DESCRIPTION
There has been EPUB NCX support code derived from https://github.com/sorotokin/adaptive-layout but that should be unnecessary. NCX was deprecated since EPUB 3.0 spec. In the current EPUB 3.3 spec, NCX is one of legacy features and it says "EPUB 3 reading systems will not use these features when presenting publications to users." See https://www.w3.org/TR/epub-33/#sec-pkg-legacy.