### PR TITLE
fix: Chromium's standard CSS zoom support check

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2995,12 +2995,7 @@ export class Viewport {
       if (needScaleRect === null) {
         // Check if getBoundingClientRect() result needs to be scaled.
         // Note: This is only needed for Chromium older than 128. (Issue #1370)
-        const savedWidth = contentContainer.style.width;
-        contentContainer.style.width = "16px";
-        needScaleRect =
-          contentContainer.clientWidth ===
-          contentContainer.getBoundingClientRect().width * this.scaleRatio;
-        contentContainer.style.width = savedWidth;
+        needScaleRect = !("currentCSSZoom" in contentContainer);
       }
       if (needScaleRect) {
         Base.setCSSProperty(


### PR DESCRIPTION
In previous fix (PR #1371 for Issue #1370), the checking method for standard CSS zoom support (Chromium 128-) was incomplete and might cause wrong result.