### PR TITLE
fix: Fix font-face deduplication ignoring font descriptors

### DIFF
--- a/packages/core/src/vivliostyle/font.ts
+++ b/packages/core/src/vivliostyle/font.ts
@@ -229,17 +229,12 @@ export class Mapper {
     documentFaces: DocumentFaces,
   ): TaskUtil.Fetcher<Face> {
     const src = srcFace.src as string;
-    const srcFamilySrc = srcFace.family + ";" + src;
-    let fetcher = this.srcURLMap[srcFamilySrc];
+    const faceKey = srcFace.family + ";" + src + ";" + srcFace.fontTraitKey;
+    let fetcher = this.srcURLMap[faceKey];
     if (fetcher) {
       fetcher.piggyback((viewFaceParam) => {
-        const viewFace = viewFaceParam as Face;
-        if (!viewFace.traitsEqual(srcFace)) {
-          Logging.logger.warn("E_FONT_FACE_INCOMPATIBLE", srcFace.src);
-        } else {
-          documentFaces.registerFamily(srcFace, viewFace);
-          Logging.logger.debug("Found already-loaded font:", src);
-        }
+        documentFaces.registerFamily(srcFace, viewFaceParam as Face);
+        Logging.logger.debug("Found already-loaded font:", src);
       });
     } else {
       fetcher = new TaskUtil.Fetcher(() => {
@@ -266,7 +261,7 @@ export class Mapper {
         }
         return frame.result();
       }, `loadFont ${src}`);
-      this.srcURLMap[srcFamilySrc] = fetcher;
+      this.srcURLMap[faceKey] = fetcher;
       fetcher.start();
     }
     return fetcher;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -51,6 +51,10 @@ module.exports = [
       { file: "selector_bug.html", title: "Selector bug" },
       { file: "outline.html", title: "Outline" },
       { file: "font-feature-settings.html", title: "Font feature settings" },
+      {
+        file: "font-variation-settings.html",
+        title: "font-variation-settings in @font-face",
+      },
       { file: "background-gradient.html", title: "Background gradient" },
       {
         file: "incorrect_layout_with_empty_partition.html",

--- a/packages/core/test/files/font-variation-settings.html
+++ b/packages/core/test/files/font-variation-settings.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>font-variation-settings in @font-face</title>
+    <style>
+      @font-face {
+        font-family: "T";
+        src: url("https://cdn.jsdelivr.net/gh/github/mona-sans@main/fonts/variable/MonaSansMonoVF%5Bwght%5D.ttf");
+        font-variation-settings: "wght" 100;
+        font-weight: 400;
+      }
+      @font-face {
+        font-family: "T";
+        src: url("https://cdn.jsdelivr.net/gh/github/mona-sans@main/fonts/variable/MonaSansMonoVF%5Bwght%5D.ttf");
+        font-variation-settings: "wght" 900;
+        font-weight: 700;
+      }
+      * {
+        font-family: "T";
+      }
+    </style>
+  </head>
+  <body>
+    <p>Test (normal weight, should be thin)</p>
+    <p><strong>Test (bold weight, should be heavy)</strong></p>
+  </body>
+</html>


### PR DESCRIPTION
Multiple `@font-face` rules with the same `font-family` and `src` but different descriptors (e.g., `font-variation-settings`, `font-weight`) were incorrectly deduplicated, causing only the first rule to be loaded. Include `fontTraitKey` in the deduplication key so that `@font-face` rules with different descriptors are treated as separate font faces.

closes #1691

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1691, pointing to the "Suspected issue" section of the issue report and the specific `E_FONT_FACE_INCOMPATIBLE` console error at `font.ts#238` as the starting point for investigation, and asked for verification via the issue's example and Chrome DevTools MCP.
- The AI traced the bug to the deduplication key omitting `font-variation-settings`/other descriptors and implemented the fix; the human author confirmed the result.

</details>
