### PR TITLE
fix: Prevent target-counter() from assigning wrong named pages after relayout

### DIFF
--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -87,6 +87,10 @@ module.exports = [
         file: "target-counter-and-margin-bug.html",
         title: "target-counter and margin bug",
       },
+      {
+        file: "target-counter-named-pages-left-right.html",
+        title: "target-counter() named pages with :left/:right (Issue #1497)",
+      },
       { file: "target-text.html", title: "target-text() - Basic Tests" },
       {
         file: "target-text-running-element.html",

--- a/packages/core/test/files/target-counter-named-pages-left-right.html
+++ b/packages/core/test/files/target-counter-named-pages-left-right.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-counter named pages with left/right</title>
+    <style>
+      :root {
+        font-family: "Times New Roman", Times, serif;
+        line-height: 1.8;
+        widows: 1;
+        orphans: 1;
+      }
+
+      * {
+        margin: 0;
+      }
+
+      @page {
+        size: 300px;
+        margin: 36px;
+        outline: 1px dotted;
+        @bottom-center {
+          content: counter(page);
+          font-size: 0.8em;
+        }
+      }
+
+      @page :first {
+        counter-reset: page 10000;
+      }
+
+      @page Cover {
+        background-color: lightgray;
+      }
+
+      @page TOC {
+        background-color: yellow;
+      }
+
+      @page A:left {
+        background-color: orange;
+      }
+
+      @page A:right {
+        background-color: cyan;
+      }
+
+      @page B:left {
+        background-color: blueviolet;
+      }
+
+      @page B:right {
+        background-color: lavender;
+      }
+
+      @page C:left {
+        background-color: pink;
+      }
+
+      @page C:right {
+        background-color: lime;
+      }
+
+      .cover {
+        page: Cover;
+        text-align: center;
+      }
+
+      nav {
+        page: TOC;
+      }
+
+      nav a::after {
+        content: " " target-counter(attr(href), page);
+      }
+
+      hr,
+      section {
+        break-before: page;
+      }
+
+      section.a {
+        page: A;
+      }
+
+      section.b {
+        page: B;
+      }
+
+      section.c {
+        page: C;
+      }
+
+      ul {
+        padding-left: 1.2em;
+      }
+
+      p,
+      li {
+        font-size: 14px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="cover">
+      <h1>Named pages + target-counter() test</h1>
+      <p>This page should be Cover (lightgray).</p>
+    </div>
+
+    <nav>
+      <ul>
+        <li>
+          <a href="#target"
+            >Target WWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW</a
+          >
+        </li>
+      </ul>
+      <hr />
+      <p>
+        TOC pages should remain yellow. target-counter() resolution may increase
+        TOC page count and flip left/right for following named pages.
+      </p>
+    </nav>
+
+    <section class="a">
+      <h2>A-1</h2>
+      <p>Expected page type and side: A:right (cyan).</p>
+    </section>
+
+    <section class="a">
+      <h2>A-2</h2>
+      <p>Expected page type and side: A:left (orange).</p>
+    </section>
+
+    <section class="a">
+      <h2>A-3</h2>
+      <p>Expected page type and side: A:right (cyan).</p>
+    </section>
+
+    <section class="b" id="target">
+      <h2>B target</h2>
+      <p>Expected page type and side: B:left (blueviolet).</p>
+      <p>This page is referenced from TOC by target-counter().</p>
+    </section>
+
+    <section class="c">
+      <h2>C-1</h2>
+      <p>Expected page type and side: C:right (lime).</p>
+    </section>
+
+    <section class="c">
+      <h2>C-2</h2>
+      <p>Expected page type and side: C:left (pink).</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
When `target-counter()` resolution triggered a rerender, named page context could be carried over incorrectly, causing subsequent pages to use wrong named page types.

This change fixes renderSinglePage rerender behavior by:
- preserving page-type state only when old layout context is still valid
- recalculating next-page named-page context when page-break position changes
- restoring styler/page-cascade state safely around unresolved-reference rerender
- preventing counter-scope side effects during recursive target-counter rerender
- refactoring renderSinglePage logic for readability and maintainability

Also add a consolidated regression test for this scenario:
- use named pages with :left/:right combinations
- verify behavior when `target-counter()` resolution increases page count and flips page sides
- register a single comprehensive test entry in file-list.js

fixes #1497

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1497 (`target-counter()` resolution leading to a wrong named page), directing verification via the running dev server and Chrome DevTools MCP.
- Across an extensive investigation (46 requests) into `epub.ts`'s `renderSinglePage`/`pushPageCounters` rerender flow, the AI identified multiple related state-restoration gaps and implemented the combined fix, then added the consolidated named-page regression test.

</details>
