### PR TITLE
fix: Fix unexpected page break before table when footnotes exist before the table

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -223,7 +223,7 @@ export function getElementClientRectAdjusted(
               (vertical ? rect2.right > rect.right : rect2.top < rect.top))
           ) {
             columnElem.setAttribute(
-              "data-vivliostyle-column-height-adjusted",
+              "data-vivliostyle-column-block-size-adjusted",
               "true",
             );
             return rect2;

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1686,12 +1686,8 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
       nodeContext.formattingContext,
     );
     const rootViewNode = formattingContext.getRootViewNode(nodeContext);
-    const frame = Task.newFrame<Vtree.NodeContext>(
-      "TableFormattingContext.layout",
-    );
-    let cont: Task.Result<Vtree.NodeContext>;
     if (!rootViewNode) {
-      cont = column.buildDeepElementView(nodeContext);
+      return column.buildDeepElementView(nodeContext);
     } else {
       if (leadingEdge) {
         RepetitiveElementImpl.appendHeaderToAncestors(
@@ -1699,26 +1695,11 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
           column,
         );
       }
-      cont = new LayoutRetryer(formattingContext, this).layout(
+      return new LayoutRetryer(formattingContext, this).layout(
         nodeContext,
         column,
       );
     }
-    cont.then((result) => {
-      frame.finish(result);
-
-      // Restore column box size if it was modified in `LayoutHelper.getElementClientRectAdjusted()`.
-      if (
-        column.element.hasAttribute("data-vivliostyle-column-height-adjusted")
-      ) {
-        Base.setCSSProperty(column.element, "width", `${column.width}px`);
-        Base.setCSSProperty(column.element, "height", `${column.height}px`);
-        column.element.removeAttribute(
-          "data-vivliostyle-column-height-adjusted",
-        );
-      }
-    });
-    return frame.result();
   }
 
   /** @override */


### PR DESCRIPTION
This update resolves an issue where an unexpected page break occurs before a table when footnotes or block-end page floats are present prior to the table.

Fixes: #1662