### PR TITLE
 Preserve values for rgb colors

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -494,14 +494,17 @@ function checkSerializationSafeness(
   return [
     serialized,
     serialized === value ||
+      // `currentColor` keyword is normalized to `currentcolor`
+      (serialized === "currentcolor" && value === "currentColor") ||
       // For reasonable rounding, leave it to be done
       areRoundedEqual(serialized, value) ||
       // For RGB representations that show the same color, allow conversions
-      areSameRGBColor(serialized, value),
+      areSameRGBColor(serialized, value) ||
+      // Allow whitespaces to be added after a comma as a result of normalization
+      JSON.stringify(serialized.split(/,\s*/)) ===
+        JSON.stringify(value.split(/,\s*/)),
   ];
 }
-
-const UNSERIALIZABLE = "vivliostyle-stash-unserializable";
 
 function toSafeBase64(str: string) {
   const bytes = new TextEncoder().encode(str);
@@ -513,6 +516,8 @@ function toSafeBase64(str: string) {
     .replace(/\//g, "_")
     .replace(/=/g, "");
 }
+
+const UNSERIALIZABLE = "vivliostyle-stash-unserializable";
 
 /**
  * Wrapper function for `elem.style.setProperty( ... )`

--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -390,7 +390,7 @@ function removeMatchingSuffix(a: string, b: string) {
     i < a.length &&
     i < b.length &&
     a[a.length - 1 - i] === b[b.length - 1 - i] &&
-    Number.isNaN(parseInt(a[a.length - 1 - i]))
+    Number.isNaN(parseInt(a[a.length - 1 - i], 10))
   ) {
     i++;
   }

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -142,21 +142,9 @@ describe("base", function () {
     it("supports rgb() with decimal values", function () {
       const elem = document.createElement("p");
       module.setCSSProperty(elem, "color", "rgb(0 0.1 0.2)");
-      const varName = "--vivliostyle-stash-unserializable-cmdiKDAgMC4xIDAuMik";
 
       const styleStr = elem.getAttribute("style");
-      if (styleStr.includes(varName)) {
-        const value = getComputedStyle(
-          document.documentElement,
-        ).getPropertyValue(varName);
-        expect(value.trim()).toMatch(
-          /^rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)$/,
-        );
-      } else {
-        expect(styleStr).toMatch(
-          /^[\s;]*color\s*:\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)[\s;]*$/,
-        );
-      }
+      expect(styleStr).toMatch(/rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)/);
     });
 
     it("supports linear gradients with rgb() integer values", function () {
@@ -180,22 +168,11 @@ describe("base", function () {
         "background-image",
         "linear-gradient(45deg, rgb(0 0.1 0.2), rgb(255 254.9 254.8))",
       );
-      const varName =
-        "--vivliostyle-stash-unserializable-bGluZWFyLWdyYWRpZW50KDQ1ZGVnLCByZ2IoMCAwLjEgMC4yKSwgcmdiKDI1NSAyNTQuOSAyNTQuOCkp";
 
       const styleStr = elem.getAttribute("style");
-      if (styleStr.includes(varName)) {
-        const value = getComputedStyle(
-          document.documentElement,
-        ).getPropertyValue(varName);
-        expect(value.trim()).toMatch(
-          /^linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*254\.9\s*,?\s*254\.8\s*\)\s*\)$/,
-        );
-      } else {
-        expect(styleStr).toMatch(
-          /^[\s;]*background-image\s*:\s*linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*254\.9\s*,?\s*254\.8\s*\)\s*\)[\s;]*$/,
-        );
-      }
+      expect(styleStr).toMatch(
+        /linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*254\.9\s*,?\s*254\.8\s*\)\s*\)/,
+      );
     });
   });
 });

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -111,9 +111,17 @@ describe("base", function () {
       expect(styleStr).toMatch(/margin:\s*10px\s+15px\s+20px\s+25px/);
     });
 
+    it("rounds CSS property values", function () {
+      const elem = document.createElement("div");
+      module.setCSSProperty(elem, "margin-right", "2.4000000000000004px");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toContain("2.4px");
+    });
+
     it("supports RGB color with integer values", function () {
       const elem = document.createElement("p");
-      module.setCSSProperty(elem, "color", "rgb(0 1 2)");
+      module.setCSSProperty(elem, "color", "rgb(0, 1, 2)");
 
       const styleStr = elem.getAttribute("style");
       expect(styleStr).toMatch(
@@ -124,11 +132,21 @@ describe("base", function () {
     it("supports RGB color with decimal values", function () {
       const elem = document.createElement("p");
       module.setCSSProperty(elem, "color", "rgb(0 0.1 0.2)");
+      const varName = "--vivliostyle-stash-unserializable-cmdiKDAgMC4xIDAuMik";
 
       const styleStr = elem.getAttribute("style");
-      expect(styleStr).toMatch(
-        /^[\s;]*color\s*:\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)[\s;]*$/,
-      );
+      if (styleStr.includes(varName)) {
+        const value = getComputedStyle(
+          document.documentElement,
+        ).getPropertyValue(varName);
+        expect(value.trim()).toMatch(
+          /^rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)$/,
+        );
+      } else {
+        expect(styleStr).toMatch(
+          /^[\s;]*color\s*:\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)[\s;]*$/,
+        );
+      }
     });
 
     it("supports linear gradients with RGB integer values", function () {
@@ -136,7 +154,7 @@ describe("base", function () {
       module.setCSSProperty(
         elem,
         "background-image",
-        "linear-gradient(45deg, rgb(0 0 0), rgb(255 255 255))",
+        "linear-gradient(45deg, rgb(0, 0, 0), rgb(255, 255, 255))",
       );
 
       const styleStr = elem.getAttribute("style");
@@ -152,11 +170,22 @@ describe("base", function () {
         "background-image",
         "linear-gradient(45deg, rgb(0 0.1 0.2), rgb(255 254.9 254.8))",
       );
+      const varName =
+        "--vivliostyle-stash-unserializable-bGluZWFyLWdyYWRpZW50KDQ1ZGVnLCByZ2IoMCAwLjEgMC4yKSwgcmdiKDI1NSAyNTQuOSAyNTQuOCkp";
 
       const styleStr = elem.getAttribute("style");
-      expect(styleStr).toMatch(
-        /^[\s;]*background-image\s*:\s*linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*254\.9\s*,?\s*255\.8\s*\)\s*\)[\s;]*$/,
-      );
+      if (styleStr.includes(varName)) {
+        const value = getComputedStyle(
+          document.documentElement,
+        ).getPropertyValue(varName);
+        expect(value.trim()).toMatch(
+          /^linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*254\.9\s*,?\s*254\.8\s*\)\s*\)$/,
+        );
+      } else {
+        expect(styleStr).toMatch(
+          /^[\s;]*background-image\s*:\s*linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*254\.9\s*,?\s*254\.8\s*\)\s*\)[\s;]*$/,
+        );
+      }
     });
   });
 });

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -71,4 +71,92 @@ describe("base", function () {
       ).toBe("abc-_:%/\\");
     });
   });
+
+  describe("setCSSProperty", function () {
+    it("sets a single CSS property", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "red");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(/color\s*:\s*red/);
+    });
+
+    it("overrides an existing CSS property", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "red");
+      module.setCSSProperty(elem, "color", "green");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(/color\s*:\s*green/);
+    });
+
+    it("adds multiple CSS properties", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "red");
+      module.setCSSProperty(elem, "background-color", "green");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(/color\s*:\s*red/);
+      expect(styleStr).toMatch(/background-color\s*:\s*green/);
+    });
+
+    it("sets shorthand CSS properties for margin", function () {
+      const elem = document.createElement("div");
+      module.setCSSProperty(elem, "margin-top", "10px");
+      module.setCSSProperty(elem, "margin-right", "15px");
+      module.setCSSProperty(elem, "margin-bottom", "20px");
+      module.setCSSProperty(elem, "margin-left", "25px");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(/margin:\s*10px\s+15px\s+20px\s+25px/);
+    });
+
+    it("supports RGB color with integer values", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "rgb(0 1 2)");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(
+        /^[\s;]*color\s*:\s*rgb\s*\(\s*0\s*,?\s*1\s*,?\s*2\s*\)[\s;]*$/,
+      );
+    });
+
+    it("supports RGB color with decimal values", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "rgb(0 0.1 0.2)");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(
+        /^[\s;]*color\s*:\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)[\s;]*$/,
+      );
+    });
+
+    it("supports linear gradients with RGB integer values", function () {
+      const elem = document.createElement("div");
+      module.setCSSProperty(
+        elem,
+        "background-image",
+        "linear-gradient(45deg, rgb(0 0 0), rgb(255 255 255))",
+      );
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(
+        /^[\s;]*background-image\s*:\s*linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\s*,?\s*0\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*255\s*,?\s*255\s*\)\s*\)[\s;]*$/,
+      );
+    });
+
+    it("supports linear gradients with RGB decimal values", function () {
+      const elem = document.createElement("div");
+      module.setCSSProperty(
+        elem,
+        "background-image",
+        "linear-gradient(45deg, rgb(0 0.1 0.2), rgb(255 254.9 254.8))",
+      );
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(
+        /^[\s;]*background-image\s*:\s*linear-gradient\s*\(\s*45deg\s*,?\s*rgb\s*\(\s*0\s*,?\s*0\.1\s*,?\s*0\.2\s*\)\s*,?\s*rgb\s*\(\s*255\s*,?\s*254\.9\s*,?\s*255\.8\s*\)\s*\)[\s;]*$/,
+      );
+    });
+  });
 });

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -119,7 +119,17 @@ describe("base", function () {
       expect(styleStr).toContain("2.4px");
     });
 
-    it("supports RGB color with integer values", function () {
+    it("serializes hex to rgb() format", function () {
+      const elem = document.createElement("p");
+      module.setCSSProperty(elem, "color", "#ff0000");
+
+      const styleStr = elem.getAttribute("style");
+      expect(styleStr).toMatch(
+        /^[\s;]*color\s*:\s*rgb\s*\(\s*255\s*,?\s*0\s*,?\s*0\s*\)[\s;]*$/,
+      );
+    });
+
+    it("supports rgb() with integer values", function () {
       const elem = document.createElement("p");
       module.setCSSProperty(elem, "color", "rgb(0, 1, 2)");
 
@@ -129,7 +139,7 @@ describe("base", function () {
       );
     });
 
-    it("supports RGB color with decimal values", function () {
+    it("supports rgb() with decimal values", function () {
       const elem = document.createElement("p");
       module.setCSSProperty(elem, "color", "rgb(0 0.1 0.2)");
       const varName = "--vivliostyle-stash-unserializable-cmdiKDAgMC4xIDAuMik";
@@ -149,7 +159,7 @@ describe("base", function () {
       }
     });
 
-    it("supports linear gradients with RGB integer values", function () {
+    it("supports linear gradients with rgb() integer values", function () {
       const elem = document.createElement("div");
       module.setCSSProperty(
         elem,
@@ -163,7 +173,7 @@ describe("base", function () {
       );
     });
 
-    it("supports linear gradients with RGB decimal values", function () {
+    it("supports linear gradients with rgb() decimal values", function () {
       const elem = document.createElement("div");
       module.setCSSProperty(
         elem,


### PR DESCRIPTION
fix: #1432

`setProperty(prop, value)`で文字列が維持されない`value`をCSS変数に退避する方針に切り替えて実装しました。要素のCSSの編集はすべて`setProperty`で行っているので、`width`・`height`が繰り返し設定されるような事態は避けられているはずです。誤差は丸められるままにしておきたい点については、別途考慮しています。

CSS変数名・style要素IDは指示いただいたものに直すつもりです。キーはひとまずbase64になっています。

現状気づいている微妙な挙動として、デフォルト値を省略した場合にも退避されてしまうようです。`counter-increment`などで目立ちます。

![image](https://github.com/user-attachments/assets/994a9311-148a-4d34-badf-59e2fca062ce)

