### PR TITLE
fix: Support counter names like "constructor"

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -33,7 +33,7 @@ import { Layout } from "./types";
 function cloneCounterValues(
   counters: CssCascade.CounterValues,
 ): CssCascade.CounterValues {
-  const result = {};
+  const result = Object.create(null) as CssCascade.CounterValues;
   Object.keys(counters).forEach((name) => {
     result[name] = Array.from(counters[name]);
   });
@@ -148,8 +148,8 @@ type NamedRunningValues = {
 
 class CounterResolver implements CssCascade.CounterResolver {
   styler: CssStyler.Styler | null = null;
-  namedStringValues: NamedRunningValues = {};
-  runningElements: NamedRunningValues = {};
+  namedStringValues: NamedRunningValues = Object.create(null);
+  runningElements: NamedRunningValues = Object.create(null);
 
   constructor(
     public readonly counterStore: CounterStore,
@@ -668,7 +668,8 @@ class CounterResolver implements CssCascade.CounterResolver {
     elementOffset: number,
   ): void {
     const values =
-      this.namedStringValues[name] || (this.namedStringValues[name] = {});
+      this.namedStringValues[name] ||
+      (this.namedStringValues[name] = Object.create(null));
     values[elementOffset] = stringValue;
   }
 
@@ -678,35 +679,46 @@ class CounterResolver implements CssCascade.CounterResolver {
    */
   setRunningElement(name: string, elementOffset: number): void {
     const values =
-      this.runningElements[name] || (this.runningElements[name] = {});
+      this.runningElements[name] ||
+      (this.runningElements[name] = Object.create(null));
     values[elementOffset] = String(elementOffset);
   }
 }
 
 export class CounterStore {
-  countersById: { [key: string]: CssCascade.CounterValues } = {};
-  pageCountersById: { [key: string]: CssCascade.CounterValues } = {};
-  pageDocCountersById: { [key: string]: CssCascade.CounterValues } = {};
-  pageTextById: { [key: string]: { [pseudoElement: string]: string } } = {};
+  countersById: { [key: string]: CssCascade.CounterValues } =
+    Object.create(null);
+  pageCountersById: { [key: string]: CssCascade.CounterValues } =
+    Object.create(null);
+  pageDocCountersById: { [key: string]: CssCascade.CounterValues } =
+    Object.create(null);
+  pageTextById: { [key: string]: { [pseudoElement: string]: string } } =
+    Object.create(null);
   currentPageDocCounters: CssCascade.CounterValues | null = null;
   previousPageDocCounters: CssCascade.CounterValues | null = null;
-  currentPageDocCounterChanges: { [key: string]: boolean } = {};
+  currentPageDocCounterChanges: { [key: string]: boolean } =
+    Object.create(null);
   currentPageDocCounterChangeTypes: {
     [key: string]: "reset" | "set" | "increment";
-  } = {};
-  currentPageCounters: CssCascade.CounterValues = {};
-  previousPageCounters: CssCascade.CounterValues = {};
+  } = Object.create(null);
+  currentPageCounters: CssCascade.CounterValues = Object.create(null);
+  previousPageCounters: CssCascade.CounterValues = Object.create(null);
   currentPageCountersStack: CssCascade.CounterValues[] = [];
   pageIndicesById: {
     [key: string]: { spineIndex: number; pageIndex: number };
-  } = {};
+  } = Object.create(null);
   currentPage: Vtree.Page = null;
   newReferencesOfCurrentPage: TargetCounterReference[] = [];
   referencesToSolve: TargetCounterReference[] = [];
   referencesToSolveStack: TargetCounterReference[][] = [];
-  unresolvedReferences: { [key: string]: TargetCounterReference[] } = {};
-  resolvedReferences: { [key: string]: TargetCounterReference[] } = {};
-  pageControlledCounterNames: { [key: string]: boolean } = { page: true };
+  unresolvedReferences: { [key: string]: TargetCounterReference[] } =
+    Object.create(null);
+  resolvedReferences: { [key: string]: TargetCounterReference[] } =
+    Object.create(null);
+  pageControlledCounterNames: { [key: string]: boolean } = Object.assign(
+    Object.create(null),
+    { page: true },
+  );
   private pagesCounterExprs: {
     expr: Exprs.Val;
     format: (p1: number[]) => string;
@@ -762,10 +774,10 @@ export class CounterStore {
     this.currentPageDocCounters = counters
       ? cloneCounterValues(counters)
       : null;
-    this.currentPageDocCounterChanges = {};
+    this.currentPageDocCounterChanges = Object.create(null);
     this.currentPageDocCounterChangeTypes = changeTypes
       ? { ...changeTypes }
-      : {};
+      : Object.create(null);
     if (changes) {
       changes.forEach((name) => {
         this.currentPageDocCounterChanges[name] = true;
@@ -774,7 +786,9 @@ export class CounterStore {
   }
 
   setPageControlledCounterNames(names: string[]) {
-    const map: { [key: string]: boolean } = { page: true };
+    const map: { [key: string]: boolean } = Object.assign(Object.create(null), {
+      page: true,
+    });
     names.forEach((name) => {
       map[name] = true;
     });
@@ -822,7 +836,7 @@ export class CounterStore {
     const docChangeTypes = this.currentPageDocCounterChangeTypes || {};
     const docCounterInfo: {
       [key: string]: { delta: number; reset: boolean; value: number };
-    } = {};
+    } = Object.create(null);
     if (this.currentPageDocCounters) {
       const prevDocCounters = this.previousPageDocCounters || {};
       for (const counterName in this.currentPageDocCounters) {
@@ -847,7 +861,7 @@ export class CounterStore {
         };
       }
     }
-    const skipIncrement: { [key: string]: boolean } = {};
+    const skipIncrement: { [key: string]: boolean } = Object.create(null);
     let resetMap: { [key: string]: number };
     const reset = cascadedPageStyle["counter-reset"] as CssCascade.CascadeValue;
     if (reset) {
@@ -905,7 +919,7 @@ export class CounterStore {
         incrementMap["page"] = 1;
       }
     } else {
-      incrementMap = {};
+      incrementMap = Object.create(null);
       if (!(docCounterInfo["page"] && docCounterInfo["page"].reset)) {
         incrementMap["page"] = 1;
       }

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -423,18 +423,18 @@ const FOOTNOTE_COUNTER_ATTR = "data-viv-footnote-counter";
 function getFootnoteCounterMap(element: Element): Record<string, number[]> {
   const stored = element.getAttribute(FOOTNOTE_COUNTER_ATTR);
   if (!stored) {
-    return {};
+    return Object.create(null);
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(stored);
   } catch {
-    return {};
+    return Object.create(null);
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return {};
+    return Object.create(null);
   }
-  const map: Record<string, number[]> = {};
+  const map: Record<string, number[]> = Object.create(null);
   Object.entries(parsed as Record<string, unknown>).forEach(([key, value]) => {
     if (Array.isArray(value)) {
       const nums = value.filter(
@@ -3095,7 +3095,7 @@ export class Cascade {
 export class CascadeInstance {
   code: Cascade;
   stack = [[], []] as ConditionItem[][];
-  conditions = {} as { [key: string]: number };
+  conditions = Object.create(null) as { [key: string]: number };
   currentElement: Element | null = null;
   currentElementOffset: number | null = null;
   currentStyle: ElementStyle | null = null;
@@ -3109,13 +3109,15 @@ export class CascadeInstance {
   currentPageType: string | null = null;
   previousPageType: string | null = null;
   firstPageType: string | null = null;
-  pageTypePageCounts: { [pageType: string]: number } = {};
+  pageTypePageCounts: { [pageType: string]: number } = Object.create(null);
   isFirst: boolean = true;
   isRoot: boolean = true;
-  counters: CounterValues = {};
+  counters: CounterValues = Object.create(null);
   lastCounterChanges: string[] = [];
-  lastCounterChangeTypes: { [key: string]: "reset" | "set" | "increment" } = {};
-  counterScoping: { [key: string]: boolean }[] = [{}];
+  lastCounterChangeTypes: {
+    [key: string]: "reset" | "set" | "increment";
+  } = Object.create(null);
+  counterScoping: { [key: string]: boolean }[] = [Object.create(null)];
   quotes: Css.Str[];
   quoteDepth: number = 0;
   lang: string = "";
@@ -3131,7 +3133,7 @@ export class CascadeInstance {
   currentFollowingSiblingTypeCounts: {
     [key: string]: { [key: string]: number };
   };
-  viewConditions: { [key: string]: Matchers.Matcher[] } = {};
+  viewConditions: { [key: string]: Matchers.Matcher[] } = Object.create(null);
   dependentConditions: string[] = [];
   elementStack: Element[];
 
@@ -3251,7 +3253,7 @@ export class CascadeInstance {
   defineCounter(counterName: string, value: number) {
     let scoping = this.counterScoping[this.counterScoping.length - 1];
     if (!scoping) {
-      scoping = {};
+      scoping = Object.create(null);
       this.counterScoping[this.counterScoping.length - 1] = scoping;
     }
     if (this.counters[counterName]) {
@@ -3269,7 +3271,7 @@ export class CascadeInstance {
     const counterChanges = new Set<string>();
     const counterChangeTypes: {
       [key: string]: "reset" | "set" | "increment";
-    } = {};
+    } = Object.create(null);
     let displayVal: Css.Val = Css.ident.inline;
     const display = props["display"] as CascadeValue;
     if (display) {
@@ -3279,12 +3281,12 @@ export class CascadeInstance {
     if (displayVal === Css.ident.none) {
       this.currentElement.setAttribute("data-viv-display-none", "true");
       this.lastCounterChanges = [];
-      this.lastCounterChangeTypes = {};
+      this.lastCounterChangeTypes = Object.create(null);
       this.counterScoping.push(null);
       return;
     } else if (this.currentElement.closest("[data-viv-display-none]")) {
       this.lastCounterChanges = [];
-      this.lastCounterChangeTypes = {};
+      this.lastCounterChangeTypes = Object.create(null);
       this.counterScoping.push(null);
       return;
     }
@@ -3322,27 +3324,27 @@ export class CascadeInstance {
       this.currentNamespace == Base.NS.XHTML
     ) {
       if (!resetMap) {
-        resetMap = {};
+        resetMap = Object.create(null);
       }
       resetMap["list-item"] = ((this.currentElement as any)?.start ?? 1) - 1;
     }
     if (Display.isListItem(displayVal)) {
       if (!incrementMap) {
-        incrementMap = {};
+        incrementMap = Object.create(null);
       }
       incrementMap["list-item"] = incrementMap["list-item"] ?? 1;
       if (
         /^\s*[-+]?\d/.test(this.currentElement?.getAttribute("value") ?? "")
       ) {
         if (!setMap) {
-          setMap = {};
+          setMap = Object.create(null);
         }
         setMap["list-item"] = (this.currentElement as any).value;
       }
     }
     if (this.currentElement?.parentNode.nodeType === Node.DOCUMENT_NODE) {
       if (!resetMap) {
-        resetMap = {};
+        resetMap = Object.create(null);
       }
       // `counter-reset: footnote 0` is implicitly applied on the root element
       if (resetMap["footnote"] === undefined) {
@@ -3351,7 +3353,7 @@ export class CascadeInstance {
     }
     if (floatVal === Css.ident.footnote) {
       if (!incrementMap) {
-        incrementMap = {};
+        incrementMap = Object.create(null);
       }
       // `counter-increment: footnote 1` is implicitly applied on the
       // element (or pseudo element) with `float: footnote`,
@@ -3644,7 +3646,7 @@ export class CascadeInstance {
     const id =
       this.currentId || this.currentXmlId || element.getAttribute("name") || "";
     if (isRoot || id) {
-      const counters: CounterValues = {};
+      const counters: CounterValues = Object.create(null);
       Object.keys(this.counters).forEach((name) => {
         counters[name] = Array.from(this.counters[name]);
       });

--- a/packages/core/src/vivliostyle/css-prop.ts
+++ b/packages/core/src/vivliostyle/css-prop.ts
@@ -208,7 +208,7 @@ export function toShape(
 }
 
 export class CountersVisitor extends Css.Visitor {
-  counters: { [key: string]: number } = {};
+  counters: { [key: string]: number } = Object.create(null);
   name: string | null = null;
 
   constructor(

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -576,7 +576,7 @@ export class PrimitiveValidator extends PropertyValidator {
   }
 }
 
-const NO_IDENTS: ValueMap = {};
+const NO_IDENTS: ValueMap = Object.create(null);
 
 export const ALWAYS_FAIL = new PrimitiveValidator(0, NO_IDENTS, NO_IDENTS);
 

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -322,7 +322,7 @@ export class Str extends Val {
   }
 }
 
-const nameTable: { [key: string]: Ident } = {};
+const nameTable: { [key: string]: Ident } = Object.create(null);
 
 export class Ident extends Val {
   constructor(public name: string) {


### PR DESCRIPTION
(Follow-up for PR #1655 and #1707)

Use null-prototype maps for counter and ident dictionaries to avoid `Object.prototype` key collisions.

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- Continuing the same session as PR #1707, the human author asked the AI to explain why `getFootnoteCounterMap` had been changed from `return {};` to `return Object.create(null);`, then confirmed their own understanding that this was needed to support counter names like `constructor` that collide with `Object.prototype` members.
- The human author asked the AI to check for other similar collision risks elsewhere in the codebase and apply the same null-prototype fix consistently, then reviewed the result and asked "ほかに見落としはないですか？" (are there other things overlooked?) before finalizing.

</details>
