### PR TITLE
fix: InvalidNodeTypeError may happen during table pagination (Regression in v2.30.0)

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -371,7 +371,7 @@ export class BoxBreakPosition
     }
     if (!this.alreadyEvaluated) {
       this.breakNodeContext = column.findBoxBreakPosition(this, penalty > 0);
-      this.alreadyEvaluated = !!this.breakNodeContext || penalty > 0;
+      this.alreadyEvaluated = true;
     }
     return this.breakNodeContext;
   }


### PR DESCRIPTION
fix #1345

This PR reverts a part of the fix for #1319 (PR #1333) that was not necessary and caused the problem.
