### PR TITLE
feat: Add device-cmyk() CSS color function support

### DIFF
--- a/packages/core/src/vivliostyle/cmyk-store.ts
+++ b/packages/core/src/vivliostyle/cmyk-store.ts
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2025 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The Vivliostyle CMYK implementation primarily in this file is not "true"
+ * CMYK support in the sense that the web browser outputs CMYK, but rather a
+ * feature that enables post-processing to replace RGB with CMYK using RGB as
+ * a key.
+ *
+ * This processing leverages the fact that Chromium can transparently reflect
+ * `color(srgb ...)` into PDF. Each RGB component has 4 decimal places (the
+ * 5th digit is half-up rounded). Specifically, this is based on reading the
+ * source code at the following commits.
+ *
+ * | Repository              | Commit Hash                              |
+ * | ----------------------- | ---------------------------------------- |
+ * | Chromium                | a2652c6fc5817d5cc643c3935e1363ddc48abb6e |
+ * | Skia (third_party/skia) | 3544942c9d424d37d82d756d6dbbbc04327e8dbb |
+ *
+ * This implementation has several inherent limitations.
+ *
+ * - The RGB display shown in the browser is merely a key and does not
+ *   necessarily reproduce the color appearance after output. Also, it is not
+ *   possible to use more than ((10^4)+1)^3 CMYK colors.
+ * - Only Chromium is supported. Similar replacement may be possible by
+ *   analyzing other web browser implementations, but this is currently
+ *   outside the scope of this module.
+ * - This implementation is not designed to create PDFs with mixed RGB and
+ *   CMYK. If you use this feature, you should specify CMYK colors for all
+ *   rendered objects.
+ *   There is no way to distinguish between "colors converted from CMYK to
+ *   RGB" and "colors originally specified as RGB" in the post-processing
+ *   stage. If these colors collide, the post-processing stage has no choice
+ *   but to replace both with CMYK.
+ * - Raster images are not handled at all. In the first place, there is no
+ *   raster image format (at the time of implementation) that can handle CMYK
+ *   and be displayed in a web browser. The possibility of replacement in the
+ *   post-processing stage is not ruled out.
+ */
+
+import * as Css from "./css";
+import * as Logging from "./logging";
+
+class SRGBValue {
+  static readonly MAX = 10000;
+
+  readonly #r: number;
+  readonly #g: number;
+  readonly #b: number;
+
+  private constructor(r: number, g: number, b: number) {
+    this.#r = Math.round(Math.max(0, Math.min(r, SRGBValue.MAX)));
+    this.#g = Math.round(Math.max(0, Math.min(g, SRGBValue.MAX)));
+    this.#b = Math.round(Math.max(0, Math.min(b, SRGBValue.MAX)));
+  }
+
+  static fromInt(r: number, g: number, b: number): SRGBValue {
+    return new SRGBValue(r, g, b);
+  }
+
+  offset(dr: number, dg: number, db: number): SRGBValue {
+    return new SRGBValue(this.#r + dr, this.#g + dg, this.#b + db);
+  }
+
+  toKey(): string {
+    return JSON.stringify([this.#r, this.#g, this.#b]);
+  }
+
+  toColorFunc(alpha: number | null): Css.Func {
+    return new Css.Func("color", [
+      new Css.SpaceList([
+        Css.getName("srgb"),
+        new Css.Num(this.#r / SRGBValue.MAX),
+        new Css.Num(this.#g / SRGBValue.MAX),
+        new Css.Num(this.#b / SRGBValue.MAX),
+        ...(alpha !== null ? [Css.slash, new Css.Num(alpha)] : []),
+      ]),
+    ]);
+  }
+}
+
+export interface CMYKValueJSON {
+  c: number;
+  m: number;
+  y: number;
+  k: number;
+}
+class CMYKValue {
+  static readonly MAX = 10000;
+
+  readonly #c: number;
+  readonly #m: number;
+  readonly #y: number;
+  readonly #k: number;
+
+  private constructor(c: number, m: number, y: number, k: number) {
+    this.#c = Math.round(Math.max(0, Math.min(c, CMYKValue.MAX)));
+    this.#m = Math.round(Math.max(0, Math.min(m, CMYKValue.MAX)));
+    this.#y = Math.round(Math.max(0, Math.min(y, CMYKValue.MAX)));
+    this.#k = Math.round(Math.max(0, Math.min(k, CMYKValue.MAX)));
+  }
+
+  static fromInt(c: number, m: number, y: number, k: number): CMYKValue {
+    return new CMYKValue(c, m, y, k);
+  }
+
+  static fromNumber(c: number, m: number, y: number, k: number): CMYKValue {
+    return new CMYKValue(
+      c * CMYKValue.MAX,
+      m * CMYKValue.MAX,
+      y * CMYKValue.MAX,
+      k * CMYKValue.MAX,
+    );
+  }
+
+  /**
+   * CSS Color Level 5 naive conversion.
+   * https://www.w3.org/TR/css-color-5/#cmyk-rgb
+   */
+  toSRGB(): SRGBValue {
+    const oneMinusK = CMYKValue.MAX - this.#k;
+    return SRGBValue.fromInt(
+      SRGBValue.MAX -
+        Math.min(
+          SRGBValue.MAX,
+          Math.round((this.#c * oneMinusK) / CMYKValue.MAX) + this.#k,
+        ),
+      SRGBValue.MAX -
+        Math.min(
+          SRGBValue.MAX,
+          Math.round((this.#m * oneMinusK) / CMYKValue.MAX) + this.#k,
+        ),
+      SRGBValue.MAX -
+        Math.min(
+          SRGBValue.MAX,
+          Math.round((this.#y * oneMinusK) / CMYKValue.MAX) + this.#k,
+        ),
+    );
+  }
+
+  equals(other: CMYKValue): boolean {
+    return (
+      this.#c === other.#c &&
+      this.#m === other.#m &&
+      this.#y === other.#y &&
+      this.#k === other.#k
+    );
+  }
+
+  toJSON(): CMYKValueJSON {
+    return { c: this.#c, m: this.#m, y: this.#y, k: this.#k };
+  }
+}
+
+function getNumValue(v: Css.Val): number | null {
+  return v instanceof Css.Num
+    ? Math.max(0, Math.min(1, v.num))
+    : v instanceof Css.Numeric && v.unit === "%"
+      ? Math.max(0, Math.min(1, v.num / 100))
+      : null;
+}
+
+export function parseDeviceCmyk(
+  func: Css.Func,
+): { cmyk: CMYKValue; alpha: number | null } | null {
+  if (func.name !== "device-cmyk") {
+    return null;
+  }
+
+  const values =
+    // Modern syntax: space-separated values in a single SpaceList
+    func.values.length === 1 && func.values[0]! instanceof Css.SpaceList
+      ? (func.values[0]! as Css.SpaceList).values
+      : // Legacy syntax: comma-separated values directly in func.values
+        func.values;
+  if (values.length < 4 || values.length > 6) {
+    return null;
+  }
+
+  const c = getNumValue(values[0]!);
+  const m = getNumValue(values[1]!);
+  const y = getNumValue(values[2]!);
+  const k = getNumValue(values[3]!);
+  if (c === null || m === null || y === null || k === null) {
+    return null;
+  }
+
+  let alpha: number | null = null;
+  if (values.length >= 5) {
+    if (values[4]! === Css.slash) {
+      // Modern syntax: c m y k / alpha - must have exactly 6 values
+      if (values.length !== 6) {
+        return null;
+      }
+      alpha = getNumValue(values[5]!);
+    } else {
+      // Legacy syntax: c, m, y, k, alpha - must have exactly 5 values
+      if (values.length !== 5) {
+        return null;
+      }
+      alpha = getNumValue(values[4]!);
+    }
+    if (alpha === null) {
+      return null;
+    }
+  }
+
+  return { cmyk: CMYKValue.fromNumber(c, m, y, k), alpha };
+}
+
+function* getOffsets(distance: number): Generator<[number, number, number]> {
+  for (let r = -distance; r <= distance; r++) {
+    for (let g = -distance; g <= distance; g++) {
+      for (let b = -distance; b <= distance; b++) {
+        if (Math.abs(r) + Math.abs(g) + Math.abs(b) === distance) {
+          yield [r, g, b];
+        }
+      }
+    }
+  }
+}
+
+export class CmykStore {
+  #map = new Map<string, CMYKValue>();
+
+  registerDeviceCmyk(func: Css.Func): Css.Func | null {
+    const result = parseDeviceCmyk(func);
+    if (!result) {
+      return null;
+    }
+    const srgb = this.#register(result.cmyk);
+    return srgb.toColorFunc(result.alpha);
+  }
+
+  #register(cmyk: CMYKValue): SRGBValue {
+    const srgb = cmyk.toSRGB();
+    const key = srgb.toKey();
+    const existing = this.#map.get(key);
+    if (existing) {
+      return existing.equals(cmyk) ? srgb : this.#findAvailableSlot(cmyk, srgb);
+    }
+    this.#map.set(key, cmyk);
+    return srgb;
+  }
+
+  toJSON(): Record<string, CMYKValueJSON> {
+    const result: Record<string, CMYKValueJSON> = {};
+    this.#map.forEach((value, key) => {
+      result[key] = value.toJSON();
+    });
+    return result;
+  }
+
+  #findAvailableSlot(cmyk: CMYKValue, baseSrgb: SRGBValue): SRGBValue {
+    for (let distance = 1; distance <= SRGBValue.MAX; distance++) {
+      for (const [dr, dg, db] of getOffsets(distance)) {
+        const candidate = baseSrgb.offset(dr, dg, db);
+        const key = candidate.toKey();
+        if (!this.#map.has(key)) {
+          this.#map.set(key, cmyk);
+          return candidate;
+        }
+      }
+    }
+
+    Logging.logger.warn(
+      `CmykStore: Exceeded trackable color limit for ${JSON.stringify(cmyk.toJSON())}`,
+    );
+    return baseSrgb;
+  }
+}
+
+export class CmykFilterVisitor extends Css.FilterVisitor {
+  readonly #store: CmykStore;
+  readonly #conversions = new Map<string, string>();
+  #hasDeviceCmyk: boolean = false;
+
+  constructor(store?: CmykStore) {
+    super();
+    this.#store = store ?? new CmykStore();
+  }
+
+  reset(): void {
+    this.#hasDeviceCmyk = false;
+  }
+  hadDeviceCmyk(): boolean {
+    return this.#hasDeviceCmyk;
+  }
+
+  recordConversion(propertyName: string, originalValue: string): void {
+    this.#conversions.set(propertyName, originalValue);
+  }
+  getConversions(): Record<string, string> | null {
+    if (this.#conversions.size === 0) {
+      return null;
+    }
+    const result: Record<string, string> = {};
+    this.#conversions.forEach((value, key) => {
+      result[key] = value;
+    });
+    return result;
+  }
+
+  override visitFunc(func: Css.Func): Css.Val {
+    const result = this.#store.registerDeviceCmyk(func);
+    if (result) {
+      this.#hasDeviceCmyk = true;
+      return result;
+    }
+    return super.visitFunc(func);
+  }
+}

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -19,6 +19,7 @@
  */
 import * as AdaptiveViewer from "./adaptive-viewer";
 import * as Base from "./base";
+import * as CmykStore from "./cmyk-store";
 import * as Constants from "./constants";
 import * as Epub from "./epub";
 import * as Profile from "./profile";
@@ -477,6 +478,17 @@ export class CoreViewer {
    */
   getCover(): Epub.OPFItem | null {
     return this.adaptViewer_.opf.cover;
+  }
+
+  /**
+   * Get the CMYK mapping for device-cmyk() colors used in the document.
+   */
+  getCmykMap(): Record<string, CmykStore.CMYKValueJSON> {
+    const opfView = this.adaptViewer_?.opfView;
+    if (!opfView?.cmykStore) {
+      return {};
+    }
+    return opfView.cmykStore.toJSON();
   }
 }
 

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -22,6 +22,7 @@
 import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as Break from "./break";
+import * as CmykStore from "./cmyk-store";
 import * as CounterStyle from "./counter-style";
 import * as Css from "./css";
 import * as CssCascade from "./css-cascade";
@@ -479,6 +480,7 @@ export class Styler implements AbstractStyler {
     public readonly counterListener: CssCascade.CounterListener,
     counterResolver: CssCascade.CounterResolver,
     counterStyleStore: CounterStyle.CounterStyleStore,
+    cmykStore: CmykStore.CmykStore,
   ) {
     this.root = xmldoc.root;
     this.cascadeHolder = cascade;
@@ -489,6 +491,7 @@ export class Styler implements AbstractStyler {
       counterResolver,
       xmldoc.lang,
       counterStyleStore,
+      cmykStore,
     );
     this.offsetMap = new SlipMap();
     const rootOffset = xmldoc.getElementOffset(this.root);

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -21,6 +21,7 @@
 import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as CFI from "./cfi";
+import * as CmykStore from "./cmyk-store";
 import * as Constants from "./constants";
 import * as Counters from "./counters";
 import * as Css from "./css";
@@ -1418,6 +1419,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
   pref: Exprs.Preferences;
   clientLayout: Vgen.DefaultClientLayout;
   counterStore: Counters.CounterStore;
+  cmykStore: CmykStore.CmykStore;
   tocAutohide: boolean = false;
   tocVisible: boolean = false;
   tocView?: Toc.TOCView;
@@ -1437,6 +1439,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.pref = Exprs.clonePreferences(pref);
     this.clientLayout = new Vgen.DefaultClientLayout(viewport);
     this.counterStore = new Counters.CounterStore(opf.documentURLTransformer);
+    this.cmykStore = new CmykStore.CmykStore();
   }
 
   private getPage(position: Position): Vtree.Page {
@@ -2570,6 +2573,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         pageNumberOffset,
         this.opf.documentURLTransformer,
         this.counterStore,
+        this.cmykStore,
         this.opf.pageProgression,
         isVersoFirstPage,
       );
@@ -2663,6 +2667,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         opf.fallbackMap,
         opf.documentURLTransformer,
         this.counterStore,
+        this.cmykStore,
       );
     }
     const viewport = this.viewport;

--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -19,6 +19,7 @@
  * @fileoverview Toc - Table of Contents view.
  */
 import * as Base from "./base";
+import * as CmykStore from "./cmyk-store";
 import * as Counters from "./counters";
 import * as Css from "./css";
 import * as Exprs from "./exprs";
@@ -109,6 +110,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
     public readonly fallbackMap: { [key: string]: string },
     public readonly documentURLTransformer: Base.DocumentURLTransformer,
     public readonly counterStore: Counters.CounterStore,
+    public readonly cmykStore: CmykStore.CmykStore,
   ) {
     this.pref = Exprs.clonePreferences(pref);
     this.pref.spreadView = false; // No spred view for TOC box
@@ -297,6 +299,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
         0,
         this.documentURLTransformer,
         this.counterStore,
+        this.cmykStore,
       );
       this.instance = instance;
       instance.pref = this.pref;

--- a/packages/core/test/files/device-cmyk/test.html
+++ b/packages/core/test/files/device-cmyk/test.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>device-cmyk() function</title>
+    <style>
+      /* @page rule with device-cmyk() */
+      @page {
+        background-color: device-cmyk(0.05 0.05 0.05 0);
+        border: 1px solid device-cmyk(0 0 0 1);
+      }
+
+      body {
+        font-family: sans-serif;
+        line-height: 1.5;
+      }
+
+      h1 {
+        color: device-cmyk(0 0 0 0.9);
+      }
+
+      /* Basic CMYK colors */
+      .cyan {
+        color: device-cmyk(1 0 0 0);
+      }
+      .magenta {
+        color: device-cmyk(0 1 0 0);
+      }
+      .yellow {
+        color: device-cmyk(0 0 1 0);
+      }
+      .black {
+        color: device-cmyk(0 0 0 1);
+      }
+
+      /* With alpha */
+      .with-alpha {
+        color: device-cmyk(0.5 0.5 0.5 0.5 / 0.5);
+      }
+
+      /* Percentage notation */
+      .percent {
+        color: device-cmyk(100% 0% 0% 0%);
+      }
+
+      /* Legacy syntax (comma-separated) */
+      .legacy-cyan {
+        color: device-cmyk(1, 0, 0, 0);
+      }
+      .legacy-mixed {
+        color: device-cmyk(0.3, 0.5, 0.7, 0.2);
+      }
+
+      /* Mixed values */
+      .mixed {
+        color: device-cmyk(0.2 0.4 0.6 0.1);
+      }
+
+      /* Background color */
+      .bg-cmyk {
+        background-color: device-cmyk(0.1 0.1 0.1 0);
+        padding: 0.5em;
+      }
+
+      /* Border color */
+      .border-cmyk {
+        border: 3px solid device-cmyk(0 0.8 0.8 0);
+        padding: 0.5em;
+      }
+
+      /* Gradient with device-cmyk() */
+      .gradient {
+        background: linear-gradient(
+          to right,
+          device-cmyk(1 0 0 0),
+          device-cmyk(0 1 0 0)
+        );
+        padding: 1em;
+        color: white;
+        text-shadow: 1px 1px 2px device-cmyk(0 0 0 0.8);
+      }
+
+      /* Rich black */
+      .rich-black {
+        color: device-cmyk(0.4 0.4 0.4 1);
+      }
+
+      /* Process colors for print */
+      .process-red {
+        color: device-cmyk(0 1 1 0);
+      }
+      .process-green {
+        color: device-cmyk(1 0 1 0);
+      }
+      .process-blue {
+        color: device-cmyk(1 1 0 0);
+      }
+
+      /* Table for color comparison */
+      table {
+        border-collapse: collapse;
+        margin: 1em 0;
+      }
+      th,
+      td {
+        border: 1px solid device-cmyk(0 0 0 0.3);
+        padding: 0.5em;
+      }
+      th {
+        background-color: device-cmyk(0 0 0 0.1);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>device-cmyk() function test</h1>
+
+    <h2>Basic CMYK Colors</h2>
+    <p class="cyan">Cyan text: device-cmyk(1 0 0 0)</p>
+    <p class="magenta">Magenta text: device-cmyk(0 1 0 0)</p>
+    <p class="yellow">Yellow text: device-cmyk(0 0 1 0)</p>
+    <p class="black">Black text: device-cmyk(0 0 0 1)</p>
+
+    <h2>With Alpha</h2>
+    <p class="with-alpha">
+      Semi-transparent: device-cmyk(0.5 0.5 0.5 0.5 / 0.5)
+    </p>
+
+    <h2>Percentage Notation</h2>
+    <p class="percent">Cyan with percent: device-cmyk(100% 0% 0% 0%)</p>
+
+    <h2>Legacy Syntax (comma-separated)</h2>
+    <p class="legacy-cyan">Legacy cyan: device-cmyk(1, 0, 0, 0)</p>
+    <p class="legacy-mixed">Legacy mixed: device-cmyk(0.3, 0.5, 0.7, 0.2)</p>
+
+    <h2>Mixed Values</h2>
+    <p class="mixed">Mixed: device-cmyk(0.2 0.4 0.6 0.1)</p>
+
+    <h2>Background Color</h2>
+    <p class="bg-cmyk">Background with device-cmyk()</p>
+
+    <h2>Border Color</h2>
+    <p class="border-cmyk">Border with device-cmyk()</p>
+
+    <h2>Gradient</h2>
+    <p class="gradient">Gradient from cyan to magenta</p>
+
+    <h2>Process Colors</h2>
+    <p class="process-red">Process Red (M+Y): device-cmyk(0 1 1 0)</p>
+    <p class="process-green">Process Green (C+Y): device-cmyk(1 0 1 0)</p>
+    <p class="process-blue">Process Blue (C+M): device-cmyk(1 1 0 0)</p>
+
+    <h2>Rich Black</h2>
+    <p class="rich-black">Rich Black: device-cmyk(0.4 0.4 0.4 1)</p>
+
+    <h2>Color Table</h2>
+    <table>
+      <tr>
+        <th>Color Name</th>
+        <th>CMYK Values</th>
+        <th>Sample</th>
+      </tr>
+      <tr>
+        <td>Cyan</td>
+        <td>1, 0, 0, 0</td>
+        <td class="cyan">Sample</td>
+      </tr>
+      <tr>
+        <td>Magenta</td>
+        <td>0, 1, 0, 0</td>
+        <td class="magenta">Sample</td>
+      </tr>
+      <tr>
+        <td>Yellow</td>
+        <td>0, 0, 1, 0</td>
+        <td class="yellow">Sample</td>
+      </tr>
+      <tr>
+        <td>Black</td>
+        <td>0, 0, 0, 1</td>
+        <td class="black">Sample</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -759,6 +759,15 @@ module.exports = [
     ],
   },
   {
+    category: "device-cmyk() function",
+    files: [
+      {
+        file: "device-cmyk/test.html",
+        title: "device-cmyk() function",
+      },
+    ],
+  },
+  {
     category: "Counter style, ::marker, and list-style",
     files: [
       {

--- a/packages/core/test/spec/vivliostyle/cmyk-store-spec.js
+++ b/packages/core/test/spec/vivliostyle/cmyk-store-spec.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2025 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as CmykStore from "../../../src/vivliostyle/cmyk-store";
+import * as Css from "../../../src/vivliostyle/css";
+
+// Helper to create device-cmyk() function
+function deviceCmyk(c, m, y, k, alpha) {
+  var values = [new Css.Num(c), new Css.Num(m), new Css.Num(y), new Css.Num(k)];
+  if (alpha !== undefined) {
+    values.push(Css.slash, new Css.Num(alpha));
+  }
+  return new Css.Func("device-cmyk", [new Css.SpaceList(values)]);
+}
+
+describe("cmyk-store", function () {
+  describe("CmykStore", function () {
+    describe("convert", function () {
+      it("converts pure cyan correctly", function () {
+        // device-cmyk(1 0 0 0) → color(srgb 0 1 1)
+        var store = new CmykStore.CmykStore();
+        var result = store.registerDeviceCmyk(deviceCmyk(1, 0, 0, 0));
+        expect(result.toString()).toBe("color(srgb 0 1 1)");
+      });
+
+      it("converts pure magenta correctly", function () {
+        // device-cmyk(0 1 0 0) → color(srgb 1 0 1)
+        var store = new CmykStore.CmykStore();
+        var result = store.registerDeviceCmyk(deviceCmyk(0, 1, 0, 0));
+        expect(result.toString()).toBe("color(srgb 1 0 1)");
+      });
+
+      it("converts pure yellow correctly", function () {
+        // device-cmyk(0 0 1 0) → color(srgb 1 1 0)
+        var store = new CmykStore.CmykStore();
+        var result = store.registerDeviceCmyk(deviceCmyk(0, 0, 1, 0));
+        expect(result.toString()).toBe("color(srgb 1 1 0)");
+      });
+
+      it("converts pure black correctly", function () {
+        // device-cmyk(0 0 0 1) → color(srgb 0 0 0)
+        var store = new CmykStore.CmykStore();
+        var result = store.registerDeviceCmyk(deviceCmyk(0, 0, 0, 1));
+        expect(result.toString()).toBe("color(srgb 0 0 0)");
+      });
+
+      it("converts white correctly", function () {
+        // device-cmyk(0 0 0 0) → color(srgb 1 1 1)
+        var store = new CmykStore.CmykStore();
+        var result = store.registerDeviceCmyk(deviceCmyk(0, 0, 0, 0));
+        expect(result.toString()).toBe("color(srgb 1 1 1)");
+      });
+
+      it("converts with alpha correctly", function () {
+        // device-cmyk(1 0 0 0 / 0.5) → color(srgb 0 1 1 / 0.5)
+        var store = new CmykStore.CmykStore();
+        var result = store.registerDeviceCmyk(deviceCmyk(1, 0, 0, 0, 0.5));
+        expect(result.toString()).toBe("color(srgb 0 1 1 / 0.5)");
+      });
+
+      it("returns null for invalid function", function () {
+        var store = new CmykStore.CmykStore();
+        var invalidFunc = new Css.Func("rgb", [new Css.Num(255)]);
+        expect(store.registerDeviceCmyk(invalidFunc)).toBe(null);
+      });
+    });
+
+    describe("toJSON", function () {
+      it("returns plain object with registered values", function () {
+        var store = new CmykStore.CmykStore();
+        store.registerDeviceCmyk(deviceCmyk(1, 0, 0, 0));
+        var json = store.toJSON();
+        expect(typeof json).toBe("object");
+        expect(Object.keys(json).length).toBe(1);
+        var key = Object.keys(json)[0];
+        expect(json[key].c).toBe(10000);
+        expect(json[key].m).toBe(0);
+        expect(json[key].y).toBe(0);
+        expect(json[key].k).toBe(0);
+      });
+
+      it("uses sRGB key format '[r,g,b]' with integers (0-10000)", function () {
+        var store = new CmykStore.CmykStore();
+        store.registerDeviceCmyk(deviceCmyk(1, 0, 0, 0));
+        var json = store.toJSON();
+        var key = Object.keys(json)[0];
+        expect(key).toBe("[0,10000,10000]");
+      });
+    });
+
+    describe("collision handling", function () {
+      it("handles multiple similar CMYK values", function () {
+        var store = new CmykStore.CmykStore();
+
+        for (var i = 0; i < 10; i++) {
+          store.registerDeviceCmyk(
+            deviceCmyk(0.25 + i * 0.0001, 0.25, 0.25, 0.25),
+          );
+        }
+
+        // All values should be registered with unique keys
+        expect(Object.keys(store.toJSON()).length).toBe(10);
+      });
+
+      it("preserves original CMYK values in map", function () {
+        var store = new CmykStore.CmykStore();
+        store.registerDeviceCmyk(deviceCmyk(1, 0, 0, 0));
+        store.registerDeviceCmyk(deviceCmyk(0, 1, 0, 0));
+
+        var json = store.toJSON();
+        var values = Object.values(json);
+
+        // Both original CMYK values should be preserved
+        expect(
+          values.some(function (v) {
+            return v.c === 10000 && v.m === 0;
+          }),
+        ).toBe(true);
+        expect(
+          values.some(function (v) {
+            return v.c === 0 && v.m === 10000;
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
resolves: #1379 

Vivliostyleに、後処理で置換可能なRGBフォールバックとして`device-cmyk()`関数のサポートを追加するPRです。Vivliostyle CLIに投稿するPRとあわせて、Vivliostyleで簡易的なCMYK出力を行えるようになります。

Chromium/Skiaが`color(srgb ...)`を小数点4桁まで透過的にPDFに反映させられることを利用しています。