### PR TITLE
fix: Ensure ::footnote-marker applies its own counter style

### DIFF
--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -694,6 +694,10 @@ module.exports = [
         title: "Footnote and page counter-reset (Issue #421)",
       },
       {
+        file: "footnotes/footnote-call-marker-counter-style.html",
+        title: "Footnote call/marker counter styles",
+      },
+      {
         file: "footnotes/footnotes-in-table.html",
         title: "Footnotes in table (Issue #438)",
       },

--- a/packages/core/test/files/footnotes/footnote-call-marker-counter-style.html
+++ b/packages/core/test/files/footnotes/footnote-call-marker-counter-style.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Footnote-call/marker counter style test</title>
+<style>
+@page {
+  size: A5;
+  @bottom-center {
+    content: "Page " counter(page);
+  }
+}
+.footnote {
+  float: footnote;
+}
+.footnote::footnote-call {
+  content: "[" counter(footnote, upper-alpha) "]";
+}
+.footnote::footnote-marker {
+  content: "(" counter(footnote, lower-alpha) ") ";
+}
+
+</style>
+</head>
+<body>
+<h1>Footnote-call/marker counter style test</h1>
+<p>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit<span class="footnote">Proin scelerisque nulla neque, non varius massa euismod nec. </span>. Nulla facilisi. Nam euismod eget lectus ultrices lacinia. Etiam nec elit non justo porttitor congue. Vivamus ut est nisi. Suspendisse semper tristique condimentum. Nunc accumsan metus vitae libero interdum, non interdum nunc finibus. In hac habitasse platea dictumst<span class="footnote">Aliquam ac blandit magna. Nullam interdum tincidunt odio, et malesuada neque imperdiet quis. Nam sed posuere nibh. Sed dapibus ipsum in lacus facilisis volutpat.</span>. 
+</p>
+<p>
+Quisque nec tellus<span class="footnote">Nunc sed quam sit amet nulla sollicitudin consectetur. </span> vel orci condimentum ultricies id volutpat justo. Aliquam ut vestibulum elit. Phasellus hendrerit sapien in erat venenatis molestie. In eleifend ac felis ac euismod<span class="footnote">Praesent quis massa quam. Vivamus id iaculis est, et fringilla eros. Nam a magna et ex consectetur bibendum vel sed leo. Cras rhoncus pulvinar lorem.</span>.  Maecenas a enim risus. Nam placerat et nunc sit amet suscipit. Proin ut rhoncus metus. Nullam ac convallis justo. Proin dolor arcu, semper non consequat a, luctus lacinia eros.
+</p>
+</body>
+</html>


### PR DESCRIPTION
(Follow-up for PR #1655)

- Preserve numeric counter values on footnote-call and format footnote-marker with its own counter style.
- Add footnote call/marker counter-style regression test

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author reported a side effect of PR #1655: when `::footnote-call` and `::footnote-marker` specify `content` with `counter()` using different counter styles, the call element's counter style was incorrectly also applied to the marker. The human author explained the exact root cause themselves (PR #1655's `data-viv-footnote-counter` attribute stored the already-formatted string instead of the raw numeric value) and directed the fix: store the numeric value and let each pseudo-element format it with its own counter style, specifying the test sample to use.
- The human author asked follow-up questions to confirm their understanding of a related change (`getFootnoteCounterMap` returning `Object.create(null)` instead of `{}`), directed that the commit message note this was a pre-release follow-up to PR #1655, and, after the human author found the fix still didn't fully work on first attempt, asked the AI to continue investigating until the counter styles rendered correctly.

</details>
