### PR TITLE
fix: Fix font-size with rem on root element causes wrong 1em size

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5439,8 +5439,9 @@ export class CalcFilterVisitor extends Css.FilterVisitor {
 
   override visitNumeric(numeric: Css.Numeric): Css.Val {
     if (
-      this.resolveViewportUnit &&
-      (Exprs.isViewportRelativeLengthUnit(numeric.unit) ||
+      (this.resolveViewportUnit &&
+        Exprs.isViewportRelativeLengthUnit(numeric.unit)) ||
+      (this.context.rootFontSize != null &&
         Exprs.isRootFontRelativeLengthUnit(numeric.unit))
     ) {
       return new Css.Numeric(


### PR DESCRIPTION
- fixes (again) #608

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to debug a `rem`-on-root-element font-size layout bug in a single request.

</details>
