### PR TITLE
fix: Fix table cell duplication and broken rowspan/colspan with footnotes

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -237,34 +237,33 @@ export class Style {
  * Collect all unique formatting context states from a LayoutPosition.
  * Formatting contexts (e.g., TableFormattingContext) are stored in
  * NodePositionStep.formattingContext within flow chunk positions.
- * This walks the position tree to find them all and save their states.
- * (Issue #1663)
+ * This walks the position tree to find them all and save their states,
+ * including those reachable through shadowSibling chains (e.g.,
+ * footnote-call → footnote element transitions). (Issue #1663)
  */
 function collectFormattingContextStates(
   layoutPosition: Vtree.LayoutPosition,
 ): Map<Vtree.FormattingContext, any> {
   const states = new Map<Vtree.FormattingContext, any>();
+  const collectFromStep = (step: Vtree.NodePositionStep): void => {
+    if (step.formattingContext && !states.has(step.formattingContext)) {
+      states.set(step.formattingContext, step.formattingContext.saveState());
+    }
+    if (step.shadowSibling) {
+      collectFromStep(step.shadowSibling);
+    }
+  };
   for (const name in layoutPosition.flowPositions) {
     const flowPos = layoutPosition.flowPositions[name];
     for (const fcp of flowPos.positions) {
       const primary = fcp.chunkPosition.primary;
       for (const step of primary.steps) {
-        if (step.formattingContext && !states.has(step.formattingContext)) {
-          states.set(
-            step.formattingContext,
-            step.formattingContext.saveState(),
-          );
-        }
+        collectFromStep(step);
       }
       if (fcp.chunkPosition.floats) {
         for (const floatPos of fcp.chunkPosition.floats) {
           for (const step of floatPos.steps) {
-            if (step.formattingContext && !states.has(step.formattingContext)) {
-              states.set(
-                step.formattingContext,
-                step.formattingContext.saveState(),
-              );
-            }
+            collectFromStep(step);
           }
         }
       }

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -233,6 +233,60 @@ export class Style {
   }
 }
 
+/**
+ * Collect all unique formatting context states from a LayoutPosition.
+ * Formatting contexts (e.g., TableFormattingContext) are stored in
+ * NodePositionStep.formattingContext within flow chunk positions.
+ * This walks the position tree to find them all and save their states.
+ * (Issue #1663)
+ */
+function collectFormattingContextStates(
+  layoutPosition: Vtree.LayoutPosition,
+): Map<Vtree.FormattingContext, any> {
+  const states = new Map<Vtree.FormattingContext, any>();
+  for (const name in layoutPosition.flowPositions) {
+    const flowPos = layoutPosition.flowPositions[name];
+    for (const fcp of flowPos.positions) {
+      const primary = fcp.chunkPosition.primary;
+      for (const step of primary.steps) {
+        if (step.formattingContext && !states.has(step.formattingContext)) {
+          states.set(
+            step.formattingContext,
+            step.formattingContext.saveState(),
+          );
+        }
+      }
+      if (fcp.chunkPosition.floats) {
+        for (const floatPos of fcp.chunkPosition.floats) {
+          for (const step of floatPos.steps) {
+            if (step.formattingContext && !states.has(step.formattingContext)) {
+              states.set(
+                step.formattingContext,
+                step.formattingContext.saveState(),
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+  return states;
+}
+
+/**
+ * Restore all formatting context states previously saved by
+ * collectFormattingContextStates(). (Issue #1663)
+ */
+function restoreFormattingContextStates(
+  states: Map<Vtree.FormattingContext, any>,
+): void {
+  for (const [fc, state] of states) {
+    if (state !== undefined) {
+      fc.restoreState(state);
+    }
+  }
+}
+
 //-------------------------------------------------------------------------------
 export class StyleInstance
   extends Exprs.Context
@@ -1650,6 +1704,15 @@ export class StyleInstance
     const frame: Task.Frame<LayoutType.Column[] | null> =
       Task.newFrame("layoutFlowColumns");
     const positionAtContainerStart = this.currentLayoutPosition.clone();
+    // Save formatting context states so they can be restored on region-level
+    // retry (e.g., when footnotes invalidate the page float context).
+    // LayoutPosition.clone() shares formatting context objects by reference
+    // (via NodePositionStep.formattingContext), so modifications like
+    // cellBreakPositions in TableFormattingContext persist across retries
+    // unless explicitly restored. (Issue #1663)
+    const savedRegionFCStates = collectFormattingContextStates(
+      this.currentLayoutPosition,
+    );
     const columnGap = boxInstance.getPropAsNumber(this, "column-gap");
 
     // Don't query columnWidth when it's not needed, so that width calculation
@@ -1724,6 +1787,9 @@ export class StyleInstance
           if (regionPageFloatLayoutContext.isInvalidated()) {
             columnIndex = 0;
             this.currentLayoutPosition = positionAtContainerStart.clone();
+            // Restore formatting context states on region-level retry
+            // (Issue #1663)
+            restoreFormattingContextStates(savedRegionFCStates);
             regionPageFloatLayoutContext.validate();
             if (regionPageFloatLayoutContext.isLocked()) {
               columns = null;
@@ -2131,6 +2197,13 @@ export class StyleInstance
 
     this.clearScope(this.style.pageScope);
     this.layoutPositionAtPageStart = cp.clone();
+    // Save formatting context states at the beginning of page layout for
+    // restoration when page-level retry occurs (Issue #1663).
+    // Formatting contexts (e.g., TableFormattingContext with cellBreakPositions)
+    // are stored in NodePositionStep.formattingContext and shared by reference
+    // across LayoutPosition.clone(). Modifications during layout persist unless
+    // explicitly restored.
+    const savedPageFCStates = collectFormattingContextStates(cp);
 
     // Resolve page size before page master selection.
     const cascadedPageStyle = isTocBox
@@ -2258,6 +2331,9 @@ export class StyleInstance
           }
           if (pageFloatLayoutContext.isInvalidated()) {
             this.currentLayoutPosition = this.layoutPositionAtPageStart.clone();
+            // Restore formatting context states on page-level retry
+            // (Issue #1663)
+            restoreFormattingContextStates(savedPageFCStates);
             pageFloatLayoutContext.validate();
             // Clear bleedBox children before retry to avoid duplicate page-box elements
             while (page.bleedBox.lastChild) {

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -165,10 +165,46 @@ export class BetweenTableRowBreakPosition extends BreakPosition.EdgeBreakPositio
       (bp) => !!bp.nodeContext,
     );
     if (allCellsBreakable) {
+      // Also verify that all non-spanning cells in the row have fully rendered.
+      // If any cell has remaining content, this between-row break would lose it
+      // because finishBreak for between-row breaks only saves break positions
+      // for row-spanning cells. An InsideTableRowBreakPosition should be used
+      // instead. (Issue #1663)
+      if (this.hasUnfinishedCells()) {
+        return null;
+      }
       return breakNodeContext;
     } else {
       return null;
     }
+  }
+
+  /**
+   * Check if any non-spanning cell in the row has content that wasn't fully
+   * rendered. This happens when page floats (footnotes) reduce available space
+   * during a retry, causing cell content to overflow within the row even though
+   * the row boundary appears acceptable. (Issue #1663)
+   */
+  private hasUnfinishedCells(): boolean {
+    const rowIndex = this.getRowIndex();
+    const allCells = this.formattingContext.getCellsFallingOnRow(rowIndex);
+    for (const cell of allCells) {
+      // Skip row-spanning cells (handled by getAcceptableCellBreakPositions)
+      if (cell.rowIndex + cell.rowSpan - 1 > rowIndex) {
+        continue;
+      }
+      const cellFragment = this.formattingContext.getCellFragmentOfCell(cell);
+      if (cellFragment) {
+        const bp = cellFragment.findAcceptableBreakPosition();
+        if (
+          bp.nodeContext &&
+          !cellFragment.pseudoColumn.isLastAfterNodeContext(bp.nodeContext)
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   override getMinBreakPenalty(): number {
@@ -630,7 +666,10 @@ export class TableFormattingContext
   }
 
   override restoreState(state: any) {
-    this.cellBreakPositions = state as BrokenTableCellPosition[];
+    // Create a fresh copy to prevent the saved state from being mutated
+    // when extractRowSpanningCellBreakPositions splices entries from
+    // this.cellBreakPositions during subsequent layout attempts (issue #1667).
+    this.cellBreakPositions = [].concat(state as BrokenTableCellPosition[]);
   }
 }
 
@@ -1212,13 +1251,13 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       this.currentRowIndex,
     ).cells;
     cells.forEach((cell) => {
-      const cellBreakPosition =
-        this.formattingContext.cellBreakPositions[cell.columnIndex];
-      if (
-        cellBreakPosition &&
-        cellBreakPosition.cell.anchorSlot.columnIndex ==
-          cell.anchorSlot.columnIndex
-      ) {
+      // Use proper lookup by cell reference instead of array index,
+      // since cellBreakPositions may contain entries from multiple rows
+      // after the fix for issue #1663.
+      const cellBreakPosition = this.formattingContext.cellBreakPositions.find(
+        (p) => p.cell === cell,
+      );
+      if (cellBreakPosition) {
         const tdNodeStep = cellBreakPosition.cellNodePosition.steps[0];
         const offset = (
           this.column.layoutContext as Vgen.ViewFactory
@@ -1784,7 +1823,6 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
       const rowIndex = formattingContext.findRowIndexBySourceNode(
         nodeContext.sourceNode,
       );
-      formattingContext.cellBreakPositions = [];
       let cells: TableCell[];
       if (!nodeContext.after) {
         cells = formattingContext.getCellsFallingOnRow(rowIndex);
@@ -1792,6 +1830,14 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
         cells =
           formattingContext.getRowSpanningCellsOverflowingTheRow(rowIndex);
       }
+      // Only remove entries for cells that are about to be re-broken,
+      // preserving break positions from other rows (e.g., from previous pages).
+      // Fix for issue #1663: unconditional reset lost previous-page break info
+      // during layout retry.
+      formattingContext.cellBreakPositions =
+        formattingContext.cellBreakPositions.filter(
+          (p) => !cells.includes(p.cell),
+        );
       if (cells.length) {
         const frame = Task.newFrame<boolean>(
           "TableLayoutProcessor.finishBreak",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -722,6 +722,10 @@ module.exports = [
         title: "Footnotes in table 2 (Issue #1657)",
       },
       {
+        file: "footnotes/footnotes-in-table-rowspan-colspan.html",
+        title: "Footnotes in table with rowspan/colspan (Issue #1667)",
+      },
+      {
         file: "footnotes/footnotes-in-multicol.html",
         title: "Footnotes in multi-column (Issue #1460)",
       },

--- a/packages/core/test/files/footnotes/footnotes-in-table-rowspan-colspan.html
+++ b/packages/core/test/files/footnotes/footnotes-in-table-rowspan-colspan.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Footnotes in table with rowspan/colspan</title>
+    <style>
+      @page {
+        size: 800px 600px;
+        margin: 50px;
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 0.8rem;
+        }
+      }
+      :root {
+        counter-reset: footnote 0;
+        font: 24px/1.5 Arial, sans-serif;
+      }
+
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+
+      td,
+      th {
+        border: solid 1px;
+        padding: 4px;
+        vertical-align: top;
+      }
+
+      .footnote {
+        float: footnote;
+        color: red;
+        counter-increment: footnote;
+        font: 0.7rem/1.25 Arial, sans-serif;
+        text-align: left;
+      }
+
+      .footnote::footnote-call {
+        content: "*" counter(footnote, decimal);
+        font-size: 0.7em;
+        vertical-align: baseline;
+        position: relative;
+        top: -0.5em;
+        white-space: nowrap;
+      }
+
+      .footnote::footnote-marker {
+        content: "*" counter(footnote, decimal) " ";
+        font-size: 0.8em;
+        vertical-align: baseline;
+        position: relative;
+        top: -0.25em;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Test: Footnotes in table with rowspan and colspan<span class="footnote" id="fn1">FOOTNOTE1 - before table</span></p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Col1</th>
+          <th>Col2</th>
+          <th>Col3</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Row 1: Cell A spans 2 rows -->
+        <tr>
+          <td rowspan="2">A. Cell with rowspan=2<span class="footnote" id="fn2">FOOTNOTE2 - in rowspan cell A</span>. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium asperiores dignissimos facilis nihil placeat voluptas qui?</td>
+          <td>B. Short cell<span class="footnote" id="fn3">FOOTNOTE3 - in cell B</span></td>
+          <td>C. Another short cell</td>
+        </tr>
+        <!-- Row 2: Cell A continues from row 1 -->
+        <tr>
+          <td colspan="2">D. Cell with colspan=2<span class="footnote" id="fn4">FOOTNOTE4 - in colspan cell D</span>. Ut scelerisque sapien eu auctor finibus. Suspendisse potenti. Nam id justo a tellus pretium iaculis. Nunc suscipit nisl in enim mattis tempus.</td>
+        </tr>
+        <!-- Row 3: Cell E spans 2 columns and 2 rows -->
+        <tr>
+          <td rowspan="2" colspan="2">E. Cell with rowspan=2 and colspan=2<span class="footnote" id="fn5">FOOTNOTE5 - in rowspan+colspan cell E</span>. Praesent bibendum turpis eu massa tristique, imperdiet vehicula libero lobortis. Fusce sed cursus urna. Fusce eros justo, sodales maximus arcu id, facilisis placerat arcu. Sed arcu diam, elementum ut ex quis, semper dignissim purus.</td>
+          <td>F. Right column cell<span class="footnote" id="fn6">FOOTNOTE6 - in cell F</span></td>
+        </tr>
+        <!-- Row 4: Cell E continues -->
+        <tr>
+          <td>G. Bottom right cell<span class="footnote" id="fn7">FOOTNOTE7 - in cell G</span>. Short content here.</td>
+        </tr>
+        <!-- Row 5: Normal row -->
+        <tr>
+          <td>H. Normal cell<span class="footnote" id="fn8">FOOTNOTE8 - in cell H</span></td>
+          <td>I. Normal cell<span class="footnote" id="fn9">FOOTNOTE9 - in cell I</span></td>
+          <td>J. Normal cell<span class="footnote" id="fn10">FOOTNOTE10 - in cell J</span></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>After table<span class="footnote" id="fn11">FOOTNOTE11 - after table</span></p>
+  </body>
+</html>


### PR DESCRIPTION
The fix in PR #1665 for table cell duplication with footnotes (issue #1663) was incomplete. When footnotes caused layout retries, table cells could still be duplicated or lost in certain cases. This commit addresses the remaining problems:

- Filter-based clearing in finishBreak to preserve `cellBreakPositions` entries from other rows instead of clearing all entries
- Use `.find()` by cell reference in `registerCellFragmentIndex` to avoid index mismatch after entries are reordered
- Add `hasUnfinishedCells()` check in `BetweenTableRowBreakPosition` to prevent accepting a between-row break when non-spanning cells have remaining content after footnote-triggered space reduction
- Save and restore `FormattingContext` states (`cellBreakPositions`) on column-level and page-level retries in `ops.ts` to prevent state loss

Additionally, fix broken table layout with rowspan/colspan and footnotes (issue #1667): `restoreState()` now creates a fresh copy of the `cellBreakPositions` array to prevent the saved state from being mutated when `extractRowSpanningCellBreakPositions` splices entries during subsequent layout attempts.

- Closes #1663
- Closes #1667

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author reported that PR #1665's earlier fix for issue #1663 was incomplete (found via a page-size variation, not a regression) and asked for a re-fix.
- The human author iteratively found and reported further edge cases (a case where cell content still went missing, then a rowspan/colspan misalignment matching issue #1667) and decided which of the newly added test cases to keep in `file-list.js`, discarding redundant variants and renaming the one covering the rowspan/colspan case.
- The human author directed the commit message to cover both issue #1663 (incomplete fix) and #1667, created the PR, and asked the AI to check and respond to review comments.

</details>
