### PR TITLE
chore(viewer): remove visual-viewport polyfill

### DIFF
--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -7,9 +7,6 @@
     <meta name="google" content="notranslate"/>
     <title>Vivliostyle Viewer</title>
     
-    <!-- WICG Visual Viewport -->
-    <script src="https://wicg.github.io/visual-viewport/polyfill/visualViewport.js"></script>
-
     <!-- MathJax -->
     <script src="resources/mathjax-config.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>


### PR DESCRIPTION
VisualViewport has been available across browsers since August 2021 (see https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport) so the polyfill is no longer necessary.