### PR TITLE
fix: Prevent target-counter rerender from missing trailing page

### DIFF
--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -91,6 +91,10 @@ module.exports = [
         file: "target-counter-named-pages-left-right.html",
         title: "target-counter() named pages with :left/:right (Issue #1497)",
       },
+      {
+        file: "target-counter-missing-page.html",
+        title: "target-counter() missing page (Issue #1498)",
+      },
       { file: "target-text.html", title: "target-text() - Basic Tests" },
       {
         file: "target-text-running-element.html",

--- a/packages/core/test/files/target-counter-missing-page.html
+++ b/packages/core/test/files/target-counter-missing-page.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <style>
+    :root {
+      font-family: 'Times New Roman', Times, serif;
+      line-height: 2;
+      widows: 1;
+      orphans: 1;
+    }
+
+    * {
+      margin: 0;
+    }
+
+    @page {
+      size: 300px;
+      margin: 50px;
+      outline: 1px dotted;
+    }
+
+    @page :first {
+      counter-reset: page 10000;
+    }
+
+    nav a::after {
+      content: " " target-counter(attr(href), page);
+    }
+
+    section {
+      break-before: page;
+    }
+  </style>
+</head>
+
+<body>
+  <nav>
+    <ul>
+      <li>
+        <a href="#two">Two WWWWWWW WWWWWWWWW WWWWWWWWW WWWWWWWWW WWWWWWWWW WWWWWWWWW</a>
+      </li>
+    </ul>
+  </nav>
+  <section>
+    <h2 id="one">One</h2>
+  </section>
+  <section>
+    <h2 id="two">Two</h2>
+  </section>
+</body>
+
+</html>


### PR DESCRIPTION
- keep view item completion state consistent with pending layout positions
- add regression test for target-counter missing page

fixes #1498

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1498 (`target-counter()` resolution leading to a missing page), pointing to the issue's `test3.html`/`test4.html` samples, and noted that one part of the originally reported bug (a TypeError on link click) no longer reproduced and was likely already fixed by another change.
- The AI added the missing test fixtures based on the issue's samples, investigated alongside the related issue #1497 fix, and implemented the page-completion state fix.

</details>
