### PR TITLE
fix: Prevent "A network error occurred." in console when using web fonts

### DIFF
--- a/packages/core/src/vivliostyle/font.ts
+++ b/packages/core/src/vivliostyle/font.ts
@@ -306,7 +306,9 @@ export class Mapper {
     fonts.forEach((fontFace) => {
       if (fontFace.status === "unloaded") {
         unloadedCount++;
-        fontFace.load();
+        fontFace.load().catch((e) => {
+          // Prevent "A network error occurred." errors in console
+        });
       }
     });
     if (unloadedCount === 0) {


### PR DESCRIPTION
This fix prevents the annoying error message "A network error occurred." in the console, for example, using Vivliostyle CLI to build a PDF from a Markdown file containing MathML.

```
$ vivliostyle build testmath.md
✔ testmath.md 
✔ testmath.md 
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
✖ A network error occurred.
◡ testmath.md 
output.pdf has been created.
🎉 Built successfully.
```


