### PR TITLE
fix: Enable column-fill: auto in non-root multi-column elements

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -53,16 +53,7 @@ export function setBrowserColumnBreaking(column: Layout.Column): void {
     "column-gap",
     `${BIG_GAP - (column.vertical ? column.height : column.width)}px`,
   );
-}
-
-/**
- * Disable the browser's multi-column feature for page/column breaking.
- * This function resets the CSS properties set by `setBrowserColumnBreaking`.
- */
-export function unsetBrowserColumnBreaking(column: Layout.Column): void {
-  Base.setCSSProperty(column.element, "column-count", "");
-  Base.setCSSProperty(column.element, "column-width", "");
-  Base.setCSSProperty(column.element, "column-gap", "");
+  Base.setCSSProperty(column.element, "column-fill", "auto");
 }
 
 /**

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3032,6 +3032,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             }
             const style = (nodeContext.viewNode as HTMLElement).style;
             if (nodeContext.after) {
+              if (
+                style.columnFill === "balance" &&
+                style.getPropertyValue("--viv--saved-column-fill") === "auto"
+              ) {
+                // Restore `column-fill: auto` after layout
+                style.columnFill = "auto";
+                style.removeProperty("--viv--saved-column-fill");
+              }
               if (nodeContext.floatSide) {
                 // Restore break-after:avoid* value at before the float
                 // (Fix for issue #904)
@@ -3624,11 +3632,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       }
       const retryer = new ColumnLayoutRetryer(leadingEdge, breakAfter);
       retryer.layout(nodeContext, this).then((nodeContextParam) => {
-        if (this.element.hasAttribute("data-vivliostyle-column")) {
-          // Unset the browser's multi-column setting.
-          LayoutHelper.unsetBrowserColumnBreaking(this);
-        }
-
         this.doFinishBreak(
           nodeContextParam,
           retryer.context.overflownNodeContext,

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1019,9 +1019,15 @@ export class ViewFactory
       // Leaves handling of multicol specified on non-root/body elements to the browser
       const insideNonRootMultiColumn = this.isInsideNonRootMultiColumn();
 
-      // column-fill:auto does not work for non-root multicol boxes yet.
-      if (computedStyle["column-fill"]) {
-        delete computedStyle["column-fill"];
+      // To make `column-fill: auto` work on non-root multi-column,
+      // we change it to `balance` here, and after layout, we change it back.
+      if (
+        !isRoot &&
+        isMultiColumn &&
+        computedStyle["column-fill"] === Css.ident.auto
+      ) {
+        computedStyle["--viv--saved-column-fill"] = Css.ident.auto;
+        computedStyle["column-fill"] = Css.ident.balance;
       }
 
       const columnSpan = computedStyle["column-span"];


### PR DESCRIPTION
This commit enables the proper handling of `column-fill: auto` in non-root multi-column elements by temporarily changing it to `column-fill: balance` during layout processing, and restoring it back to `auto` at the end of the layout of the multi-column element. In addition, `column-fill: auto` setting is now applied to root-level multi-column elements so that the non-root multi-column elements with `column-fill: auto` can work correctly, and the `unsetBrowserColumnBreaking()` function has been removed as it is no longer helpful.