### PR TITLE
fix(react): support React 18.2+ with flexible peer dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,8 +21,8 @@
     "@vivliostyle/core": "^2.40.0"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
## Summary

This PR addresses issue #1643 by updating the peer dependencies in @vivliostyle/react to support React 18.2+ and React 19.x instead of only React 19.

## Changes

- Changed `peerDependencies` in package.json:
  - `react`: `^19.0.0` → `^18.2.0 || ^19.0.0`
  - `react-dom`: `^19.0.0` → `^18.2.0 || ^19.0.0`

## Rationale

1. **No React 19-specific features used**: The codebase only uses standard React APIs (`useEffect`, `useRef`, `useState`) that are available in React 18.2+
2. **Broader compatibility**: This allows projects using React 18.2+ to use @vivliostyle/react without forcing them to upgrade to React 19
3. **Version range best practices**: The pattern `^18.2.0 || ^19.0.0` follows React ecosystem conventions and explicitly declares tested major versions
4. **Future-proof with safety**: Supports both React 18.x and 19.x series while preventing automatic upgrades to potentially incompatible major versions (e.g., React 20)

## Impact

- Projects using React 18.2+ or React 19.x can use @vivliostyle/react without compatibility issues
- When React 20 is released, we can verify compatibility and add `|| ^20.0.0` as needed
- Users get clear feedback through peer dependency warnings if using untested major versions

Closes #1643