### PR TITLE
feat: Implement target-text()

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -301,6 +301,8 @@ CONTENT_LIST = [ STRING | URI | counter(IDENT LIST_STYLE_TYPE?) |
     target-counter(ATTR IDENT LIST_STYLE_TYPE?) |
     target-counters([ STRING | URI ] IDENT STRING LIST_STYLE_TYPE?) |
     target-counters(ATTR IDENT STRING LIST_STYLE_TYPE?) |
+    target-text([ STRING | URI ] [content | before | after | first-letter]?) |
+    target-text(ATTR [content | before | after | first-letter]?) |
     leader([ dotted | solid | space ] | STRING ) |
     open-quote | close-quote | no-open-quote | no-close-quote |
     content([ text | before | after | first-letter ]?) |

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -269,8 +269,11 @@ class CounterResolver implements CssCascade.CounterResolver {
           );
           return pseudoElem ? (pseudoElem.textContent || "").trim() : "";
         }
-        // For other pseudo-elements, fall back to full content
-        return (element.textContent || "").trim();
+        // For other pseudo-elements, fall back to content (excluding ::before and ::after)
+        const clone = element.cloneNode(true) as Element;
+        const pseudos = clone.querySelectorAll("[data-adapt-pseudo]");
+        pseudos.forEach((pseudo) => pseudo.remove());
+        return (clone.textContent || "").trim();
       }
       return "";
     } else {

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -436,7 +436,8 @@ class CounterResolver implements CssCascade.CounterResolver {
             return "??";
           }
 
-          const text = beforeText || contentText || afterText || "";
+          const text =
+            (beforeText ?? "") + (contentText ?? "") + (afterText ?? "");
           this.counterStore.resolveReference(transformedId);
 
           const match = text.match(Base.firstLetterPattern);

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -436,7 +436,7 @@ class CounterResolver implements CssCascade.CounterResolver {
             return "??";
           }
 
-          const text = beforeText ?? contentText ?? afterText ?? "";
+          const text = beforeText || contentText || afterText || "";
           this.counterStore.resolveReference(transformedId);
 
           const match = text.match(Base.firstLetterPattern);

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1098,7 +1098,7 @@ export class CounterStore {
       if (expr && expr.transformedId) {
         const text = this.pageTextById[expr.transformedId];
         if (text) {
-          node.textContent = text[expr.pseudoElement];
+          node.textContent = text[expr.pseudoElement] ?? "";
         }
       }
     }

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2230,7 +2230,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
         }
         break;
       case "target-text":
