### PR TITLE
fix: Preserve fractional values for RGB colors

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -384,17 +384,28 @@ export function getPrefixedPropertyNames(prop: string): string[] | null {
   return null;
 }
 
+/**
+ * Using `elem.style.setProperty("prop", ...)` / `elem.style["prop"] = ...` / `elem.style.prop = ...`
+ * causes fractional precision issues in `rgb()` values (Issue #1432)
+ */
+function appendStyleString(elem: Element, prop: string, value: string) {
+  const existingStyle = (elem.getAttribute("style") || "").replace(/;\s*$/, "");
+  elem.setAttribute(
+    "style",
+    `${existingStyle === "" ? "" : `${existingStyle}; `}${prop}: ${value};`,
+  );
+}
+
 export function setCSSProperty(
   elem: Element,
   prop: string,
   value: string,
 ): void {
-  const elemStyle = (elem as HTMLElement)?.style;
-  if (!elemStyle) {
+  if (!elem) {
     return;
   }
   if (prop.startsWith("--")) {
-    elemStyle.setProperty(prop, value || " ");
+    appendStyleString(elem, prop, value || " ");
     return;
   }
   const prefixedPropertyNames = getPrefixedPropertyNames(prop);
@@ -414,12 +425,12 @@ export function setCSSProperty(
         switch (value) {
           case "all":
             // workaround for Chrome 93 bug https://crbug.com/1242755
-            elemStyle.setProperty("text-indent", "0");
+            appendStyleString(elem, "text-indent", "0");
             break;
         }
         break;
     }
-    elemStyle.setProperty(prefixed, value);
+    appendStyleString(elem, prefixed, value);
   }
 }
 

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -71,4 +71,22 @@ describe("base", function () {
       ).toBe("abc-_:%/\\");
     });
   });
+
+  describe("setCSSProperty", function () {
+    it("sets a simple CSS property with integer values", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "rgb(0 1 2)");
+      expect(elem.getAttribute("style")).toMatch(
+        /^[\s;]*color\s*:\s*rgb\s*\(\s*0\s*,?\s*1\s*,?\s*2\s*\)[\s;]*$/,
+      );
+    });
+
+    it("sets a CSS property with fractional values while maintaining precision", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "rgb(0 0.1 0.2)");
+      expect(elem.getAttribute("style")).toMatch(
+        /^[\s;]*color\s*:\s*rgb\s*\(\s*0\s*,?\s*0.1\s*,?\s*0.2\s*\)[\s;]*$/,
+      );
+    });
+  });
 });


### PR DESCRIPTION
fix #1432 