### PR TITLE
fix: limit non-root multicol max-block-size workaround to chromium

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -982,6 +982,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   private setMaxBlockSizeForNonRootMultiColumn(element: HTMLElement): void {
+    if (Base.browserType !== "chromium") {
+      // On Firefox/Safari, overflow columns in nested multicol are handled
+      // inside the same multicol container, so this Chromium-specific
+      // workaround causes horizontal overflow.
+      return;
+    }
+
     if (element.hasAttribute("data-vivliostyle-column")) {
       // Root column element.
       return;


### PR DESCRIPTION
- Restrict the max-block-size workaround for non-root multi-column elements to Chromium only.
- Avoid horizontal overflow on Firefox/Safari where overflow columns stay within the nested multicol container.
- follow-up to #1721