### PR TITLE
fix: Fix layout-box right/bottom in Debug mode

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -104,6 +104,8 @@ export const VivliostyleViewportCss = `
 }
 
 [data-vivliostyle-debug] [data-vivliostyle-layout-box] {
+  right: auto;
+  bottom: auto;
   z-index: auto;
   overflow: visible;
 }


### PR DESCRIPTION
PR #1646 is not sufficient to fix the debug mode issue which was a regression caused by PR #1640.

The problem was that text selection in the page container was not possible in debug mode because the empty layout-box covers the page container and prevents text selection. This is because the layout-box is positioned absolutely with all sides set to 0, which makes it cover the entire area of the page container.

To prevent this issue, the right and bottom properties of the layout-box in debug mode should be set to auto rather than 0.