### PR TITLE
fix: Increase specificity for :nth(An+B of PageType) in page selectors

### DIFF
--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -3149,7 +3149,8 @@ export class PageParserHandler
               this.chain.push(
                 new IsNthOfPageTypeAction(this.scope, a, b, pageType),
               );
-              this.specificity += 256;
+              // specificity of :nth(An+B) pseudo-class + page type selector
+              this.specificity += 65536 + 256;
             } else {
               // :nth(An+B) syntax - applies to document page number
               this.currentPseudoPageClassSelectors.push(

--- a/packages/core/test/spec/vivliostyle/css-page-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-page-spec.js
@@ -326,5 +326,24 @@ describe("css-page", function () {
         adapt_css.ident.crop,
       );
     });
+
+    it(":nth(An+B of <page-type>) has higher specificity than page type selector", function () {
+      handler.startSelectorRule();
+      handler.pseudoclassSelector("nth", [2, 1, "chapter"]);
+      handler.startRuleBody();
+      handler.simpleProperty("size", new adapt_css.Numeric(100, "px"));
+      handler.endRule();
+
+      handler = createHandler();
+      handler.startSelectorRule();
+      handler.tagSelector(null, "chapter");
+      handler.startRuleBody();
+      handler.simpleProperty("size", new adapt_css.Numeric(200, "px"));
+      handler.endRule();
+
+      expect(pageProps[":nth(2n+1 of chapter)"].size.priority).toBeGreaterThan(
+        pageProps["chapter"].size.priority,
+      );
+    });
   });
 });


### PR DESCRIPTION
- treat `:nth(An+B of <page-type>)` specificity as pseudo-class + page type selector
- make it outrank plain `@page <page-type>` rules in cascade
- add regression test for specificity ordering in PageParserHandler
- fixes #1736

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix the page-selector specificity bug described in issue #1736.
- The AI investigated `PageParserHandler`'s specificity calculation and implemented the fix along with a regression test.

</details>
