### PR TITLE
fix: Respect inline elements in leader

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2277,6 +2277,73 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
     );
     const innerInit = column.clientLayout.getElementClientRect(pseudoAfter);
     const innerMarginInlineEnd = column.parseComputedLength(marginInlineEnd);
+
+    // Calculate width of following inline siblings (Issue #1563)
+    let followingInlineSiblingsWidth = 0;
+    const inlineElements: Element[] = [];
+    let lastInlineElement: Element | null = null;
+    let sibling = pseudoAfter.parentElement.nextSibling;
+
+    // Collect all following inline siblings
+    while (sibling) {
+      if (sibling.nodeType !== 1) {
+        // Node.ELEMENT_NODE
+        sibling = sibling.nextSibling;
+        continue;
+      }
+
+      const elem = sibling as Element;
+      const computedStyle = column.clientLayout.getElementComputedStyle(elem);
+      const display = computedStyle.display;
+      const float = computedStyle.float;
+      const position = computedStyle.position;
+
+      // Skip out-of-flow elements
+      if (float !== "none" || position === "absolute" || position === "fixed") {
+        sibling = sibling.nextSibling;
+        continue;
+      }
+
+      // Collect inline-level elements
+      if (
+        display === "inline" ||
+        display === "inline-block" ||
+        display === "inline-flex" ||
+        display === "inline-grid" ||
+        display === "inline-table"
+      ) {
+        inlineElements.push(elem);
+        lastInlineElement = elem;
+      } else if (
+        display === "block" ||
+        display === "flex" ||
+        display === "grid" ||
+        display === "table" ||
+        display === "list-item"
+      ) {
+        break;
+      }
+      sibling = sibling.nextSibling;
+    }
+
+    // Measure the entire range of following siblings including spaces between them
+    if (inlineElements.length > 0 && pseudoAfter.parentElement) {
+      // Measure from the parent element's right edge to the last sibling's right edge
+      // This includes the space between the leader's parent and the first sibling
+      const parentRect = column.clientLayout.getElementClientRect(
+        pseudoAfter.parentElement,
+      );
+      const lastRect = column.clientLayout.getElementClientRect(
+        lastInlineElement!,
+      );
+
+      if (writingMode === "vertical-rl" || writingMode === "vertical-lr") {
+        followingInlineSiblingsWidth = lastRect.bottom - parentRect.bottom;
+      } else {
+        followingInlineSiblingsWidth = lastRect.right - parentRect.right;
+      }
+    }
+
     // capture the line boundary
     // Some leader text ("_" e.g.) creates higher top than container.
     if (writingMode === "vertical-rl" || writingMode === "vertical-lr") {
@@ -2289,6 +2356,14 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
       box.right = innerInit.right;
       box.top = Math.min(innerInit.top, box.top);
       box.bottom = Math.max(innerInit.bottom, box.bottom);
+      // Reserve space for following inline siblings (Issue #1563)
+      if (followingInlineSiblingsWidth > 0) {
+        if (direction === "rtl") {
+          box.top += followingInlineSiblingsWidth;
+        } else {
+          box.bottom -= followingInlineSiblingsWidth;
+        }
+      }
     } else {
       if (direction === "rtl") {
         box.left += innerMarginInlineEnd;
@@ -2299,6 +2374,14 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
       box.bottom = innerInit.bottom;
       box.left = Math.min(innerInit.left, box.left);
       box.right = Math.max(innerInit.right, box.right);
+      // Reserve space for following inline siblings (Issue #1563)
+      if (followingInlineSiblingsWidth > 0) {
+        if (direction === "rtl") {
+          box.left += followingInlineSiblingsWidth;
+        } else {
+          box.right -= followingInlineSiblingsWidth;
+        }
+      }
     }
 
     function overrun() {
@@ -2382,17 +2465,23 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
       return inset;
     }
     let padding = 0;
-    if (direction == "rtl") {
-      if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
-        padding = innerInline.top - innerAligned.top - getInset("top");
+    // When following siblings exist, the leader has already been constrained to the
+    // correct length by box.right adjustment. Additional margin-inline-start would
+    // push the following siblings to the next line. Therefore, padding remains 0.
+    if (followingInlineSiblingsWidth <= 0) {
+      if (direction == "rtl") {
+        if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
+          padding = innerInline.top - innerAligned.top - getInset("top");
+        } else {
+          padding = innerInline.left - innerAligned.left - getInset("left");
+        }
       } else {
-        padding = innerInline.left - innerAligned.left - getInset("left");
-      }
-    } else {
-      if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
-        padding = innerAligned.bottom - innerInline.bottom - getInset("bottom");
-      } else {
-        padding = innerAligned.right - innerInline.right - getInset("right");
+        if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
+          padding =
+            innerAligned.bottom - innerInline.bottom - getInset("bottom");
+        } else {
+          padding = innerAligned.right - innerInline.right - getInset("right");
+        }
       }
     }
     padding = Math.max(0, padding - 0.1); // prevent line wrapping (Issue #1112)

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2465,25 +2465,20 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
       return inset;
     }
     let padding = 0;
