### PR TITLE
fix: Support footnotes and page floats inside page float areas

### DIFF
--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -117,6 +117,15 @@ export class FootnoteLayoutStrategy
     if (pageContext.hasSameContainerAs(regionContext)) {
       floatReference = PageFloats.FloatReference.PAGE;
     }
+
+    // When inside a page float area, use PAGE level so the footnote fragment
+    // survives page-level layout retries triggered by the outer page float.
+    // (Issue #1675)
+    const insidePageFloat = !!pageFloatLayoutContext.generatingNodePosition;
+    if (insidePageFloat && floatReference !== PageFloats.FloatReference.PAGE) {
+      floatReference = PageFloats.FloatReference.PAGE;
+    }
+
     const nodePosition = nodeContext.toNodePosition();
     Asserts.assert(pageFloatLayoutContext.flowName);
     const float: PageFloats.PageFloat = new Footnote(
@@ -126,6 +135,14 @@ export class FootnoteLayoutStrategy
       nodeContext.footnotePolicy,
       nodeContext.floatMinWrapBlock,
     );
+    float.insidePageFloatArea = insidePageFloat;
+    if (insidePageFloat) {
+      const parentNodePos = pageFloatLayoutContext.generatingNodePosition;
+      if (parentNodePos) {
+        float.parentPageFloat =
+          pageFloatLayoutContext.findPageFloatByNodePosition(parentNodePos);
+      }
+    }
     pageFloatLayoutContext.addPageFloat(float);
     return Task.newResult(float);
   }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1575,8 +1575,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         float.floatReference,
       );
 
-    // TODO: establish how to specify an appropriate generating element for the
-    // new page float layout context
+    // Create the page float area context without a parent to avoid side
+    // effects (children registration, invalidation propagation, etc.).
+    // Instead, set outerContext for getParent() navigation so nested page
+    // floats and footnotes can propagate to the region/page level.
+    // (Issue #1675)
     const pageFloatLayoutContext = new PageFloats.PageFloatLayoutContext(
       null,
       PageFloats.FloatReference.COLUMN,
@@ -1586,6 +1589,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       null,
       null,
     );
+    pageFloatLayoutContext.setOuterContext(this.pageFloatLayoutContext);
     const parentContainer = parentPageFloatLayoutContext.getContainer();
     const floatArea = new PageFloatArea(
       floatSide,
@@ -1716,6 +1720,24 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   ): Task.Result<boolean> {
     const context = this.pageFloatLayoutContext;
     const float = continuation.float;
+
+    // Snapshot insidePageFloatArea fragments before the layout attempt.
+    // If this float's layout is cancelled, any NEW insidePageFloatArea
+    // fragments (from nested page floats or footnotes inside the page float
+    // area) need to be cleaned up from ancestor contexts. (Issue #1675)
+    const savedInsideFragments = new Set<PageFloats.PageFloatFragment>();
+    for (
+      let ctx = context as PageFloats.PageFloatLayoutContext;
+      ctx;
+      ctx = ctx.effectiveParent
+    ) {
+      for (const frag of ctx.floatFragments) {
+        if (frag.continuations.some((c) => c.float.insidePageFloatArea)) {
+          savedInsideFragments.add(frag);
+        }
+      }
+    }
+
     context.stashEndFloatFragments(float);
 
     function cancelLayout(floatArea, pageFloatFragment) {
@@ -1724,6 +1746,30 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       } else if (floatArea) {
         floatArea.element.parentNode.removeChild(floatArea.element);
       }
+
+      // Remove insidePageFloatArea fragments created during the cancelled
+      // page float area's content layout. These fragments were added to
+      // ancestor contexts (e.g. PAGE level) but the parent page float that
+      // contains them was cancelled, so they are orphaned. (Issue #1675)
+      const fragmentsToRemove: PageFloats.PageFloatFragment[] = [];
+      for (
+        let ctx = context as PageFloats.PageFloatLayoutContext;
+        ctx;
+        ctx = ctx.effectiveParent
+      ) {
+        for (const frag of ctx.floatFragments) {
+          if (
+            !savedInsideFragments.has(frag) &&
+            frag.continuations.some((c) => c.float.insidePageFloatArea)
+          ) {
+            fragmentsToRemove.push(frag);
+          }
+        }
+      }
+      for (const frag of fragmentsToRemove) {
+        context.removePageFloatFragment(frag, true);
+      }
+
       context.restoreStashedFragments(float.floatReference);
       context.deferPageFloat(continuation);
     }
