### PR TITLE
fix: Do not remove table top border with thead and bottom border with tfoot at page break

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1423,14 +1423,14 @@ export const VivliostylePolyfillCss = `
   border-start-end-radius: 0 !important;
   border-end-end-radius: 0 !important;
 }
-[data-viv-box-break~="block-start"]:not([data-viv-box-break~="clone"]) {
+[data-viv-box-break~="block-start"]:not([data-viv-box-break~="clone"]):not(table[style*="border-collapse: collapse"]:has(>thead)) {
   margin-block-start: 0 !important;
   padding-block-start: 0 !important;
   border-block-start-width: 0 !important;
   border-start-start-radius: 0 !important;
   border-start-end-radius: 0 !important;
 }
-[data-viv-box-break~="block-end"]:not([data-viv-box-break~="clone"]) {
+[data-viv-box-break~="block-end"]:not([data-viv-box-break~="clone"]):not(table[style*="border-collapse: collapse"]:has(>tfoot)) {
   margin-block-end: 0 !important;
   padding-block-end: 0 !important;
   border-block-end-width: 0 !important;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1536,11 +1536,8 @@ export class ViewFactory
             Break.setBoxBreakFlag(result, "block-start");
             if (Break.isCloneBoxDecorationBreak(result)) {
               Break.setBoxBreakFlag(result, "clone");
-
-              // When box-decoration-break: clone, cloned margins are always
-              // truncated to zero.
-              Break.setMarginDiscardFlag(result, "block-start");
             }
+            Break.setMarginDiscardFlag(result, "block-start");
           } else if (
             !Display.isAbsolutelyPositioned(computedStyle["position"])
           ) {
@@ -2632,8 +2629,8 @@ export class ViewFactory
         }
         if (Break.isCloneBoxDecorationBreak(elem)) {
           Break.setBoxBreakFlag(elem, "clone");
-          Break.setMarginDiscardFlag(elem, "block-end");
         }
+        Break.setMarginDiscardFlag(elem, "block-end");
       }
     }
   }


### PR DESCRIPTION
When a table with `border-collapse: collapse` style is split across pages, the top border of the table should not be removed if the table has thead and the bottom border should not be removed if the table has tfoot.

[CSS Table Module Level 3 §6.2. Repeating headers across pages](https://drafts.csswg.org/css-tables/#repeated-headers) says:

> When the header rows are being repeated, user agents must leave room and if needed render the table top border. The same applies for footer rows and the table bottom border.
