### PR TITLE
fix: Fix error when footnote or page float is inside page float

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3488,6 +3488,22 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       PageFloats.isPageFloat(nodeContext.floatReference) ||
       nodeContext.floatSide === "footnote"
     ) {
+      // Check if we're inside a page float area (has generatingNodePosition).
+      // If so, footnotes and page floats cannot be properly placed, so layout
+      // them as regular blocks instead of letting them disappear.
+      // (Issue #1668, #1669)
+      if (this.pageFloatLayoutContext.generatingNodePosition) {
+        // Clear float-related properties and layout as a regular block
+        const nodeContextMod = nodeContext.modify();
+        nodeContextMod.floatSide = null;
+        nodeContextMod.floatReference = null;
+        nodeContextMod.clearSide = null;
+        if (this.isBreakable(nodeContextMod)) {
+          return this.layoutBreakableBlock(nodeContextMod);
+        } else {
+          return this.layoutUnbreakable(nodeContextMod);
+        }
+      }
       return this.layoutPageFloat(nodeContext);
     } else {
       return this.layoutFloat(nodeContext);


### PR DESCRIPTION
When a footnote or page float is specified inside a page float area, the layout engine would throw "Error: No PageFloatLayoutContext for region" and the content would disappear.

This fix adds a fallback in layoutFloatOrFootnote() that detects when we're inside a page float area (by checking generatingNodePosition) and layouts the footnote/page float as a regular block instead. This prevents the error and ensures the content remains visible within the parent page float box.

Proper placement of footnotes/page floats from within page float areas to their correct positions (e.g., page bottom for footnotes) is left for future work (Issue #1669).

closes #1668