### PR TITLE
fix: Improve epub:noteref/footnote support

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1306,22 +1306,26 @@ m|math[display="block"] {
 
 /*------------------ epub-specific ---------------------*/
 
-a[epub|type="noteref"] {
+a[epub|type="noteref"],
+a[epub\\:type="noteref"] {
   font-size: 0.75em;
   vertical-align: super;
   line-height: 0.01;
 }
 
-a[epub|type="noteref"]:href-epub-type(footnote, aside) {
+a[epub|type="noteref"]:href-epub-type(footnote, aside),
+a[epub\\:type="noteref"]:href-epub-type(footnote, aside) {
   -adapt-template: footnote;
   text-decoration: none;
 }
 
-aside[epub|type="footnote"] {
+aside[epub|type="footnote"],
+aside[epub\\:type="footnote"] {
   display: none;
 }
 
-aside[epub|type="footnote"]:footnote-content {
+aside[epub|type="footnote"]:footnote-content,
+aside[epub\\:type="footnote"]:footnote-content {
   display: block;
   margin: 0.25em;
   font-size: 1.2em;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -874,16 +874,17 @@ export class CheckTargetEpubTypeAction extends ChainedAction {
 
   override apply(cascadeInstance: CascadeInstance): void {
     const elem = cascadeInstance.currentElement;
-    if (elem && cascadeInstance.currentLocalName == "a") {
-      const href = elem.getAttribute("href");
-      if (href && href.match(/^#/)) {
-        const id = href.substring(1);
+    if (elem instanceof HTMLAnchorElement) {
+      if (elem.hash && elem.href == elem.baseURI + elem.hash) {
+        const id = elem.hash.substring(1);
         const target = elem.ownerDocument.getElementById(id);
         if (
           target &&
           (!this.targetLocalName || target.localName == this.targetLocalName)
         ) {
-          const epubType = target.getAttributeNS(Base.NS.epub, "type");
+          const epubType =
+            target.getAttributeNS(Base.NS.epub, "type") ||
+            target.getAttribute("epub:type");
           if (epubType && epubType.match(this.epubTypePatt)) {
             this.chained.apply(cascadeInstance);
           }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -404,19 +404,19 @@ export class ViewFactory
         } else {
           cont2 = Task.newResult(shadow);
         }
-      });
-      cont2.then((shadow) => {
-        shadow = this.createPseudoelementShadow(
-          element,
-          isRoot,
-          cascStyle,
-          computedStyle,
-          styler,
-          context,
-          shadowContext,
-          shadow,
-        );
-        frame.finish(shadow);
+        cont2.then((shadow) => {
+          shadow = this.createPseudoelementShadow(
+            element,
+            isRoot,
+            cascStyle,
+            computedStyle,
+            styler,
+            context,
+            shadowContext,
+            shadow,
+          );
+          frame.finish(shadow);
+        });
       });
     });
     return frame.result();


### PR DESCRIPTION
Vivliostyle.js supports EPUB footnotes with `epub:type="noteref"` and `epub:type="footnote"` attributes. However, there were the following issues:

- `epub:type="noteref"` did not work when the `href` attribute contains a file name, e.g., `<a href="sample.xhtml#fn1" epub:type="noteref">`, even if the file name is the same as the current document.
- It only worked with XHTML documents.