### PR TITLE
fix: Fix margin-block-start ignored on block with forced page break after clearing a page float

### DIFF
--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -757,7 +757,11 @@ export class NodeContext implements Vtree.NodeContext {
         ? this.shadowSibling.toNodePositionStep()
         : null,
       formattingContext: this.formattingContext,
-      fragmentIndex: this.fragmentIndex,
+
+      // fragmentIndex needs to be reset to 0 if this viewNode has been removed
+      // from the view tree by forced break processing. (Issue #1557)
+      fragmentIndex:
+        this.viewNode?.parentNode === null ? 0 : this.fragmentIndex,
     };
   }
 


### PR DESCRIPTION
- fix #1557

The problem was that the fragmentIndex was not being reset correctly when a viewNode was removed from the view tree due to forced break processing. This caused incorrect margin-block-start discarding.