### PR TITLE
fix: Respect default line-height preference setting

### DIFF
--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -654,9 +654,7 @@ export class Styler implements AbstractStyler {
               break;
             case "lh":
             case "rlh":
-              px *=
-                (this.context.initialFontSize * Exprs.defaultUnitSizes["lh"]) /
-                Exprs.defaultUnitSizes["em"];
+              px *= this.context.initialFontSize * this.context.pref.lineHeight;
               break;
             default: {
               const unitSize = Exprs.defaultUnitSizes[val.unit];
@@ -668,10 +666,8 @@ export class Styler implements AbstractStyler {
           this.context.rootLineHeight = px;
         }
       } else {
-        // Note: "rlh" unit is inaccurate for line-height:normal, not using font metrics.
         this.context.rootLineHeight =
-          (this.context.fontSize() * Exprs.defaultUnitSizes["lh"]) /
-          Exprs.defaultUnitSizes["em"];
+          this.context.fontSize() * this.context.pref.lineHeight;
       }
     }
   }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -592,6 +592,12 @@ export class ViewFactory
         0,
       ),
     } as CssCascade.ElementStyle;
+    if (isRoot) {
+      props["line-height"] = new CssCascade.CascadeValue(
+        new Css.Num(this.context.pref.lineHeight),
+        0,
+      );
+    }
     const inheritanceVisitor = new CssCascade.InheritanceVisitor(
       props,
       this.context,


### PR DESCRIPTION
Vivliostyle.js has a defaultPreferences setting that includes a default line-height setting (lineHeight: 1.25) for the root element, but it was being ignored. Fix it to respect this setting.