### PR TITLE
fix: Adjust font-size and line-height to prevent text overflow due to sub-pixel rounding errors

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -196,7 +196,7 @@ export class AdaptiveViewer {
     // Pixel ratio emulation on PDF output (PR #1079) does not work with
     // non-Chromium browsers.
     this.pixelRatioLimit =
-      /Chrome/.test(navigator.userAgent) &&
+      Base.browserType === "chromium" &&
       // Check non-legacy CSS zoom support (Chromium>=128)
       "currentCSSZoom" in Element.prototype
         ? 16 // max pixelRatio value on Chromium browsers

--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -22,6 +22,18 @@ import * as Logging from "./logging";
 import * as Asserts from "./asserts";
 
 /**
+ * Browser type detection
+ */
+export const browserType: "chromium" | "firefox" | "webkit" | "unknown" =
+  navigator.userAgent.includes("Chrome")
+    ? "chromium"
+    : navigator.userAgent.includes("Firefox")
+      ? "firefox"
+      : navigator.userAgent.includes("AppleWebKit")
+        ? "webkit"
+        : "unknown";
+
+/**
  * RegExp pattern for ::first-letter pseudo element:
  * https://drafts.csswg.org/css-pseudo-4/#first-letter-pseudo
  */


### PR DESCRIPTION
- Adjust font-size and line-height slightly smaller to prevent unexpected text overflow due to sub-pixel rounding errors in browsers.

- fixes issue #1590