### PR TITLE
fix: Wrong handling of shorthand properties with variables in conditional rules

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -514,7 +514,11 @@ export function mergeIn(
       Array.prototype.push.apply(ts, as);
     } else {
       // regular properties: higher priority wins
-      const av = getProp(style, prop).increaseSpecificity(specificity);
+      const cascval = getProp(style, prop);
+      if (!cascval.isEnabled(context)) {
+        continue;
+      }
+      const av = cascval.increaseSpecificity(specificity);
       setPropCascadeValue(target, prop, av, context);
 
       // Expand shorthand property (its value contains variables).


### PR DESCRIPTION
Fix the bug that when using variables in shorthand property values in conditional rules (`@media` or `@supports`) and the condition is false, the property values are reset to empty unexpectedly.

- fix #1313

