### PR TITLE
fix(viewer): Do not remove console output in vivliostyle-viewer.js

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -31,7 +31,6 @@
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^6.0.1",
-    "@rollup/plugin-strip": "^3.0.2",
     "@rollup/plugin-typescript": "^12.1.1",
     "@types/node": "^22.9.0",
     "@typescript-eslint/eslint-plugin": "^8.14.0",

--- a/packages/viewer/rollup.config.js
+++ b/packages/viewer/rollup.config.js
@@ -4,7 +4,6 @@ import replace from "@rollup/plugin-replace";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import commonJS from "@rollup/plugin-commonjs";
-import strip from "@rollup/plugin-strip";
 import { terser } from "rollup-plugin-terser";
 import pkg from "./package.json";
 import corePkg from "../core/package.json";
@@ -44,19 +43,6 @@ const plugins = [
   commonJS({
     sourceMap: true,
   }),
-  // Remove clutter
-  !isDevelopment
-    ? strip({
-        debugger: false,
-        functions: [
-          "console.*",
-          "console.warn.apply",
-          "console.info.apply",
-          "console.debug.apply",
-          "console.error.apply",
-        ],
-      })
-    : {},
   // Minimize module size
   !isDevelopment ? terser() : {},
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,15 +3014,6 @@
     "@rollup/pluginutils" "^5.0.1"
     magic-string "^0.30.3"
 
-"@rollup/plugin-strip@^3.0.2":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-strip/-/plugin-strip-3.0.4.tgz#ad623cc18cf305b484f8bf38fde4ae855c1229e4"
-  integrity sha512-LDRV49ZaavxUo2YoKKMQjCxzCxugu1rCPQa0lDYBOWLj6vtzBMr8DcoJjsmg+s450RbKbe3qI9ZLaSO+O1oNbg==
-  dependencies:
-    "@rollup/pluginutils" "^5.0.1"
-    estree-walker "^2.0.2"
-    magic-string "^0.30.3"
-
 "@rollup/plugin-typescript@^12.1.1":
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-12.1.1.tgz#008d16b8283a422650c463f99ae0c610cf6c9727"


### PR DESCRIPTION
So far, `packages/viewer/rollup.config.js` has removed `console.*` output in release build. This is a problem because especially in Vivliostyle CLI, the browser console output is used for error detection.

This problem has become apparent since v2.30.6 (Vivliostyle CLI v8.16.2). The reason is that in v2.30.6, the build of vivliostyle.js (core) was changed from microbundle to esbuild.

- https://github.com/vivliostyle/vivliostyle.js/pull/1417

In the JS code generated by microbundle, the original source code `console.error(...msg)` was transformed into `(n=console).error.apply(n,t)`, so when vivliostyle-viewer.js was built with vivliostyle.js (core) bundled, that part was not removed. However, in the JS code generated by esbuild, that transformation is not done, so when vivliostyle-viewer.js is built with vivliostyle.js (core) bundled, that part is removed.

This commit stops removing `console.*` output in release build.