### PR TITLE
feat: Do not load MathJax unless specified in the document

### DIFF
--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -7,9 +7,9 @@
     <meta name="google" content="notranslate"/>
     <title>Vivliostyle Viewer</title>
     
-    <!-- MathJax; remove if not needed -->
-    <script src="resources/mathjax-config.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    <!-- MathJax; uncomment if needed -->
+    <!-- <script src="resources/mathjax-config.js"></script> -->
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script> -->
 
     <!--Marks Plugin; may not present -->
     <!-- <script src="resources/marks-store-plugin.js" type="module"></script> -->


### PR DESCRIPTION
Removed MathJax loading from Vivliostyle Viewer, and MathJax is now loaded only when the source HTML document references the MathJax library.

To use MathJax as before, please add a `<script>` element referencing the MathJax library in the `<head>` element of your HTML documents, like this:

```html
<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
```

Test Sample: https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/test/files/math-sample.html

**Note**: Currently, Vivliostyle.js only supports MathJax version 2. MathJax version 3 or 4 is not yet supported, so using them may result in incorrect rendering.

- resolve #1501
