### PR TITLE
chore(viewer): Fix Vivliostyle.profiler unavailable in dev mode

### DIFF
--- a/packages/viewer/src/vivliostyle.ts
+++ b/packages/viewer/src/vivliostyle.ts
@@ -18,13 +18,4 @@
  */
 
 import * as Vivliostyle from "@vivliostyle/core";
-
-declare global {
-  interface Window {
-    Vivliostyle: typeof Vivliostyle;
-  }
-}
-
-export default process.env.NODE_ENV === "production"
-  ? Vivliostyle
-  : window.Vivliostyle;
+export default Vivliostyle;


### PR DESCRIPTION
When testing Vivliostyle Viewer in dev mode (using `yarn dev`), the profiler (with URL parameter `&profile=true`) was unavailable because it caused error (`Vivliostyle.profiler` is undefined) at:

https://github.com/vivliostyle/vivliostyle.js/blob/1e44b1f47733b7ae6bb4af251ed6bc622eaf6f23/packages/viewer/src/viewmodels/viewer-app.ts#L129
