### PR TITLE
feat: Add cmykReserveMap for pre-registering RGB to CMYK mappings

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -20,6 +20,7 @@
  */
 import * as Asserts from "./asserts";
 import * as Base from "./base";
+import * as CmykStore from "./cmyk-store";
 import * as Constants from "./constants";
 import * as Epub from "./epub";
 import * as Exprs from "./exprs";
@@ -105,6 +106,7 @@ export class AdaptiveViewer {
   // force relayout
   viewport: Vgen.Viewport | null;
   opfView: Epub.OPFView;
+  cmykReserveMap: CmykStore.CmykReserveMapEntry[] | undefined;
 
   constructor(
     public readonly window: Window,
@@ -249,6 +251,9 @@ export class AdaptiveViewer {
       url: string | null;
       text: string | null;
     }[];
+    this.cmykReserveMap = command["cmykReserveMap"] as
+      | CmykStore.CmykReserveMapEntry[]
+      | undefined;
     this.viewport = null;
     const frame: Task.Frame<boolean> = Task.newFrame("loadPublication");
     this.configure(command).then(() => {
@@ -288,6 +293,9 @@ export class AdaptiveViewer {
       url: string | null;
       text: string | null;
     }[];
+    this.cmykReserveMap = command["cmykReserveMap"] as
+      | CmykStore.CmykReserveMapEntry[]
+      | undefined;
 
     // force relayout
     this.viewport = null;
@@ -817,6 +825,7 @@ export class AdaptiveViewer {
       this.fontMapper,
       this.pref,
       this.setPageSize.bind(this),
+      this.cmykReserveMap,
     );
     if (tocVisible) {
       this.sendCommand({ a: "toc", v: "show", autohide: tocAutohide });

--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -266,7 +266,7 @@ export class AdaptiveViewer {
         store.loadPubDoc(pubURL).then((opf) => {
           if (opf) {
             this.opf = opf;
-            this.loadCmykReserveMap(store, pubURL).then(() => {
+            this.loadCmykReserveMap(store).then(() => {
               this.render(fragment).then(() => {
                 frame.finish(true);
               });
@@ -314,7 +314,7 @@ export class AdaptiveViewer {
         this.packageURL = resolvedParams.map((p) => p.url);
         this.opf = new Epub.OPFDoc(store, "");
         this.opf.initWithChapters(resolvedParams, doc).then(() => {
-          this.loadCmykReserveMap(store, resolvedParams[0].url).then(() => {
+          this.loadCmykReserveMap(store).then(() => {
             this.render(fragment).then(() => {
               frame.finish(true);
             });
@@ -808,15 +808,15 @@ export class AdaptiveViewer {
     }
   }
 
-  private loadCmykReserveMap(
-    store: Epub.EPUBDocStore,
-    baseURL: string,
-  ): Task.Result<boolean> {
+  private loadCmykReserveMap(store: Epub.EPUBDocStore): Task.Result<boolean> {
     if (!this.cmykReserveMapUrl) {
       this.cmykReserveMap = undefined;
       return Task.newResult(true);
     }
-    const resolvedUrl = Base.resolveURL(this.cmykReserveMapUrl, baseURL);
+    const resolvedUrl = Base.resolveURL(
+      Base.convertSpecialURL(this.cmykReserveMapUrl),
+      Base.baseURL,
+    );
     const frame: Task.Frame<boolean> = Task.newFrame("loadCmykReserveMap");
     store.loadAsJSON(resolvedUrl).then((data) => {
       if (CmykStore.isValidCmykReserveMap(data)) {

--- a/packages/core/src/vivliostyle/cmyk-store.ts
+++ b/packages/core/src/vivliostyle/cmyk-store.ts
@@ -114,18 +114,33 @@ export function isValidCmykReserveMap(
   if (!Array.isArray(data)) {
     return false;
   }
-  return data.every(
-    (entry) =>
-      Array.isArray(entry) &&
-      entry.length === 2 &&
-      typeof entry[0]?.r === "number" &&
-      typeof entry[0]?.g === "number" &&
-      typeof entry[0]?.b === "number" &&
-      typeof entry[1]?.c === "number" &&
-      typeof entry[1]?.m === "number" &&
-      typeof entry[1]?.y === "number" &&
-      typeof entry[1]?.k === "number",
-  );
+  return data.every((entry) => {
+    if (!Array.isArray(entry) || entry.length !== 2) {
+      return false;
+    }
+    const [rgb, cmyk] = entry;
+    if (
+      !rgb ||
+      typeof rgb !== "object" ||
+      Array.isArray(rgb) ||
+      !cmyk ||
+      typeof cmyk !== "object" ||
+      Array.isArray(cmyk)
+    ) {
+      return false;
+    }
+    const rgbObj = rgb as { r: unknown; g: unknown; b: unknown };
+    const cmykObj = cmyk as { c: unknown; m: unknown; y: unknown; k: unknown };
+    return (
+      Number.isFinite(rgbObj.r as number) &&
+      Number.isFinite(rgbObj.g as number) &&
+      Number.isFinite(rgbObj.b as number) &&
+      Number.isFinite(cmykObj.c as number) &&
+      Number.isFinite(cmykObj.m as number) &&
+      Number.isFinite(cmykObj.y as number) &&
+      Number.isFinite(cmykObj.k as number)
+    );
+  });
 }
 
 class CMYKValue {

--- a/packages/core/src/vivliostyle/cmyk-store.ts
+++ b/packages/core/src/vivliostyle/cmyk-store.ts
@@ -99,6 +99,35 @@ export interface CMYKValueJSON {
   y: number;
   k: number;
 }
+
+export interface RGBValueJSON {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export type CmykReserveMapEntry = [RGBValueJSON, CMYKValueJSON];
+
+export function isValidCmykReserveMap(
+  data: unknown,
+): data is CmykReserveMapEntry[] {
+  if (!Array.isArray(data)) {
+    return false;
+  }
+  return data.every(
+    (entry) =>
+      Array.isArray(entry) &&
+      entry.length === 2 &&
+      typeof entry[0]?.r === "number" &&
+      typeof entry[0]?.g === "number" &&
+      typeof entry[0]?.b === "number" &&
+      typeof entry[1]?.c === "number" &&
+      typeof entry[1]?.m === "number" &&
+      typeof entry[1]?.y === "number" &&
+      typeof entry[1]?.k === "number",
+  );
+}
+
 class CMYKValue {
   static readonly MAX = 10000;
 
@@ -255,6 +284,14 @@ export class CmykStore {
     }
     this.#map.set(key, cmyk);
     return srgb;
+  }
+
+  registerCmykReserveMap(entries: CmykReserveMapEntry[]): void {
+    for (const [rgb, cmyk] of entries) {
+      const srgb = SRGBValue.fromInt(rgb.r, rgb.g, rgb.b);
+      const cmykVal = CMYKValue.fromInt(cmyk.c, cmyk.m, cmyk.y, cmyk.k);
+      this.#map.set(srgb.toKey(), cmykVal);
+    }
   }
 
   toJSON(): Record<string, CMYKValueJSON> {

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -20,6 +20,7 @@
 import * as AdaptiveViewer from "./adaptive-viewer";
 import * as Base from "./base";
 import * as CmykStore from "./cmyk-store";
+export { isValidCmykReserveMap } from "./cmyk-store";
 import * as Constants from "./constants";
 import * as Epub from "./epub";
 import * as Profile from "./profile";
@@ -140,6 +141,7 @@ export type DocumentOptions = {
   fragment?: string;
   authorStyleSheet?: { url?: string; text?: string }[];
   userStyleSheet?: { url?: string; text?: string }[];
+  cmykReserveMap?: CmykStore.CmykReserveMapEntry[];
 };
 
 /**
@@ -338,6 +340,7 @@ export class CoreViewer {
         fragment: documentOptions["fragment"],
         authorStyleSheet: authorStyleSheet,
         userStyleSheet: userStyleSheet,
+        cmykReserveMap: documentOptions["cmykReserveMap"],
       },
       convertViewerOptions(this.options),
     );

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -20,7 +20,6 @@
 import * as AdaptiveViewer from "./adaptive-viewer";
 import * as Base from "./base";
 import * as CmykStore from "./cmyk-store";
-export { isValidCmykReserveMap } from "./cmyk-store";
 import * as Constants from "./constants";
 import * as Epub from "./epub";
 import * as Profile from "./profile";
@@ -141,7 +140,7 @@ export type DocumentOptions = {
   fragment?: string;
   authorStyleSheet?: { url?: string; text?: string }[];
   userStyleSheet?: { url?: string; text?: string }[];
-  cmykReserveMap?: CmykStore.CmykReserveMapEntry[];
+  cmykReserveMapUrl?: string;
 };
 
 /**
@@ -340,7 +339,7 @@ export class CoreViewer {
         fragment: documentOptions["fragment"],
         authorStyleSheet: authorStyleSheet,
         userStyleSheet: userStyleSheet,
-        cmykReserveMap: documentOptions["cmykReserveMap"],
+        cmykReserveMapUrl: documentOptions["cmykReserveMapUrl"],
       },
       convertViewerOptions(this.options),
     );

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1453,11 +1453,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
       p3: number,
       p4: number,
     ) => any,
+    cmykReserveMap?: CmykStore.CmykReserveMapEntry[],
   ) {
     this.pref = Exprs.clonePreferences(pref);
     this.clientLayout = new Vgen.DefaultClientLayout(viewport);
     this.counterStore = new Counters.CounterStore(opf.documentURLTransformer);
     this.cmykStore = new CmykStore.CmykStore();
+    if (cmykReserveMap?.length) {
+      this.cmykStore.registerCmykReserveMap(cmykReserveMap);
+    }
   }
 
   private getPage(position: Position): Vtree.Page {

--- a/packages/viewer/src/models/document-options.ts
+++ b/packages/viewer/src/models/document-options.ts
@@ -162,6 +162,7 @@ class DocumentOptions {
       fragment: this.fragment(),
       authorStyleSheet: convertStyleSheetArray(this.authorStyleSheet()),
       userStyleSheet: convertStyleSheetArray(this.userStyleSheet()),
+      cmykReserveMapUrl: this.cmykReserveMapUrl,
     };
   }
 

--- a/packages/viewer/src/models/document-options.ts
+++ b/packages/viewer/src/models/document-options.ts
@@ -33,6 +33,7 @@ function getDocumentOptionsFromURL(): DocumentOptionsType {
   const fragment = urlParameters.getParameter("f")[0];
   const style = urlParameters.getParameter("style");
   const userStyle = urlParameters.getParameter("userStyle");
+  const cmykReserveMapUrl = urlParameters.getParameter("cmykReserveMap")[0];
   return {
     srcUrls: srcUrls.length
       ? srcUrls
@@ -56,6 +57,7 @@ function getDocumentOptionsFromURL(): DocumentOptionsType {
     fragment: fragment || null,
     authorStyleSheet: style.length ? style : [],
     userStyleSheet: userStyle.length ? userStyle : [],
+    cmykReserveMapUrl: cmykReserveMapUrl || null,
   };
 }
 
@@ -67,6 +69,7 @@ interface DocumentOptionsType {
   fragment?: string;
   authorStyleSheet?: Array<string>;
   userStyleSheet?: Array<string>;
+  cmykReserveMapUrl?: string;
 }
 
 class DocumentOptions {
@@ -77,6 +80,7 @@ class DocumentOptions {
   fragment?: Observable<string>;
   authorStyleSheet?: Observable<Array<string>>;
   userStyleSheet?: Observable<Array<string>>;
+  cmykReserveMapUrl?: string;
 
   constructor(defaultBookMode: boolean) {
     const urlOptions = getDocumentOptionsFromURL();
@@ -89,6 +93,7 @@ class DocumentOptions {
     this.userStyleSheet = ko.observable(urlOptions.userStyleSheet as string[]);
     this.pageStyle = new PageStyle();
     this.dataCustomStyleIndex = -1;
+    this.cmykReserveMapUrl = urlOptions.cmykReserveMapUrl;
 
     this.bookMode.subscribe((bookMode) => {
       if (bookMode === defaultBookMode) {


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle-cli/pull/742 に対応するVivliostyle.js側の変更です。新たなURLパラメータ`cmykReserveMap`を追加し、JSONを受け入れて変換マップの初期化に割り込めるようにします。