-        if (func.values.length <= 2) {
+        if (func.values.length >= 1 && func.values.length <= 2) {
           return this.visitFuncTargetText(func.values);
         }
         break;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2090,14 +2090,6 @@ export class ContentPropVisitor extends Css.FilterVisitor {
    */
   visitFuncTargetText(values: Css.Val[]): Css.Val {
     const targetUrl = values[0];
-
-    // target-text() does not support function values like string() as the first argument
-    // Only URL, string literals, and attr() are supported
-    if (targetUrl instanceof Css.Func) {
-      // Return empty string constant to avoid infinite loop
-      return new Css.SpaceList([new Css.Str("")]);
-    }
-
     let targetUrlStr: string;
     if (targetUrl instanceof Css.URL) {
       targetUrlStr = targetUrl.url;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -79,6 +79,19 @@ module.exports = [
         file: "target-counter-and-margin-bug.html",
         title: "target-counter and margin bug",
       },
+      { file: "target-text.html", title: "target-text() - Basic Tests" },
+      {
+        file: "target-text-running-element.html",
+        title: "target-text() in Running Elements",
+      },
+      {
+        file: [
+          "target-text-multiple/first.html",
+          "target-text-multiple/second.html",
+          "target-text-multiple/third.html",
+        ],
+        title: "target-text() - Cross-Document References",
+      },
       {
         file: "exclusion_with_printer_marks.html",
         title: "Exclusion with printer marks",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -101,6 +101,14 @@ module.exports = [
         title: "target-text() vs Named Strings - first-letter with punctuation",
       },
       {
+        file: "target-text-vs-named-strings-3.html",
+        title: "target-text() vs Named Strings - with ::before",
+      },
+      {
+        file: "target-text-vs-named-strings-4.html",
+        title: "target-text() vs Named Strings - with ::before and ::after",
+      },
+      {
         file: "exclusion_with_printer_marks.html",
         title: "Exclusion with printer marks",
       },

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -93,6 +93,14 @@ module.exports = [
         title: "target-text() - Cross-Document References",
       },
       {
+        file: "target-text-vs-named-strings.html",
+        title: "target-text() vs Named Strings",
+      },
+      {
+        file: "target-text-vs-named-strings-2.html",
+        title: "target-text() vs Named Strings - first-letter with punctuation",
+      },
+      {
         file: "exclusion_with_printer_marks.html",
         title: "Exclusion with printer marks",
       },

--- a/packages/core/test/files/target-text-multiple/first.html
+++ b/packages/core/test/files/target-text-multiple/first.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>First Document - target-text() Cross-Document Test</title>
+    <style>
+      @page {
+        size: 640px 480px;
+        margin: 30px;
+        @bottom-center {
+          font-size: 10px;
+          content: counter(page);
+        }
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: serif;
+        widows: 1;
+        orphans: 1;
+      }
+
+      section {
+        page-break-before: always;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 10px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin-top: 10px;
+      }
+
+      [id] {
+        background-color: #ffffcc;
+        margin: 8px;
+        padding: 4px;
+      }
+
+      .xref::after {
+        content: target-text(attr(href url));
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h2>Document 1: Cross-Document target-text()</h2>
+
+      <p id="target">Target on Document 1</p>
+
+      <h3>Test 1.1:</h3>
+      <p>Expected: <a href="#">Target on Document 2</a></p>
+      <p>Actual: <a href="second.html#target" class="xref"></a></p>
+
+      <h3>Test 1.2:</h3>
+      <p>Expected: <a href="#">Target on Document 3</a></p>
+      <p>Actual: <a href="third.html#target" class="xref"></a></p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-multiple/second.html
+++ b/packages/core/test/files/target-text-multiple/second.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Second Document - target-text() Cross-Document Test</title>
+    <style>
+      @page {
+        size: 640px 480px;
+        margin: 30px;
+        @bottom-center {
+          font-size: 10px;
+          content: counter(page);
+        }
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: serif;
+        widows: 1;
+        orphans: 1;
+      }
+
+      section {
+        page-break-before: always;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 10px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin-top: 10px;
+      }
+
+      [id] {
+        background-color: #ffffcc;
+        margin: 8px;
+        padding: 4px;
+      }
+
+      .xref::after {
+        content: target-text(attr(href url));
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h2>Document 2: Cross-Document target-text()</h2>
+
+      <p id="target">Target on Document 2</p>
+
+      <h3>Test 2.1:</h3>
+      <p>Expected: <a href="#">Target on Document 1</a></p>
+      <p>Actual: <a href="first.html#target" class="xref"></a></p>
+
+      <h3>Test 2.2:</h3>
+      <p>Expected: <a href="#">Target on Document 3</a></p>
+      <p>Actual: <a href="third.html#target" class="xref"></a></p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-multiple/third.html
+++ b/packages/core/test/files/target-text-multiple/third.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Third Document - target-text() Cross-Document Test</title>
+    <style>
+      @page {
+        size: 640px 480px;
+        margin: 30px;
+        @bottom-center {
+          font-size: 10px;
+          content: counter(page);
+        }
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: serif;
+        widows: 1;
+        orphans: 1;
+      }
+
+      section {
+        page-break-before: always;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 10px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin-top: 10px;
+      }
+
+      [id] {
+        background-color: #ffffcc;
+        margin: 8px;
+        padding: 4px;
+      }
+
+      .xref::after {
+        content: target-text(attr(href url));
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h2>Document 3: Cross-Document target-text()</h2>
+
+      <p id="target">Target on Document 3</p>
+
+      <h3>Test 3.1:</h3>
+      <p>Expected: <a href="#">Target on Document 1</a></p>
+      <p>Actual: <a href="first.html#target" class="xref"></a></p>
+
+      <h3>Test 3.2:</h3>
+      <p>Expected: <a href="#">Target on Document 2</a></p>
+      <p>Actual: <a href="second.html#target" class="xref"></a></p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-running-element.html
+++ b/packages/core/test/files/target-text-running-element.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>target-text() in Running Elements Test</title>
+    <style>
+      @page {
+        size: 640px 480px;
+        margin: 30px;
+        font-size: 10px;
+        @top-right {
+          content: element(top-right);
+        }
+        @bottom-center {
+          content: counter(page);
+        }
+        @bottom-left {
+          content: target-text(url(#page-margin-target));
+        }
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: serif;
+        widows: 1;
+        orphans: 1;
+      }
+
+      section {
+        page-break-before: always;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 10px;
+      }
+
+      [id] {
+        background-color: #ffffcc;
+        margin: 8px;
+        padding: 4px;
+      }
+
+      .running-header {
+        position: running(top-right);
+        font-size: 10px;
+      }
+      .running-reference::before {
+        content: target-text(attr(href url));
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h2>Page Margin Box</h2>
+
+      <p id="page-margin-target">This text should appear in the bottom-left</p>
+    </section>
+
+    <section>
+      <h2>Running Element</h2>
+
+      <div class="running-header">
+        <span href="#running-target" class="running-reference"></span>
+      </div>
+
+      <p id="running-target">This text should appear in the top-right</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-running-element.html
+++ b/packages/core/test/files/target-text-running-element.html
@@ -68,7 +68,7 @@
       <h2>Running Element</h2>
 
       <div class="running-header">
-        <span href="#running-target" class="running-reference"></span>
+        <a href="#running-target" class="running-reference"></a>
       </div>
 
       <p id="running-target">This text should appear in the top-right</p>

--- a/packages/core/test/files/target-text-vs-named-strings-2.html
+++ b/packages/core/test/files/target-text-vs-named-strings-2.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-text() and named strings</title>
+    <style>
+      h1 {
+        string-set:
+          before content(before),
+          text content(text),
+          after content(after),
+          first-letter content(first-letter);
+      }
+
+      h1::before {
+        content: "『(Before)』";
+      }
+
+      h1::after {
+        content: "【(After)】";
+      }
+
+      .target-text h3::after {
+        content: target-text("#t", before) target-text("#t", content)
+          target-text("#t", after);
+      }
+
+      .target-text pre::after {
+        content: 'text: "' target-text("#t", content) '";\A' 'before: "'
+          target-text("#t", before) '";\A' 'after: "' target-text("#t", after)
+          '";\A' 'first-letter: "' target-text("#t", first-letter) '";';
+      }
+
+      .named-strings h3::after {
+        content: string(before) string(text) string(after);
+      }
+
+      .named-strings pre::after {
+        content: 'text: "' string(text) '";\A' 'before: "' string(before) '";\A'
+          'after: "' string(after) '";\A' 'first-letter: "' string(first-letter)
+          '";';
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1 id="t">「..Target..」</h1>
+
+    <section class="target-text">
+      <h2>Using target-text()</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+
+    <section class="named-strings">
+      <h2>Using Named Strings</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-vs-named-strings-3.html
+++ b/packages/core/test/files/target-text-vs-named-strings-3.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-text() and named strings</title>
+    <style>
+      h1 {
+        string-set:
+          before content(before),
+          text content(text),
+          after content(after),
+          first-letter content(first-letter);
+      }
+
+      h1::before {
+        content: "“‘";
+      }
+
+      h1::after {
+        content: "”’";
+      }
+
+      .target-text h3::after {
+        content: target-text("#t", before) target-text("#t", content)
+          target-text("#t", after);
+      }
+
+      .target-text pre::after {
+        content: 'text: "' target-text("#t", content) '";\A' 'before: "'
+          target-text("#t", before) '";\A' 'after: "' target-text("#t", after)
+          '";\A' 'first-letter: "' target-text("#t", first-letter) '";';
+      }
+
+      .named-strings h3::after {
+        content: string(before) string(text) string(after);
+      }
+
+      .named-strings pre::after {
+        content: 'text: "' string(text) '";\A' 'before: "' string(before) '";\A'
+          'after: "' string(after) '";\A' 'first-letter: "' string(first-letter)
+          '";';
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1 id="t">Target</h1>
+
+    <section class="target-text">
+      <h2>Using target-text()</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+
+    <section class="named-strings">
+      <h2>Using Named Strings</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-vs-named-strings-4.html
+++ b/packages/core/test/files/target-text-vs-named-strings-4.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-text() and named strings</title>
+    <style>
+      h1 {
+        string-set:
+          before content(before),
+          text content(text),
+          after content(after),
+          first-letter content(first-letter);
+      }
+
+      h1::before {
+        content: "“‘";
+      }
+
+      h1::after {
+        content: "After”’";
+      }
+
+      .target-text h3::after {
+        content: target-text("#t", before) target-text("#t", content)
+          target-text("#t", after);
+      }
+
+      .target-text pre::after {
+        content: 'text: "' target-text("#t", content) '";\A' 'before: "'
+          target-text("#t", before) '";\A' 'after: "' target-text("#t", after)
+          '";\A' 'first-letter: "' target-text("#t", first-letter) '";';
+      }
+
+      .named-strings h3::after {
+        content: string(before) string(text) string(after);
+      }
+
+      .named-strings pre::after {
+        content: 'text: "' string(text) '";\A' 'before: "' string(before) '";\A'
+          'after: "' string(after) '";\A' 'first-letter: "' string(first-letter)
+          '";';
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1 id="t"></h1>
+
+    <section class="target-text">
+      <h2>Using target-text()</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+
+    <section class="named-strings">
+      <h2>Using Named Strings</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-vs-named-strings.html
+++ b/packages/core/test/files/target-text-vs-named-strings.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-text() and named strings</title>
+    <style>
+      h1 {
+        string-set:
+          before content(before),
+          text content(text),
+          after content(after),
+          first-letter content(first-letter);
+      }
+
+      h1::before {
+        content: "Before ";
+      }
+
+      h1::after {
+        content: " After";
+      }
+
+      .target-text h3::after {
+        content: target-text("#t", before) target-text("#t", content)
+          target-text("#t", after);
+      }
+
+      .target-text pre::after {
+        content: 'text: "' target-text("#t", content) '";\A' 'before: "'
+          target-text("#t", before) '";\A' 'after: "' target-text("#t", after)
+          '";\A' 'first-letter: "' target-text("#t", first-letter) '";';
+      }
+
+      .named-strings h3::after {
+        content: string(before) string(text) string(after);
+      }
+
+      .named-strings pre::after {
+        content: 'text: "' string(text) '";\A' 'before: "' string(before) '";\A'
+          'after: "' string(after) '";\A' 'first-letter: "' string(first-letter)
+          '";';
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1 id="t">Target</h1>
+
+    <section class="target-text">
+      <h2>Using target-text()</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+
+    <section class="named-strings">
+      <h2>Using Named Strings</h2>
+      <h3></h3>
+      <pre></pre>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text.html
+++ b/packages/core/test/files/target-text.html
@@ -174,7 +174,7 @@
     <section>
       <h2>Section 4: Nested Elements</h2>
 
-      <h4>Test 4.1:</h4>
+      <h3>Test 4.1:</h3>
       <p>
         Expected: <a href="#">Outer text inner text bold inner more outer</a>
       </p>

--- a/packages/core/test/files/target-text.html
+++ b/packages/core/test/files/target-text.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>target-text() CSS Function Test</title>
+    <style>
+      @page {
+        size: 640px 480px;
+        margin: 30px;
+        @bottom-center {
+          font-size: 10px;
+          content: counter(page);
+        }
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: serif;
+        widows: 1;
+        orphans: 1;
+      }
+
+      section {
+        page-break-before: always;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 10px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin-top: 10px;
+      }
+
+      [id] {
+        background-color: #ffffcc;
+        margin: 8px;
+        padding: 4px;
+      }
+
+      .section-1-basic::after {
+        content: target-text(attr(href url));
+      }
+      .section-1-url::after {
+        content: target-text(url(#target1));
+      }
+      .section-1-string::after {
+        content: target-text("#target2");
+      }
+
+      .section-2::after {
+        content: target-text(attr(href url));
+      }
+
+      #pseudo-target::before {
+        content: "[Before]";
+      }
+      #pseudo-target::after {
+        content: "[After]";
+      }
+      .section-3-content::after {
+        content: target-text(attr(href url), content);
+      }
+      .section-3-before::after {
+        content: target-text(attr(href url), before);
+      }
+      .section-3-after::after {
+        content: target-text(attr(href url), after);
+      }
+      .section-3-first-letter::after {
+        content: target-text(attr(href url), first-letter);
+      }
+
+      #nested-target .inner {
+        font-style: italic;
+      }
+      #nested-target .inner strong {
+        color: red;
+      }
+      .section-4::after {
+        content: target-text(attr(href url), content);
+      }
+
+      .section-5::after {
+        content: target-text(attr(href url), content);
+      }
+
+      .section-6 {
+        counter-reset: section-6-chapter 0;
+      }
+      .section-6-toc-entry::after {
+        content: target-text(attr(href url), before) "　"
+          target-text(attr(href url), content) leader(dotted)
+          target-counter(attr(href url), page);
+      }
+      .section-6-chapter {
+        counter-increment: section-6-chapter;
+      }
+      .section-6-chapter::before {
+        content: "Chapter " counter(section-6-chapter);
+        margin-right: 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h2>Section 1: Basic</h2>
+
+      <h3>Test 1.1: <code>target-text(attr(href url))</code></h3>
+      <p>Expected: <a href="#">Target 1</a></p>
+      <p>Actual: <a href="#target1" class="section-1-basic"></a></p>
+
+      <h3>Test 1.2: <code>target-text(url(#target1))</code></h3>
+      <p>Expected: <a href="#">Target 1</a></p>
+      <p>Actual: <a href="#" class="section-1-url"></a></p>
+
+      <h3>Test 1.3: <code>target-text("#target2")</code></h3>
+      <p>Expected: <a href="#">Target 2</a></p>
+      <p>Actual: <a href="#" class="section-1-string"></a></p>
+
+      <p id="target1">Target 1</p>
+      <p id="target2">Target 2</p>
+    </section>
+
+    <section>
+      <h2>Section 2: Forward and Backward References</h2>
+
+      <p id="target-backward">Target for backward reference</p>
+
+      <h3>Test 2.1: Backward reference (target is above)</h3>
+      <p>Expected: <a href="#">Target for backward reference</a></p>
+      <p>Actual: <a href="#target-backward" class="section-2"></a></p>
+
+      <h3>Test 2.2: Forward reference (target is below)</h3>
+      <p>Expected: <a href="#">Target for forward reference</a></p>
+      <p>Actual: <a href="#target-forward" class="section-2"></a></p>
+
+      <p id="target-forward">Target for forward reference</p>
+    </section>
+
+    <section>
+      <h2>Section 3: Pseudo-element Content</h2>
+
+      <h3>Test 3.1: <code>target-text(attr(href url), content)</code></h3>
+      <p>Expected: <a href="#">Main content</a></p>
+      <p>Actual: <a href="#pseudo-target" class="section-3-content"></a></p>
+
+      <h3>Test 3.2: <code>target-text(attr(href url), before)</code></h3>
+      <p>Expected: <a href="#">[Before]</a></p>
+      <p>Actual: <a href="#pseudo-target" class="section-3-before"></a></p>
+
+      <h3>Test 3.3: <code>target-text(attr(href url), after)</code></h3>
+      <p>Expected: <a href="#">[After]</a></p>
+      <p>Actual: <a href="#pseudo-target" class="section-3-after"></a></p>
+
+      <h3>Test 3.4: <code>target-text(attr(href url), first-letter)</code></h3>
+      <p>Expected: <a href="#">M</a></p>
+      <p>
+        Actual: <a href="#pseudo-target" class="section-3-first-letter"></a>
+      </p>
+
+      <p id="pseudo-target">Main content</p>
+    </section>
+
+    <section>
+      <h2>Section 4: Nested Elements</h2>
+
+      <h4>Test 4.1:</h4>
+      <p>
+        Expected: <a href="#">Outer text inner text bold inner more outer</a>
+      </p>
+      <p>Actual: <a href="#nested-target" class="section-4"></a></p>
+
+      <div id="nested-target">
+        Outer text
+        <span class="inner">inner text <strong>bold inner</strong></span>
+        more outer
+      </div>
+    </section>
+
+    <section>
+      <h2>Section 5: Edge cases</h2>
+
+      <h3>Test 5.1: Empty</h3>
+      <p>Expected: {<a href="#"></a>}</p>
+      <p>Actual: {<a href="#empty-target" class="section-5"></a>}</p>
+
+      <p id="empty-target"></p>
+
+      <h3>Test 5.2: Whitespace-only</h3>
+      <p>Expected: {<a href="#"></a>}</p>
+      <p>Actual: {<a href="#whitespace-target" class="section-5"></a>}</p>
+
+      <!-- prettier-ignore -->
+      <p id="whitespace-target">
+        
+
+      </p>
+
+      <h3>Test 5.3: Non-existent target</h3>
+      <p>Expected: <a href="#">??</a></p>
+      <p>Actual: <a href="#does-not-exist" class="section-5"></a></p>
+
+      <div style="break-after: page"></div>
+
+      <h3>Test 5.4: Long Text Content</h3>
+      <p>
+        Expected:
+        <a href="#"
+          >This is a very long text content that spans multiple lines and
+          contains various words and punctuation marks to test how target-text()
+          handles longer text content with spaces and formatting.</a
+        >
+      </p>
+      <p>Actual: <a href="#long-target" class="section-5"></a></p>
+      <p id="long-target">
+        This is a very long text content that spans multiple lines and contains
+        various words and punctuation marks to test how target-text() handles
+        longer text content with spaces and formatting.
+      </p>
+    </section>
+
+    <section class="section-6">
+      <h2>Section 6: Table of Contents Style</h2>
+
+      <nav style="break-after: page">
+        <a href="#section-6-1" class="section-6-toc-entry"></a>
+        <a href="#section-6-2" class="section-6-toc-entry"></a>
+        <a href="#section-6-3" class="section-6-toc-entry"></a>
+      </nav>
+
+      <h2 id="section-6-1" class="section-6-chapter" style="break-after: page">
+        Introduction
+      </h2>
+
+      <h2 id="section-6-2" class="section-6-chapter" style="break-after: page">
+        Methodology
+      </h2>
+
+      <h2 id="section-6-3" class="section-6-chapter" style="break-after: page">
+        Conclusion
+      </h2>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-text.html
+++ b/packages/core/test/files/target-text.html
@@ -169,7 +169,7 @@
       <p>Actual: <a href="#pseudo-target" class="section-3-after"></a></p>
 
       <h3>Test 3.4: <code>target-text(attr(href url), first-letter)</code></h3>
-      <p>Expected: <a href="#">M</a></p>
+      <p>Expected: <a href="#">[B</a></p>
       <p>
         Actual: <a href="#pseudo-target" class="section-3-first-letter"></a>
       </p>
@@ -186,11 +186,11 @@
       </p>
       <p>Actual: <a href="#nested-target" class="section-4"></a></p>
 
-      <div id="nested-target">
+      <p id="nested-target">
         Outer text
         <span class="inner">inner text <strong>bold inner</strong></span>
         more outer
-      </div>
+      </p>
     </section>
 
     <section>
@@ -203,13 +203,13 @@
       <p id="empty-target"></p>
 
       <h3>Test 5.2: Whitespace-only</h3>
-      <p>Expected: {<a href="#"></a>}</p>
+      <p>Expected: {<a href="#">(whitespace character)</a>}</p>
       <p>Actual: {<a href="#whitespace-target" class="section-5"></a>}</p>
 
       <!-- prettier-ignore -->
       <p id="whitespace-target">
         
-
+        
       </p>
 
       <h3>Test 5.3: Non-existent target</h3>

--- a/packages/core/test/files/target-text.html
+++ b/packages/core/test/files/target-text.html
@@ -93,6 +93,12 @@
       .section-5::after {
         content: target-text(attr(href url), content);
       }
+      .section-5-string-set {
+        string-set: some-string "#invalid-target";
+      }
+      .section-5-invalid-func::after {
+        content: target-text(string(some-string));
+      }
 
       .section-6 {
         counter-reset: section-6-chapter 0;
@@ -210,9 +216,13 @@
       <p>Expected: <a href="#">??</a></p>
       <p>Actual: <a href="#does-not-exist" class="section-5"></a></p>
 
-      <div style="break-after: page"></div>
+      <h3 class="section-5-string-set">
+        Test 5.4: Invalid function (string())
+      </h3>
+      <p>Expected: <a href="#"></a> (E_INVALID_PROPERTY_VALUE in console)</p>
+      <p>Actual: <a href="#" class="section-5-invalid-func"></a></p>
 
-      <h3>Test 5.4: Long Text Content</h3>
+      <h3>Test 5.5: Long Text Content</h3>
       <p>
         Expected:
         <a href="#"


### PR DESCRIPTION
fix #1544 

テストケースを追加し、`target-text()`を実装しました。用意したサンプルは通っており既存の処理を壊すような処理はなさそうですが、とくに無効値の処理方法はあまり理解できていないと感じています。