@@ -1745,9 +1791,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           pageFloatFragment,
         ]).then((success) => {
           if (success) {
-            // Add again to invalidate the context
+            // Add again to invalidate the context.
+            // When inside a page float area (generatingNodePosition is set),
+            // suppress invalidation to avoid interrupting the outer page float
+            // layout. The region will be invalidated later when the outer page
+            // float fragment is added. (Issue #1675)
             Asserts.assert(newFragment);
-            context.addPageFloatFragment(newFragment);
+            const isInsidePageFloat = !!context.generatingNodePosition;
+            context.addPageFloatFragment(newFragment, isInsidePageFloat);
             context.discardStashedFragments(float.floatReference);
             if (newPosition) {
               const continuation = new PageFloats.PageFloatContinuation(
@@ -2006,6 +2057,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             // This ensures footnote-call and following content are processed
             // in the same postLayoutBlock, allowing correct text-spacing.
             if (nodeContext.floatSide === "footnote") {
+              return Task.newResult(nodeContextAfter);
+            }
+            // When inside a page float area, return nodeContextAfter to continue
+            // processing the remaining content. Without this, the layout terminates
+            // early and computedBlockSize doesn't reflect the full CSS box size,
+            // resulting in incorrect exclusion float sizing. (Issue #1675)
+            if (context.generatingNodePosition) {
               return Task.newResult(nodeContextAfter);
             }
             return Task.newResult(null as Vtree.NodeContext);
@@ -3646,22 +3704,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       PageFloats.isPageFloat(nodeContext.floatReference) ||
       nodeContext.floatSide === "footnote"
     ) {
-      // Check if we're inside a page float area (has generatingNodePosition).
-      // If so, footnotes and page floats cannot be properly placed, so layout
-      // them as regular blocks instead of letting them disappear.
-      // (Issue #1668, #1669)
-      if (this.pageFloatLayoutContext.generatingNodePosition) {
-        // Clear float-related properties and layout as a regular block
-        const nodeContextMod = nodeContext.modify();
-        nodeContextMod.floatSide = null;
-        nodeContextMod.floatReference = null;
-        nodeContextMod.clearSide = null;
-        if (this.isBreakable(nodeContextMod)) {
-          return this.layoutBreakableBlock(nodeContextMod);
-        } else {
-          return this.layoutUnbreakable(nodeContextMod);
-        }
-      }
       return this.layoutPageFloat(nodeContext);
     } else {
       return this.layoutFloat(nodeContext);

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -112,6 +112,21 @@ export class PageFloat implements PageFloats.PageFloat {
   order: number | null = null;
   id: PageFloatID | null = null;
 
+  /**
+   * Set to true when this float is created inside a page float area.
+   * Used to bypass the normal anchor check in isAllowedOnContext because
+   * the anchor node is lost after page-level invalidation. (Issue #1675)
+   */
+  insidePageFloatArea: boolean = false;
+
+  /**
+   * Reference to the parent page float that contains this float.
+   * Set when this float is created inside a page float area, allowing
+   * isAllowedOnContext to check whether the parent is still present.
+   * (Issue #1675)
+   */
+  parentPageFloat: PageFloat | null = null;
+
   constructor(
     public readonly nodePosition: Vtree.NodePosition,
     public readonly floatReference: FloatReference,
@@ -136,7 +151,21 @@ export class PageFloat implements PageFloats.PageFloat {
   }
 
   isAllowedOnContext(pageFloatLayoutContext: PageFloatLayoutContext): boolean {
-    return pageFloatLayoutContext.isAnchorAlreadyAppeared(this.getId());
+    if (pageFloatLayoutContext.isAnchorAlreadyAppeared(this.getId())) {
+      return true;
+    }
+    // When the float was created inside a page float area, its anchor node
+    // is lost after page-level invalidation (the page float area context is
+    // detached during re-layout). Check whether the parent page float still
+    // has a fragment on this context: if the parent was removed (e.g. by
+    // checkAndForbidNotAllowedFloat), this float should also be removed
+    // to avoid orphaned fragments on the page. (Issue #1675)
+    if (this.insidePageFloatArea && this.parentPageFloat) {
+      return !!pageFloatLayoutContext.findPageFloatFragment(
+        this.parentPageFloat,
+      );
+    }
+    return false;
   }
 
   isAllowedToPrecede(other: PageFloat): boolean {
@@ -329,6 +358,15 @@ export class PageFloatLayoutContext
   private layoutConstraints: LayoutType.LayoutConstraint[] = [];
   private locked: boolean = false;
 
+  /**
+   * Reference to the outer column's context for page float area contexts.
+   * Used only for getParent() navigation to propagate nested page floats
+   * and footnotes to region/page level. Unlike `parent`, this does NOT
+   * affect children registration, isInvalidated() propagation, or
+   * getFloatFragmentExclusions(). (Issue #1675)
+   */
+  private outerContext: PageFloatLayoutContext | null = null;
+
   constructor(
     public readonly parent: PageFloatLayoutContext,
     private readonly floatReference: FloatReference | null,
@@ -351,11 +389,37 @@ export class PageFloatLayoutContext
       : [];
   }
 
+  /**
+   * Returns the effective parent context for hierarchy traversal.
+   * For normal contexts, returns `parent`. For page float area contexts
+   * (where `parent` is null), falls back to `outerContext`. (Issue #1675)
+   */
+  get effectiveParent(): PageFloatLayoutContext | null {
+    return this.parent ?? this.outerContext;
+  }
+
   private getParent(floatReference: FloatReference): PageFloatLayoutContext {
-    if (!this.parent) {
-      throw new Error(`No PageFloatLayoutContext for ${floatReference}`);
+    if (this.parent) {
+      return this.parent;
     }
-    return this.parent;
+    // Fall back to the outer context for page float area contexts.
+    // This allows nested page floats and footnotes inside page float areas
+    // to propagate to the region/page level without the side effects of
+    // a full parent connection. (Issue #1675)
+    if (this.outerContext) {
+      return this.outerContext;
+    }
+    throw new Error(`No PageFloatLayoutContext for ${floatReference}`);
+  }
+
+  /**
+   * Set the outer context for a page float area context.
+   * This shares the float store so that page floats/footnotes created inside
+   * a page float area are visible at all levels. (Issue #1675)
+   */
+  setOuterContext(outerContext: PageFloatLayoutContext) {
+    this.outerContext = outerContext;
+    this.floatStore = outerContext.floatStore;
   }
 
   private getPreviousSiblingOf(
@@ -1913,6 +1977,7 @@ export class NormalPageFloatLayoutStrategy implements PageFloatLayoutStrategy {
     Asserts.assert(nodeContext.floatSide);
     const floatSide: string = nodeContext.floatSide;
     const nodePosition = nodeContext.toNodePosition();
+    const insidePageFloat = !!pageFloatLayoutContext.generatingNodePosition;
     return column
       .resolveFloatReferenceFromColumnSpan(
         floatReference,
@@ -1930,6 +1995,14 @@ export class NormalPageFloatLayoutStrategy implements PageFloatLayoutStrategy {
           pageFloatLayoutContext.flowName,
           nodeContext.floatMinWrapBlock,
         );
+        float.insidePageFloatArea = insidePageFloat;
+        if (insidePageFloat) {
+          const parentNodePos = pageFloatLayoutContext.generatingNodePosition;
+          if (parentNodePos) {
+            float.parentPageFloat =
+              pageFloatLayoutContext.findPageFloatByNodePosition(parentNodePos);
+          }
+        }
         pageFloatLayoutContext.addPageFloat(float);
         return Task.newResult(float);
       });

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -641,6 +641,8 @@ export namespace PageFloats {
   export interface PageFloat {
     order: number | null;
     id: PageFloatID | null;
+    insidePageFloatArea: boolean;
+    parentPageFloat: PageFloat | null;
     readonly nodePosition: Vtree.NodePosition;
     readonly floatReference: FloatReference;
     readonly floatSide: string;
@@ -688,11 +690,13 @@ export namespace PageFloats {
     direction: Css.Val;
     floatFragments: PageFloatFragment[];
     readonly parent: PageFloatLayoutContext;
+    readonly effectiveParent: PageFloatLayoutContext | null;
     readonly flowName: string | null;
     readonly generatingNodePosition: Vtree.NodePosition | null;
 
     getContainer(floatReference?: FloatReference): Vtree.Container;
     setContainer(container: Vtree.Container);
+    setOuterContext(outerContext: PageFloatLayoutContext): void;
     addPageFloat(float: PageFloat): void;
     getPageFloatLayoutContext(
       floatReference: FloatReference,

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -667,6 +667,10 @@ module.exports = [
         file: "page_floats/target-counter-and-page-floats.html",
         title: "Target-counter and Page Floats",
       },
+      {
+        file: "page_floats/page-float-in-page-float.html",
+        title: "Page float in page float (Issue #1675)",
+      },
     ],
   },
   {
@@ -733,6 +737,10 @@ module.exports = [
         file: "footnotes/footnotes-in-multicol-vertical.html",
         title:
           "Footnotes in multi-column (vertical writing-mode) (Issue #1460)",
+      },
+      {
+        file: "footnotes/footnote-in-page-float.html",
+        title: "Footnotes in page float (Issue #1675)",
       },
       {
         file: "footnotes/footnotes-anywhere.html",

--- a/packages/core/test/files/footnotes/footnote-in-page-float.html
+++ b/packages/core/test/files/footnotes/footnote-in-page-float.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Footnote in page float</title>
+    <style>
+      @page {
+        size: 500px 500px;
+        margin: 50px;
+      }
+
+      :root {
+        font: 1rem/1.5 Arial, sans-serif;
+      }
+
+      .footnote {
+        float: footnote;
+        color: red;
+        font: 0.7rem/1.25 Arial, sans-serif;
+        text-align: start;
+      }
+
+      .footnote::footnote-call {
+        content: counter(footnote, decimal);
+        font-size: 0.7em;
+        vertical-align: baseline;
+        position: relative;
+        inset-block-start: -0.5em;
+      }
+
+      .footnote::footnote-marker {
+        content: counter(footnote, decimal) " ";
+        font-size: 0.8em;
+        vertical-align: baseline;
+        position: relative;
+        inset-block-start: -0.25em;
+      }
+
+      .page-float-box {
+        float-reference: page;
+        float: top right;
+        width: 200px;
+        height: 100px;
+        border: 1px solid;
+        padding: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Lorem ipsum dolor sit amet<span class="footnote">FOOTNOTE in normal
+        paragraph</span>
+      consectetur adipisicing elit. Culpa perferendis ducimus distinctio odit
+      voluptas unde et libero eaque expedita, accusamus esse ipsa ad iure
+      obcaecati. Cum ex quisquam molestiae neque? Lorem ipsum dolor sit amet
+      consectetur adipisicing elit.
+    </p>
+    <div class="page-float-box">
+      Here is a page float box<span class="footnote">FOOTNOTE in page float
+        box</span>.
+    </div>
+    <p>
+      Molestiae nostrum adipisci, accusantium corrupti voluptates, minus iusto
+      porro dolores perferendis inventore ipsum facilis minima veritatis
+      repellat odit atque dolorum, repellendus iste?
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/page_floats/page-float-in-page-float.html
+++ b/packages/core/test/files/page_floats/page-float-in-page-float.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Page float in page float</title>
+    <style>
+      @page {
+        size: 500px 500px;
+        margin: 50px;
+      }
+
+      :root {
+        font: 1rem/1.5 Arial, sans-serif;
+      }
+
+      .page-float-1 {
+        float-reference: page;
+        float: top right;
+        width: 200px;
+        height: 100px;
+        border: 1px solid;
+        padding: 2px;
+      }
+      .page-float-2 {
+        float-reference: page;
+        float: bottom left;
+        width: 200px;
+        height: 100px;
+        border: 1px solid;
+        padding: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa perferendis
+      ducimus distinctio odit voluptas unde et libero eaque expedita, accusamus
+      esse ipsa ad iure obcaecati. Cum ex quisquam molestiae neque? Lorem ipsum
+      dolor sit amet consectetur adipisicing elit.
+    </p>
+    <div class="page-float-1">
+      Page float 1<span class="page-float-2"
+        >Page float 2 anchored in page float 1</span
+      >
+    </div>
+    <p>
+      Molestiae nostrum adipisci, accusantium corrupti voluptates, minus iusto
+      porro dolores perferendis inventore ipsum facilis minima veritatis
+      repellat odit atque dolorum, repellendus iste?
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Page floats and footnotes inside page float areas were not functioning because the page float area's PageFloatLayoutContext was created with `parent: null`, preventing nested floats/footnotes from propagating to region/page level.

Changes:
- Add `outerContext` mechanism to PageFloatLayoutContext for page float areas to navigate to parent levels without side effects (no children registration, invalidation propagation, or exclusion sharing)
- Add `insidePageFloatArea` flag and `parentPageFloat` reference on PageFloat to track the relationship between inner and outer floats
- In `isAllowedOnContext`, check the parent page float's fragment existence instead of unconditionally allowing inner floats, preventing orphaned fragments when the parent is removed during re-layout
- Clean up inner float fragments in `cancelLayout` when the parent page float's layout fails (snapshot-based approach)
- Force PAGE-level float reference for footnotes inside page float areas
- Suppress invalidation when adding fragments inside page float areas
- Continue content layout after nested float placement to ensure correct exclusion float sizing
- Remove workaround from #1668/#1669 that rendered nested floats/footnotes as regular blocks

Closes #1675

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1675 (footnotes/page floats not working inside page float areas); the AI implemented the `outerContext`/`parentPageFloat` mechanism.
- The human author asked the AI to retry after an initial attempt, pointed to a pre-copied test file location, and confirmed via a master-branch comparison that a related test case had behaved correctly before this work began (ruling out a pre-existing issue).
- The human author asked to relocate a test case to the more appropriate "Footnotes" test category, then requested a commit message and created the PR, asking the AI to check review comments.
- After the PR was created, the human author found and reported an additional bug (duplicated page-float/footnote content across two pages at a specific page size) through further manual testing, and the AI iterated on it using `git commit --amend` (at the human author's request, to keep history simple) across multiple rounds of reviewer feedback.

</details>