-    // When following siblings exist, the leader has already been constrained to the
-    // correct length by box.right adjustment. Additional margin-inline-start would
-    // push the following siblings to the next line. Therefore, padding remains 0.
-    if (followingInlineSiblingsWidth <= 0) {
-      if (direction == "rtl") {
-        if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
-          padding = innerInline.top - innerAligned.top - getInset("top");
-        } else {
-          padding = innerInline.left - innerAligned.left - getInset("left");
-        }
+    if (direction == "rtl") {
+      if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
+        padding = innerInline.top - innerAligned.top - getInset("top");
       } else {
-        if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
-          padding =
-            innerAligned.bottom - innerInline.bottom - getInset("bottom");
-        } else {
-          padding = innerAligned.right - innerInline.right - getInset("right");
-        }
+        padding = innerInline.left - innerAligned.left - getInset("left");
+      }
+    } else {
+      if (writingMode == "vertical-rl" || writingMode == "vertical-lr") {
+        padding = innerAligned.bottom - innerInline.bottom - getInset("bottom");
+      } else {
+        padding = innerAligned.right - innerInline.right - getInset("right");
       }
     }
+    padding -= followingInlineSiblingsWidth;
     padding = Math.max(0, padding - 0.1); // prevent line wrapping (Issue #1112)
     pseudoAfter.style.float = "";
     leaderElem.style.marginInlineStart = `${padding}px`;

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -2879,6 +2879,11 @@ export function evaluateExprToCSS(
   val: Exprs.Val,
   propName: string,
 ): Css.Val {
+  // Preserve viv-leader expressions as Css.Expr (Issue #1563)
+  // leader() must be processed by ContentPropertyHandler, not evaluated here
+  if (val instanceof Exprs.Native && val.str === "viv-leader") {
+    return new Css.Expr(val);
+  }
   const result = val.evaluate(context);
   switch (typeof result) {
     case "number":

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -188,6 +188,10 @@ module.exports = [
         file: "leader/inline-siblings.html",
         title: "leader() with inline sibling elements",
       },
+      {
+        file: "leader/inline-siblings-vertical.html",
+        title: "leader() with inline sibling elements (Vertical)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -184,6 +184,10 @@ module.exports = [
         file: "leader/toc-leader-vertical.html",
         title: "Table of Contents with leader() in vertical writing-mode",
       },
+      {
+        file: "leader/inline-siblings.html",
+        title: "leader() with inline sibling elements",
+      },
     ],
   },
   {

--- a/packages/core/test/files/leader/inline-siblings-vertical.html
+++ b/packages/core/test/files/leader/inline-siblings-vertical.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>leader() with inline sibling elements (Vertical Writing Mode)</title>
+    <style>
+      @page {
+        size: 640px 480px;
+        margin: 30px;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: serif;
+        widows: 1;
+        orphans: 1;
+        writing-mode: vertical-rl;
+      }
+
+      section {
+        margin-bottom: 20px;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 10px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin-top: 10px;
+      }
+
+      ol {
+        margin: 0;
+        padding: 0;
+        display: inline;
+      }
+
+      li {
+        list-style: none;
+        display: inline;
+      }
+
+      ol > li:not(:last-child)::after {
+        content: "、";
+      }
+
+      a::before {
+        content: target-counter(attr(href url), page_);
+      }
+
+      .has-leader-dotted::after {
+        content: leader(dotted) "";
+      }
+
+      .has-leader-custom::after {
+        content: leader("・") "";
+      }
+
+      .has-leader-alone::after {
+        content: leader(dotted);
+      }
+    </style>
+  </head>
+
+  <body>
+    <section>
+      <h3>leader() 単独 (空文字列なし)</h3>
+      <p><span class="has-leader-alone">縦書き</span></p>
+    </section>
+
+    <section>
+      <h3>単一のインライン兄弟要素</h3>
+      <p><span class="has-leader-dotted">縦書き</span><span>兄弟</span></p>
+    </section>
+
+    <section>
+      <h3>複数のインライン兄弟要素</h3>
+      <p>
+        <span class="has-leader-dotted">縦書き</span>
+        <strong>太字</strong>
+        <em>斜体</em>
+        <code>コード</code>
+      </p>
+    </section>
+
+    <section>
+      <h3>ネストされたインライン兄弟要素</h3>
+      <div id="page-11" style="counter-set: page_ 11"></div>
+      <div id="page-42" style="counter-set: page_ 42"></div>
+      <div>
+        <span class="has-leader-dotted">縦書き</span>
+        <ol>
+          <li><a href="#page-11"></a></li>
+          <li><a href="#page-42"></a></li>
+        </ol>
+      </div>
+    </section>
+
+    <section>
+      <h3>カスタム文字列リーダー</h3>
+      <p><span class="has-leader-custom">縦書き</span><span>兄弟</span></p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/leader/inline-siblings-vertical.html
+++ b/packages/core/test/files/leader/inline-siblings-vertical.html
@@ -58,11 +58,11 @@
       }
 
       .has-leader-dotted::after {
-        content: leader(dotted) "";
+        content: leader(dotted);
       }
 
       .has-leader-custom::after {
-        content: leader("・") "";
+        content: leader("・");
       }
 
       .has-leader-alone::after {
@@ -73,7 +73,7 @@
 
   <body>
     <section>
-      <h3>leader() 単独 (空文字列なし)</h3>
+      <h3>兄弟要素なし</h3>
       <p><span class="has-leader-alone">縦書き</span></p>
     </section>
 

--- a/packages/core/test/files/leader/inline-siblings.html
+++ b/packages/core/test/files/leader/inline-siblings.html
@@ -63,10 +63,19 @@
       .has-leader-custom::after {
         content: leader("·") "";
       }
+
+      .has-leader-alone::after {
+        content: leader(dotted);
+      }
     </style>
   </head>
 
   <body>
+    <section>
+      <h3>leader() alone (without trailing empty string)</h3>
+      <p><span class="has-leader-alone">text</span></p>
+    </section>
+
     <section>
       <h3>Single inline sibling</h3>
       <p><span class="has-leader-dotted">text</span><span>sibling</span></p>

--- a/packages/core/test/files/leader/inline-siblings.html
+++ b/packages/core/test/files/leader/inline-siblings.html
@@ -57,11 +57,11 @@
       }
 
       .has-leader-dotted::after {
-        content: leader(dotted) "";
+        content: leader(dotted);
       }
 
       .has-leader-custom::after {
-        content: leader("·") "";
+        content: leader("·");
       }
 
       .has-leader-alone::after {
@@ -72,7 +72,7 @@
 
   <body>
     <section>
-      <h3>leader() alone (without trailing empty string)</h3>
+      <h3>Without siblings</h3>
       <p><span class="has-leader-alone">text</span></p>
     </section>
 

--- a/packages/core/test/files/leader/inline-siblings.html
+++ b/packages/core/test/files/leader/inline-siblings.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>leader() with inline sibling elements</title>
+    <style>
+      @page {
+        size: 640px 480px;
+        margin: 30px;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+      }
+
+      html {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: serif;
+        widows: 1;
+        orphans: 1;
+      }
+
+      section {
+        margin-bottom: 20px;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 10px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin-top: 10px;
+      }
+
+      ol {
+        margin: 0;
+        padding: 0;
+        display: inline;
+      }
+
+      li {
+        list-style: none;
+        display: inline;
+      }
+
+      ol > li:not(:last-child)::after {
+        content: ", ";
+      }
+
+      a::before {
+        content: target-counter(attr(href url), page_);
+      }
+
+      .has-leader-dotted::after {
+        content: leader(dotted) "";
+      }
+
+      .has-leader-custom::after {
+        content: leader("·") "";
+      }
+    </style>
+  </head>
+
+  <body>
+    <section>
+      <h3>Single inline sibling</h3>
+      <p><span class="has-leader-dotted">text</span><span>sibling</span></p>
+    </section>
+
+    <section>
+      <h3>Multiple inline siblings</h3>
+      <p>
+        <span class="has-leader-dotted">text</span>
+        <strong>Bold</strong>
+        <em>Italic</em>
+        <code>Code</code>
+      </p>
+    </section>
+
+    <section>
+      <h3>Nested inline siblings</h3>
+      <div id="page-11" style="counter-set: page_ 11"></div>
+      <div id="page-42" style="counter-set: page_ 42"></div>
+      <div>
+        <span class="has-leader-dotted">text</span>
+        <ol>
+          <li><a href="#page-11"></a></li>
+          <li><a href="#page-42"></a></li>
+        </ol>
+      </div>
+    </section>
+
+    <section>
+      <h3>With custom string leader</h3>
+      <p><span class="has-leader-custom">text</span><span>sibling</span></p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
fix #1563

`content`に`leader()`単独で指定した際に表示されない点と、リーダーをつけた要素の兄弟にさらにインライン要素が存在する場合に差し引く挙動を実装しました。`leader()`単独で表示させるためにcss-parser.ts
に加えた箇所が、少し理解があいまいです。