### PR TITLE
fix: Apply text-spacing to ::footnote-call pseudo-element

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -546,3 +546,24 @@ export function findAncestorSpecialInlineNodeContext(
   }
   return null;
 }
+
+export function findLastTextNodeInElement(element: Node): Node | null {
+  let node: Node | null = element;
+  while (node) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent.length > 0) {
+      return node;
+    }
+    if (node.lastChild) {
+      node = node.lastChild;
+    } else {
+      while (node && !node.previousSibling) {
+        node = node.parentNode;
+        if (node === element || !node) {
+          return null;
+        }
+      }
+      node = node?.previousSibling || null;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1654,7 +1654,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const parent = nodeContext.viewNode.parentNode;
     const anchor = parent.ownerDocument.createElement("span");
     anchor.setAttribute(LayoutHelper.SPECIAL_ATTR, "1");
-    parent.appendChild(anchor);
     if (nodeContext.floatSide === "footnote") {
       // Defaults for footnote-call, can be overriden by the stylesheet.
       this.layoutContext.applyPseudoelementStyle(
@@ -1663,6 +1662,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         anchor,
       );
     }
+    parent.appendChild(anchor);
     parent.removeChild(nodeContext.viewNode);
     const nodeContextAfter = nodeContext.modify();
     nodeContextAfter.after = true;

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1795,12 +1795,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             Asserts.assert(float);
             if (!success) {
               context.registerPageFloatAnchor(float, nodeContextAfter.viewNode);
+              return Task.newResult(nodeContextAfter);
             }
-            // Issue #868: Always return nodeContextAfter so the layout loop
+            // Issue #868: For footnotes, return nodeContextAfter so the layout loop
             // continues to process following elements (like text after footnote-call).
             // This ensures footnote-call and following content are processed
             // in the same postLayoutBlock, allowing correct text-spacing.
-            return Task.newResult(nodeContextAfter);
+            if (nodeContext.floatSide === "footnote") {
+              return Task.newResult(nodeContextAfter);
+            }
+            return Task.newResult(null as Vtree.NodeContext);
           });
         }
       }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1654,6 +1654,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const parent = nodeContext.viewNode.parentNode;
     const anchor = parent.ownerDocument.createElement("span");
     anchor.setAttribute(LayoutHelper.SPECIAL_ATTR, "1");
+    parent.appendChild(anchor);
     if (nodeContext.floatSide === "footnote") {
       // Defaults for footnote-call, can be overriden by the stylesheet.
       this.layoutContext.applyPseudoelementStyle(
@@ -1662,7 +1663,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         anchor,
       );
     }
