### PR TITLE
refactor: Simplify page counter fix by relying only on waitForPreviousSpines

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -699,27 +699,12 @@ export class CounterStore {
 
   /**
    * Forcefully set the `page` page-based counter to the specified value.
-   * However, if the counter would decrease and we're not in a pushed state
-   * (i.e., during target-counter resolution), skip the update to avoid
-   * corrupting the counter during background rendering.
-   * (Fix for issue #1616)
    */
   forceSetPageCounter(pageNumber: number) {
     const counters = this.currentPageCounters["page"];
     if (!counters || !counters.length) {
       this.currentPageCounters["page"] = [pageNumber];
     } else {
-      const currentValue = counters[counters.length - 1];
-      // Don't decrease the counter unless we're in a pushed state
-      // (during target-counter resolution). This prevents the counter
-      // from being corrupted when navigating to a later spine item
-      // while background rendering is in progress.
-      if (
-        this.currentPageCountersStack.length === 0 &&
-        pageNumber < currentValue
-      ) {
-        return;
-      }
       counters[counters.length - 1] = pageNumber;
     }
   }
@@ -793,20 +778,6 @@ export class CounterStore {
    */
   popPageCounters() {
     this.currentPageCounters = this.currentPageCountersStack.pop();
-  }
-
-  /**
-   * Get the base (non-pushed) page counters. This returns the original
-   * currentPageCounters before any pushPageCounters calls, which is needed
-   * when calculating page counter offset for a new spine item during
-   * target-counter resolution.
-   * (Fix for issue #1616)
-   */
-  getBasePageCounters(): CssCascade.CounterValues {
-    if (this.currentPageCountersStack.length > 0) {
-      return this.currentPageCountersStack[0];
-    }
-    return this.currentPageCounters;
   }
 
   /**

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2593,12 +2593,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             ? previousViewItem.instance.pageNumberOffset +
               previousViewItem.pages.length
             : 0;
-          // Use getBasePageCounters() to get the original page counter value
-          // that is not affected by pushPageCounters() during target-counter
-          // resolution. This fixes the issue where page numbers become incorrect
-          // when navigating to a later spine item while target-counter resolution
-          // is in progress. (Fix for issue #1616)
-          const counters = this.counterStore.getBasePageCounters()["page"];
+          const counters = this.counterStore.currentPageCounters["page"];
           pageCounterOffset =
             !counters || !counters.length
               ? pageNumberOffset


### PR DESCRIPTION
Follow-up to #1632.

The waitForPreviousSpines() method alone is sufficient to prevent page counter corruption during link navigation. Remove unnecessary changes in counters.ts:
- Remove skip-decrease logic from forceSetPageCounter()
- Remove getBasePageCounters() method

In epub.ts, revert to using currentPageCounters directly instead of getBasePageCounters() for calculating pageCounterOffset.

This simplification works because waitForPreviousSpines() ensures all previous spine items are fully rendered before accessing a later spine item, which prevents the race condition that was causing page counter corruption.