### PR TITLE
fix: Fix table fragmentation problem overflowing page area

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1577,6 +1577,14 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
         formattingContext.colGroups.cloneNode(true),
         firstChild,
       );
+      // Set table-layout to fixed so that the widths of the columns
+      // are respected. (Fix for issue #1475)
+      Base.setCSSProperty(rootViewNode, "table-layout", "fixed");
+      Base.setCSSProperty(
+        rootViewNode,
+        formattingContext.vertical ? "height" : "width",
+        `${formattingContext.tableWidth}px`,
+      );
     }
   }
 


### PR DESCRIPTION
- fix #1475

This fixes the problem that the widths of the columns of the table may change after fragmentation, causing the table cell content to overflow the page area.