### PR TITLE
feat: Support GitHub Gist URL with fragment as source file

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -147,6 +147,11 @@ export function resolveURL(relURL: string, baseURL: string): string {
 }
 
 /**
+ * Convert special URLs (e.g. GitHub, Gist) to their raw equivalents.
+ * This is useful for fetching content from these services in a format
+ * that can be easily processed by Vivliostyle.js.
+ *
+ * @param url URL to convert
  * @return converted URL
  */
 export function convertSpecialURL(url: string): string {
@@ -177,6 +182,13 @@ export function convertSpecialURL(url: string): string {
   ) {
     // Convert Gist URL to Gist raw URL
     url = `${r[1]}//gist.githubusercontent.com/${r[2]}/raw/${r[6]}`;
+  } else if (
+    (r = /^(https?:)\/\/gist\.github\.com\/([^/]+\/\w+)#file-(.*)-(\w+)$/.exec(
+      url,
+    ))
+  ) {
+    // Convert Gist URL with fragment to Gist raw URL
+    url = `${r[1]}//gist.githubusercontent.com/${r[2]}/raw/${r[3]}.${r[4]}`;
   } else if (
     (r =
       /^(https?:)\/\/(?:[^/.]+\.)?jsbin\.com\/(?!(?:blog|help)\b)(\w+)((\/\d+)?).*$/.exec(


### PR DESCRIPTION
When a GitHub Gist URL is specified as the source file, Vivliostyle.js fetches the raw content of the Gist and renders it. This allows users to easily use Gist files as source files in Vivliostyle.js.

This commit adds support for Gist URLs with fragments, enabling users to specify a specific file within a Gist.