### PR TITLE
fix "Internal error" for footnotes in pseudo-elements

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2433,11 +2433,14 @@ export class ViewFactory
         // Only insert if footnote-call hasn't been processed yet for this footnote
         // Skip for template-based footnotes (where styler.getStyle returns undefined)
         // as they define their own call content in HTML, not via ::footnote-call
+        // Also skip for pseudo-elements (shadowContext exists) as they are not in the
+        // source document tree (PR #1607 follow-up fix)
         if (
           nodeContext.floatSide === "footnote" &&
           !this.isFootnote &&
           !nodeContext.after &&
           !nodeContext.pluginProps["footnoteCallProcessed"] &&
+          !nodeContext.shadowContext &&
           this.styler.getStyle(nodeContext.sourceNode as Element, false)
         ) {
           // Mark as processed to avoid infinite loop when returning via shadowSibling


### PR DESCRIPTION
When a `float: footnote` element exists inside a pseudo-element like `::before`, the `nextInTree` method would call `styler.getStyle()` with a `sourceNode` that belongs to the pseudo-element document (not the main source document tree), causing `getElementOffset` to fail.

Added a check for `nodeContext.shadowContext` to skip the footnote-call insertion logic for pseudo-elements, as they are not in the source document tree.

Fixes follow-up issue from PR #1607