### PR TITLE
fix: Replace XMLHttpRequest with fetch API

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -2797,12 +2797,12 @@ export function parseStylesheetFromURL(
   return Task.handle(
     "parseStylesheetFromURL",
     (frame) => {
-      Net.ajax(url).then((xhr) => {
-        if (!xhr.responseText) {
+      Net.fetchFromURL(url).then((response) => {
+        if (!response.responseText) {
           frame.finish(true);
         } else {
           parseStylesheetFromText(
-            xhr.responseText,
+            response.responseText,
             handler,
             url,
             classes,

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -94,7 +94,7 @@ export class EPUBDocStore extends OPS.OPSDocStore {
   loadPubDoc(url: string): Task.Result<OPFDoc> {
     const frame: Task.Frame<OPFDoc> = Task.newFrame("loadPubDoc");
 
-    Net.ajax(url, null, "HEAD").then((response) => {
+    Net.fetchFromURL(url, null, "HEAD").then((response) => {
       if (response.status >= 400) {
         // This url can be the root of an unzipped EPUB.
         this.loadEPUBDoc(url).then((opf) => {
@@ -326,6 +326,10 @@ export class EPUBDocStore extends OPS.OPSDocStore {
         urls.find((url) => this.resources[url] && removePath(url) === domain)
       ) {
         // if there is an already loaded resource with the same domain, no CORS problem
+        return false;
+      }
+      if (!/^https?:?\/\/[^/]/.test(docURL)) {
+        // not a valid URL
         return false;
       }
       if (/\.(xhtml|xht|xml|opf)$/i.test(docURL)) {

--- a/packages/core/src/vivliostyle/font.ts
+++ b/packages/core/src/vivliostyle/font.ts
@@ -261,12 +261,12 @@ export class Mapper {
           ? documentFaces.deobfuscator(url)
           : null;
         if (deobfuscator) {
-          Net.ajax(url, Net.XMLHttpRequestResponseType.BLOB).then((xhr) => {
-            if (!xhr.responseBlob) {
+          Net.fetchFromURL(url, Net.FetchResponseType.BLOB).then((response) => {
+            if (!response.responseBlob) {
               frame.finish(null);
               return;
             }
-            deobfuscator(xhr.responseBlob).then((fontBytes) => {
+            deobfuscator(response.responseBlob).then((fontBytes) => {
               this.initFont(srcFace, fontBytes, documentFaces).thenFinish(
                 frame,
               );

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -2172,7 +2172,7 @@ export type StyleSource = {
 };
 
 export function parseOPSResource(
-  response: Net.Response,
+  response: Net.FetchResponse,
   store: XmlDoc.XMLDocStore,
 ): Task.Result<XmlDoc.XMLDocHolder> {
   return (store as OPSDocStore).parseOPSResource(response);
@@ -2192,7 +2192,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
       | ((p1: string) => ((p1: Blob) => Task.Result<Blob>) | null)
       | null,
   ) {
-    super(parseOPSResource, Net.XMLHttpRequestResponseType.DOCUMENT);
+    super(parseOPSResource, Net.FetchResponseType.DOCUMENT);
   }
 
   init(
@@ -2266,7 +2266,9 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
     });
   }
 
-  parseOPSResource(response: Net.Response): Task.Result<XmlDoc.XMLDocHolder> {
+  parseOPSResource(
+    response: Net.FetchResponse,
+  ): Task.Result<XmlDoc.XMLDocHolder> {
     const frame: Task.Frame<XmlDoc.XMLDocHolder> =
       Task.newFrame("OPSDocStore.load");
     const url = response.url;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -585,7 +585,7 @@ export namespace LayoutProcessor {
 }
 
 export namespace Net {
-  export type Response = {
+  export type FetchResponse = {
     status: number;
     statusText: string | null;
     url: string;
@@ -599,7 +599,7 @@ export namespace Net {
     resources: { [key: string]: Resource };
     fetchers: { [key: string]: TaskUtil.Fetcher<Resource> };
     readonly parser: (
-      p1: Response,
+      p1: FetchResponse,
       p2: ResourceStore<Resource>,
     ) => Task.Result<Resource>;
     readonly type: XMLHttpRequestResponseType;

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -316,7 +316,7 @@ export function parseAndReturnNullIfError(
  * @returns null if contentType cannot be inferred from HTTP header and file
  *     extension
  */
-export function resolveContentType(response: Net.Response): string | null {
+export function resolveContentType(response: Net.FetchResponse): string | null {
   const contentType = response.contentType;
   if (contentType) {
     const supportedKeys = Object.keys(DOMParserSupportedType);
@@ -351,7 +351,7 @@ export function resolveContentType(response: Net.Response): string | null {
 }
 
 export function parseXMLResource(
-  response: Net.Response,
+  response: Net.FetchResponse,
   store: XMLDocStore,
 ): Task.Result<XmlDoc.XMLDocHolder> {
   let doc = response.responseXML;
@@ -406,7 +406,7 @@ export function parseXMLResource(
 export function newXMLDocStore(): XMLDocStore {
   return new Net.ResourceStore(
     parseXMLResource,
-    Net.XMLHttpRequestResponseType.DOCUMENT,
+    Net.FetchResponseType.DOCUMENT,
   );
 }
 


### PR DESCRIPTION
This commit replaces XMLHttpRequest with the fetch API in the `ajax` function (renamed to `fetchFromURL`) in net.ts.

This change is necessary for the new architecture of Vivliostyle Pub, which requires the use of the fetch API instead of XMLHttpRequest.