### PR TITLE
fix: Fix page-margin box image size with `box-sizing: border-box`

### DIFF
--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1388,12 +1388,19 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
 
     for (let i = 0; i < passSingleUriContentProperties.length; i++) {
       const name = passSingleUriContentProperties[i];
-      if (
-        (name === "width" && !hasWidth()) ||
-        (name === "height" && !hasHeight())
-      ) {
-        // Don't propagate width/height to the img element if it's not specified.
-        // (Issue #1177)
+      if (name === "width" || name === "height") {
+        if (
+          (name === "width" && !hasWidth()) ||
+          (name === "height" && !hasHeight())
+        ) {
+          // Don't propagate width/height to the img element if it's not specified.
+          // (Issue #1177)
+          continue;
+        }
+        // Since the width/height is already set on the container element,
+        // we set it to 100% on the img element so that it fills the container.
+        // This is needed for the `box-sizing: border-box` to work correctly.
+        Base.setCSSProperty(element, name, "100%");
         continue;
       }
       this.propagatePropertyToElement(context, element, name, docFaces);


### PR DESCRIPTION
In PR #1535, the `box-sizing: border-box` was implemented for page-margin boxes, but it was incomplete for images used as content of page-margin boxes.

Test sample: https://gist.githubusercontent.com/MurakamiShinyu/28106b91c36d19c2d5ed7dc163748e6f/raw/page-margin-boxes-image-box-sizing.html
