### PR TITLE
fix marker position calculation when list-item has border, padding, or text-indent

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1590,7 +1590,7 @@ span[data-viv-leader] {
   position: absolute;
   text-indent: 0;
 }
-[data-adapt-pseudo="marker"]._viv-marker-outside > span {
+[data-adapt-pseudo="marker"] > ._viv-marker-outside-content {
   position: absolute;
   inset-inline-end: 0;
 }

--- a/packages/core/src/vivliostyle/pseudo-element.ts
+++ b/packages/core/src/vivliostyle/pseudo-element.ts
@@ -192,7 +192,9 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
       // Use special styling to simulate outside markers.
       element.classList.add("_viv-marker-outside");
       // Create a span to hold the marker content.
-      element.appendChild(element.ownerDocument.createElement("span"));
+      const span = element.ownerDocument.createElementNS(Base.NS.XHTML, "span");
+      span.classList.add("_viv-marker-outside-content");
+      element.appendChild(span);
 
       // Prevent text-spacing-trim and hanging-punctuation from trimming or
       // hanging the suffix "、" of counter styles such as "cjk-decimal".

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -999,8 +999,8 @@ export class ViewFactory
           }
         }
       }
-      const listItem =
-        Display.isListItem(display) && computedStyle["ua-list-item-count"];
+      const isListItem =
+        Display.isListItem(display) && !!computedStyle["ua-list-item-count"];
       const breakInside = computedStyle["break-inside"];
       if (
         floating ||
@@ -1261,7 +1261,7 @@ export class ViewFactory
       } else {
         custom = !!this.customRenderer;
       }
-      if (listItem) {
+      if (isListItem) {
         // We don't use browser's list item rendering, so we change
         // `display: list-item` to `display: block` and
         // `display: inline list-item` to `display: inline`.
@@ -1650,12 +1650,29 @@ export class ViewFactory
             }
           }
         }
-        if (listItem) {
+        if (isListItem) {
           result.setAttribute(
             "value",
             computedStyle["ua-list-item-count"].stringValue(),
           );
         }
+        if (result.classList.contains("_viv-marker-outside-content")) {
+          // Adjust marker position for outside markers
+          if (Display.isListItem(this.nodeContext.parent?.parent?.display)) {
+            const style = this.viewport.window.getComputedStyle(
+              this.nodeContext.parent.parent.viewNode as Element,
+            );
+            const markerOffset =
+              parseFloat(style.borderInlineStartWidth) +
+              parseFloat(style.paddingInlineStart) +
+              parseFloat(style.textIndent);
+            if (markerOffset) {
+              (result as HTMLElement).style.insetInlineEnd =
+                `${markerOffset}px`;
+            }
+          }
+        }
+
         this.viewNode = result;
         if (fetchers.length) {
           TaskUtil.waitForFetchers(fetchers).then(() => {


### PR DESCRIPTION
This is a follow-up fix for #1609 and #1612.

When list-style-position is outside, the position of the marker should be based on the inline-start edge of the list-item's border-box.