### PR TITLE
feat: Extend CSS @ footnote rule with ::before content rendering

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -889,19 +889,16 @@ export const UserAgentPageCss = `
   break-before: right;
 }
 
-@page {
-  @footnote {
-    margin-block-start: 0.5em;
-  }
-  @footnote ::before {
-    display: block;
-    border-block-start-width: 1px;
-    border-block-start-style: solid;
-    border-block-start-color: black;
-    margin-block-end: 0.4em;
-    margin-inline-start: 0;
-    margin-inline-end: 60%;
-  }
+@footnote {
+  margin-block-start: 0.5em;
+}
+@footnote ::before {
+  border-block-start-width: 1px;
+  border-block-start-style: solid;
+  border-block-start-color: black;
+  margin-block-end: 0.4em;
+  margin-inline-start: 0;
+  margin-inline-end: 60%;
 }
 
 /* default page master */

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -3112,7 +3112,6 @@ export class PageParserHandler
     parent: CssCascade.CascadeParserHandler,
     validatorSet: CssValidator.ValidatorSet,
     private readonly pageProps: { [key: string]: CssCascade.ElementStyle },
-    private readonly footnoteProps?: CssCascade.ElementStyle,
   ) {
     super(scope, owner, parent?.condition, parent, null, validatorSet, false);
   }
@@ -3306,27 +3305,14 @@ export class PageParserHandler
   }
 
   override startFootnoteRule(pseudoelem: string | null): void {
-    // Check if we're inside a page rule with selectors
-    const hasPageSelectors =
-      this.currentPageSelectors.length > 0 &&
-      this.currentPageSelectors[0].selectors !== null;
-
-    // Determine target style based on whether we have page selectors
-    let style: CssCascade.ElementStyle;
-    if (hasPageSelectors || !this.footnoteProps) {
-      // Store in page-specific elementStyle for page selector support
-      const footnoteAreaMap = CssCascade.getMutableStyleMap(
-        this.elementStyle,
-        footnoteAreaKey,
-      );
-      style = footnoteAreaMap["area"];
-      if (!style) {
-        style = {} as CssCascade.ElementStyle;
-        footnoteAreaMap["area"] = style;
-      }
-    } else {
-      // No page selectors - add directly to global footnoteProps for backward compatibility
-      style = this.footnoteProps;
+    const footnoteAreaMap = CssCascade.getMutableStyleMap(
+      this.elementStyle,
+      footnoteAreaKey,
+    );
+    let style = footnoteAreaMap["area"];
+    if (!style) {
+      style = {} as CssCascade.ElementStyle;
+      footnoteAreaMap["area"] = style;
     }
 
     // Handle pseudoelement if specified

--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -167,20 +167,25 @@ export class FootnoteLayoutStrategy
     floatArea: Layout.PageFloatArea,
     floatContainer: Vtree.Container,
     column: Layout.Column,
-  ) {
+  ): Task.Result<void> {
     floatArea.isFootnote = true;
     floatArea.adjustContentRelativeSize = false;
     const element = floatArea.element;
     Asserts.assert(element);
-    floatArea.vertical = column.layoutContext.applyFootnoteStyle(
-      floatContainer.vertical,
-      (column.layoutContext as any).nodeContext &&
-        (column.layoutContext as any).nodeContext.direction === "rtl",
-      element,
-    );
-    floatArea.convertPercentageSizesToPx(element);
-    column.setComputedInsets(element, floatArea);
-    column.setComputedWidthAndHeight(element, floatArea);
+    return column.layoutContext
+      .applyFootnoteStyle(
+        floatContainer.vertical,
+        (column.layoutContext as any).nodeContext &&
+          (column.layoutContext as any).nodeContext.direction === "rtl",
+        element,
+      )
+      .thenAsync((vertical) => {
+        floatArea.vertical = vertical;
+        floatArea.convertPercentageSizesToPx(element);
+        column.setComputedInsets(element, floatArea);
+        column.setComputedWidthAndHeight(element, floatArea);
+        return Task.newResult(undefined);
+      });
   }
 
   /** @override */

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -2479,7 +2479,6 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       this,
       this.validatorSet,
       this.masterHandler.pageProps,
-      this.masterHandler.footnoteProps,
     );
     this.masterHandler.pushHandler(pageHandler);
     pageHandler.startPageRule();

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1967,7 +1967,9 @@ export class NormalPageFloatLayoutStrategy implements PageFloatLayoutStrategy {
     floatArea: LayoutType.PageFloatArea,
     floatContainer: Vtree.Container,
     column: LayoutType.Column,
-  ) {}
+  ): Task.Result<void> {
+    return Task.newResult(undefined);
+  }
 
   /** @override */
   forbid(float: PageFloat, pageFloatLayoutContext: PageFloatLayoutContext) {}

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -296,14 +296,14 @@ export namespace Layout {
       anchorEdge: number | null,
       strategy: PageFloats.PageFloatLayoutStrategy,
       condition: PageFloats.PageFloatPlacementCondition,
-    ): boolean;
+    ): Task.Result<boolean>;
     createPageFloatArea(
       float: PageFloats.PageFloat | null,
       floatSide: string,
       anchorEdge: number | null,
       strategy: PageFloats.PageFloatLayoutStrategy,
       condition: PageFloats.PageFloatPlacementCondition,
-    ): PageFloatArea | null;
+    ): Task.Result<PageFloatArea | null>;
     layoutSinglePageFloatFragment(
       continuations: PageFloats.PageFloatContinuation[],
       floatSide: string,
@@ -802,7 +802,7 @@ export namespace PageFloats {
       floatArea: Layout.PageFloatArea,
       floatContainer: Vtree.Container,
       column: Layout.Column,
-    );
+    ): Task.Result<void>;
     forbid(float: PageFloat, pageFloatLayoutContext: PageFloatLayoutContext);
   }
 }
@@ -1068,7 +1068,7 @@ export namespace Vtree {
       vertical: boolean,
       rtl: boolean,
       target: Element,
-    ): boolean;
+    ): Task.Result<boolean>;
     /**
      * Peel off innermost first-XXX pseudoelement, create and create view nodes
      * after the end of that pseudoelement.

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -694,6 +694,14 @@ module.exports = [
         title: "Footnote area with @footnote",
       },
       {
+        file: "footnotes/footnote-area-page-overrides-top-level.html",
+        title: "@page @footnote overrides top-level @footnote (Issue #1723)",
+      },
+      {
+        file: "footnotes/footnote-before-content.html",
+        title: "@footnote ::before content (Issue #1723)",
+      },
+      {
         file: "footnote-text-spacing.html",
         title: "Footnote text-spacing (Issue #868)",
       },

--- a/packages/core/test/files/footnotes/footnote-area-page-overrides-top-level.html
+++ b/packages/core/test/files/footnotes/footnote-area-page-overrides-top-level.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@page @footnote overrides top-level @footnote</title>
+    <style>
+      @page {
+        size: 420px 320px;
+        margin: 24px;
+
+        @footnote {
+          margin-block-start: 0.8em;
+          border-block-start: 3px solid green;
+          padding-block-start: 0.4em;
+        }
+      }
+
+      @footnote {
+        margin-block-start: 0.8em;
+      }
+
+      @footnote ::before {
+        display: block;
+        border-block-start: 2px solid red;
+        margin-block-end: 0.4em;
+        margin-inline-end: 60%;
+      }
+
+      body,
+      p {
+        margin: 0;
+      }
+
+      .footnote {
+        float: footnote;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      If @page @footnote overrides top-level @footnote correctly, only one green
+      separator line appears above the footnote and no red line is shown<span
+        class="footnote"
+        >This is a footnote used to verify override precedence.</span
+      >.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/footnotes/footnote-before-content.html
+++ b/packages/core/test/files/footnotes/footnote-before-content.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@footnote ::before content</title>
+    <style>
+      @page composed {
+        size: 420px 320px;
+        margin: 24px;
+
+        @footnote {
+          margin-block-start: 0.8em;
+          border-block-start: 2px solid green;
+          padding-block-start: 0.4em;
+        }
+
+        @footnote ::before {
+          content: url("../img/50x50.png") " Footnotes " counter(page) ":";
+          margin-block-end: 0.3em;
+          color: maroon;
+        }
+      }
+
+      @page urlonly {
+        size: 420px 320px;
+        margin: 24px;
+
+        @footnote {
+          margin-block-start: 0.8em;
+          border-block-start: 2px solid green;
+          padding-block-start: 0.4em;
+        }
+
+        @footnote ::before {
+          content: url("../img/50x50.png");
+          margin-block-end: 0.3em;
+        }
+      }
+
+      body,
+      p {
+        margin: 0;
+      }
+
+      .composed {
+        page: composed;
+      }
+
+      .url-only {
+        page: urlonly;
+        break-before: page;
+      }
+
+      .footnote {
+        float: footnote;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="composed">
+      <p>
+        The footnote area should show an image and a composed label like
+        "Footnotes 1:" before the notes<span
+          class="footnote"
+          >This is a footnote for content property verification.</span
+        >.
+      </p>
+    </div>
+
+    <div class="url-only">
+      <p>
+        The footnote area should show an image before this note<span
+          class="footnote"
+          >This is a footnote for url-only content verification.</span
+        >.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Follow up #1644 to make `@footnote` styling work as users expect.

What this fixes for users:
- Prevents double separator lines when a standard `@page @footnote` border is used. Previously, the default `@footnote ::before` separator could add a second line below the `@footnote` border.
- Enables `content` on `@footnote ::before`, which was previously ignored.
- Supports practical content patterns, including `text/counter/url` combinations and `url()`-only values.
- Makes `display: block` the default for `@footnote ::before` when `display` is not explicitly specified.
- Waits for `::before` images before footnote area sizing, avoiding clipped footnote content.

Behavior changes:
- When `@page @footnote` is defined, it takes precedence over top-level `@footnote`.
- Legacy behavior remains available where possible, while prioritizing standard `@footnote` usage.

Tests:
- Added/updated footnote regression tests for:
  - page-level `@footnote` precedence over top-level `@footnote`
  - `@footnote ::before` `content` rendering
  - `url()`-only `::before` content rendering

closes #1723

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to extend PR #1644's `@footnote` rule support, describing the remaining non-standard legacy behaviors that needed reconciling with standard CSS GCPM usage.
- The human author asked for a test proving a specific rendering bug (double separator lines), then asked the AI to explain in detail why the fix reduced code rather than adding it.
- Across several rounds the human author caught real bugs while manually testing in Chrome DevTools MCP: `@footnote ::before`'s default `display: block` not taking effect (traced to a missing-declaration handling difference explained by the human), `content` values being restricted to plain strings when they needed to support `url()`/`counter()` combinations, and footnote content being clipped because layout didn't wait for `::before` images to load.
- The human author asked to file a follow-up GitHub issue for further `@footnote` enhancements beyond this PR's scope, drafting it collaboratively and correcting details before filing; directed the eventual commit title to match the issue title, and refined specific wording in the commit body for technical accuracy.

</details>
