### PR TITLE
fix: Top page float should not absorb margin/border/padding of the block below (Regression in v2.33.0)

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -67,18 +67,21 @@ export const VivliostyleViewportScreenCss = `
   }
 
   [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view="true"]
+    [data-vivliostyle-spread-container]
     [data-vivliostyle-page-container][data-vivliostyle-page-side="left"] {
     margin-right: 1px;
     transform-origin: right top;
   }
 
   [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view="true"]
+    [data-vivliostyle-spread-container]
     [data-vivliostyle-page-container][data-vivliostyle-page-side="right"] {
     margin-left: 1px;
     transform-origin: left top;
   }
 
   [data-vivliostyle-viewer-viewport][data-vivliostyle-spread-view="true"]
+    [data-vivliostyle-spread-container]
     [data-vivliostyle-page-container][data-vivliostyle-unpaired-page="true"] {
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
fixes again #1071.

This bug was once fixed in v2.21.0 (PR #1075) but was reintroduced in v2.33.0 as a side effect of the changes made in PR #1519.