### PR TITLE
fix: Fix table rowspan layout regression caused by stale cellBreakPositions

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1300,6 +1300,10 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     );
     if (brokenCell) {
       const cellBreakPosition = brokenCell.position;
+      // Remove the consumed entry from cellBreakPositions so that
+      // subsequent rows are not affected by stale entries.
+      // (Old code used cellBreakPositions.shift() which consumed entries.)
+      this.formattingContext.cellBreakPositions.splice(brokenCell.index, 1);
       nodeContext.fragmentIndex =
         cellBreakPosition.cellNodePosition.steps[0].fragmentIndex + 1;
       cont = Task.newResult(cellBreakPosition.breakChunkPosition);


### PR DESCRIPTION
PR #1665 replaced cellBreakPositions.shift() with findBrokenCellAtSlot() for sourceNode-based lookup but did not remove the consumed entry. Stale entries caused isFirstTime to return false for subsequent rows and extractRowSpanningCellBreakPositions to re-extract already-consumed cells, breaking the 4th table in the table_rowspan test case.

Add splice() after consuming the break position to restore the consume-on-use behavior.

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author noticed a regression in the `table_rowspan.html` test case's 4th table after PR #1665 and its follow-ups, and asked the AI to investigate and fix it.
- The human author ran `/draft-commit` once satisfied with the fix.

</details>
