### PR TITLE
fix: Restore overflow: visible for layout-box in Debug mode

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -105,6 +105,7 @@ export const VivliostyleViewportCss = `
 
 [data-vivliostyle-debug] [data-vivliostyle-layout-box] {
   z-index: auto;
+  overflow: visible;
 }
 
 [data-vivliostyle-layout-box] [data-vivliostyle-page-container] {


### PR DESCRIPTION
**Problem:**

In PR #1640 (fix: Fix incorrect page layout depending on Viewer window size), the `overflow: visible;` specification for layout-box in Debug mode was removed. As a result, when the content of the layout-box overflows, it becomes invisible.

The reason for removing it was to prevent scrollbars from appearing in the viewer-viewport when displaying the layout process in Debug mode, which caused flickering of the scrollbars when switching between the display of the laid-out pages and the display of the layout process in the layout-box. It was also thought that it would not be a problem if the parts overflowing from the page were not visible.

However, this judgment was incorrect. In Vivliostyle.js, to improve rendering precision, the zoom property is used to enlarge the content of the layout-box and the transform property is used to display it in a reduced size. Therefore, if the overflow of the layout-box is not visible, most of the content of the layout-box becomes invisible.

**Fix:**

Restore the `overflow: visible;` specification for layout-box in Debug mode.