-    parent.appendChild(anchor);
     parent.removeChild(nodeContext.viewNode);
     const nodeContextAfter = nodeContext.modify();
     nodeContextAfter.after = true;

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -343,9 +343,9 @@ class TextSpacingPolyfill {
 
   processGeneratedContent(
     element: HTMLElement,
-    autospaceVal: PropertyValue,
-    spacingTrimVal: PropertyValue,
-    hangingPunctuationVal: PropertyValue,
+    autospaceVal: Css.Val,
+    spacingTrimVal: Css.Val,
+    hangingPunctuationVal: Css.Val,
     lang: string,
     vertical: boolean,
   ): void {
@@ -1147,9 +1147,9 @@ export function preprocessForTextSpacing(element: Element): void {
 
 export function processGeneratedContent(
   element: HTMLElement,
-  textAutospace: PropertyValue,
-  textSpacingTrim: PropertyValue,
-  hangingPunctuation: PropertyValue,
+  textAutospace: Css.Val,
+  textSpacingTrim: Css.Val,
+  hangingPunctuation: Css.Val,
   lang: string,
   vertical: boolean,
 ): void {

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -20,6 +20,7 @@ import * as Base from "./base";
 import * as Css from "./css";
 import * as LayoutHelper from "./layout-helper";
 import * as Plugin from "./plugin";
+import * as PseudoElement from "./pseudo-element";
 import * as Vtree from "./vtree";
 
 type PropertyValue = string | number | Css.Val;
@@ -622,6 +623,24 @@ class TextSpacingPolyfill {
           ) {
             prevNode = prevP.viewNode;
             break;
+          }
+          // Issue #868: Look inside footnote-call for the last text node.
+          // BUT skip and look further back if we're inside that same footnote-call.
+          if (
+            prevP.viewNode?.nodeType === Node.ELEMENT_NODE &&
+            PseudoElement.getPseudoName(prevP.viewNode as Element) ===
+              "footnote-call"
+          ) {
+            if (prevP.viewNode.contains(p.viewNode)) {
+              continue;
+            }
+            const lastText = LayoutHelper.findLastTextNodeInElement(
+              prevP.viewNode,
+            );
+            if (lastText) {
+              prevNode = lastText;
+              break;
+            }
           }
           if (
             (prevP.display && !/^(inline|ruby)\b/.test(prevP.display)) ||

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -343,9 +343,9 @@ class TextSpacingPolyfill {
 
   processGeneratedContent(
     element: HTMLElement,
-    autospaceVal: Css.Val,
-    spacingTrimVal: Css.Val,
-    hangingPunctuationVal: Css.Val,
+    autospaceVal: PropertyValue,
+    spacingTrimVal: PropertyValue,
+    hangingPunctuationVal: PropertyValue,
     lang: string,
     vertical: boolean,
   ): void {
@@ -1147,9 +1147,9 @@ export function preprocessForTextSpacing(element: Element): void {
 
 export function processGeneratedContent(
   element: HTMLElement,
-  textAutospace: Css.Val,
-  textSpacingTrim: Css.Val,
-  hangingPunctuation: Css.Val,
+  textAutospace: PropertyValue,
+  textSpacingTrim: PropertyValue,
+  hangingPunctuation: PropertyValue,
   lang: string,
   vertical: boolean,
 ): void {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -40,6 +40,7 @@ import * as RepetitiveElement from "./repetitive-element";
 import * as Scripts from "./scripts";
 import * as Task from "./task";
 import * as TaskUtil from "./task-util";
+import * as TextPolyfill from "./text-polyfill";
 import * as Urls from "./urls";
 import * as Vtree from "./vtree";
 import * as Layout from "./layout";
@@ -2662,6 +2663,15 @@ export class ViewFactory
           content,
           this.exprContentListener,
         ),
+      );
+      // text-spacing support (Issue #868)
+      TextPolyfill.processGeneratedContent(
+        target as HTMLElement,
+        computedStyle["text-autospace"],
+        computedStyle["text-spacing-trim"],
+        computedStyle["hanging-punctuation"],
+        nodeContext.lang,
+        nodeContext.vertical,
       );
       delete computedStyle["content"];
     }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2667,9 +2667,12 @@ export class ViewFactory
       // text-spacing support (Issue #868)
       TextPolyfill.processGeneratedContent(
         target as HTMLElement,
-        computedStyle["text-autospace"],
-        computedStyle["text-spacing-trim"],
-        computedStyle["hanging-punctuation"],
+        computedStyle["text-autospace"] ??
+          nodeContext.inheritedProps["text-autospace"],
+        computedStyle["text-spacing-trim"] ??
+          nodeContext.inheritedProps["text-spacing-trim"],
+        computedStyle["hanging-punctuation"] ??
+          nodeContext.inheritedProps["hanging-punctuation"],
         nodeContext.lang,
         nodeContext.vertical,
       );

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2425,11 +2425,14 @@ export class ViewFactory
 
         // Issue #868: Insert footnote-call before footnote element
         // Only insert if footnote-call hasn't been processed yet for this footnote
+        // Skip for template-based footnotes (where styler.getStyle returns undefined)
+        // as they define their own call content in HTML, not via ::footnote-call
         if (
           nodeContext.floatSide === "footnote" &&
           !this.isFootnote &&
           !nodeContext.after &&
-          !nodeContext.pluginProps["footnoteCallProcessed"]
+          !nodeContext.pluginProps["footnoteCallProcessed"] &&
+          this.styler.getStyle(nodeContext.sourceNode as Element, false)
         ) {
           // Mark as processed to avoid infinite loop when returning via shadowSibling
           nodeContext.pluginProps["footnoteCallProcessed"] = 1;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -40,7 +40,6 @@ import * as RepetitiveElement from "./repetitive-element";
 import * as Scripts from "./scripts";
 import * as Task from "./task";
 import * as TaskUtil from "./task-util";
-import * as TextPolyfill from "./text-polyfill";
 import * as Urls from "./urls";
 import * as Vtree from "./vtree";
 import * as Layout from "./layout";
@@ -2663,18 +2662,6 @@ export class ViewFactory
           content,
           this.exprContentListener,
         ),
-      );
-      // text-spacing support (Issue #868)
-      TextPolyfill.processGeneratedContent(
-        target as HTMLElement,
-        computedStyle["text-autospace"] ??
-          nodeContext.inheritedProps["text-autospace"],
-        computedStyle["text-spacing-trim"] ??
-          nodeContext.inheritedProps["text-spacing-trim"],
-        computedStyle["hanging-punctuation"] ??
-          nodeContext.inheritedProps["hanging-punctuation"],
-        nodeContext.lang,
-        nodeContext.vertical,
       );
       delete computedStyle["content"];
     }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -664,6 +664,10 @@ module.exports = [
         title: "Footnote with pseudoelement",
       },
       { file: "footnotes/footnote-policy.html", title: "footnote-policy" },
+      {
+        file: "footnote-text-spacing.html",
+        title: "Footnote text-spacing (Issue #868)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnote-text-spacing.html
+++ b/packages/core/test/files/footnote-text-spacing.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <style>
+      :root {
+        text-spacing: auto;
+      }
+      .footnote {
+        float: footnote;
+      }
+      .footnote::footnote-call {
+        content: "『「" counter(footnote) "」』";
+        color: maroon;
+      }
+      .footnote::footnote-marker {
+        content: "『「" counter(footnote) "」』";
+        color: maroon;
+      }
+      .expected {
+        color: maroon;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h2>Issue #868: ::footnote-call に text-spacing を適用</h2>
+
+    <p>Expected: テスト。<span class="expected">『「1」』</span>（後続）</p>
+    <p>Actual: テスト。<span class="footnote">脚注1</span>（後続）</p>
+
+    <p>Expected: テスト。<span class="expected">『「2」』</span>（後続）</p>
+    <p>Actual: テスト。<span class="footnote">脚注2</span>（後続）</p>
+
+    <p>テスト。</p>
+    <p>テスト。</p>
+    <p>テスト。</p>
+  </body>
+</html>


### PR DESCRIPTION
fix: #868 

`::footnote-call`疑似要素に対して、テキストノード分割・`viv-ts-*`要素の挿入・クラス設定の一連の処理が行われていませんでした。ページマージンボックスを処理している箇所を参考にして、`TextPolyfill.processGeneratedContent()`を使用しました。`processGeneratedContent()`が内部で`offsetWidth`/`offsetHeight`を使っており、事前にDOMに追加する必要がありました。

https://github.com/vivliostyle/vivliostyle.js/blob/b4360e060ba9d82bbccfe6d3525334bf31940fc5/packages/core/src/vivliostyle/ops.ts#L1636-L1644

<img width="1477" height="1582" alt="image" src="https://github.com/user-attachments/assets/ced6b514-ae0d-4e4e-8fa3-52396c65d9a1" />
