### PR TITLE
chore: update now.sh to vercel.app

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,7 +53,7 @@ Vivliostyle Core contains following components:
 [build-status-url]: https://travis-ci.com/vivliostyle/vivliostyle.js
 [deps]: https://img.shields.io/david/vivliostyle/vivliostyle.js?path=packages/core
 [deps-url]: https://david-dm.org/vivliostyle/vivliostyle.js/?path=packages/core
-[size]: https://packagephobia.now.sh/badge?p=@vivliostyle/core
-[size-url]: https://packagephobia.now.sh/result?p=@vivliostyle/core
+[size]: https://packagephobia.vercel.app/badge?p=@vivliostyle/core
+[size-url]: https://packagephobia.vercel.app/result?p=@vivliostyle/core
 [downloads]: https://img.shields.io/npm/dw/@vivliostyle/core.svg
 [downloads-url]: https://www.npmjs.com/package/@vivliostyle/core

--- a/packages/core/test/files/index.html
+++ b/packages/core/test/files/index.html
@@ -99,7 +99,10 @@
             ).className = "prod";
           }
           tr.appendChild(
-            makeTd("https://vivliostyle.now.sh/" + parameterOnline, "canary"),
+            makeTd(
+              "https://vivliostyle.vercel.app/" + parameterOnline,
+              "canary",
+            ),
           ).className = "canary";
           tr.appendChild(
             makeTd(

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -75,7 +75,7 @@ Licensed under [AGPL Version 3](https://www.gnu.org/licenses/agpl-3.0.html).
 [build-status-url]: https://travis-ci.com/vivliostyle/vivliostyle.js
 [deps]: https://img.shields.io/david/vivliostyle/vivliostyle.js?path=packages/viewer
 [deps-url]: https://david-dm.org/vivliostyle/vivliostyle.js/?path=packages/viewer
-[size]: https://packagephobia.now.sh/badge?p=@vivliostyle/viewer
-[size-url]: https://packagephobia.now.sh/result?p=@vivliostyle/viewer
+[size]: https://packagephobia.vercel.app/badge?p=@vivliostyle/viewer
+[size-url]: https://packagephobia.vercel.app/result?p=@vivliostyle/viewer
 [downloads]: https://img.shields.io/npm/dw/@vivliostyle/viewer.svg
 [downloads-url]: https://www.npmjs.com/package/@vivliostyle/viewer


### PR DESCRIPTION
The old domain name for Vercel app "now.sh" needs to be updated to "vercel.app".
