### PR TITLE
fix: Fix `column-fill: auto` handling in multi-column elements

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3061,14 +3061,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             const viewElement = nodeContext.viewNode as HTMLElement;
             const style = viewElement.style;
             if (nodeContext.after) {
-              if (
-                style.columnFill === "balance" &&
-                viewElement.getAttribute("data-vivliostyle-column-fill") ===
-                  "auto"
-              ) {
-                // Restore `column-fill: auto` after layout
-                style.columnFill = "auto";
-              }
               if (nodeContext.floatSide) {
                 // Restore break-after:avoid* value at before the float
                 // (Fix for issue #904)

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1324,17 +1324,6 @@ export class ViewFactory
           result = this.createElement(ns, tag);
         }
 
-        if (
-          !isRoot &&
-          isMultiColumn &&
-          computedStyle["column-fill"] === Css.ident.auto
-        ) {
-          // To make `column-fill: auto` work on non-root multi-column,
-          // we change it to `balance` here, and after layout, we change it back.
-          result.setAttribute("data-vivliostyle-column-fill", "auto");
-          computedStyle["column-fill"] = Css.ident.balance;
-        }
-
         if (tag != originalTag) {
           result.setAttribute("data-vivliostyle-original-tag", originalTag);
           if (originalTag === "html" || originalTag === "body") {


### PR DESCRIPTION
- fix #1618
- Remove unnecessary and problematic code that changed `column-fill: auto` to `balance` during multi-column layout processing.
  - This code was a part of the fix in PR #1580. Through further testing, it was found to be unnecessary and could cause issues in certain cases with forced page breaks.