### PR TITLE
fix: `epub:type="footnote"` on non-`aside` element should not cause footnote layout

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1312,7 +1312,7 @@ a[epub|type="noteref"] {
   line-height: 0.01;
 }
 
-a[epub|type="noteref"]:href-epub-type(footnote) {
+a[epub|type="noteref"]:href-epub-type(footnote, aside) {
   -adapt-template: url(user-agent.xml#footnote);
   text-decoration: none;
 }

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1674,6 +1674,17 @@ export class Parser {
                   if (token.type === TokenType.IDENT) {
                     params = [token.text];
                     tokenizer.consume();
+                    if (
+                      text === "href-epub-type" &&
+                      tokenizer.token().type === TokenType.COMMA
+                    ) {
+                      tokenizer.consume();
+                      token = tokenizer.token();
+                      if (token.type === TokenType.IDENT) {
+                        params.push(token.text);
+                        tokenizer.consume();
+                      }
+                    }
                     break;
                   } else {
                     break pseudoclassType;


### PR DESCRIPTION
fix #1363