### PR TITLE
fix: Fix EPUB footnote (epub:type="footnote") not working (Regression in v2.31.2)

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -888,7 +888,10 @@ export class CheckTargetEpubTypeAction extends ChainedAction {
   override apply(cascadeInstance: CascadeInstance): void {
     const elem = cascadeInstance.currentElement;
     if (elem instanceof HTMLAnchorElement) {
-      if (elem.hash && elem.href == elem.baseURI + elem.hash) {
+      if (
+        elem.hash &&
+        elem.href == elem.baseURI.replace(/#.*$/, "") + elem.hash
+      ) {
         const id = elem.hash.substring(1);
         const target = elem.ownerDocument.getElementById(id);
         if (


### PR DESCRIPTION
This bug was a side effect of the change to use the fetch API instead of XMLHttpRequest for fetching documents (PR #1461).

The problem was that the `URL` of the parsed document was set to the URL of the Vivliostyle Viewer with fragment `#src=...`, instead of the original document URL, because the `DOMParser.parseFromString()` method sets the `URL` of the parsed document to the URL of the current `window.document`. This caused the `elem.href == elem.baseURI + elem.hash` check to fail, preventing the EPUB footnote processing from working.

- fix #1521