### PR TITLE
fix: Set print-color-adjust:exact to avoid background graphics from being removed

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -186,6 +186,7 @@ export const VivliostyleViewportCss = `
     --viv-devicePixelRatio: 1 !important;
     zoom: normal !important;
     transform: none !important;
+    print-color-adjust: exact;
   }
 
   @supports (zoom: 8) {


### PR DESCRIPTION
Added `print-color-adjust: exact` to the viewer's stylesheets for print.

This resolves the problem that background graphics are removed when printing using browser's print dialog unless the "Background graphics" check box is checked.

See the example below.

Sample: https://raw.githack.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/background-gradient.html

Open this sample with Vivliostyle Viewer, then open the print dialog, leave the "Background graphics" check box unchecked.

Screenshot of Google Chrome's print preview, before this fix:

![Screenshot 2025-06-09 15 32 30](https://github.com/user-attachments/assets/3fc6d65e-25d6-4ed1-add2-90e332bd4660)

After this fix:

![Screenshot 2025-06-09 15 31 52](https://github.com/user-attachments/assets/2b5ea809-751e-452c-8384-152c6b05e712)
