### PR TITLE
fix: Fix print layout in Firefox

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -211,20 +211,6 @@ export const VivliostyleViewportCss = `
   [data-vivliostyle-spread-container] [data-vivliostyle-page-container]:not(:last-child) {
     break-after: page;
   }
-
-  /* Gecko-only hack, see https://bugzilla.mozilla.org/show_bug.cgi?id=267029#c17 */
-  @-moz-document url-prefix()  {
-    [data-vivliostyle-spread-container] [data-vivliostyle-page-container]:nth-last-child(n + 2) {
-      top: -1px;
-      margin-top: 1px;
-      margin-bottom: -1px;
-    }
-    /* Workaround Gecko problem on page break */
-    [data-vivliostyle-spread-container] [data-vivliostyle-page-container] {
-      break-after: auto !important;
-      height: 100% !important;
-    }
-  }
 }
 `;
 


### PR DESCRIPTION
Removed old Gecko-only hack that is no longer necessary (since the firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=267029 was fixed) and that causes broken print layout on current Firefox.


This will fix the vivliostyle-print issue:
- https://github.com/vivliostyle/vivliostyle-print/issues/17