### PR TITLE
feat: Add errorCallback config option to VivliostylePrint/printHTML()

### DIFF
--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -23,12 +23,13 @@ import * as Constants from "./constants";
 import * as Epub from "./epub";
 import * as Profile from "./profile";
 import * as Toc from "./toc";
+import { ErrorInfo } from "./logging";
 
 export interface Payload {
   type: string;
   internal: boolean;
   href: string;
-  content: string;
+  content: ErrorInfo;
   cfi: string;
   first: boolean;
   last: boolean;
@@ -251,11 +252,20 @@ export class CoreViewer {
     opt_documentOptions?: DocumentOptions,
     opt_viewerOptions?: CoreViewerOptions,
   ) {
-    if (!singleDocumentOptions) {
+    if (
+      !singleDocumentOptions ||
+      (Array.isArray(singleDocumentOptions)
+        ? !singleDocumentOptions[0] ||
+          (typeof singleDocumentOptions[0] !== "string" &&
+            !singleDocumentOptions[0].url)
+        : typeof singleDocumentOptions !== "string" &&
+          !singleDocumentOptions.url)
+    ) {
       this.eventTarget.dispatchEvent({
         type: "error",
-        content: "No URL specified",
+        content: { error: new Error("No URL specified") },
       });
+      return;
     }
     this.loadDocumentOrPublication(
       singleDocumentOptions,
@@ -276,8 +286,9 @@ export class CoreViewer {
     if (!pubUrl) {
       this.eventTarget.dispatchEvent({
         type: "error",
-        content: "No URL specified",
+        content: { error: new Error("No URL specified") },
       });
+      return;
     }
     this.loadDocumentOrPublication(
       null,

--- a/packages/core/src/vivliostyle/logging.ts
+++ b/packages/core/src/vivliostyle/logging.ts
@@ -38,7 +38,7 @@ export type ErrorInfo = {
  * Class logging error, warning, information or debug messages.
  */
 export class Logger {
-  private listeners: { [key in LogLevel]?: ((p1: ErrorInfo) => void)[] } = {};
+  private listeners: { [key in LogLevel]?: (p1: ErrorInfo) => void } = {};
 
   constructor(private opt_console?: Console) {}
 
@@ -91,11 +91,9 @@ export class Logger {
   }
 
   private triggerListeners(level: LogLevel, args: ErrorInfo) {
-    const listeners = this.listeners[level];
-    if (listeners) {
-      listeners.forEach((listener) => {
-        listener(args);
-      });
+    const listener = this.listeners[level];
+    if (listener) {
+      listener(args);
     }
   }
 
@@ -104,11 +102,7 @@ export class Logger {
    * occurs.
    */
   addListener(level: LogLevel, listener: (p1: ErrorInfo) => void) {
-    let listeners = this.listeners[level];
-    if (!listeners) {
-      listeners = this.listeners[level] = [];
-    }
-    listeners.push(listener);
+    this.listeners[level] = listener;
   }
 
   debug(...var_args: any[]) {

--- a/packages/core/src/vivliostyle/print.ts
+++ b/packages/core/src/vivliostyle/print.ts
@@ -10,6 +10,7 @@ interface IFrameWindowForPrint {
 export interface PrintConfig {
   title: string;
   printCallback: (iframeWin: Window) => void;
+  errorCallback: (message: string) => void | null;
   hideIframe: boolean;
   removeIframe: boolean;
 }
@@ -18,6 +19,7 @@ class VivliostylePrint {
   htmlDoc: string;
   title: string;
   printCallback: (iframeWin: Window) => void;
+  errorCallback: (message: string) => void;
   hideIframe: boolean;
   removeIframe: boolean;
   iframe: HTMLIFrameElement;
@@ -29,6 +31,7 @@ class VivliostylePrint {
     {
       title = "",
       printCallback = (iframeWin: Window) => iframeWin.print(),
+      errorCallback = null,
       hideIframe = true,
       removeIframe = true,
     }: PrintConfig,
@@ -36,6 +39,7 @@ class VivliostylePrint {
     this.htmlDoc = htmlDoc;
     this.title = title;
     this.printCallback = printCallback;
+    this.errorCallback = errorCallback;
     this.hideIframe = hideIframe;
     this.removeIframe = removeIframe;
   }
@@ -109,6 +113,15 @@ class VivliostylePrint {
           resolve();
         }
       });
+
+      if (this.errorCallback) {
+        Viewer.addListener("error", (payload) => {
+          const message =
+            payload.content.error?.toString() ??
+            payload.content.messages.join("\n");
+          this.errorCallback(message);
+        });
+      }
 
       Viewer.loadDocument({
         url: docURL,

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -138,8 +138,11 @@ export const Renderer = ({
   }
 
   function registerEventHandlers() {
+    const getMessage = (payload: Payload) =>
+      payload.content.error?.toString() ?? payload.content.messages.join("\n");
+
     function handleMessage(payload: Payload, type: MessageType) {
-      onMessage && onMessage(payload.content, type);
+      onMessage && onMessage(getMessage(payload), type);
     }
 
     const handleDebug = (payload: Payload) => handleMessage(payload, "debug");
@@ -147,7 +150,7 @@ export const Renderer = ({
     const handleWarn = (payload: Payload) => handleMessage(payload, "warn");
 
     function handleError(payload: Payload) {
-      onError && onError(payload.content);
+      onError && onError(getMessage(payload));
     }
 
     function handleReadyStateChange() {

--- a/packages/react/src/stories/Renderer.stories.js
+++ b/packages/react/src/stories/Renderer.stories.js
@@ -39,7 +39,7 @@ export const Basic = () => (
     onLoad={action("loaded")}
     onError={action("error")}
     onNavigation={action("navigation")}
-    onMessage={(msg, type) => action("message")(type, msg.messages[0])}
+    onMessage={(msg, type) => action("message")(type, msg)}
     onReadyStateChange={action("readyStateChange")}
     onHyperlink={action("hyperlink")}
   />

--- a/packages/viewer/src/viewmodels/message-dialog.ts
+++ b/packages/viewer/src/viewmodels/message-dialog.ts
@@ -39,15 +39,7 @@ class MessageDialog {
   }
 
   getDisplayMessage(errorInfo: ErrorInfo): string {
-    const e = errorInfo.error;
-    let msg = e && (e.toString() || e.frameTrace || e.stack);
-    if (msg) {
-      msg = msg.split("\n", 1)[0];
-    }
-    if (!msg) {
-      msg = errorInfo.messages.join("\n");
-    }
-    return msg;
+    return errorInfo.error?.toString() ?? errorInfo.messages.join("\n");
   }
 }
 


### PR DESCRIPTION
So far VivliostylePrint has no way to handle errors. This PR adds a new config option `errorCallback` to VivliostylePrint/`printHTML()` to handle errors.

Usage example:

```ts
  const config = {
    errorCallback: (message) => {
      alert(message);
    }
  };
  printHTML(htmlDoc, config);
```

This PR also fixes the following issues on error handling:

- `Payload.content` type should be `ErrorInfo` instead of `string`.
- `loadDocument()` and `loadPublication()` in CoreViewer needed to fix the "No URL specified" error handling.
- `Logging.logger.addListener(level, listener)` used to push a listener to an array per level so that multiple listeners can be registered for the same level. However, that was problematic because the `Logging.logger` is a singleton instance but the CoreViewer instance with an AdaptiveViewer instance is created each time `printHTML()` is called, and new listeners are added each time without removing the old ones, causing the listeners to be duplicated. This commit changes the `Logging.logger.addListener` method to replace the listener for the level if it already exists.

#1268 
