### PR TITLE
fix(viewer): remove deprecated css causing firefox devtools warnings

### DIFF
--- a/packages/viewer/src/scss/lib/_mixins.scss
+++ b/packages/viewer/src/scss/lib/_mixins.scss
@@ -58,7 +58,6 @@
   text-transform: none;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  speak: none;
 }
 
 // - Viewer Status

--- a/packages/viewer/src/scss/ui.arrows.scss
+++ b/packages/viewer/src/scss/ui.arrows.scss
@@ -34,7 +34,7 @@ $button-offset: 0;
     background: rgba(0, 0, 0, 0.125);
     transition: 0.25s ease-in;
   }
-  @media (hover: hover), (-moz-touch-enabled: 0) {
+  @media (hover: hover) {
     &:hover {
       color: rgba(255, 255, 255, 0.75);
       background: rgba(0, 0, 0, 0.125);
@@ -81,7 +81,7 @@ $button-offset: 0;
   &:after {
     content: fa-content($fa-var-arrow-circle-up);
   }
-  @media (hover: hover), (-moz-touch-enabled: 0) {
+  @media (hover: hover) {
     &:hover {
       cursor: n-resize;
     }

--- a/packages/viewer/src/scss/ui.loading-overlay.scss
+++ b/packages/viewer/src/scss/ui.loading-overlay.scss
@@ -61,7 +61,7 @@ $animation-ROTATE: ROTATE 1.5s linear infinite normal;
   @include on-loading() {
     opacity: 1;
     visibility: visible;
-    transition: 0.1s liner;
+    transition: 0.1s linear;
     .vivliostyle-loading-spinner {
       @include spinner($spinner-width);
     }

--- a/packages/viewer/src/scss/ui.menu-bar.scss
+++ b/packages/viewer/src/scss/ui.menu-bar.scss
@@ -26,7 +26,7 @@
   background: black;
   box-shadow: $menu-box-shadow;
   -webkit-font-smoothing: subpixel-antialiased;
-  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   @include prefix(user-select, none); // prevent unwanted text selection
   * {
     margin: 0;
@@ -352,7 +352,7 @@
           background-position: center center;
           background-size: contain;
           filter: grayscale(0%);
-          @media (hover: hover), (-moz-touch-enabled: 0) {
+          @media (hover: hover) {
             &:hover {
               opacity: 0.75;
               filter: grayscale(50%);
@@ -516,7 +516,7 @@
           }
           &.active {
             background: rgb(128, 128, 128) !important;
-            transition: 0 linear;
+            transition: 0s linear;
           }
           transition: 0.15s linear;
         }
@@ -687,7 +687,7 @@
             text-decoration: none;
             border-bottom: solid 1px rgb(192, 192, 192);
             transition: linear 0.1s;
-            @media (hover: hover), (-moz-touch-enabled: 0) {
+            @media (hover: hover) {
               &:hover {
                 color: black;
                 border-bottom-color: black;
@@ -741,7 +741,9 @@
     outline: none;
   }
   [role="button"]:focus {
-    text-shadow: 1px 0 5px #4d90fe, -1px 0 5px #4d90fe;
+    text-shadow:
+      1px 0 5px #4d90fe,
+      -1px 0 5px #4d90fe;
     box-shadow: none;
     outline: none;
   }


### PR DESCRIPTION
- remove deprecated -moz-touch-enabled media queries
- remove unsupported speak property from font-icon mixin
- replace invalid transition values and typo (liner -> linear)
- switch -webkit-text-size-adjust to text-size-adjust

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author pasted the full list of Firefox DevTools console warnings observed when running the Vivliostyle Viewer and asked the AI to check and remove or fix the outdated CSS in `packages/viewer/src/scss/` causing them.
- The AI identified each warning's cause (obsolete `-moz-touch-enabled` media feature, unsupported `speak` property, invalid `transition` values including a `liner`/`linear` typo, and non-standard `-webkit-text-size-adjust`) and applied the fixes.

</details>
