### PR TITLE
test: Restructure test commands for CI and local development

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,20 +22,53 @@ yarn test           # Test
 
 ## Development Workflows
 
-### Testing
+### Core Unit Testing
 
-- `cd packages/core/test && yarn test` (Karma + Jasmine)
-- Tests live in `spec/vivliostyle/*-spec.js`
+- `yarn test:core` or `cd packages/core/test && yarn test` (Karma + Jasmine, headless browser)
+- `yarn test:core-local` or `cd packages/core/test && yarn test-local` (Karma + Jasmine, manual browser for debugging)
+- Tests live in `packages/core/test/spec/vivliostyle/*-spec.js`
 
 ### Interactive Development Workflow
 
-- **Viewer dev**: `yarn dev` at root → http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html
-- **Debug build**: `yarn build-dev` (sets `VIVLIOSTYLE_DEBUG=true`)
-- **CSS tests**: Add HTML to `packages/core/test/files/` + entry in `file-list.js`
+- **Core+Viewer dev**: `yarn dev` at root → auto-opens http://localhost:3000/core/test/files/ (Test cases)
+- **Test files**: Add HTML to `packages/core/test/files/` + entry in `file-list.js` (appears in Test cases)
 
-### Lerna
+### Visual Testing with Chrome DevTools MCP
 
-- Use `lerna add <pkg> --scope=@vivliostyle/<target>` or `lerna link` for symlinks
+Use Chrome DevTools MCP to automatically verify rendering results:
+
+**Single Page Test**:
+
+1. Start dev server: `yarn dev` (background)
+2. Open test in browser: Navigate to viewer URL with test file
+3. Wait for rendering: Use `wait_for` to ensure page is loaded
+4. Capture results: Take screenshot to verify rendering
+5. Check structure: Use `take_snapshot` for text-based page structure
+
+**Multi-Page Test**:
+
+1. Navigate to test URL
+2. Take screenshot of first page
+3. Navigate pages: Use `press_key("ArrowDown")` for next page, `press_key("ArrowUp")` for previous
+4. Capture each page to verify pagination
+5. Use `press_key("Home")` / `press_key("End")` to jump to first/last page
+
+**Bug Fix Workflow**:
+
+1. Record current state with screenshots (all pages if multi-page)
+2. Modify core source code (`packages/core/src/`)
+3. `yarn dev` auto-rebuilds → viewer auto-reloads
+4. Reload browser page if needed
+5. Take new screenshots and compare with pre-fix state
+6. Iterate until bug is resolved
+
+**Test URLs**:
+
+- Test cases: http://localhost:3000/core/test/files/
+- Local test:
+  - With test file: `http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/<test>.html`
+  - With any URL: `http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=<URL>`
+- Note: Omit `&debug=true` for visual testing to avoid flickering during render process
 
 ## Naming Conventions
 
@@ -53,9 +86,29 @@ yarn test           # Test
 
 ## Release Process
 
