### PR TITLE
fix: Improve page/column breaking inside tables

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1667,6 +1667,17 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     }
     cont.then((result) => {
       frame.finish(result);
+
+      // Restore column box size if it was modified in `LayoutHelper.getElementClientRectAdjusted()`.
+      if (
+        column.element.hasAttribute("data-vivliostyle-column-height-adjusted")
+      ) {
+        Base.setCSSProperty(column.element, "width", `${column.width}px`);
+        Base.setCSSProperty(column.element, "height", `${column.height}px`);
+        column.element.removeAttribute(
+          "data-vivliostyle-column-height-adjusted",
+        );
+      }
     });
     return frame.result();
   }

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -2043,7 +2043,7 @@ export class EntireTableLayoutConstraint
     // be registered in the first place. See
     // TableLayoutProcessor.prototype.doInitialLayout.
 
-    // Asserts.assert(!nodeContext.overflow);
+    Asserts.assert(!nodeContext.overflow);
     return false;
   }
 

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1644,6 +1644,13 @@ export class ViewFactory
       if (!style) {
         break;
       }
+      if ((node as Element).hasAttribute("data-vivliostyle-column")) {
+        // This is a root column element.
+        // Note: Since PR #1571 (Improve page/column breaking using browser multi-column feature),
+        // `column-count` and `column-width` are set on the root column element.
+        // See `LayoutHelper.setBrowserColumnBreaking()`.
+        break;
+      }
       if (
         !isNaN(parseFloat(style.columnCount)) ||
         !isNaN(parseFloat(style.columnWidth))

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1031,7 +1031,10 @@ export class ViewFactory
         ) {
           this.nodeContext.breakAfter = breakAfter.toString();
           if (Break.forcedBreakValues[this.nodeContext.breakAfter]) {
-            delete computedStyle["break-after"];
+            // delete computedStyle["break-after"];
+
+            // Instead of deleting, set to "column" so that the browser can handle it.
+            computedStyle["break-after"] = Css.ident.column;
           }
         }
         const breakBefore = computedStyle["break-before"];
@@ -1042,7 +1045,10 @@ export class ViewFactory
         ) {
           this.nodeContext.breakBefore = breakBefore.toString();
           if (Break.forcedBreakValues[this.nodeContext.breakBefore]) {
-            delete computedStyle["break-before"];
+            // delete computedStyle["break-before"];
+
+            // Instead of deleting, set to "column" so that the browser can handle it.
+            computedStyle["break-before"] = Css.ident.column;
           }
           if (this.nodeContext.fragmentIndex !== 1) {
             this.nodeContext.breakBefore = null;


### PR DESCRIPTION
This fixes the issue where forced page breaks (break-before/after) specified on table rows (tr) or cells (td) were ignored, by utilizing the browser's multi-column layout feature to handle breaks within tables.

- fix #1492