### PR TITLE
feat: Support CSS :nth(An+B of C) page selector

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2796,6 +2796,7 @@ export class CascadeInstance {
   currentPageType: string | null = null;
   previousPageType: string | null = null;
   firstPageType: string | null = null;
+  pageTypePageCounts: { [pageType: string]: number } = {};
   isFirst: boolean = true;
   isRoot: boolean = true;
   counters: CounterValues = {};

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1751,6 +1751,24 @@ export class Parser {
                       continue;
                     }
                     break;
+                  } else if (text === "nth") {
+                    // check for optional "of <page-type>" syntax for :nth() page selector
+                    token1 = tokenizer.nthToken(0);
+                    if (
+                      token1.type === TokenType.IDENT &&
+                      token1.text === "of"
+                    ) {
+                      tokenizer.consume();
+                      token1 = tokenizer.token();
+                      if (token1.type === TokenType.IDENT) {
+                        params.push(token1.text); // add page type name to params
+                        tokenizer.consume();
+                      } else {
+                        // Invalid ":nth(... of ...)" syntax: "of" must be followed by an identifier
+                        break pseudoclassType;
+                      }
+                    }
+                    break;
                   } else {
                     break;
                   }

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1848,6 +1848,9 @@ export class StyleInstance
     page.isBlankPage = cp.isBlankPage;
     cp.page++;
 
+    // Save previous page type before it gets updated
+    const prevPageType = this.styler.cascade.previousPageType;
+
     if (page.pageType == null) {
       page.pageType =
         (page.isBlankPage
@@ -1856,6 +1859,18 @@ export class StyleInstance
       // Fix for issue #1309
       this.styler.cascade.previousPageType =
         this.styler.cascade.currentPageType;
+    }
+
+    // Update page type page counts for :nth(An+B of <page-type>) selector
+    // Use pageCascadeInstance which is used for page rule evaluation
+    const pageCascade = this.pageManager.pageCascadeInstance;
+    if (page.pageType) {
+      // If page type changed from the previous page, reset count for the new page type (new page group)
+      if (prevPageType !== page.pageType) {
+        pageCascade.pageTypePageCounts[page.pageType] = 0;
+      }
+      pageCascade.pageTypePageCounts[page.pageType] =
+        (pageCascade.pageTypePageCounts[page.pageType] || 0) + 1;
     }
 
     this.clearScope(this.style.pageScope);

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -322,6 +322,10 @@ module.exports = [
         ],
         title: "nth() page selector & page counter reset in multiple documents",
       },
+      {
+        file: "nth-page/nth-of-page.html",
+        title: ":nth(An+B of C) page selector",
+      },
     ],
   },
   {

--- a/packages/core/test/files/nth-page/nth-of-page.html
+++ b/packages/core/test/files/nth-page/nth-of-page.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nth(An+B of C) Page Selector</title>
+    <style>
+      @page {
+        size: 16cm 12cm;
+        margin: 1.5cm;
+
+        @top-right {
+          content: "Page " counter(page);
+        }
+      }
+      @page A {
+        @top-left {
+          content: "A";
+        }
+      }
+      @page B {
+        @top-center {
+          content: "B";
+        }
+      }
+      @page :nth(odd of A) {
+        /* will select odd pages of page type A */
+        @bottom-left {
+          content: ":nth(odd of A)";
+        }
+      }
+      @page :nth(1 of B) {
+        /* will select first page of page type B page group */
+        @bottom-center {
+          content: ":nth(1 of B)";
+        }
+      }
+      @page :nth(5) {
+        /* will select 5th page of document */
+        @bottom-right {
+          content: ":nth(5)";
+        }
+      }
+      div.chapter-a {
+        page: A;
+        break-before: page;
+      }
+      div.chapter-b {
+        page: B;
+        break-before: page;
+      }
+      .break-before-page {
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Nth(An+B of C) Page Selector Test</h1>
+    <p>Page 1</p>
+    <p>This page should have no footer</p>
+    <div class="chapter-a">
+      <p>Page 2 - Chapter A Start (A page 1)</p>
+      <p>This page should have footer: ":nth(odd of A)"</p>
+      <p class="break-before-page">Page 3 - Chapter A (A page 2)</p>
+      <p>This page should have no footer</p>
+      <p class="break-before-page">Page 4 - Chapter A (A page 3)</p>
+      <p>This page should have footer: ":nth(odd of A)"</p>
+      <p class="break-before-page">Page 5 - Chapter A End (A page 4)</p>
+      <p>This page should have footer: ":nth(5)"</p>
+    </div>
+    <div class="chapter-b">
+      <p>Page 6 - Chapter B Start (B page 1)</p>
+      <p>This page should have footer: ":nth(1 of B)"</p>
+      <p class="break-before-page">Page 7 - Chapter B End (B page 2)</p>
+      <p>This page should have no footer</p>
+    </div>
+    <div class="chapter-a">
+      <p>Page 8 - Chapter A Start (A page 1, new group)</p>
+      <p>This page should have footer: ":nth(odd of A)"</p>
+      <p class="break-before-page">Page 9 - Chapter A End (A page 2)</p>
+      <p>This page should have no footer</p>
+    </div>
+    <div class="chapter-b">
+      <p>Page 10 - Chapter B Start (B page 1, new group)</p>
+      <p>This page should have footer: ":nth(1 of B)"</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Add support for the `:nth(An+B of C)` page selector syntax from CSS GCPM 3 specification (https://drafts.csswg.org/css-gcpm-3/#document-page-selectors).
This allows selecting pages based on their position within a page group of a specific named page type.

## Changes

### css-parser.ts
- Parse `of <page-type>` syntax for `:nth()` page selector

### css-cascade.ts
- Add `pageTypePageCounts` property to `CascadeInstance` to track page counts per page type

### css-page.ts
- Add `IsNthOfPageTypeAction` class for matching pages within a page type group
- Expose `pageCascadeInstance` on `PageManager` for page rule evaluation
- Handle 3-element params array in `pseudoclassSelector` for `:nth(An+B of C)`

### ops.ts
- Update `pageTypePageCounts` during page layout
- Reset count when page type changes (new page group)

## Supported features
- Count pages within consecutive page groups of the same named page type
- Reset count when page type changes
- Example: `@page :nth(1 of chapter)` selects the first page of each chapter

## Limitations
- Full page group support with nested named pages is not implemented
- Only consecutive pages of the same page type are counted as a group

Closes #1621