### PR TITLE
feat: Add crop-marks-line-color property for at-page rule

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -507,6 +507,7 @@ bleed = auto | LENGTH;
 marks = none | [ crop || cross ];
 size = POS_LENGTH{1,2} | auto | [ PAGE_SIZE || [ portrait | landscape ] ];
 crop-offset = auto | LENGTH;
+crop-marks-line-color = auto | COLOR;
 
 /* CSS Page Floats */
 float-reference = inline | column | region | page;

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1400,6 +1400,7 @@ const propsExcludedFromAll = [
   "bleed",
   "conflicting-partitions",
   "crop-offset",
+  "crop-marks-line-color",
   "enabled",
   "flow-consume",
   "flow-from",


### PR DESCRIPTION
- resolves #1502

Example:

```css
@page {
  crop-marks-line-color: #48F0DA;
  marks: crop cross;
  bleed: 3mm;
}
```

The `crop-marks-line-color` property's default value `auto` is equivalent to `#010101`. For the reason why it is not `#00000`, see PR #911 (issue #910). 