-1. `yarn lint && yarn test && yarn clean && yarn build`
-2. Version: `yarn version:prerelease` / `yarn version:graduate` / `yarn version:bump`
-3. `git push` (CI publishes)
+1. `yarn lint && yarn test && yarn build`
+2. Version: `yarn version:prerelease` / `yarn version:graduate` / `yarn version:bump` (auto-pushes to GitHub)
+3. CI publishes to npm
+
+## Commit Message Guidelines
+
+Follow [Conventional Commits](https://conventionalcommits.org):
+
+- **Format**: `<type>[optional scope]: <description>`
+- **Types**:
+  - `feat:` New feature
+  - `fix:` Bug fix
+  - `chore:` Maintenance (deps, config, etc.)
+  - `docs:` Documentation only
+  - `refactor:` Code restructuring
+  - `test:` Test updates
+- **Scope**: Package name for react/viewer (`fix(react):`, `feat(viewer):`). Core package changes omit scope.
+- **Description**: Imperative mood, lowercase, no period
+- **Issue**: Reference with `closes #1234` or `fixes #1234`
+- **Examples**:
+  - `fix: Fix footnotes in tables being ignored`
+  - `feat(viewer): Add dark mode support`
+  - `chore(deps): bump lodash from 4.17.21 to 4.17.23`
 
 ## Common Pitfalls
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
           cd packages/core/test
           # packages/core/test has its own package.json with test-specific dependencies
           yarn install
-          yarn test-ci
+          yarn test
         env:
           TEST_BROWSER: ${{ matrix.browser }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,15 @@
+# Build artifacts and configs
 lerna.json
 package.json
+
+# Test files and samples
 /scripts/package-artifacts/samples/
 /packages/core/test/files/**/*.html
+
+# Generated/vendor files
+/packages/viewer/src/fonts/
+/packages/viewer/src/html/
+
+# Documentation (prevent unintended formatting)
+/docs/**/*.md
+!/docs/**/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,6 @@
     - [3. Publish](#3-publish)
 - [Consistent Naming Guideline](#consistent-naming-guideline)
 - [Commit Message Guideline](#commit-message-guideline)
-- [Troubleshooting](#troubleshooting)
-  - [Cannot find `node_modules/@vivliostyle/core`](#cannot-find-node_modulesvivliostylecore)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -97,9 +95,3 @@ After running `yarn version:*` command above, just `git push` and CI will do the
 
 All notable changes to this project will be documented in `CHANGELOG.md`.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## Troubleshooting
-
-### Cannot find `node_modules/@vivliostyle/core`
-
-This occurs after `yarn add`. Run `lerna link` to recreate symlinks after the installation, otherwise use `lerna add` instead of `yarn add`.

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -108,12 +108,6 @@ yarn version:bump
 All notable changes to this project will be documented in `CHANGELOG.md`.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## Troubleshooting
-
-### Cannot find `node_modules/@vivliostyle/core`
-
-This occurs after `yarn add`. Run `lerna link` to recreate symlinks after the installation, otherwise use `lerna add` instead of `yarn add`.
-
 ## Maintaining documents
 
 Please update the following documents as developing.

--- a/docs/ja/contribution-guide.md
+++ b/docs/ja/contribution-guide.md
@@ -102,19 +102,13 @@ yarn version:bump
 1. 一貫性を保つために、クラス名とそのファイル名を一致させます。
 2. モジュールのインポート名にはPascalCaseを、ファイル名にはkebab-caseを使用して、違いを視覚的に区別しやすくします。
 3. 分かりやすさのために、ファイル名とクラス名に省略語を使わないようにします。ただし以下を除きます:
-    1. イニシャリズム（EPUB、PDFなど）。
-    2. 長い名前（conditional-properties よりも conditional-props が好ましい）。
+   1. イニシャリズム（EPUB、PDFなど）。
+   2. 長い名前（conditional-properties よりも conditional-props が好ましい）。
 
 ## コミットメッセージのガイドライン
 
 このプロジェクトへの重要な変更は `CHANGELOG.md` に記録されます。
 そのためのコミットメッセージのガイドラインは [Conventional Commits](https://conventionalcommits.org) を参照。
-
-## トラブルシューティング
-
-### Cannot find `node_modules/@vivliostyle/core`
-
-これは `yarn add` の後に発生します。 インストール後にシンボリックリンクを再作成するには、 `lerna link` を実行します。それ以外の場合は、`yarn add` の代わりに `lerna add` を使用します。
 
 ## ドキュメントのメンテナンス
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "ship:canary": "lerna publish --canary",
     "ship:prerelease": "yarn ship --dist-tag next",
     "test": "lerna run test --parallel --stream",
+    "test:core": "yarn workspace @vivliostyle/core test",
+    "test:core-local": "yarn workspace @vivliostyle/core test-local",
     "version:amend": "git tag --points-at HEAD | xargs -I{} git tag --delete {} && git reset --hard HEAD^",
     "version:bump": "lerna version --conventional-commits --preid pre",
     "version:graduate": "lerna version --conventional-commits --conventional-graduate",

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -1,2 +1,0 @@
-test/files/**/*.html
-package.json

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
     "dev": "yarn build-dev --watch=forever",
     "format": "prettier --write \"{*.{js,md,json},{src,types,test,resources}/**/*.{ts,js}}\"",
     "lint": "eslint src --fix -f codeframe",
-    "test": "yarn --cwd test install && yarn --cwd test test"
+    "test": "yarn --cwd test install && yarn --cwd test test",
+    "test-local": "yarn --cwd test install && yarn --cwd test test-local"
   },
   "dependencies": {
     "fast-diff": "^1.2.0"

--- a/packages/core/test/package.json
+++ b/packages/core/test/package.json
@@ -1,8 +1,8 @@
 {
   "name": "core-test",
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=--openssl-legacy-provider karma start conf/karma-local.conf.js",
-    "test-ci": "cross-env NODE_OPTIONS=--openssl-legacy-provider karma start conf/karma-ci.conf.js"
+    "test": "cross-env NODE_OPTIONS=--openssl-legacy-provider karma start conf/karma-ci.conf.js",
+    "test-local": "cross-env NODE_OPTIONS=--openssl-legacy-provider karma start conf/karma-local.conf.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.2",

--- a/packages/viewer/.prettierignore
+++ b/packages/viewer/.prettierignore
@@ -1,3 +1,0 @@
-src/fonts/
-src/html/
-package.json


### PR DESCRIPTION
- Swap test commands: `yarn test` now runs headless CI version (karma-ci.conf.js), `yarn test-local` runs manual browser version (karma-local.conf.js) for debugging
- Add root-level shortcuts: `yarn test:core` and `yarn test:core-local` for easier access from workspace root
- Update CI workflow to use `yarn test` instead of `yarn test-ci`
- Update copilot-instructions.md:
  - Rename "Testing" to "Core Unit Testing" with clearer command descriptions
  - Add "Visual Testing with Chrome DevTools MCP" section for automated rendering verification workflow
  - Refine Release Process (remove unnecessary yarn clean and git push)
  - Add Commit Message Guidelines for AI-assisted commits
- Remove obsolete Lerna troubleshooting from CONTRIBUTING.md and contribution-guide.md (yarn workspaces now handle symlinks automatically)
- Consolidate .prettierignore to root and exclude docs Markdown files to prevent unintended formatting