### PR TITLE
fix: Avoid parsing HTTP error responses as resource content

### DIFF
--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -72,8 +72,9 @@ export function fetchFromURL(
         .toLowerCase();
 
       if (!res.ok) {
-        // TODO: Handle error response
-        return res.text();
+        throw new Error(
+          `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""}`,
+        );
       }
       if (opt_type === FetchResponseType.BLOB) {
         return res.blob();
@@ -122,7 +123,15 @@ export function fetchFromURL(
       continuation.schedule(response);
     })
     .catch((e) => {
-      Logging.logger.warn(e, `Error fetching ${url}`);
+      if (response.status >= 400) {
+        Logging.logger.warn(
+          `Error fetching ${url} (${response.status}${
+            response.statusText ? " " + response.statusText : ""
+          })`,
+        );
+      } else {
+        Logging.logger.warn(e, `Error fetching ${url}`);
+      }
       continuation.schedule(response);
     });
   return frame.result();


### PR DESCRIPTION
- fixes #1717

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1717 (wrong error handling for unfound files); the human verified the fixed console output and build themselves.
- The human author asked for a commit message and created the PR, then asked the AI to check and address a Copilot review comment.

</details>
