### PR TITLE
fix: Prevent 404 error for META-INF/encryption.xml when EPUB OPF file is directly specified

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -213,16 +213,24 @@ export class EPUBDocStore extends OPS.OPSDocStore {
         if (!opfXML) {
           this.reportLoadError(url);
         } else {
-          this.loadAsPlainXML(`${pubURL}META-INF/encryption.xml`).then(
-            (encXML) => {
-              opf = new OPFDoc(this, pubURL);
-              opf.initWithXMLDoc(opfXML, encXML).then(() => {
-                this.opfByURL[url] = opf;
-                this.primaryOPFByEPubURL[pubURL] = opf;
-                frame.finish(opf);
-              });
-            },
-          );
+          opf = new OPFDoc(this, pubURL);
+          this.opfByURL[url] = opf;
+          this.primaryOPFByEPubURL[pubURL] = opf;
+          if (this.plainXMLStore.resources[pubURL + "META-INF/container.xml"]) {
+            this.loadAsPlainXML(pubURL + "META-INF/encryption.xml").then(
+              (encXML) => {
+                opf.initWithXMLDoc(opfXML, encXML).then(() => {
+                  frame.finish(opf);
+                });
+              },
+            );
+          } else {
+            // OPF file is directly specified, not via container.xml.
+            // In this case, encryption.xml is not available.
+            opf.initWithXMLDoc(opfXML, null).then(() => {
+              frame.finish(opf);
+            });
+          }
         }
       },
     );


### PR DESCRIPTION
- fix #1523

Vivliostyle CLI でEPUBファイルのpreviewやPDFへのbuildを指定した場合、展開されたEPUB内のOPFファイルのURLがVivliostyle.jsに渡されます。展開されたEPUBのルートディレクトリではなくOPFファイルが渡された場合、これまでは、そのOPFファイルの場所をEPUBのルートとみなしてそこからMETA-INF/encryption.xmlファイルを探しに行っていました。もしそのEPUBにencryption.xmlファイルが存在しても、OPFファイルの場所は通常はEPUBのルートではないため、encryption.xmlファイルは見つからず、役に立ちません。

そこで、OPFファイルが渡された場合には、encryption.xmlファイルをロードしようとするのをやめることにしました。Vivliostyleで扱うEPUBにencryption.xmlファイルが使われることはほとんどないのでこれで問題ないと思います。

これにより、Vivliostyle CLI でEPUBファイルのPDFへのbuildを実行したときに「ERROR 404 …/META-INF/encryption.xml」が出る問題が解消されます。
