### PR TITLE
fix: `-adapt-template: footnote` should work for "user-agent.xml#footnote"

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -465,7 +465,7 @@ src = COMMA([SPACE(URI format(STRING+)?) | local(FAMILY)]+); /* for font-face */
 [epubx]utilization = NUM;
 [epubx]text-zoom = font-size | scale;
 
-[adapt]template = URI_OR_NONE;
+[adapt]template = URI_OR_NONE | footnote;
 [adapt]behavior = IDENT;
 
 /* CSS Fonts */
@@ -1313,7 +1313,7 @@ a[epub|type="noteref"] {
 }
 
 a[epub|type="noteref"]:href-epub-type(footnote, aside) {
-  -adapt-template: url(user-agent.xml#footnote);
+  -adapt-template: footnote;
   text-decoration: none;
 }
 

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -336,8 +336,14 @@ export class ViewFactory
     const shadow: Vtree.ShadowContext = null;
     const templateURLVal = computedStyle["template"];
     let cont: Task.Result<Vtree.ShadowContext>;
-    if (templateURLVal instanceof Css.URL) {
-      const url = (templateURLVal as Css.URL).url;
+    if (
+      templateURLVal instanceof Css.URL ||
+      templateURLVal === Css.ident.footnote
+    ) {
+      const url =
+        templateURLVal instanceof Css.URL
+          ? templateURLVal.url
+          : Base.resolveURL("user-agent.xml#footnote", Base.resourceBaseURL);
       cont = this.createRefShadow(
         url,
         Vtree.ShadowType.ROOTLESS,


### PR DESCRIPTION
So far `-adapt-template: url(user-agent.xml#footnote)` is used for EPUB footnote in the UA default style sheet. However, this feature could not be used easily in user or author style sheets because the "user-agent.xml" is bundled in the "assets.ts" file.

This fix enables `-adapt-template: footnote` that should work same as
`-adapt-template: url(user-agent.xml#footnote)` in the UA default style sheet.