### PR TITLE
fix: Fix table layout problem with table-cells across pages

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -278,12 +278,6 @@ export class InsideTableRowBreakPosition extends BreakPosition.AbstractBreakPosi
         (cellFragments[i].cellNodeContext.sourceNode as HTMLTableCellElement)
           .rowSpan > 1,
     );
-    if (
-      !foundBoxBreakInRowSpanningCell &&
-      !formattingContext.isFreelyFragmentableRow(row)
-    ) {
-      penalty += 10;
-    }
 
     breakPositions.forEach((bp, i) => {
       let penalty1 = bp.breakPosition.getMinBreakPenalty();
@@ -477,10 +471,6 @@ export class TableFormattingContext
       this.cellFragments[cell.rowIndex] &&
       this.cellFragments[cell.rowIndex][cell.columnIndex]
     );
-  }
-
-  isFreelyFragmentableRow(row: TableRow): boolean {
-    return row.getMinimumHeight() > this.tableWidth / 2;
   }
 
   getColumnCount(): number {
@@ -1767,6 +1757,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
         return frame.result();
       }
     }
+    adjustRowHeight(nodeContext);
     formattingContext.finishFragment();
     return LayoutProcessor.blockLayoutProcessor.finishBreak(
       column,
@@ -1851,7 +1842,7 @@ function adjustRowHeight(nodeContext: Vtree.NodeContext): void {
   }
   // Find row elements that only have rowspanning cells and empty cells.
   const spanStartRows = tbodyElement.querySelectorAll(
-    ":scope>tr:not(:has(>:not([rowspan]:not([rowspan='1']),:empty)))",
+    ":scope>tr:has(>:empty):not(:has(>:not([rowspan]:not([rowspan='1']),:empty)))",
   );
   if (spanStartRows.length === 0) {
     return;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1533,6 +1533,20 @@ export class ViewFactory
           }
         } else {
           if (!firstTime) {
+            const blockSizeP = this.nodeContext.vertical ? "width" : "height";
+            if (Base.getCSSProperty(result, blockSizeP)) {
+              // When a box with a specified block size is fragmented,
+              // the fragmented box should not have the block size.
+              // If the box is table-row, set a very small block size
+              // (0 does not work in Firefox, so use 0.01px instead)
+              // to prevent the row block size from expanding due to
+              // large rowspanning cells.
+              Base.setCSSProperty(
+                result,
+                blockSizeP,
+                this.nodeContext.display === "table-row" ? "0.01px" : "",
+              );
+            }
             Break.setBoxBreakFlag(result, "block-start");
             if (Break.isCloneBoxDecorationBreak(result)) {
               Break.setBoxBreakFlag(result, "clone");
@@ -2593,6 +2607,12 @@ export class ViewFactory
           }
         }
       } else {
+        const blockSizeP = this.nodeContext.vertical ? "width" : "height";
+        if (Base.getCSSProperty(elem, blockSizeP)) {
+          // When a box with a specified block size is fragmented,
+          // the fragmented box should not have the block size.
+          Base.setCSSProperty(elem, blockSizeP, "");
+        }
         Break.setBoxBreakFlag(elem, "block-end");
         if (!blockNestCount++) {
           if (nc !== nodeContext1) {


### PR DESCRIPTION
- Fix #980
  - Remove unnecessary restriction on table-row breaking only allowing when the table-row height is greater than 1/2 of the table width.
  - When boxes (e.g., table cells) with specified block-size are split across pages, the fragmented boxes should not have the same block-size. In this fix, the block-size is unset on fragmented boxes. Note: This is a temporary fix and should be improved in the future so that the total block-size of the fragmented boxes is the same as the original box.