### PR TITLE
fix: Set page-progression to the vivliostyle viewer viewport

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -235,6 +235,14 @@ export class AdaptiveViewer {
     if (this.readyState !== readyState) {
       this.readyState = readyState;
       this.viewportElement.setAttribute(VIEWPORT_STATUS_ATTRIBUTE, readyState);
+      // Set page-progression attribute (Issue #1681)
+      const pageProgression = this.getCurrentPageProgression();
+      if (pageProgression) {
+        this.viewportElement.setAttribute(
+          "data-vivliostyle-page-progression",
+          pageProgression,
+        );
+      }
       this.callback({ t: "readystatechange" });
     }
   }


### PR DESCRIPTION
- fix #1681

So far, the vivliostyle-viewer-viewport element's `data-vivliostyle-page-progression` attribute was set in the Vivliostyle Viewer (`@vivliostyle/viewer` package), but it was not set in React Vivliostyle (`@vivliostyle/react` package).

In this update, the `data-vivliostyle-page-progression` attribute is set in Vivliostyle Core and it fixes the React Vivliostyle issue.