### PR TITLE
fix: Fix cross-scope counter behavior with counters()/target-counter()/target-counters()

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2274,25 +2274,25 @@ export class ContentPropVisitor extends Css.FilterVisitor {
       const docStartCounters =
         store.currentPageDocCounters?.[counterName] || [];
       const pageStartCounters = store.currentPageCounters?.[counterName] || [];
-      const docStartVal = docStartCounters.length
-        ? docStartCounters[docStartCounters.length - 1]
-        : 0;
       const pageStartVal = pageStartCounters.length
         ? pageStartCounters[pageStartCounters.length - 1]
         : 0;
-      const docVal = docCounters.length
-        ? docCounters[docCounters.length - 1]
-        : 0;
-      const adjusted = pageStartVal + (docVal - docStartVal);
-      if (!isList) {
-        result = this.format(adjusted, type);
-        return storeFootnoteCounterValueIfNeeded(result);
-      }
+      // Adjust the outermost (first) counter value with the page contribution.
+      // The page counter operates at the outermost scope, so only the first
+      // level gets the cross-scope adjustment. Nested scopes created by
+      // counter-reset in the document are not affected.
+      const docStartVal = docStartCounters.length ? docStartCounters[0] : 0;
+      const docVal0 = docCounters.length ? docCounters[0] : 0;
+      const adjustedFirst = pageStartVal + (docVal0 - docStartVal);
       const adjustedCounters = docCounters.length
-        ? docCounters.slice(0, -1).concat([adjusted])
+        ? [adjustedFirst, ...docCounters.slice(1)]
         : pageStartCounters.length
           ? pageStartCounters
           : [0];
+      if (!isList) {
+        result = this.formatLastValue(adjustedCounters, type);
+        return storeFootnoteCounterValueIfNeeded(result);
+      }
       result = this.formatCounterList(
         adjustedCounters,
         separator as string,

--- a/packages/core/test/files/cross-scope-counters.html
+++ b/packages/core/test/files/cross-scope-counters.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cross-scope counters</title>
+    <style>
+      @page {
+        counter-increment: foo bar;
+        size: 500px;
+        margin: 50px;
+        @top-center {
+          content: "Page " counter(page);
+        }
+      }
+      section {
+        break-before: page;
+      }
+      .foo {
+        counter-increment: foo;
+      }
+      .foo::after {
+        content: counter(foo);
+      }
+      .foofoo:first-child {
+        counter-reset: foo;
+      }
+      .foofoo {
+        counter-increment: foo;
+      }
+      .foofoo::after {
+        content: counters(foo, "-");
+      }
+      .ref-foo::before {
+        content: target-counter(url(#foo-target), foo);
+      }
+      .ref-foofoo::before {
+        content: target-counters(url("#foofoo-target"), foo, "-");
+      }
+      .bar {
+        counter-increment: bar;
+      }
+      .bar::after {
+        content: counter(bar);
+      }
+      .barbar:first-child {
+        counter-reset: bar;
+      }
+      .barbar {
+        counter-increment: bar;
+      }
+      .barbar::after {
+        content: counters(bar, "-");
+      }
+      [data-ref-bar]::before {
+        content: target-counter(attr(data-ref-bar url), bar);
+      }
+      [data-ref-barbar]::before {
+        content: target-counters(attr(data-ref-barbar url), bar, "-");
+      }
+      .foo,
+      .bar {
+        border: solid maroon;
+        padding: 0.25em;
+      }
+      .foofoo,
+      .barbar {
+        border: solid orange;
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <p>'foo' value of #foo-target = <span class="ref-foo"></span></p>
+      <p>'foo' values of #foofoo-target = <span class="ref-foofoo"></span></p>
+      <p class="foo">foo=</p>
+      <p class="foo">foo=</p>
+      <p class="foo" id="foo-target">(#foo-target) foo=</p>
+      <p class="foo">
+        <span class="foofoo">foos=</span>,
+        <span class="foofoo" id="foofoo-target">(#foofoo-target) foos=</span>,
+        foo=
+      </p>
+      <p class="foo">foo=</p>
+    </section>
+    <section>
+      <p>'bar' value of #bar-target = <span data-ref-bar="#bar-target"></span></p>
+      <p>'bar' values of #barbar-target = <span data-ref-barbar="#barbar-target"></span></p>
+      <p class="bar">bar=</p>
+      <p class="bar">bar=</p>
+      <p class="bar" id="bar-target">(#bar-target) bar=</p>
+      <p class="bar">
+        <span class="barbar">bars=</span>,
+        <span class="barbar" id="barbar-target">(#barbar-target) bars=</span>,
+        bar=
+      </p>
+      <p class="bar">bar=</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -76,6 +76,10 @@ module.exports = [
       { file: "relative_floats.html", title: "Floats with position: relative" },
       { file: "target-counter.html", title: "target-counter" },
       {
+        file: "cross-scope-counters.html",
+        title: "Cross-scope counters (#Issue 1692)",
+      },
+      {
         file: "target-counter-and-margin-bug.html",
         title: "target-counter and margin bug",
       },

--- a/packages/core/test/files/target-counter.html
+++ b/packages/core/test/files/target-counter.html
@@ -7,7 +7,7 @@
       @page {
         size: 460px;
         margin: 50px;
-        counter-increment: foo bar baz bazz bazzz qux;
+        counter-increment: baz bazz bazzz qux;
         @top-center {
           font-size: 10px;
           content: "Page " counter(page);


### PR DESCRIPTION
Fix issues where `counters()`, `target-counter()`, and `target-counters()` did not correctly resolve counter values across page and document scopes, introduced by PR #1655.

- Fix `buildCounterText` to adjust the outermost (first) counter value instead of the innermost (last) for page-controlled counters with nested scopes (counter-reset in document context)
- Fix `getTargetCounterVal` to apply cross-scope adjustment for page-controlled counters and always use deferred `Native` expressions instead of Const to ensure correct resolution at layout time
- Fix `getTargetCountersVal` to properly merge element counters with cross-scope adjustment instead of concatenating page and element counter arrays
- Add `pageDocCountersById` to `CounterStore` to preserve document counter snapshots per element for cross-scope adjustment in target functions
- Add `cross-scope-counters.html` test case
- Remove `foo`/`bar` from `@page` counter-increment in `target-counter.html` to avoid cross-scope dependency in that test

closes #1692

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author described issue #1692 as an incomplete follow-up to PR #1655's counter-resolution changes, and asked the AI to fix the cross-scope counter behavior.
- The human author ran `/draft-commit` once satisfied with the fix.

</details>
