### PR TITLE
fix: Set `line-height: 1` on `sub` and `sup` in the default stylesheet

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1202,6 +1202,10 @@ sub {
 sup {
   vertical-align: super;
 }
+sub,
+sup {
+  line-height: 1;
+}
 table {
   box-sizing: border-box;
   border-spacing: 2px;


### PR DESCRIPTION
set `line-height: 1` on `sub` and `sup` in UserAgentBaseCss. this reduces unexpected line-height expansion when superscripts/subscripts appear in paragraphs.

avoid using `line-height: 0` as a default because it can cause overlap in some cases. keep the change minimal and compatible with existing footnote noteref rules.

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author had already made the `line-height: 1` change to the default stylesheet themselves and explained their reasoning (avoiding uneven line spacing from `sup`/`sub` while avoiding the overlap risk of `line-height: 0`), then asked the AI to check for any conflicts with existing rules (e.g. footnote noteref styling) and, if none, draft a commit message explaining the rationale.
- The AI checked for conflicts with the existing footnote-reference `line-height: 0` exception rule, confirmed none, and drafted the commit message.

</details>
