### PR TITLE
fix(viewer): Deprecated meta tag "apple-mobile-web-app-capable"

### DIFF
--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="google" content="notranslate"/>
     <title>Vivliostyle Viewer</title>
     


### PR DESCRIPTION
Recently, Chrome/Chromium puts the following warning message in the console when `<meta name="apple-mobile-web-app-capable" content="yes">` is used:

> warning  `<meta name="apple-mobile-web-app-capable" content="yes">` is deprecated. Please include `<meta name="mobile-web-app-capable" content="yes">`

This fix follows the request in that warning.