### PR TITLE
fix: Attribute selectors with wildcard namespace not worked

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1780,8 +1780,9 @@ export class Parser {
           }
           token = tokenizer.token();
           if (token.type == TokenType.BAR) {
-            ns = text ? this.namespacePrefixToURI[text] : text;
-            if (ns == null) {
+            ns = text && this.namespacePrefixToURI[text];
+            // if ns === null, it's wildcard namespace
+            if (ns === undefined) {
               this.actions = actionsErrorSelector;
               handler.error("E_CSS_UNDECLARED_PREFIX", token);
               tokenizer.consume();

--- a/packages/core/src/vivliostyle/display.ts
+++ b/packages/core/src/vivliostyle/display.ts
@@ -31,7 +31,7 @@ export function isFlowRoot(element: Element): boolean {
  *     https://drafts.csswg.org/css2/visuren.html#dis-pos-flo
  */
 export function blockify(display: Css.Ident): Css.Ident {
-  const displayStr = display.toString();
+  const displayStr = display?.toString() || "block";
   let blockifiedStr: string;
   switch (displayStr) {
     case "inline-flex":

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -736,12 +736,6 @@ export function getMathJaxHub(): object {
   return null;
 }
 
-export function checkMathJax(): void {
-  if (getMathJaxHub()) {
-    CssCascade.supportedNamespaces[Base.NS.MATHML] = true;
-  }
-}
-
 export const supportedMediaTypes = {
   "application/xhtml+xml": true,
   "image/jpeg": true,
@@ -779,7 +773,6 @@ export class OPFDoc {
     public readonly pubURL: string,
   ) {
     this.documentURLTransformer = this.createDocumentURLTransformer();
-    checkMathJax();
   }
 
   // FIXME: TS4055


### PR DESCRIPTION
This fixes the problem that the attribute selectors with wildcard namespace, e.g. `[*|type="footnote"]`, was not worked.

Additionally, this fixes `supportedNamespaces` that MathML namespace should be included by default, because all modern browsers support it natively.