### PR TITLE
fix: "Failed to parse stylesheet" warning (Firefox and Safari)

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -421,11 +421,11 @@ export class SkippingParserHandler extends ParserHandler {
   }
 
   override getCurrentToken(): CssTokenizer.Token {
-    return this.owner.getCurrentToken();
+    return this.owner?.getCurrentToken();
   }
 
   override error(mnemonics: string, token: CssTokenizer.Token): void {
-    this.owner.errorMsg(mnemonics, token);
+    this.owner?.errorMsg(mnemonics, token);
   }
 
   override startRuleBody(): void {


### PR DESCRIPTION
"Failed to parse stylesheet" warning message was shown in browser console (Firefox and Safari).

