### PR TITLE
fix: Clear duplicate page-box elements created during layout retry

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -2218,6 +2218,10 @@ export class StyleInstance
           if (pageFloatLayoutContext.isInvalidated()) {
             this.currentLayoutPosition = this.layoutPositionAtPageStart.clone();
             pageFloatLayoutContext.validate();
+            // Clear bleedBox children before retry to avoid duplicate page-box elements
+            while (page.bleedBox.lastChild) {
+              page.bleedBox.removeChild(page.bleedBox.lastChild);
+            }
             loopFrame.continueLoop();
           } else {
             loopFrame.breakLoop();


### PR DESCRIPTION
## Summary

When page float layout is invalidated and requires retry in `layoutNextPage()`, the bleedBox children are now cleared before retrying layout. This prevents multiple page-box elements from accumulating in the DOM.

## Problem

Previously, each layout retry during footnote/page-float processing would create new page-box elements via `layoutContainer()` without removing the old ones. These duplicate page-boxes were hidden by the CSS rule:

```css
[data-vivliostyle-page-box] ~ [data-vivliostyle-page-box] { display: none; }
```

However, this resulted in hidden but unnecessary duplicate elements remaining in the DOM structure.

## Solution

Clear all children from `page.bleedBox` before retrying layout when `pageFloatLayoutContext.isInvalidated()` returns true.

## Testing

- All 474 unit tests pass
- Visually verified that each `bleed-box` now contains exactly 1 `page-box` element (tested with footnotes-in-table and column_page_floats test files)

Assisted-by: GitHub Copilot Chat:claude-opus-4.5

<details>
<summary>How the AI was used</summary>

- After finishing an unrelated table-cell-duplication fix (PR #1665) earlier in the same session, the human author separately asked the AI to investigate why duplicate `page-box` elements — hidden by a CSS sibling-selector rule but still present in the DOM — accumulate inside each `bleed-box` whenever footnote/page-float layout retries occur.
- The AI traced page-box creation through `layoutContainer()` and `layoutNextPage()` and found that retries triggered by `pageFloatLayoutContext.isInvalidated()` never cleared the previous `bleedBox` children before creating new ones.
- The AI implemented the fix, ran the full unit test suite (474 passing), and used the VS Code integrated browser to directly inspect the rendered DOM on multiple test pages, confirming each `bleed-box` contained exactly one `page-box` before the human author asked to open the PR.

</details>
