### PR TITLE
fix(react): handle React StrictMode double-mount issue

### DIFF
--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -235,6 +235,7 @@ export const Renderer = ({
     userStyleSheet,
     zoom,
     fitToScreen,
+    bookMode,
   ]);
 
   useEffect(() => {

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -83,6 +83,8 @@ export const Renderer = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const instanceRef = useRef<CoreViewer | undefined>(undefined);
   const stateRef = React.useRef<VolatileState | undefined>(undefined);
+  // Use a key to force re-creation of the container element on re-mount (e.g., in StrictMode)
+  const [containerKey, setContainerKey] = React.useState(0);
 
   function setViewerOptions() {
     const viewerOptions = {
@@ -209,17 +211,31 @@ export const Renderer = ({
 
   // initialize document and event handlers
   useEffect(() => {
+    // Increment key to force new container element, ensuring previous CoreViewer's
+    // async rendering won't affect the new container (handles StrictMode double-mount)
+    setContainerKey((k) => k + 1);
+  }, []);
+
+  useEffect(() => {
     initInstance();
     setViewerOptions();
 
     const cleanup = registerEventHandlers();
     return cleanup;
-  }, []);
+  }, [containerKey]);
 
   useEffect(() => {
+    if (containerKey === 0) return; // Skip initial render before key is set
     loadSource();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source, authorStyleSheet, userStyleSheet, zoom, fitToScreen]);
+  }, [
+    containerKey,
+    source,
+    authorStyleSheet,
+    userStyleSheet,
+    zoom,
+    fitToScreen,
+  ]);
 
   useEffect(() => {
     setViewerOptions();
@@ -239,7 +255,12 @@ export const Renderer = ({
   }, [page]);
 
   const container = (
-    <Container ref={containerRef} style={style} background={background} />
+    <Container
+      key={containerKey}
+      ref={containerRef}
+      style={style}
+      background={background}
+    />
   );
 
   if (typeof children === "function" && children instanceof Function) {


### PR DESCRIPTION
In React 18 StrictMode, components are mounted twice in development mode. This caused CoreViewer to be initialized twice, resulting in duplicate page rendering where the first page remained visible as an artifact.

The fix uses a containerKey state that increments on each mount, which:
1. Forces the Container element to be recreated with a new key
2. Ensures the previous CoreViewer's async rendering goes to the old (unmounted) container element
3. Only initializes and loads content after the key is set

Fixes #1629