### PR TITLE
feat: Support `fit-content` / `min-content` / `max-content` sizing values on page-margin boxes

### DIFF
--- a/packages/core/src/vivliostyle/sizing.ts
+++ b/packages/core/src/vivliostyle/sizing.ts
@@ -25,10 +25,6 @@ import * as Vtree from "./vtree";
  * @enum {string}
  */
 export enum Size {
-  FILL_AVAILABLE_INLINE_SIZE = "fill-available inline size",
-  FILL_AVAILABLE_BLOCK_SIZE = "fill-available block size",
-  FILL_AVAILABLE_WIDTH = "fill-available width",
-  FILL_AVAILABLE_HEIGHT = "fill-available height",
   MAX_CONTENT_INLINE_SIZE = "max-content inline size",
   MAX_CONTENT_BLOCK_SIZE = "max-content block size",
   MAX_CONTENT_WIDTH = "max-content width",
@@ -51,168 +47,70 @@ export function getSize(
   element: Element,
   sizes: Size[],
 ): { [key in Size]: number } {
+  const element1 = element as HTMLElement;
   const original = {
-    display: (element as any).style.display,
-    position: (element as any).style.position,
-    width: (element as any).style.width as string,
-    maxWidth: (element as any).style.maxWidth as string,
-    minWidth: (element as any).style.minWidth as string,
-    height: (element as any).style.height as string,
-    maxHeight: (element as any).style.maxHeight as string,
-    minHeight: (element as any).style.minHeight as string,
-    top: (element as any).style.top as string,
-    right: (element as any).style.right as string,
-    bottom: (element as any).style.bottom as string,
-    left: (element as any).style.left as string,
+    width: element1.style.width,
+    height: element1.style.height,
   };
-  const doc = element.ownerDocument;
-  const parent = element.parentNode;
-
-  // wrap the element with a dummy container element
-  const container = doc.createElement("div");
-  Base.setCSSProperty(container, "position", original.position);
-  parent.insertBefore(container, element);
-  container.appendChild(element);
-  Base.setCSSProperty(element, "width", "auto");
-  Base.setCSSProperty(element, "max-width", "none");
-  Base.setCSSProperty(element, "min-width", "0");
-  Base.setCSSProperty(element, "height", "auto");
-  Base.setCSSProperty(element, "max-height", "none");
-  Base.setCSSProperty(element, "min-height", "0");
 
   function getComputedValue(name: string): string {
     return clientLayout.getElementComputedStyle(element).getPropertyValue(name);
   }
-  const writingModeProperty = Base.getPrefixedPropertyNames("writing-mode");
-  const writingModeValue =
-    (writingModeProperty ? getComputedValue(writingModeProperty[0]) : null) ||
-    getComputedValue("writing-mode");
-  const isVertical =
-    writingModeValue === "vertical-rl" ||
-    writingModeValue === "tb-rl" ||
-    writingModeValue === "vertical-lr" ||
-    writingModeValue === "tb-lr";
+
+  const writingModeValue = getComputedValue("writing-mode");
+  const isVertical = writingModeValue !== "horizontal-tb";
   const inlineSizeName = isVertical ? "height" : "width";
   const blockSizeName = isVertical ? "width" : "height";
 
-  function getFillAvailableInline(): string {
-    if (original.position === "absolute" || original.position === "fixed") {
-      // For absolutely positioned elements, use the element's original size
-      // and position to calculate the fill-available inline size.
-      // This is needed to get correct available inline size for page floats.
-      Base.setCSSProperty(container, "width", original.width);
-      Base.setCSSProperty(container, "height", original.height);
-      Base.setCSSProperty(container, "top", original.top);
-      Base.setCSSProperty(container, "right", original.right);
-      Base.setCSSProperty(container, "bottom", original.bottom);
-      Base.setCSSProperty(container, "left", original.left);
-    }
-    Base.setCSSProperty(element, "display", "block");
-    Base.setCSSProperty(element, "position", "static");
-    const r = getComputedValue(inlineSizeName);
-    Base.setCSSProperty(container, "width", "");
-    Base.setCSSProperty(container, "height", "");
-    Base.setCSSProperty(container, "top", "");
-    Base.setCSSProperty(container, "right", "");
-    Base.setCSSProperty(container, "bottom", "");
-    Base.setCSSProperty(container, "left", "");
+  function getSizeValue(
+    sizeName: "width" | "height",
+    minMaxFitContent: "min-content" | "max-content" | "fit-content",
+  ): string {
+    element1.style[sizeName] = minMaxFitContent;
+    const r = getComputedValue(sizeName);
+    element1.style[sizeName] = original[sizeName];
     return r;
   }
 
-  // Inline size of an inline-block element is the fit-content
-  // (shrink-to-fit) inline size.
-  function getMaxContentInline(): string {
-    Base.setCSSProperty(element, "display", "inline-block");
-
-    // When the available inline size is sufficiently large, the fit-content
-    // inline size equals to the max-content inline size.
-    Base.setCSSProperty(container, inlineSizeName, "99999999px"); // 'sufficiently large' value
-    const r = getComputedValue(inlineSizeName);
-    Base.setCSSProperty(container, inlineSizeName, "");
-    return r;
-  }
-
-  function getMinContentInline(): string {
-    Base.setCSSProperty(element, "display", "inline-block");
-
-    // When the available inline size is zero, the fit-content inline size
-    // equals to the min-content inline size.
-    Base.setCSSProperty(container, inlineSizeName, "0");
-    const r = getComputedValue(inlineSizeName);
-    Base.setCSSProperty(container, inlineSizeName, "");
-    return r;
-  }
-
-  function getFitContentInline(): string {
-    const fillAvailableInline = getFillAvailableInline();
-    const minContentInline = getMinContentInline();
-    const parsedFillAvailable = parseFloat(fillAvailableInline);
-    if (parsedFillAvailable <= parseFloat(minContentInline)) {
-      return minContentInline;
-    } else {
-      const maxContentInline = getMaxContentInline();
-      if (parsedFillAvailable <= parseFloat(maxContentInline)) {
-        return fillAvailableInline;
-      } else {
-        return maxContentInline;
-      }
-    }
-  }
-
-  function getIdealBlock(): string {
-    return getComputedValue(blockSizeName);
-  }
-
-  function getFillAvailableBlock(): string {
-    throw new Error("Getting fill-available block size is not implemented");
-  }
   const result = {} as { [key in Size]: number };
-  sizes.forEach((size) => {
+  for (const size of sizes) {
     let r: string;
     switch (size) {
-      case Size.FILL_AVAILABLE_INLINE_SIZE:
-        r = getFillAvailableInline();
-        break;
       case Size.MAX_CONTENT_INLINE_SIZE:
-        r = getMaxContentInline();
+        r = getSizeValue(inlineSizeName, "max-content");
         break;
       case Size.MIN_CONTENT_INLINE_SIZE:
-        r = getMinContentInline();
+        r = getSizeValue(inlineSizeName, "min-content");
         break;
       case Size.FIT_CONTENT_INLINE_SIZE:
-        r = getFitContentInline();
-        break;
-      case Size.FILL_AVAILABLE_BLOCK_SIZE:
-        r = getFillAvailableBlock();
+        r = getSizeValue(inlineSizeName, "fit-content");
         break;
       case Size.MAX_CONTENT_BLOCK_SIZE:
+        r = getSizeValue(blockSizeName, "max-content");
+        break;
       case Size.MIN_CONTENT_BLOCK_SIZE:
+        r = getSizeValue(blockSizeName, "min-content");
+        break;
       case Size.FIT_CONTENT_BLOCK_SIZE:
-        r = getIdealBlock();
-        break;
-      case Size.FILL_AVAILABLE_WIDTH:
-        r = isVertical ? getFillAvailableBlock() : getFillAvailableInline();
-        break;
-      case Size.FILL_AVAILABLE_HEIGHT:
-        r = isVertical ? getFillAvailableInline() : getFillAvailableBlock();
+        r = getSizeValue(blockSizeName, "fit-content");
         break;
       case Size.MAX_CONTENT_WIDTH:
-        r = isVertical ? getIdealBlock() : getMaxContentInline();
+        r = getSizeValue("width", "max-content");
         break;
       case Size.MAX_CONTENT_HEIGHT:
-        r = isVertical ? getMaxContentInline() : getIdealBlock();
+        r = getSizeValue("height", "max-content");
         break;
       case Size.MIN_CONTENT_WIDTH:
-        r = isVertical ? getIdealBlock() : getMinContentInline();
+        r = getSizeValue("width", "min-content");
         break;
       case Size.MIN_CONTENT_HEIGHT:
-        r = isVertical ? getMinContentInline() : getIdealBlock();
+        r = getSizeValue("height", "min-content");
         break;
       case Size.FIT_CONTENT_WIDTH:
-        r = isVertical ? getIdealBlock() : getFitContentInline();
+        r = getSizeValue("width", "fit-content");
         break;
       case Size.FIT_CONTENT_HEIGHT:
-        r = isVertical ? getFitContentInline() : getIdealBlock();
+        r = getSizeValue("height", "fit-content");
         break;
     }
     // Workaround for the case that the element has an image that is
@@ -226,16 +124,7 @@ export function getSize(
       r = "1px";
     }
     result[size] = parseFloat(r);
-    Base.setCSSProperty(element, "position", original.position);
-    Base.setCSSProperty(element, "display", original.display);
-  });
-  Base.setCSSProperty(element, "width", original.width);
-  Base.setCSSProperty(element, "max-width", original.maxWidth);
-  Base.setCSSProperty(element, "min-width", original.minWidth);
-  Base.setCSSProperty(element, "height", original.height);
-  Base.setCSSProperty(element, "max-height", original.maxHeight);
-  Base.setCSSProperty(element, "min-height", original.minHeight);
-  parent.insertBefore(element, container);
-  parent.removeChild(container);
+  }
+
   return result;
 }

--- a/packages/core/test/spec/vivliostyle/sizing-spec.js
+++ b/packages/core/test/spec/vivliostyle/sizing-spec.js
@@ -50,11 +50,7 @@ describe("sizing", function () {
     containingBlockDisplay: "block",
     containingBlockPosition: "relative",
     elementWidth: 1,
-    elementMaxWidth: 3,
-    elementMinWidth: 2,
     elementHeight: 1,
-    elementMaxHeight: 3,
-    elementMinHeight: 2,
     elementDisplay: "block",
     elementPosition: "static",
     marginLeft: 5,
@@ -79,11 +75,7 @@ describe("sizing", function () {
     cStyle.position = initialProperties.containingBlockPosition;
     var eStyle = element.style;
     eStyle.width = initialProperties.elementWidth + "px";
-    eStyle.maxWidth = initialProperties.elementMaxWidth + "px";
-    eStyle.minWidth = initialProperties.elementMinWidth + "px";
     eStyle.height = initialProperties.elementHeight + "px";
-    eStyle.maxHeight = initialProperties.elementMaxHeight + "px";
-    eStyle.minHeight = initialProperties.elementMinHeight + "px";
     eStyle.display = initialProperties.elementDisplay;
     eStyle.position = initialProperties.elementPosition;
     eStyle.marginLeft = initialProperties.marginLeft + "px";
@@ -109,11 +101,7 @@ describe("sizing", function () {
     expect(cStyle.position).toBe(initialProperties.containingBlockPosition);
     var eStyle = element.style;
     expect(eStyle.width).toBe(initialProperties.elementWidth + "px");
-    expect(eStyle.maxWidth).toBe(initialProperties.elementMaxWidth + "px");
-    expect(eStyle.minWidth).toBe(initialProperties.elementMinWidth + "px");
     expect(eStyle.height).toBe(initialProperties.elementHeight + "px");
-    expect(eStyle.maxHeight).toBe(initialProperties.elementMaxHeight + "px");
-    expect(eStyle.minHeight).toBe(initialProperties.elementMinHeight + "px");
     expect(eStyle.display).toBe(initialProperties.elementDisplay);
     expect(eStyle.position).toBe(initialProperties.elementPosition);
     expect(eStyle.marginLeft).toBe(initialProperties.marginLeft + "px");
@@ -195,159 +183,9 @@ describe("sizing", function () {
     initialProperties.marginRight;
   var maxContentInlineSize = 10 + 20 + 30 + 20;
   var minContentInlineSize = 30;
-  var idealBlockSize = 30 + 20 + 20;
+  var idealBlockSize = 10 + 20 + 30 + 20 + 20; // was 30 + 20 + 20 before the fix in PR #1540
 
   describe("getSize", function () {
-    describe("fill-available inline size", function () {
-      it("is the available inline size minus element's margins, border, and padding", function () {
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        var expected = fillAvailableInlineSize;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-
-        element.style.borderLeft = "none";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expected += initialProperties.borderLeft;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-
-        element.style.borderRight = "none";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expected += initialProperties.borderRight;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-      });
-
-      it("any auto margin is treated as zero", function () {
-        element.style.marginLeft = "auto";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        var expected =
-          initialProperties.containingBlockWidth -
-          horizontalBorderAndPadding -
-          initialProperties.marginRight;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-
-        element.style.marginRight = "auto";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expected =
-          initialProperties.containingBlockWidth - horizontalBorderAndPadding;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-      });
-
-      it("is the available inline size minus element's margins, border, and padding (in vertical writing mode)", function () {
-        setVertical();
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        var expected =
-          initialProperties.containingBlockHeight -
-          verticalBorderAndPadding -
-          initialProperties.marginTop -
-          initialProperties.marginBottom;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-
-        element.style.borderTop = "none";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expected += initialProperties.borderTop;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-
-        element.style.borderBottom = "none";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expected += initialProperties.borderBottom;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-      });
-
-      it("any auto margin is treated as zero (in vertical writing mode)", function () {
-        setVertical();
-        element.style.marginTop = "auto";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        var expected =
-          initialProperties.containingBlockHeight -
-          verticalBorderAndPadding -
-          initialProperties.marginBottom;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-
-        element.style.marginBottom = "auto";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expected =
-          initialProperties.containingBlockHeight - verticalBorderAndPadding;
-        expect(size[Size.FILL_AVAILABLE_INLINE_SIZE]).toBe(expected);
-      });
-
-      it("the original properties and DOM structure are restored after measurement", function () {
-        sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        checkOriginalPropertiesAndDOMStructure();
-      });
-    });
-
-    describe("fill-available width", function () {
-      it("is fill-available inline size in horizontal writing mode", function () {
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_WIDTH,
-        ]);
-        var fillAvailableInline = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FILL_AVAILABLE_WIDTH]).toBe(
-          fillAvailableInline[Size.FILL_AVAILABLE_INLINE_SIZE],
-        );
-      });
-    });
-
-    describe("fill-available height", function () {
-      it("is fill-available inline size in vertical writing mode", function () {
-        setVertical();
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_HEIGHT,
-        ]);
-        var fillAvailableInline = sizing.getSize(clientLayout, element, [
-          Size.FILL_AVAILABLE_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FILL_AVAILABLE_HEIGHT]).toBe(
-          fillAvailableInline[Size.FILL_AVAILABLE_INLINE_SIZE],
-        );
-      });
-    });
-
     describe("max-content inline size", function () {
       it("is the narrowest inline size it could take if none of the soft wrap opportunities were taken", function () {
         var size = sizing.getSize(clientLayout, element, [
@@ -571,121 +409,6 @@ describe("sizing", function () {
         expect(size[Size.MIN_CONTENT_HEIGHT]).toBe(
           minContentInline[Size.MIN_CONTENT_INLINE_SIZE],
         );
-      });
-    });
-
-    describe("fit-content inline size", function () {
-      it("equals min-content size when (fill-available size) < (min-content size)", function () {
-        containingBlock.style.width =
-          horizontalMarginAndBorderAndPadding + minContentInlineSize - 1 + "px";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBe(minContentInlineSize);
-      });
-
-      it("equals fill-available size when (min-content size) <= (fill-available size) <= (max-content size)", function () {
-        containingBlock.style.width =
-          horizontalMarginAndBorderAndPadding + minContentInlineSize + 1 + "px";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBe(
-          minContentInlineSize + 1,
-        );
-
-        containingBlock.style.width =
-          horizontalMarginAndBorderAndPadding + maxContentInlineSize - 1 + "px";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBe(
-          maxContentInlineSize - 1,
-        );
-      });
-
-      it("equals max-content size when (max-content size) < (fill-available size)", function () {
-        containingBlock.style.width =
-          horizontalMarginAndBorderAndPadding + maxContentInlineSize + 1 + "px";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBeCloseTo(
-          maxContentInlineSize,
-          1,
-        );
-      });
-
-      it("the original properties and DOM structure are restored after measurement", function () {
-        sizing.getSize(clientLayout, element, [Size.FIT_CONTENT_INLINE_SIZE]);
-
-        checkOriginalPropertiesAndDOMStructure();
-      });
-
-      it("equals min-content size when (fill-available size) < (min-content size) (in vertical writing mode)", function () {
-        setVertical();
-        containingBlock.style.height =
-          verticalMarginAndBorderAndPadding + minContentInlineSize - 1 + "px";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBe(minContentInlineSize);
-      });
-
-      it("equals fill-available size when (min-content size) <= (fill-available size) <= (max-content size) (in vertical writing mode)", function () {
-        setVertical();
-        containingBlock.style.height =
-          verticalMarginAndBorderAndPadding + minContentInlineSize + 1 + "px";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBe(
-          minContentInlineSize + 1,
-        );
-
-        containingBlock.style.height =
-          verticalMarginAndBorderAndPadding + maxContentInlineSize - 1 + "px";
-
-        size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBe(
-          maxContentInlineSize - 1,
-        );
-      });
-
-      it("equals max-content size when (max-content size) < (fill-available size) (in vertical writing mode)", function () {
-        setVertical();
-        containingBlock.style.height =
-          verticalMarginAndBorderAndPadding + maxContentInlineSize + 1 + "px";
-
-        var size = sizing.getSize(clientLayout, element, [
-          Size.FIT_CONTENT_INLINE_SIZE,
-        ]);
-
-        expect(size[Size.FIT_CONTENT_INLINE_SIZE]).toBeCloseTo(
-          maxContentInlineSize,
-          1,
-        );
-      });
-
-      it("the original properties and DOM structure are restored after measurement", function () {
-        sizing.getSize(clientLayout, element, [Size.FIT_CONTENT_BLOCK_SIZE]);
-
-        checkOriginalPropertiesAndDOMStructure();
       });
     });
 


### PR DESCRIPTION
- Implemented support for `min-content`, `max-content`, and `fit-content` sizing values for `width` and `height` (also `inline-size` and `block-size`) properties on page-margin boxes.
  - resolves #1520
- Fixed issues with `min-height`, `max-height`, `min-width`, and `max-width` properties not working correctly on page-margin boxes.
- Improved `auto` margin handling for page-margin boxes.
- Refactored `Sizing.getSize()` function to utilize browser's native `min-content`, `max-content`, and `fit-content` sizing capabilities, with the following changes:
  - When getting `width: *-content` or `height: *-content` computed values, other specified properties such as `min-width`, `max-width`, `min-height`, and `max-height` are respected.
  - Removed `Size.FILLAVAILABLE_*` constants, as they are no longer needed.
  - Updated test: packages/core/test/spec/vivliostyle/sizing-spec.js