### PR TITLE
fix: CSS break-before may cause wrong layout in print (Regression in v2.34.1)

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1040,11 +1040,12 @@ export class ViewFactory
           !Css.isDefaultingValue(breakBefore) &&
           !(insideNonRootMultiColumn && breakBefore === Css.ident.column)
         ) {
-          if (this.nodeContext.fragmentIndex === 1) {
-            this.nodeContext.breakBefore = breakBefore.toString();
-          }
+          this.nodeContext.breakBefore = breakBefore.toString();
           if (Break.forcedBreakValues[this.nodeContext.breakBefore]) {
             delete computedStyle["break-before"];
+          }
+          if (this.nodeContext.fragmentIndex !== 1) {
+            this.nodeContext.breakBefore = null;
           }
         }
         // Named page type


### PR DESCRIPTION
This fixes a bug where the layout may be broken in print output when the CSS `break-before` property is specified on an element that spans multiple pages.

- fix #1572

This bug was caused by an error in the following fix in [v2.28.0](https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.28.0):

- #1280

With this potential issue, when an element with `break-before` spans multiple pages, the `break-before` style remained on the second and subsequent pages in the view tree. Since Vivliostyle.js handles the processing of CSS `break-before` property, it should not remain in the view tree.

This issue became apparent after the following fix in [v2.34.1](https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.34.1), which changed the positioning of each page from `position: absolute;` to `position: relative;`:

- #1543

According to the CSS specification, `break-before` and `break-after` properties do not apply to absolutely positioned boxes. Therefore, when the page content was previously placed within `position: absolute;` boxes, this issue did not occur. It became apparent when it was changed to `position: relative;`.

- spec https://drafts.csswg.org/css-break/#break-between
  
  > 3.1. Breaks Between Boxes: the `break-before` and `break-after` properties
  >
  > … User agents must not apply these properties to absolutely-positioned boxes.
