### PR TITLE
feat: Enable page-scoped footnote resets and cross-scope counter use

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1431,7 +1431,8 @@ export class Parser {
     for (; count > 0; --count) {
       token = tokenizer.token();
 
-      // For relational pseudo-class `:has()` support
+      // For relational pseudo-class `:has()` support: capture raw selector text
+      // so matching can be delegated to querySelector later.
       if (parsingFunctionParam && selectorStartPosition === null) {
         // token.position may be token's start position + 1
         selectorStartPosition = token.position - 1;
@@ -2976,6 +2977,9 @@ export function evaluateExprToCSS(
   if (val instanceof Exprs.Native && val.str === "viv-leader") {
     return new Css.Expr(val);
   }
+  if (propName === "content" && val instanceof Exprs.Native) {
+    return new Css.Expr(val);
+  }
   const result = val.evaluate(context);
   switch (typeof result) {
     case "number":
@@ -2989,6 +2993,9 @@ export function evaluateExprToCSS(
     case "string":
       if (!result) {
         return Css.empty;
+      }
+      if (propName === "content") {
+        return new Css.Str(result as string);
       }
 
       // TODO: where baseURL should come from???

--- a/packages/core/src/vivliostyle/css-prop.ts
+++ b/packages/core/src/vivliostyle/css-prop.ts
@@ -211,7 +211,10 @@ export class CountersVisitor extends Css.Visitor {
   counters: { [key: string]: number } = {};
   name: string | null = null;
 
-  constructor(public readonly reset: boolean) {
+  constructor(
+    public readonly reset: boolean,
+    public readonly defaultValue: number,
+  ) {
     super();
   }
 
@@ -220,14 +223,16 @@ export class CountersVisitor extends Css.Visitor {
     if (this.reset) {
       this.counters[this.name] = 0;
     } else {
-      this.counters[this.name] = (this.counters[this.name] || 0) + 1;
+      this.counters[this.name] =
+        (this.counters[this.name] || 0) + this.defaultValue;
     }
     return ident;
   }
 
   override visitInt(num: Css.Int): Css.Val {
     if (this.name) {
-      this.counters[this.name] += num.num - (this.reset ? 0 : 1);
+      this.counters[this.name] +=
+        num.num - (this.reset ? 0 : this.defaultValue);
     }
     return num;
   }
@@ -240,9 +245,11 @@ export class CountersVisitor extends Css.Visitor {
 
 export function toCounters(
   val: Css.Val,
-  reset: boolean,
+  options?: { reset?: boolean; defaultValue?: number },
 ): { [key: string]: number } {
-  const visitor = new CountersVisitor(reset);
+  const reset = options?.reset ?? false;
+  const defaultValue = options?.defaultValue ?? (reset ? 0 : 1);
+  const visitor = new CountersVisitor(reset, defaultValue);
   try {
     val.visit(visitor);
   } catch (err) {

--- a/packages/core/test/files/counters-function-in-page-margin-box.html
+++ b/packages/core/test/files/counters-function-in-page-margin-box.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>counters() in page margin boxes</title>
+<style>
+@page {
+  size: 600px 600px;
+  margin: 50px;
+  @bottom-center {
+    content: "Section " counters(section, ".");
+  }
+}
+
+:root {
+  font: 16px/1.25 Arial, sans-serif;
+  counter-reset: section;
+}
+
+.section {
+  counter-increment: section;
+  break-before: page;
+}
+
+.subsection {
+  counter-increment: section;
+  break-before: page;
+}
+
+.subsection-wrapper {
+  counter-reset: section;
+}
+
+.section > h2::before,
+.subsection > h3::before {
+  content: "Section " counters(section, ".") ": ";
+}
+</style>
+</head>
+<body>
+<section class="section">
+  <h2>Section One</h2>
+  <p>This page should show "Section 1" in the footer.</p>
+  <div class="subsection-wrapper">
+    <section class="subsection">
+      <h3>Subsection One</h3>
+      <p>This page should show "Section 1.1" in the footer.</p>
+    </section>
+    <section class="subsection">
+      <h3>Subsection Two</h3>
+      <p>This page should show "Section 1.2" in the footer.</p>
+    </section>
+  </div>
+</section>
+
+<section class="section">
+  <h2>Section Two</h2>
+  <p>This page should show "Section 2" in the footer.</p>
+  <div class="subsection-wrapper">
+    <section class="subsection">
+      <h3>Subsection One</h3>
+      <p>This page should show "Section 2.1" in the footer.</p>
+    </section>
+  </div>
+</section>
+</body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -132,6 +132,10 @@ module.exports = [
         file: "content-in-page-margin-box.html",
         title: "Content in page margin box",
       },
+      {
+        file: "counters-function-in-page-margin-box.html",
+        title: "counters() in page margin boxes",
+      },
       { file: "flowchunk_overflow_bug.html", title: "Flowchunk overflow bug" },
       { file: "pages_counter.html", title: "pages counter" },
       {
@@ -671,6 +675,10 @@ module.exports = [
       {
         file: "footnote-text-spacing.html",
         title: "Footnote text-spacing (Issue #868)",
+      },
+      {
+        file: "footnotes/footnote-page-counter-reset.html",
+        title: "Footnote and page counter-reset (Issue #421)",
       },
     ],
   },

--- a/packages/core/test/files/footnotes/footnote-page-counter-reset.html
+++ b/packages/core/test/files/footnotes/footnote-page-counter-reset.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Footnote and page counter-reset</title>
+<style>
+@page {
+  size: 600px 600px;
+  margin: 50px;
+  counter-reset: footnote;
+  @bottom-center {
+    content: "Section " counter(section) ", Page " counter(page);
+  }
+}
+
+:root {
+  font: 16px/1.25 Arial, sans-serif;
+  counter-reset: section;
+}
+
+.footnote {
+  float: footnote;
+}
+.footnote::footnote-call {
+  content: "[" counter(footnote) "]";
+}
+.footnote::footnote-marker {
+  content: "[" counter(footnote) "] ";
+}
+
+section {
+  counter-increment: section;
+  break-before: page;
+}
+section > h2::before {
+  content: "Section " counter(section) ": ";
+}
+section:nth-of-type(3) {
+  counter-set: page 10;
+}
+section:nth-of-type(6) {
+  counter-reset: page 20;
+}
+</style>
+</head>
+<body>
+  <h1>Footnote and page counter-reset</h1>
+  <p>This page should have a footer showing "Section 0, Page 1".</p>
+  <section>
+    <h2>Lorem Ipsum</h2>
+    <p>This page should have footnotes "[1]", "[2]", "[3]", and a footer showing "Section 1, Page 2".</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <span class="footnote">This is a footnote.</span>
+      Sed lobortis nisl a ultrices porttitor. Duis pellentesque porta tellus, 
+      porta suscipit sem iaculis quis. Sed efficitur massa et ligula lacinia, 
+      ut facilisis nibh consequat. Nullam sed tristique lorem. 
+      <span class="footnote">This is another footnote.</span>
+      Duis ac nisi vestibulum, vestibulum lacus quis, mattis odio. 
+      <span class="footnote">This is one more footnote.</span>
+      Pellentesque aliquam at arcu hendrerit placerat. Nulla facilisi. 
+      Proin pharetra arcu vitae elit condimentum vestibulum.</p>
+  </section>
+  <section>
+    <h2>Lorem Ipsum</h2>
+    <p>This page should have footnotes "[1]", "[2]", "[3]", and footer showing "Section 2, Page 3".</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <span class="footnote">This is a footnote.</span>
+      Sed lobortis nisl a ultrices porttitor. Duis pellentesque porta tellus, 
+      porta suscipit sem iaculis quis. Sed efficitur massa et ligula lacinia, 
+      ut facilisis nibh consequat. Nullam sed tristique lorem. 
+      <span class="footnote">This is another footnote.</span>
+      Duis ac nisi vestibulum, vestibulum lacus quis, mattis odio. 
+      <span class="footnote">This is one more footnote.</span>
+      Pellentesque aliquam at arcu hendrerit placerat. Nulla facilisi. 
+      Proin pharetra arcu vitae elit condimentum vestibulum.</p>
+  </section>
+  <section>
+    <h2>Lorem Ipsum</h2>
+    <p>This page should have footnotes "[1]", "[2]", "[3]", and footer showing "Section 3, Page 10".</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <span class="footnote">This is a footnote.</span>
+      Sed lobortis nisl a ultrices porttitor. Duis pellentesque porta tellus, 
+      porta suscipit sem iaculis quis. Sed efficitur massa et ligula lacinia, 
+      ut facilisis nibh consequat. Nullam sed tristique lorem. 
+      <span class="footnote">This is another footnote.</span>
+      Duis ac nisi vestibulum, vestibulum lacus quis, mattis odio. 
+      <span class="footnote">This is one more footnote.</span>
+      Pellentesque aliquam at arcu hendrerit placerat. Nulla facilisi. 
+      Proin pharetra arcu vitae elit condimentum vestibulum.</p>
+  </section>
+  <section>
+    <h2>Lorem Ipsum</h2>
+    <p>This page should have footnotes "[1]", "[2]", "[3]", and footer showing "Section 4, Page 11".</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <span class="footnote">This is a footnote.</span>
+      Sed lobortis nisl a ultrices porttitor. Duis pellentesque porta tellus, 
+      porta suscipit sem iaculis quis. Sed efficitur massa et ligula lacinia, 
+      ut facilisis nibh consequat. Nullam sed tristique lorem. 
+      <span class="footnote">This is another footnote.</span>
+      Duis ac nisi vestibulum, vestibulum lacus quis, mattis odio. 
+      <span class="footnote">This is one more footnote.</span>
+      Pellentesque aliquam at arcu hendrerit placerat. Nulla facilisi. 
+      Proin pharetra arcu vitae elit condimentum vestibulum.</p>
+  </section>
+  <section>
+    <h2>Lorem Ipsum</h2>
+    <p>This page should have footnotes "[1]", "[2]", "[3]", and footer showing "Section 5, Page 12".</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <span class="footnote">This is a footnote.</span>
+      Sed lobortis nisl a ultrices porttitor. Duis pellentesque porta tellus, 
+      porta suscipit sem iaculis quis. Sed efficitur massa et ligula lacinia, 
+      ut facilisis nibh consequat. Nullam sed tristique lorem. 
+      <span class="footnote">This is another footnote.</span>
+      Duis ac nisi vestibulum, vestibulum lacus quis, mattis odio. 
+      <span class="footnote">This is one more footnote.</span>
+      Pellentesque aliquam at arcu hendrerit placerat. Nulla facilisi. 
+      Proin pharetra arcu vitae elit condimentum vestibulum.</p>
+  </section>
+  <section>
+    <h2>Lorem Ipsum</h2>
+    <p>This page should have footnotes "[1]", "[2]", "[3]", and footer showing "Section 6, Page 20".</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <span class="footnote">This is a footnote.</span>
+      Sed lobortis nisl a ultrices porttitor. Duis pellentesque porta tellus, 
+      porta suscipit sem iaculis quis. Sed efficitur massa et ligula lacinia, 
+      ut facilisis nibh consequat. Nullam sed tristique lorem. 
+      <span class="footnote">This is another footnote.</span>
+      Duis ac nisi vestibulum, vestibulum lacus quis, mattis odio. 
+      <span class="footnote">This is one more footnote.</span>
+      Pellentesque aliquam at arcu hendrerit placerat. Nulla facilisi. 
+      Proin pharetra arcu vitae elit condimentum vestibulum.</p>
+  </section>
+  <section>
+    <h2>Lorem Ipsum</h2>
+    <p>This page should have footnotes "[1]", "[2]", "[3]", and footer showing "Section 7, Page 21".</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <span class="footnote">This is a footnote.</span>
+      Sed lobortis nisl a ultrices porttitor. Duis pellentesque porta tellus, 
+      porta suscipit sem iaculis quis. Sed efficitur massa et ligula lacinia, 
+      ut facilisis nibh consequat. Nullam sed tristique lorem. 
+      <span class="footnote">This is another footnote.</span>
+      Duis ac nisi vestibulum, vestibulum lacus quis, mattis odio. 
+      <span class="footnote">This is one more footnote.</span>
+      Pellentesque aliquam at arcu hendrerit placerat. Nulla facilisi. 
+      Proin pharetra arcu vitae elit condimentum vestibulum.</p>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
This update enhances Vivliostyle.js to support cross-scope CSS counter manipulation between page and document contexts.

Key improvements include:

- Allows document-scoped counters such as "footnote" to be reset or set from the page context without breaking numbering consistency.
- Allows page-scoped counters such as "page" to be reset or set in document flow while keeping page-based updates consistent.
- Allows document-scoped counters to be referenced in page margin boxes, using page-start snapshots that reflect the correct pre-consumed state.
- Stabilizes cross-scope counter evaluation so page counters and document counters can be used together without double counting or drift on relayout.
- Preserves footnote call/marker numbering across page resets by persisting the call-time value on the call element.
- Fixes counter-set default value handling so an omitted value defaults to 0 (per spec), preventing unexpected increments.

Tests:

- [footnote-page-counter-reset.html](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/test/files/footnotes/footnote-page-counter-reset.html)
- [counters-function-in-page-margin-box.html](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/test/files/counters-function-in-page-margin-box.html)

Resolves: #421