### PR TITLE
fix: Fix accessibility problem in output PDF (failed to read aloud)

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -194,7 +194,9 @@ export const VivliostyleViewportCss = `
   @supports (zoom: 8) {
     [data-vivliostyle-spread-container] [data-vivliostyle-page-container] {
       zoom: var(--viv-outputPixelRatio,1);
-      transform: scale(calc(1 / var(--viv-outputPixelRatio,1)));
+      /* transform: scale(calc(1 / var(--viv-outputPixelRatio,1))); */
+      /* Use matrix instead of scale (Workaround for issue #1555) */
+      transform: matrix(calc(1 / var(--viv-outputPixelRatio,1)), 0, 5e-324, calc(1 / var(--viv-outputPixelRatio,1)), 0, 0);
       transform-origin: left top;
     }
   }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2259,7 +2259,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const viewport = viewItem.instance.viewport;
     const pageCont = viewport.document.createElement("div") as HTMLElement;
     pageCont.setAttribute("data-vivliostyle-page-container", "true");
-    pageCont.setAttribute("role", "region");
+    pageCont.role = "presentation";
 
     if (!Constants.isDebug) {
       pageCont.style.visibility = "hidden";
@@ -2267,6 +2267,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     viewport.layoutBox.appendChild(pageCont);
     const bleedBox = viewport.document.createElement("div") as HTMLElement;
     bleedBox.setAttribute("data-vivliostyle-bleed-box", "true");
+    bleedBox.role = "presentation";
     pageCont.appendChild(bleedBox);
     const page = new Vtree.Page(pageCont, bleedBox);
     page.spineIndex = viewItem.item.spineIndex;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1494,6 +1494,10 @@ export class StyleInstance
     const dontExclude = wrapFlow === Css.ident.auto;
     const flowName = boxInstance.getProp(this, "flow-from");
     const boxContainer = this.viewport.document.createElement("div");
+    boxContainer.role =
+      boxInstance instanceof CssPage.PageMarginBoxPartitionInstance
+        ? "complementary"
+        : "presentation";
     const position = boxInstance.getProp(this, "position");
     Base.setCSSProperty(
       boxContainer,

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1194,6 +1194,7 @@ export class ViewFactory
       const fetchers = [];
       let ns = element.namespaceURI;
       let tag = element.localName;
+      let originalTag = tag;
       if (ns == Base.NS.XHTML) {
         if (
           tag == "html" ||
@@ -1280,6 +1281,12 @@ export class ViewFactory
           return;
         } else {
           result = this.createElement(ns, tag);
+        }
+        if (tag != originalTag) {
+          result.setAttribute("data-vivliostyle-original-tag", originalTag);
+          if (originalTag === "html" || originalTag === "body") {
+            result.role = "presentation";
+          }
         }
         if (tag == "a") {
           result.addEventListener("click", this.page.hrefHandler, false);
@@ -3037,6 +3044,7 @@ export class Viewport {
     if (!outerZoomBox) {
       outerZoomBox = this.document.createElement("div");
       outerZoomBox.setAttribute("data-vivliostyle-outer-zoom-box", "true");
+      outerZoomBox.role = "presentation";
       this.root.appendChild(outerZoomBox);
     }
     let contentContainer = outerZoomBox.firstElementChild as HTMLElement;
@@ -3046,6 +3054,7 @@ export class Viewport {
         "data-vivliostyle-spread-container",
         "true",
       );
+      contentContainer.role = "presentation";
       outerZoomBox.appendChild(contentContainer);
     }
 
@@ -3084,6 +3093,7 @@ export class Viewport {
     if (!layoutBox) {
       layoutBox = this.document.createElement("div");
       layoutBox.setAttribute("data-vivliostyle-layout-box", "true");
+      layoutBox.role = "presentation";
       this.root.appendChild(layoutBox);
     }
     this.outerZoomBox = outerZoomBox;


### PR DESCRIPTION
- fix #1555

Fix the issue where Adobe Reader fails to read aloud text in PDFs generated by Vivliostyle with Chromium. See the issue for more details.