### PR TITLE
fix: Fix broken internal links in output PDF (workaround for Chromium>=138 bug)

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -149,10 +149,9 @@ export const VivliostyleViewportCss = `
 }
 
 [data-vivliostyle-bleed-box] {
-  position: absolute;
+  position: relative;
   overflow: hidden;
   background-origin: content-box !important;
-  box-sizing: border-box;
 }
 
 [data-vivliostyle-page-box] ~ [data-vivliostyle-page-box] {

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -1937,6 +1937,11 @@ export class PageRulePartitionInstance extends PageMaster.PartitionInstance<Page
       true,
     );
     super.prepareContainer(context, container, page, docFaces, clientLayout);
+
+    // Avoid using `position: absolute` to work around Chromium 138- PDF link bug. (Issue #1541)
+    Base.setCSSProperty(container.element, "position", "relative");
+    Base.setCSSProperty(container.element, "inset", "");
+    Base.setCSSProperty(container.element, "display", "flow-root");
   }
 }
 
@@ -2022,6 +2027,11 @@ export class PageAreaPartitionInstance extends PageMaster.PartitionInstance<Page
     // Set page area size for vw/vh unit calculation
     context.pageAreaWidth = parseFloat(page.pageAreaElement.style.width);
     context.pageAreaHeight = parseFloat(page.pageAreaElement.style.height);
+
+    // Avoid using `position: absolute` to work around Chromium 138- PDF link bug. (Issue #1541)
+    Base.setCSSProperty(container.element, "position", "relative");
+    Base.setCSSProperty(container.element, "inset", "");
+    Base.setCSSProperty(container.element, "display", "flow-root");
   }
 }
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2260,9 +2260,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const pageCont = viewport.document.createElement("div") as HTMLElement;
     pageCont.setAttribute("data-vivliostyle-page-container", "true");
     pageCont.setAttribute("role", "region");
-    pageCont.style.position = "absolute";
-    pageCont.style.top = "0";
-    pageCont.style.left = "0";
 
     if (!Constants.isDebug) {
       pageCont.style.visibility = "hidden";

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1974,9 +1974,9 @@ export class StyleInstance
     page.container.style.width = `${this.pageSheetWidth}px`;
     page.container.style.height = `${this.pageSheetHeight}px`;
     page.bleedBox.style.left = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
-    page.bleedBox.style.right = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
+    page.bleedBox.style.width = `${evaluatedPageSizeAndBleed.pageWidth}px`;
     page.bleedBox.style.top = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
-    page.bleedBox.style.bottom = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
+    page.bleedBox.style.height = `${evaluatedPageSizeAndBleed.pageHeight}px`;
     page.bleedBox.style.padding = `${evaluatedPageSizeAndBleed.bleed}px`;
   }
 }


### PR DESCRIPTION
- fix #1541

This commit addresses the issue of broken internal links in the generated PDF when using Vivliostyle.js with Chromium version 138 and later. The problem arises when link targets are inside elements with `position: absolute`, which causes the links to not function correctly in the output PDF.

- Chromium issue: [Internal links in generated PDF do not work when link targets are inside position:absolute elements](https://issues.chromium.org/issues/437456046)

This fix modifies the way Vivliostyle.js handles the positioning of page-related elements to avoid using `position: absolute` and ensures that link targets are not inside such positioned elements. This workaround allows internal links to work correctly in the generated PDF with Chromium>=138.

This change is a temporary workaround until the underlying issue in Chromium is resolved, and it will be revisited when the Chromium bug is resolved.