### PR TITLE
refactor: Revert position:absolute to relative change for workaround of Chromium PDF link bug

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -152,7 +152,7 @@ export const VivliostyleViewportCss = `
 }
 
 [data-vivliostyle-bleed-box] {
-  position: relative;
+  position: absolute;
   overflow: hidden;
   background-origin: content-box !important;
 }

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -1107,8 +1107,6 @@ export class PageRuleMasterInstance extends PageMaster.PageMasterInstance<PageRu
   override initVertical(): void {
     const style = this.style;
 
-    // Shift 1px to workaround Chrome printing bug
-    // style["top"] = new Css.Numeric(-1, "px");
     style["top"] = Css.numericZero;
     style["margin-top"] = Css.numericZero;
     style["border-top-width"] = Css.numericZero;
@@ -1937,11 +1935,6 @@ export class PageRulePartitionInstance extends PageMaster.PartitionInstance<Page
       true,
     );
     super.prepareContainer(context, container, page, docFaces, clientLayout);
-
-    // Avoid using `position: absolute` to work around Chromium 138- PDF link bug. (Issue #1541)
-    Base.setCSSProperty(container.element, "position", "relative");
-    Base.setCSSProperty(container.element, "inset", "");
-    Base.setCSSProperty(container.element, "display", "flow-root");
   }
 }
 
@@ -2027,11 +2020,6 @@ export class PageAreaPartitionInstance extends PageMaster.PartitionInstance<Page
     // Set page area size for vw/vh unit calculation
     context.pageAreaWidth = parseFloat(page.pageAreaElement.style.width);
     context.pageAreaHeight = parseFloat(page.pageAreaElement.style.height);
-
-    // Avoid using `position: absolute` to work around Chromium 138- PDF link bug. (Issue #1541)
-    Base.setCSSProperty(container.element, "position", "relative");
-    Base.setCSSProperty(container.element, "inset", "");
-    Base.setCSSProperty(container.element, "display", "flow-root");
   }
 }
 

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1978,9 +1978,9 @@ export class StyleInstance
     page.container.style.width = `${this.pageSheetWidth}px`;
     page.container.style.height = `${this.pageSheetHeight}px`;
     page.bleedBox.style.left = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
-    page.bleedBox.style.width = `${evaluatedPageSizeAndBleed.pageWidth}px`;
+    page.bleedBox.style.right = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
     page.bleedBox.style.top = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
-    page.bleedBox.style.height = `${evaluatedPageSizeAndBleed.pageHeight}px`;
+    page.bleedBox.style.bottom = `${evaluatedPageSizeAndBleed.bleedOffset}px`;
     page.bleedBox.style.padding = `${evaluatedPageSizeAndBleed.bleed}px`;
   }
 }

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -181,9 +181,6 @@ export class PageMaster<
       Css.ident.visible,
       0,
     );
-
-    // Shift 1px to workaround Chrome printing bug
-    // this.specified["top"] = new CssCascade.CascadeValue(new Css.Numeric(-1, "px"), 0);
   }
 
   override createInstance(parentInstance: PageBoxInstance): PageBoxInstance {


### PR DESCRIPTION
- Revert the change from position:absolute to position:relative for link targets that was made as a workaround for Chromium PDF link bug (PR #1543).
- This change is no longer necessary as the Chromium bug has been fixed in version 140.
- Restore original behavior to simplify code and avoid potential side effects.
- Improve link target insertion for table rows to avoid layout problem (Issue #1439).