### PR TITLE
Fix wrong page counter values with target-counter()/target-text()

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1761,7 +1761,18 @@ export class OPFView implements Vgen.CustomRendererFactory {
           offsetChanged;
         if (oldPage && (!nextPage || positionChanged)) {
           viewItem.complete = false;
-          cont = this.renderSinglePage(viewItem, pos);
+          // When inside a target-counter/target-text resolution scope
+          // (pushPageCounters/popPageCounters), do not cascade to render
+          // pages that have not been rendered yet. Creating new pages
+          // inside the push/pop scope causes currentPageCounters to
+          // advance, but popPageCounters then restores stale values,
+          // leading to wrong page counter numbers on subsequently
+          // rendered pages.
+          const inCounterResolveScope =
+            this.counterStore.currentPageCountersStack.length > 0;
+          if (nextPage || !inCounterResolveScope) {
+            cont = this.renderSinglePage(viewItem, pos);
+          }
         }
       }
       if (!cont) {


### PR DESCRIPTION
Fix wrong page counter values with target-counter()/target-text()
(follow-up fix for PR #1656)

When target-counter() or target-text() triggers re-rendering of a referenced page, the cascading renderSinglePage call could create new pages that have not yet been rendered. This advanced currentPageCounters inside a pushPageCounters/popPageCounters scope, and the subsequent popPageCounters restored stale counter values, causing later pages to show wrong page numbers.

Prevent cascading to unrendered (new) pages when inside a counter resolution scope. Re-rendering of existing pages is still allowed. New page creation is deferred to the main rendering loop where counter state is correct.

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author reported this regression from PR #1656, listing three specific test cases with the exact wrong page-counter values observed on specific pages (e.g. "page 4 shows 'Page 2', should be '4'"), and asked the AI to investigate and fix it using the running dev server and Chrome DevTools MCP.
- The AI traced the issue to stale counter state being restored after cascaded re-rendering of not-yet-rendered pages and implemented the fix; the human author confirmed the listed test cases were resolved.

</details>
