### PR TITLE
fix: Fix missing last page on target-text reflow

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -1026,7 +1026,7 @@ export class AdaptiveViewer {
                         t: "nav",
                         epageCount: epageCount,
                         first: this.currentPage.isFirstPage,
-                        last: this.currentPage.isLastPage,
+                        last: this.isLastPageForNotification(this.currentPage),
                         metadata: this.opf.metadata,
                         docTitle:
                           this.opf.spine[this.pagePosition.spineIndex].title,
@@ -1101,7 +1101,7 @@ export class AdaptiveViewer {
     const notification = {
       t: "nav",
       first: page.isFirstPage,
-      last: page.isLastPage,
+      last: this.isLastPageForNotification(page),
       metadata: this.opf.metadata,
       docTitle: this.opf.spine[page.spineIndex].title,
     };
@@ -1117,6 +1117,20 @@ export class AdaptiveViewer {
         frame.finish(true);
       });
     return frame.result();
+  }
+
+  private isLastPageForNotification(page: Vtree.Page): boolean {
+    if (!this.opfView || !this.pagePosition) {
+      return page.isLastPage;
+    }
+    const viewItem = this.opfView.spineItems[this.pagePosition.spineIndex];
+    if (!viewItem || !viewItem.complete) {
+      return false;
+    }
+    const isLastSpine = viewItem.item.spineIndex === this.opf.spine.length - 1;
+    const isLastPage =
+      this.pagePosition.pageIndex === viewItem.pages.length - 1;
+    return isLastSpine && isLastPage;
   }
 
   getCurrentPageProgression(): Constants.PageProgression | null {


### PR DESCRIPTION
Fixes #1648.
    
- epub.ts: keep re-layout running when page break positions shift after target-text resolution
- adaptive-viewer.ts: compute last for nav notifications from current layout state to avoid total page count shrinking after reflow
    
Intent: prevent losing the final page and keep the UI total page count consistent when target-text causes late reflow