### PR TITLE
feat: Support CSS @ footnote rule for styling footnote areas

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 lerna.json
 package.json
 /scripts/package-artifacts/samples/
+/packages/core/test/files/**/*.html

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -1,5 +1,2 @@
-test/files/table/table_col_width_vertical.html
-test/files/table/table_col_width.html
-test/files/table/table_vertical_align_vertical.html
-test/files/table/table_vertical_align.html
+test/files/**/*.html
 package.json

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -902,20 +902,19 @@ export const UserAgentPageCss = `
   break-before: right;
 }
 
-@-adapt-footnote-area {
-  display: block;
-  margin-block-start: 0.5em;
-  margin-block-end: 0.5em;
-}
-
-@-adapt-footnote-area ::before {
-  display: block;
-  border-block-start-width: 1px;
-  border-block-start-style: solid;
-  border-block-start-color: black;
-  margin-block-end: 0.4em;
-  margin-inline-start: 0;
-  margin-inline-end: 60%;
+@page {
+  @footnote {
+    margin-block-start: 0.5em;
+  }
+  @footnote ::before {
+    display: block;
+    border-block-start-width: 1px;
+    border-block-start-style: solid;
+    border-block-start-color: black;
+    margin-block-end: 0.4em;
+    margin-inline-start: 0;
+    margin-inline-end: 60%;
+  }
 }
 
 /* default page master */

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1394,6 +1394,7 @@ export class Parser {
       case "-epubx-viewport":
       case "-epubx-define":
       case "-adapt-footnote-area":
+      case "footnote":
         return true;
     }
     return false;
@@ -2419,7 +2420,21 @@ export class Parser {
                 continue;
               }
               break;
+            case "-epubx-region":
+              tokenizer.consume();
+              handler.startRegionRule();
+              this.regionRule = true;
+              this.actions = actionsSelectorStart;
+              continue;
+            case "page":
+              tokenizer.consume();
+              handler.startPageRule();
+              this.pageRule = true;
+              this.actions = actionsSelectorCont;
+              continue;
             case "-adapt-footnote-area":
+            case "footnote":
+              // @footnote can be used both inside and outside @page
               tokenizer.consume();
               token = tokenizer.token();
               switch (token.type) {
@@ -2437,11 +2452,13 @@ export class Parser {
                     token.type == TokenType.IDENT &&
                     tokenizer.nthToken(1).type == TokenType.O_BRC
                   ) {
-                    text = token.text;
+                    const pseudoName = token.text;
                     tokenizer.consume();
                     tokenizer.consume();
-                    handler.startFootnoteRule(text);
-                    this.ruleStack.push("-adapt-footnote-area");
+                    handler.startFootnoteRule(pseudoName);
+                    this.ruleStack.push(
+                      text === "footnote" ? "footnote" : "-adapt-footnote-area",
+                    );
                     handler.startRuleBody();
                     this.inStyleDeclaration = true;
                     continue;
@@ -2449,18 +2466,6 @@ export class Parser {
                   break;
               }
               break;
-            case "-epubx-region":
-              tokenizer.consume();
-              handler.startRegionRule();
-              this.regionRule = true;
-              this.actions = actionsSelectorStart;
-              continue;
-            case "page":
-              tokenizer.consume();
-              handler.startPageRule();
-              this.pageRule = true;
-              this.actions = actionsSelectorCont;
-              continue;
             case "top-left-corner":
             case "top-left":
             case "top-center":

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -247,6 +247,7 @@ export class StyleInstance
   stylerMap: { [key: string]: CssStyler.Styler } = null;
   currentLayoutPosition: Vtree.LayoutPosition = null;
   layoutPositionAtPageStart: Vtree.LayoutPosition = null;
+  currentCascadedPageStyle: CssCascade.ElementStyle = null;
   lookupOffset: number = 0;
   faces: Font.DocumentFaces;
   pageBoxInstances: { [key: string]: PageMaster.PageBoxInstance } = {};
@@ -1438,6 +1439,8 @@ export class StyleInstance
       this.customRenderer,
       this.fallbackMap,
       this.documentURLTransformer,
+      this.style.pageProps,
+      this.currentCascadedPageStyle,
     );
     let columnIndex = 0;
     let column: LayoutType.Column = null;
@@ -1889,6 +1892,9 @@ export class StyleInstance
       ? ({} as CssCascade.ElementStyle)
       : this.pageManager.getCascadedPageStyle(page.pageType);
 
+    // Store cascadedPageStyle for use in ViewFactory
+    this.currentCascadedPageStyle = cascadedPageStyle;
+
     // Substitute var()
     this.styler.cascade.applyVarFilter([cascadedPageStyle], this.styler, null);
 
@@ -2176,12 +2182,11 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       }
     }
     this.masterHandler.pushHandler(
-      new CssCascade.PropSetParserHandler(
+      new CssPage.PageFootnoteAreaParserHandler(
         this.scope,
         this.owner,
-        null,
-        style,
         this.masterHandler.validatorSet,
+        style,
       ),
     );
   }
@@ -2198,6 +2203,7 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       this,
       this.validatorSet,
       this.masterHandler.pageProps,
+      this.masterHandler.footnoteProps,
     );
     this.masterHandler.pushHandler(pageHandler);
     pageHandler.startPageRule();

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -665,6 +665,10 @@ module.exports = [
       },
       { file: "footnotes/footnote-policy.html", title: "footnote-policy" },
       {
+        file: "footnotes/footnote-area-at-footnote.html",
+        title: "Footnote area with @footnote",
+      },
+      {
         file: "footnote-text-spacing.html",
         title: "Footnote text-spacing (Issue #868)",
       },

--- a/packages/core/test/files/footnotes/footnote-area-at-footnote.html
+++ b/packages/core/test/files/footnotes/footnote-area-at-footnote.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@footnote test</title>
+    <style>
+      @page {
+        size: 400px 300px;
+        margin: 20px;
+
+        @footnote {
+          margin-block-start: 1em;
+          padding: 10px;
+          border: 2px solid green;
+          /* Using shorthand property */
+          background: lightgreen;
+          border-radius: 5px;
+        }
+
+        @footnote ::before {
+          display: block;
+          margin-block-end: 0.5em;
+          margin-inline-end: 50%;
+          /* Using logical property */
+          border-block-start: 2px dashed red;
+        }
+      }
+
+      @page :right {
+        @footnote {
+          /* Testing cascading: longhand property overrides shorthand */
+          background-color: lightyellow;
+        }
+
+        @footnote ::before {
+          /* Testing cascading: logical property */
+          border-block-start-color: maroon;
+        }
+      }
+
+      @page :left {
+        @footnote {
+          /* Testing cascading: longhand property overrides shorthand */
+          background-color: lightblue;
+        }
+
+        @footnote ::before {
+          /* Testing cascading: physical property overrides logical property */
+          border-top-color: blue;
+        }
+      }
+
+      :root {
+        line-height: 1.5;
+      }
+
+      body,
+      p {
+        margin: 0;
+      }
+
+      section {
+        page-break-after: always;
+      }
+
+      .footnote {
+        float: footnote;
+        counter-increment: footnote;
+      }
+
+      .footnote::footnote-marker,
+      .footnote::footnote-call {
+        content: "[" counter(footnote) "]";
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <p>
+        Page 1 (right page): This page has a footnote<span class="footnote">First footnote</span>.
+      </p>
+      <p>
+        The footnote area should have a green border, light yellow background,
+        and a maroon dashed line before the footnote content.
+      </p>
+    </section>
+    <section>
+      <p>
+        Page 2 (left page): This page also has a footnote<span class="footnote">Second footnote</span>.
+      </p>
+      <p>
+        The footnote area should have a green border, light blue background, and
+        a blue dashed line before the footnote content.
+      </p>
+    </section>
+    <section>
+      <p>
+        Page 3 (right page): Another page with a footnote<span class="footnote">Third footnote</span>.
+      </p>
+      <p>
+        The footnote area should have a green border, light yellow background,
+        and a maroon dashed line before the footnote content.
+      </p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
This implements support for the CSS Generated Content for Paged Media (GCPM) specification's `@footnote` at-rule, which provides a standard way to style footnote areas in paged media.

Key features:
- `@footnote` rules inside `@page` contexts: `@page { @footnote {…} }`
- Page selector support: e.g., `@page :left`/`@page :right` with `@footnote`
- Backward compatibility and non-standard features:
  - `@-adapt-footnote-area {…}` and `@-adapt-footnote-area ::before {…}` continue to work.
  - `@footnote ::before` can be used for styling the separator, inherited from `@-adapt-footnote-area ::before` functionality.

Style improvement:
- Removed `margin-block-end: 0.5em` from default footnote area styling. This ensures consistent page bottom margins regardless of footnote presence. The footnote area now aligns to the bottom edge of the page area as expected.

Resolves #1045