### PR TITLE
fix: Disable column-fill balance during leader calculation (#1598)

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -27,6 +27,7 @@ import * as CssTokenizer from "./css-tokenizer";
 import * as CssValidator from "./css-validator";
 import * as Display from "./display";
 import * as Exprs from "./exprs";
+import * as LayoutHelper from "./layout-helper";
 import * as Logging from "./logging";
 import * as Matchers from "./matchers";
 import * as Plugin from "./plugin";
@@ -2340,6 +2341,19 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
     pseudoElem.style.display = "inline-block";
     pseudoElem.style.textIndent = "0"; // cancel inherited text-indent
 
+    // Workaround for Issue #1598:
+    // In multi-column layout with column-fill: balance, changing leader length
+    // triggers column rebalancing, making the initially measured `box` unreliable.
+    // Temporarily switch column-fill to auto to prevent rebalancing during
+    // leader calculation.
+    const columnContainer = LayoutHelper.findAncestorNonRootMultiColumn(
+      container.viewNode,
+    ) as HTMLElement | null;
+    const originalColumnFill = columnContainer?.style.columnFill || null;
+    if (columnContainer) {
+      columnContainer.style.columnFill = "auto";
+    }
+
     const box = column.clientLayout.getElementClientRect(
       container.viewNode as Element,
     );
@@ -2539,6 +2553,15 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
     padding = Math.max(0, padding - 0.1); // prevent line wrapping (Issue #1112)
     pseudoElem.style.float = "";
     leaderElem.style.marginInlineStart = `${padding}px`;
+
+    // Restore column-fill
+    if (columnContainer) {
+      if (originalColumnFill) {
+        columnContainer.style.columnFill = originalColumnFill;
+      } else {
+        columnContainer.style.removeProperty("column-fill");
+      }
+    }
   }
 };
 

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2346,6 +2346,9 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
     // triggers column rebalancing, making the initially measured `box` unreliable.
     // Temporarily switch column-fill to auto to prevent rebalancing during
     // leader calculation.
+    // Note: findAncestorNonRootMultiColumn is correct here. Root-level multi-column
+    // is handled by Vivliostyle's own column balancing (ColumnBalancer), not the
+    // browser's column-fill: balance, so this issue only affects non-root multi-column.
     const columnContainer = LayoutHelper.findAncestorNonRootMultiColumn(
       container.viewNode,
     ) as HTMLElement | null;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -241,6 +241,10 @@ module.exports = [
         file: "leader/multi-column-balance.html",
         title: "leader() in multi-column with column-fill: balance",
       },
+      {
+        file: "leader/multi-column-balance-on-body.html",
+        title: "leader() in multi-column on body with column-fill: balance",
+      },
     ],
   },
   {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -237,6 +237,10 @@ module.exports = [
         file: "leader/long-content-vertical.html",
         title: "leader() with long content (Vertical)",
       },
+      {
+        file: "leader/multi-column-balance.html",
+        title: "leader() in multi-column with column-fill: balance",
+      },
     ],
   },
   {

--- a/packages/core/test/files/leader/multi-column-balance-on-body.html
+++ b/packages/core/test/files/leader/multi-column-balance-on-body.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>
+      Test leader() in multi-column on body with column-fill: balance
+    </title>
+    <style>
+      @page {
+        size: 400px 300px;
+        margin: 20px;
+      }
+      body {
+        margin: 0;
+        font-size: 12px;
+        line-height: 1.4;
+        column-count: 2;
+        column-gap: 20px;
+        /* column-fill: balance is the default */
+      }
+      .entry {
+        margin: 0;
+      }
+      .entry::after {
+        content: leader(dotted) attr(data-page);
+      }
+    </style>
+  </head>
+  <body>
+    <p class="entry" data-page="150">Lorem ipsum dolor sit amet consectetur</p>
+    <p class="entry" data-page="96">
+      Sed do eiusmod tempor incididunt ut labore
+    </p>
+    <p class="entry" data-page="170">Ut enim ad minim veniam</p>
+    <p class="entry" data-page="98">
+      Duis aute irure dolor in reprehenderit voluptate
+    </p>
+    <p class="entry" data-page="120">Excepteur sint occaecat cupidatat</p>
+    <p class="entry" data-page="85">Sunt in culpa qui officia deserunt</p>
+    <p class="entry" data-page="200">Mollit anim id est laborum consectetur</p>
+    <p class="entry" data-page="45">Quis nostrud exercitation ullamco</p>
+  </body>
+</html>

--- a/packages/core/test/files/leader/multi-column-balance.html
+++ b/packages/core/test/files/leader/multi-column-balance.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Test leader() in multi-column with column-fill: balance</title>
+    <style>
+      @page {
+        size: 400px 300px;
+        margin: 20px;
+      }
+      body {
+        margin: 0;
+        font-size: 12px;
+        line-height: 1.4;
+      }
+      .register {
+        column-count: 2;
+        column-gap: 20px;
+        /* column-fill: balance is the default */
+      }
+      .entry {
+        margin: 0;
+      }
+      .entry::after {
+        content: leader(dotted) attr(data-page);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="register">
+      <p class="entry" data-page="150">
+        Lorem ipsum dolor sit amet consectetur
+      </p>
+      <p class="entry" data-page="96">
+        Sed do eiusmod tempor incididunt ut labore
+      </p>
+      <p class="entry" data-page="170">Ut enim ad minim veniam</p>
+      <p class="entry" data-page="98">
+        Duis aute irure dolor in reprehenderit voluptate
+      </p>
+      <p class="entry" data-page="120">Excepteur sint occaecat cupidatat</p>
+      <p class="entry" data-page="85">Sunt in culpa qui officia deserunt</p>
+      <p class="entry" data-page="200">
+        Mollit anim id est laborum consectetur
+      </p>
+      <p class="entry" data-page="45">Quis nostrud exercitation ullamco</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
fix: #1598 

マルチカラムレイアウトの自動再配置が原因であることがわかったので、リーダーの長さを調べている間に限り`column-fill`を（デフォルトの）`balance`から`auto`に切り替えて再配置を抑制します。対象の親を見つけるようなヘルパー関数があったので、これを使って実装しています。

Issueで提示していただいたサンプルについて、修正後の組版結果では対象ページの先頭に来る項目が変わっているため、この変更で他の箇所にも影響が出ているようです。確認後draftを外してレビューを依頼します。