### PR TITLE
Plug-in hook for tracking pagination progress

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -85,6 +85,15 @@ Note that even if the same function are registered multiple times, this method r
 - `name` (string) — Name of the hook.
 - `fn` (function) — Function to be removed from the hook.
 
+### `plugin.HOOKS.PAGINATION_PROGRESS`
+
+Called when pagination progresses during document load.
+
+The hook receives a payload object:
+
+- `fraction` (number) — Fraction of the HTML content already paginated (0-1).
+- `pages` (number) — Number of pages created so far.
+
 ## profile
 
 ### `profile.profiler.registerStartTiming(name, timestamp)`

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -85,6 +85,15 @@ Note that even if the same function are registered multiple times, this method r
 - `name` (string) — Name of the hook.
 - `fn` (function) — Function to be removed from the hook.
 
+### `plugin.HOOKS.PAGINATION_PROGRESS`
+
+ドキュメント読み込み中のページ分割の進捗時に呼び出されます。
+
+フックには次のペイロードオブジェクトが渡されます:
+
+- `fraction` (number) — 既にページ分割されたHTML内容の割合 (0-1)。
+- `pages` (number) — 作成済みページ数。
+
 ## profile
 
 ### `profile.profiler.registerStartTiming(name, timestamp)`

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -137,6 +137,15 @@ export enum HOOKS {
    *  {Layout.Column} column
    */
   POST_LAYOUT_BLOCK = "POST_LAYOUT_BLOCK",
+
+  /**
+   * Called when pagination progresses during document load.
+   *
+   * The hook is called with an object with the following properties:
+   *  {number} fraction: Fraction of the HTML content already paginated (0-1)
+   *  {number} pages: Number of pages created so far
+   */
+  PAGINATION_PROGRESS = "PAGINATION_PROGRESS",
 }
 
 export type PreProcessSingleDocumentHook = (p1: Document) => any;
@@ -180,6 +189,11 @@ export type PostLayoutBlockHook = (
   p2: Vtree.NodeContext[],
   p3: Layout.Column,
 ) => void;
+
+export type PaginationProgressHook = (p1: {
+  fraction: number;
+  pages: number;
+}) => void;
 
 const hooks = {};
 


### PR DESCRIPTION
## PR Description

Adds a new plugin hook, `PAGINATION_PROGRESS`, that reports pagination progress during document load. The hook is emitted from `OPFView` as pages are rendered, calculates a global fraction based on total/processed content offsets across spine items, and passes `{fraction, pages}` to registered plugins, with guards to keep progress monotonic and to prevent regressions when offsets temporarily decrease. Documentation is updated in both English and Japanese API docs.

### Summary of Changes
- Introduce `plugin.HOOKS.PAGINATION_PROGRESS` and `PaginationProgressHook` type.
- Track per-spine total/rendered offsets in `OPFView` to compute overall progress.
- Emit progress updates after each page is finished, with error-safe hook invocation.
- Document the new hook in `docs/api.md` and `docs/ja/api.md`.

### Testing
- Not included in the commit as existing hooks are also not tested.