### PR TITLE
fix: Browser-native MathML should be enabled when MathJax is not loaded

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1301,6 +1301,7 @@ bdo[dir="rtl"] {
 /* MathML */
 m|math[display="block"] {
   display: block;
+  display: block math;
 }
 
 /*------------------ epub-specific ---------------------*/

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -512,8 +512,13 @@ export class ViewFactory
     // Compute values of display, position and float
     const position = computedStyle["position"] as Css.Ident;
     const float = computedStyle["float"] as Css.Ident;
+    const display =
+      (computedStyle["display"] as Css.Ident) ||
+      ((this.sourceNode as Element).namespaceURI === Base.NS.XHTML
+        ? Css.ident.inline
+        : undefined); // leave it to the browser for MathML and SVG
     const displayValues = Display.getComputedDisplayValue(
-      (computedStyle["display"] as Css.Ident) || Css.ident.inline,
+      display,
       position,
       float,
       this.sourceNode === this.xmldoc.root,

--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -7,7 +7,7 @@
     <meta name="google" content="notranslate"/>
     <title>Vivliostyle Viewer</title>
     
-    <!-- MathJax -->
+    <!-- MathJax; remove if not needed -->
     <script src="resources/mathjax-config.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 


### PR DESCRIPTION
Browser-native MathML should be enabled when MathJax is not loaded, but before this fix that did not work. 