### PR TITLE
fix: Prevent TOC box from interfering with main content rendering

### DIFF
--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -282,7 +282,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
         viewport.window,
         viewportSize.fontSize,
         0,
-        viewport.root,
+        elem,
         viewportSize.width,
         viewportSize.height,
       );

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -3161,7 +3161,7 @@ export class Viewport {
   width: number;
   height: number;
   scaleRatio: number = 1;
-  layoutUnitPerPixel: number;
+  layoutUnitPerPixel: number = 64;
   layoutUnitAdj: number = 0;
 
   constructor(
@@ -3174,6 +3174,14 @@ export class Viewport {
   ) {
     this.document = window.document;
     this.root = opt_root || this.document.body;
+
+    if (this.root.hasAttribute("data-vivliostyle-toc-box")) {
+      // TOC viewport does not need zoom box and layout box.
+      this.outerZoomBox = this.contentContainer = this.layoutBox = this.root;
+      this.width = opt_width || this.root.clientWidth;
+      this.height = opt_height || this.root.clientHeight;
+      return;
+    }
 
     let outerZoomBox = this.root.firstElementChild as HTMLElement;
     if (!outerZoomBox) {


### PR DESCRIPTION
Opening the TOC menu during page rendering could cause incorrect rendering results. This was due to TOC box and main content sharing the same viewport root element, where the CSS variable `--viv-layoutUnitAdj` was being overwritten when TOC box rendering started.

Changes:
- toc.ts: Pass TOC box container element (elem) as viewport root instead of sharing the main viewport's root
- vgen.ts: Add early return in Viewport constructor for TOC box (data-vivliostyle-toc-box), skipping CSS variable setup that would interfere with main content rendering

Fix #1616