### PR TITLE
feat: Support footnotes using role="doc-noteref"/"doc-footnote" attributes

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1005,7 +1005,7 @@ export const UserAgentPageCss = `
 `;
 
 /** user-agent-base.css */
-export const UserAgentBaseCss = `
+export const UserAgentBaseCss = String.raw`
 @namespace "http://www.w3.org/1999/xhtml";
 @namespace m "http://www.w3.org/1998/Math/MathML";
 @namespace epub "http://www.idpf.org/2007/ops";
@@ -1347,34 +1347,54 @@ m|math[display="block"] {
   display: block math;
 }
 
-/*------------------ epub-specific ---------------------*/
+/* EPUB/DPUB footnotes */
 
 a[epub|type="noteref"],
-a[epub\\:type="noteref"] {
+a[epub\:type="noteref"],
+a[role="doc-noteref"] {
   font-size: 0.75em;
   vertical-align: super;
-  line-height: 0.01;
+  line-height: 0;
+}
+
+sup > a[epub|type="noteref"],
+a[epub|type="noteref"] > sup,
+sup > a[epub\:type="noteref"],
+a[epub\:type="noteref"] > sup,
+sup > a[role="doc-noteref"],
+a[role="doc-noteref"] > sup {
+  font-size: unset;
+  vertical-align: unset;
+  line-height: unset;
 }
 
 a[epub|type="noteref"]:href-epub-type(footnote, aside),
-a[epub\\:type="noteref"]:href-epub-type(footnote, aside) {
+a[epub\:type="noteref"]:href-epub-type(footnote, aside),
+a[role="doc-noteref"]:href-role-type(doc-footnote, aside) {
   -adapt-template: footnote;
   text-decoration: none;
 }
 
 aside[epub|type="footnote"],
-aside[epub\\:type="footnote"] {
+aside[epub\:type="footnote"],
+aside[role="doc-footnote"] {
   display: none;
 }
 
 aside[epub|type="footnote"]:footnote-content,
-aside[epub\\:type="footnote"]:footnote-content {
+aside[epub\:type="footnote"]:footnote-content,
+aside[role="doc-footnote"]:footnote-content {
   display: block;
-  margin: 0.25em;
-  font-size: 1.2em;
+  color: initial;
+  text-align: initial;
+  text-align-last: initial;
+  text-indent: initial;
+  font: initial;
+  font-size: 0.9rem;
   line-height: 1.2;
 }
 
+/* EPUB-specific */
 epub|trigger {
   display: none;
 }

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1690,12 +1690,14 @@ export class Parser {
                   continue;
                 case "lang":
                 case "href-epub-type":
+                case "href-role-type":
                   token = tokenizer.token();
                   if (token.type === TokenType.IDENT) {
                     params = [token.text];
                     tokenizer.consume();
                     if (
-                      text === "href-epub-type" &&
+                      (text === "href-epub-type" ||
+                        text === "href-role-type") &&
                       tokenizer.token().type === TokenType.COMMA
                     ) {
                       tokenizer.consume();

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -705,6 +705,14 @@ module.exports = [
         file: "footnotes/footnotes-anywhere.html",
         title: "Footnotes anywhere (Issue #1669)",
       },
+      {
+        file: "footnotes/dpub-footnotes-target-counter.html",
+        title: "DPUB footnotes with target-counter() (Issue #1700)",
+      },
+      {
+        file: "footnotes/epub-footnotes-static-number.html",
+        title: "EPUB footnotes (static numbering)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnotes/dpub-footnotes-target-counter.html
+++ b/packages/core/test/files/footnotes/dpub-footnotes-target-counter.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB Footnotes with target-counter()</title>
+  <style>
+    :root {
+      counter-reset: footnote;
+    }
+
+    a {
+      text-decoration: none;
+    }
+
+    a[role="doc-noteref"] {
+      counter-increment: footnote;
+    }
+
+    a[role="doc-noteref"]::after {
+      content: counter(footnote);
+    }
+
+    a[role="doc-backlink"] {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+    }
+
+    a[role="doc-backlink"]::after {
+      content: target-counter(attr(href), footnote);
+    }
+  </style>
+</head>
+<body>
+  <h1>DPUB Footnote Sample</h1>
+
+  <p>
+    This specification note uses semantic footnotes<a id="fnref1" href="#fn1" role="doc-noteref">*</a>
+    and demonstrates generated numbering.
+  </p>
+
+  <p>
+    A second reference appears later in the document<a id="fnref2" href="#fn2" role="doc-noteref">*</a>
+    to verify independent numbering.
+  </p>
+
+  <aside id="fn1" role="doc-footnote">
+    <a href="#fnref1" role="doc-backlink">*</a>
+    This is the first footnote body. Its marker is resolved by
+    target-counter() from the corresponding reference.
+  </aside>
+
+  <aside id="fn2" role="doc-footnote">
+    <a href="#fnref2" role="doc-backlink">*</a>
+    This is the second footnote body. The numbering follows the
+    reference counter value.
+  </aside>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/epub-footnotes-static-number.html
+++ b/packages/core/test/files/footnotes/epub-footnotes-static-number.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EPUB Footnotes (Static Numbering)</title>
+  <style>
+    a {
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <h1>EPUB Footnote Sample</h1>
+
+  <p>
+    This paragraph uses EPUB footnote semantics with explicit numbering<a id="fnref1" href="#fn1" epub:type="noteref">[1]</a>
+    in the document source.
+  </p>
+
+  <p>
+    Another annotated statement appears here<a id="fnref2" href="#fn2" epub:type="noteref">[2]</a>
+    to confirm stable static markers.
+  </p>
+
+  <aside id="fn1" epub:type="footnote">
+    <a href="#fnref1" epub:type="backlink">[1]</a>
+    This is the first EPUB footnote body with static numbering.
+  </aside>
+
+  <aside id="fn2" epub:type="footnote">
+    <a href="#fnref2" epub:type="backlink">[2]</a>
+    This is the second EPUB footnote body with static numbering.
+  </aside>
+</body>
+</html>


### PR DESCRIPTION
- support DPUB-ARIA footnotes in addition to existing EPUB semantics
- treat `a[role="doc-noteref"]` linking to `aside[role="doc-footnote"]` as footnote references and apply footnote template flow
- apply default UA styling for role-based noteref/footnote elements and footnote-content rendering
- add parser/cascade support for `:href-role-type()` to match role-based footnote targets
- avoid duplicate `::footnote-call` for semantic EPUB/DPUB footnotes and fix nested shadow content traversal
- add regression samples for DPUB target-counter and EPUB static-numbering footnotes
- update test file list entries for issue #1700

closes #1700

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author, mid-way through implementing issue #1700 (DPUB-ARIA footnote support) themselves, reported a specific remaining bug: footnotes disappeared when the test used a CSS counter for numbering (`doc-footnote-counter.html`) but worked fine without one (`doc-footnote-test.html`), and asked the AI to find and fix the discrepancy using Chrome DevTools MCP against both linked gist test cases.
- The AI traced the issue to `processMarker()`/counter-related handling not being invoked consistently for role-based footnotes and implemented the fix.

</details>
