### PR TITLE
feat: Add default styles for ::footnote-call and ::footnote-marker

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1351,6 +1351,18 @@ m|math[display="block"] {
   display: block math;
 }
 
+/* CSS GCPM footnotes */
+::footnote-marker {
+  content: counter(footnote) ". ";
+  list-style-position: inside;
+}
+::footnote-call {
+  content: counter(footnote);
+  font-size: 0.75em;
+  vertical-align: super;
+  line-height: 0;
+}
+
 /* EPUB/DPUB footnotes */
 
 a[epub|type="noteref"],

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -713,6 +713,10 @@ module.exports = [
         file: "footnotes/epub-footnotes-static-number.html",
         title: "EPUB footnotes (static numbering)",
       },
+      {
+        file: "footnotes/default-footnote-pseudo-styles.html",
+        title: "Default ::footnote-call/::footnote-marker styles (Issue #1701)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnotes/default-footnote-pseudo-styles.html
+++ b/packages/core/test/files/footnotes/default-footnote-pseudo-styles.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Default footnote pseudo styles</title>
+    <style>
+      @page {
+        size: 500px 350px;
+      }
+
+      body {
+        font-family: serif;
+        line-height: 1.5;
+      }
+
+      .footnote {
+        float: footnote;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Footnote call should be rendered by default as a superscript counter<span class="footnote"
+        >Footnote marker should be rendered by default with the footnote counter and a trailing period.</span
+      >.
+    </p>
+    <p>
+      Another footnote should increment the counter automatically<span class="footnote"
+        >This is the second footnote for default marker/call style verification.</span
+      >.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Add default UA styles for footnote pseudo-elements.

- `::footnote-call`: render as superscript counter
- `::footnote-marker`: render as "1. " style counter marker

closes #1701

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author had already added the default UA styles for issue #1701 and verified they worked in a simple test case, then asked the AI to add a regression test for the default styles.
- The human author tested the result themselves, made a couple of small adjustments directly (page size, test ordering in `file-list.js`), and corrected the AI's proposed commit type from `fix:` to `feat:` (since this was new functionality, not a bug fix), also directing which details belonged in the commit body and which unrelated in-progress changes should be left out.

</details>
