### PR TITLE
fix: Stop treating CSS "ex" unit as 1/2 em

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -345,12 +345,6 @@ export class AdaptiveViewer {
       if (unit === "em" || unit === "rem") {
         return value * this.fontSize;
       }
-      if (unit === "ex") {
-        return (
-          (value * Exprs.defaultUnitSizes["ex"] * this.fontSize) /
-          Exprs.defaultUnitSizes["em"]
-        );
-      }
       const unitSize = Exprs.defaultUnitSizes[unit];
       if (unitSize) {
         return value * unitSize;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -622,7 +622,6 @@ export class InheritanceVisitor extends Css.FilterVisitor {
       return convertFontSizeToPx(numeric, this.getFontSize(), this.context);
     } else if (
       numeric.unit === "em" ||
-      numeric.unit === "ex" ||
       numeric.unit === "rem" ||
       numeric.unit === "lh" ||
       numeric.unit === "rlh"
@@ -652,9 +651,8 @@ export function convertFontRelativeLengthToPx(
 ): Css.Numeric {
   const unit = numeric.unit;
   const num = numeric.num;
-  if (unit === "em" || unit === "ex") {
-    const ratio = Exprs.defaultUnitSizes[unit] / Exprs.defaultUnitSizes["em"];
-    return new Css.Numeric(num * ratio * baseFontSize, "px");
+  if (unit === "em") {
+    return new Css.Numeric(num * baseFontSize, "px");
   } else if (unit === "rem") {
     return new Css.Numeric(num * context.fontSize(), "px");
   } else if (unit === "rlh") {

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -614,11 +614,6 @@ export class Styler implements AbstractStyler {
             case "rem":
               px *= this.context.initialFontSize;
               break;
-            case "ex":
-              px *=
-                (this.context.initialFontSize * Exprs.defaultUnitSizes["ex"]) /
-                Exprs.defaultUnitSizes["em"];
-              break;
             case "%":
               px *= this.context.initialFontSize / 100;
               break;
@@ -653,11 +648,6 @@ export class Styler implements AbstractStyler {
             case "em":
             case "rem":
               px *= rootFontSize;
-              break;
-            case "ex":
-              px *=
-                (rootFontSize * Exprs.defaultUnitSizes["ex"]) /
-                Exprs.defaultUnitSizes["em"];
               break;
             case "%":
               px *= rootFontSize / 100;

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -257,7 +257,6 @@ export function isViewportRelativeLengthUnit(unit: string): boolean {
 export function isFontRelativeLengthUnit(unit: string): boolean {
   switch (unit?.toLowerCase()) {
     case "em":
-    case "ex":
     case "rem":
     case "lh":
     case "rlh":
@@ -287,7 +286,6 @@ export const defaultUnitSizes: { [key: string]: number } = {
   q: 96 / 2.54 / 40,
   em: 16,
   rem: 16,
-  ex: 8,
   lh: 20,
   rlh: 20,
   // <resolution>
@@ -424,13 +422,6 @@ export class Context {
     }
     if (unit == "em" || unit == "rem") {
       return isRoot ? this.initialFontSize : this.fontSize();
-    }
-    if (unit == "ex") {
-      return (
-        (defaultUnitSizes["ex"] *
-          (isRoot ? this.initialFontSize : this.fontSize())) /
-        defaultUnitSizes["em"]
-      );
     }
     if (unit == "lh" || unit == "rlh") {
       // FIXME: "lh" unit is incorrect, treated same as "rlh"


### PR DESCRIPTION
Remove old code that treated the "ex" unit as 1/2 em, and let the browser handle the "ex" unit.