### PR TITLE
refactor: Remove scaleRect logic that was only needed for old Chromium

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -195,9 +195,12 @@ export class AdaptiveViewer {
 
     // Pixel ratio emulation on PDF output (PR #1079) does not work with
     // non-Chromium browsers.
-    this.pixelRatioLimit = /Chrome/.test(navigator.userAgent)
-      ? 16 // max pixelRatio value on Chromium browsers
-      : 0; // disable pixelRatio emulation on non-Chromium browsers
+    this.pixelRatioLimit =
+      /Chrome/.test(navigator.userAgent) &&
+      // Check non-legacy CSS zoom support (Chromium>=128)
+      "currentCSSZoom" in Element.prototype
+        ? 16 // max pixelRatio value on Chromium browsers
+        : 0; // disable pixelRatio emulation on non-Chromium browsers
     this.pixelRatio = Math.min(8, this.pixelRatioLimit);
   }
 

--- a/packages/viewer/src/utils/scale-util.ts
+++ b/packages/viewer/src/utils/scale-util.ts
@@ -15,19 +15,6 @@
  * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const scaleRect = (rect: DOMRect): DOMRect => {
-  const style = document.getElementById("vivliostyle-viewer-viewport").style;
-  const scaleRectRatio = parseFloat(
-    style.getPropertyValue("--viv-scaleRectRatio") || "1",
-  );
-  return new DOMRect(
-    rect.x * scaleRectRatio,
-    rect.y * scaleRectRatio,
-    rect.width * scaleRectRatio,
-    rect.height * scaleRectRatio,
-  );
-};
-
 export const applyTransformToRect = (
   rect: DOMRect,
   parentRect: DOMRect,

--- a/packages/viewer/src/viewmodels/find-box.ts
+++ b/packages/viewer/src/viewmodels/find-box.ts
@@ -22,7 +22,7 @@ import Navigation from "./navigation";
 import urlParameters from "../stores/url-parameters";
 import keyUtil from "../utils/key-util";
 import stringUtil from "../utils/string-util";
-import { scaleRect, applyTransformToRect } from "../utils/scale-util";
+import { applyTransformToRect } from "../utils/scale-util";
 
 const { Keys } = keyUtil;
 
@@ -247,9 +247,9 @@ class FindBox {
     const parent = this.foundRange.startContainer.parentElement.closest(
       "[data-vivliostyle-page-container='true']",
     );
-    const parentRect = scaleRect(parent.getBoundingClientRect());
+    const parentRect = parent.getBoundingClientRect();
     for (const clientRect of this.foundRange.getClientRects()) {
-      const rect = applyTransformToRect(scaleRect(clientRect), parentRect);
+      const rect = applyTransformToRect(clientRect, parentRect);
       const highlightElement = document.createElement("div");
       highlightElement.setAttribute("data-viv-found-highlight", "true");
       highlightElement.style.position = "absolute";

--- a/packages/viewer/src/viewmodels/marks-store.ts
+++ b/packages/viewer/src/viewmodels/marks-store.ts
@@ -20,7 +20,7 @@ import ko, { Computed, Observable, ObservableArray } from "knockout";
 import ViewerOptions from "../models/viewer-options";
 import Viewer from "./viewer";
 import urlParameters from "../stores/url-parameters";
-import { scaleRect, applyTransformToRect } from "../utils/scale-util";
+import { applyTransformToRect } from "../utils/scale-util";
 
 const t = i18n.t.bind(i18n);
 
@@ -100,7 +100,7 @@ const textNodeRects = (tn: TextInRange): DOMRect[] => {
   const r = document.createRange();
   r.setStart(tn.t, tn.startOffset);
   r.setEnd(tn.t, tn.endOffset);
-  return [...r.getClientRects()].map((rect) => scaleRect(rect));
+  return [...r.getClientRects()];
 };
 
 const markExistIn = (markId: string, e: Element): boolean => {
@@ -177,7 +177,7 @@ const highlight = (
     const parent = tn.t.parentElement.closest(
       "[data-vivliostyle-page-container='true']",
     );
-    const parentRect = scaleRect(parent.getBoundingClientRect());
+    const parentRect = parent.getBoundingClientRect();
     const pageIndex = getPageIndex(parent);
     const spineIndex = getSpineIndex(parent);
     for (const r of textNodeRects(tn)) {


### PR DESCRIPTION
- Remove scaleRect() and related logic that was only needed for pixel ratio emulation (PR #1079) in Chromium versions older than 128 (Issue #1370).
- Assume modern Chromium behavior where getBoundingClientRect() returns accurate values without scaling.
- This simplifies the codebase and removes unnecessary complexity related to scaling.