### PR TITLE
feat: Support CSS initial-letter property

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -567,6 +567,8 @@ hanging-punctuation = none | [ first || [ force-end | allow-end ] || last ];
 [epub,webkit]text-emphasis-style = none | [[ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]] | STRING;
 [webkit]text-underline-position = auto | [ under || [ left | right ]];
 
+[webkit]initial-letter = normal | [ POS_NUM POS_INT? ];
+
 /* CSS Transforms */
 [webkit]backface-visibility = visible | hidden;
 
@@ -1593,6 +1595,12 @@ span[data-viv-leader] {
 [data-adapt-pseudo="marker"] > ._viv-marker-outside-content {
   position: absolute;
   inset-inline-end: 0;
+}
+
+/* initial-letter */
+[style*="--viv-initialLetter"]:has(>[data-adapt-pseudo="first-letter"])::first-letter {
+  -webkit-initial-letter: var(--viv-initialLetter);
+  initial-letter: var(--viv-initialLetter);
 }
 `;
 

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3190,6 +3190,25 @@ export class CascadeInstance {
                 element,
                 styler,
               );
+            } else if (
+              pseudoName === "first-letter" &&
+              pseudoProps["initial-letter"]
+            ) {
+              // initial-letter on ::first-letter
+              const initialLetter = pseudoProps[
+                "initial-letter"
+              ] as CascadeValue;
+              const initialLetterVal = initialLetter.evaluate(this.context);
+              if (
+                initialLetterVal !== Css.ident.normal &&
+                !Css.isDefaultingValue(initialLetterVal)
+              ) {
+                this.currentStyle["--viv-initialLetter"] = new CascadeValue(
+                  initialLetterVal,
+                  0,
+                );
+              }
+              delete pseudoProps["initial-letter"];
             }
           } else {
             this.stack[this.stack.length - 2].push(

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1468,6 +1468,8 @@ export const shorthandValidators: {
 //---- validation grammar parser and public property validator
 //------------------------
 
+const propsBrowserDependent = ["initial-letter"];
+
 /**
  * Object that validates simple and shorthand properties, breaking up shorthand
  * properties into corresponding simple ones, also stripping property prefixes.
@@ -2116,6 +2118,16 @@ export class ValidatorSet {
         receiver.unknownProperty(origName, value);
       }
       return;
+    } else if (propsBrowserDependent.includes(name)) {
+      // For properties whose support depends on browser, check via CSS.supports
+      if (
+        !Object.keys(px).some((p) =>
+          Base.checkIfPropertySupported(p ? `-${p}-` : "", name),
+        )
+      ) {
+        receiver.unknownProperty(origName, value);
+        return;
+      }
     }
     const validator = this.validators[name];
     if (validator) {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -178,6 +178,10 @@ module.exports = [
         file: "border-width-test.html",
         title: "border-width test",
       },
+      {
+        file: "initial-letter.html",
+        title: "initial-letter property",
+      },
     ],
   },
   {

--- a/packages/core/test/files/initial-letter.html
+++ b/packages/core/test/files/initial-letter.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>initial-letter property</title>
+    <style>
+      .IL_normal::first-letter {
+        initial-letter: normal;
+      }
+      .IL1half::first-letter {
+        initial-letter: 1.5;
+      }
+      .IL2::first-letter {
+        initial-letter: 2;
+      }
+      .IL3::first-letter {
+        initial-letter: 3;
+      }
+      .IL3_1::first-letter {
+        initial-letter: 3 1;
+      }
+      .IL3_2::first-letter {
+        initial-letter: 3 2;
+      }
+      .IL3_3::first-letter {
+        initial-letter: 3 3;
+      }
+      .IL3half_3::first-letter {
+        initial-letter: 3.5 3;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="IL_normal">
+      Paragraph with initial-letter: normal; Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Suspendisse at viverra justo, id aliquet
+      felis. Nam scelerisque facilisis convallis. Etiam iaculis ligula eget leo
+      auctor, sed volutpat magna porta. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia curae. Nam urna velit, egestas et
+      viverra id, lacinia sit amet nisl.
+    </p>
+    <p class="IL1half">
+      Paragraph with initial-letter: 1.5; Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Suspendisse at viverra justo, id aliquet
+      felis. Nam scelerisque facilisis convallis. Etiam iaculis ligula eget leo
+      auctor, sed volutpat magna porta. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia curae. Nam urna velit, egestas et
+      viverra id, lacinia sit amet nisl.
+    </p>
+    <p class="IL2">
+      Paragraph with initial-letter: 2; Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit. Suspendisse at viverra justo, id aliquet felis. Nam
+      scelerisque facilisis convallis. Etiam iaculis ligula eget leo auctor, sed
+      volutpat magna porta. Vestibulum ante ipsum primis in faucibus orci luctus
+      et ultrices posuere cubilia curae. Nam urna velit, egestas et viverra id,
+      lacinia sit amet nisl.
+    </p>
+    <p class="IL3">
+      Paragraph with initial-letter: 3; Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit. Suspendisse at viverra justo, id aliquet felis. Nam
+      scelerisque facilisis convallis. Etiam iaculis ligula eget leo auctor, sed
+      volutpat magna porta. Vestibulum ante ipsum primis in faucibus orci luctus
+      et ultrices posuere cubilia curae. Nam urna velit, egestas et viverra id,
+      lacinia sit amet nisl.
+    </p>
+    <p class="IL3_1">
+      Paragraph with initial-letter: 3 1; Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Suspendisse at viverra justo, id aliquet
+      felis. Nam scelerisque facilisis convallis. Etiam iaculis ligula eget leo
+      auctor, sed volutpat magna porta. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia curae. Nam urna velit, egestas et
+      viverra id, lacinia sit amet nisl.
+    </p>
+    <p class="IL3_2">
+      Paragraph with initial-letter: 3 2; Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Suspendisse at viverra justo, id aliquet
+      felis. Nam scelerisque facilisis convallis. Etiam iaculis ligula eget leo
+      auctor, sed volutpat magna porta. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia curae. Nam urna velit, egestas et
+      viverra id, lacinia sit amet nisl.
+    </p>
+    <p class="IL3_3">
+      Paragraph with initial-letter: 3 3; Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Suspendisse at viverra justo, id aliquet
+      felis. Nam scelerisque facilisis convallis. Etiam iaculis ligula eget leo
+      auctor, sed volutpat magna porta. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia curae. Nam urna velit, egestas et
+      viverra id, lacinia sit amet nisl.
+    </p>
+    <p class="IL3half_3">
+      Paragraph with initial-letter: 3.5 3; Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Suspendisse at viverra justo, id aliquet
+      felis. Nam scelerisque facilisis convallis. Etiam iaculis ligula eget leo
+      auctor, sed volutpat magna porta. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia curae. Nam urna velit, egestas et
+      viverra id, lacinia sit amet nisl.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
- resolve #1491

**Limitation:**

This implementation uses browser's `initial-letter` property support, so it does not work currently in Firefox which does not support this property yet.
