### PR TITLE
fix: Fix incorrect page layout depending on Viewer window size

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -60,7 +60,7 @@ export const VivliostyleViewportScreenCss = `
     flex-direction: row-reverse;
   }
 
-  [data-vivliostyle-viewer-viewport] [data-vivliostyle-page-container] {
+  [data-vivliostyle-spread-container] [data-vivliostyle-page-container] {
     margin: 0 auto;
     flex: none;
     transform-origin: center top;
@@ -104,10 +104,11 @@ export const VivliostyleViewportCss = `
 }
 
 [data-vivliostyle-debug] [data-vivliostyle-layout-box] {
-  right: auto;
-  bottom: auto;
-  overflow: visible;
   z-index: auto;
+}
+
+[data-vivliostyle-layout-box] [data-vivliostyle-page-container] {
+  margin: 0 auto 0 0;
 }
 
 [data-vivliostyle-spread-container] {


### PR DESCRIPTION
The Vivliostyle.js page layout processing assumes that the page-container element is aligned to the left edge within the layout-box element. However, the layout-box element had both `left: 0` and `right: 0` specified with `position: absolute`, and the page-container element had `margin: 0 auto` specified with `position: relative`. As a result, when the width of the layout-box element was larger than that of the page-container element, the page-container element was centered horizontally within the layout-box element, causing incorrect page layout.

- Fixes #1638