### PR TITLE
feat: Support page-group-aware `:nth(An+B of <page-type>)` matching

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3109,7 +3109,7 @@ export class CascadeInstance {
   currentPageType: string | null = null;
   previousPageType: string | null = null;
   firstPageType: string | null = null;
-  pageTypePageCounts: { [pageType: string]: number } = Object.create(null);
+  pageTypePageIndices: { [pageType: string]: number[] } = Object.create(null);
   isFirst: boolean = true;
   isRoot: boolean = true;
   counters: CounterValues = Object.create(null);

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -2959,14 +2959,15 @@ export class IsNthOfPageTypeAction extends CssCascade.IsNthAction {
   }
 
   override apply(cascadeInstance: CssCascade.CascadeInstance): void {
-    if (cascadeInstance.currentPageType !== this.pageType) {
+    const pageTypeIndices = cascadeInstance.pageTypePageIndices[this.pageType];
+    if (!pageTypeIndices) {
       return;
     }
-    // Get page count for this page type within the current page group
-    const pageTypeCount =
-      cascadeInstance.pageTypePageCounts[this.pageType] || 0;
-    if (this.matchANPlusB(pageTypeCount)) {
-      this.chained.apply(cascadeInstance);
+    for (const pageTypeIndex of pageTypeIndices) {
+      if (this.matchANPlusB(pageTypeIndex)) {
+        this.chained.apply(cascadeInstance);
+        return;
+      }
     }
   }
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -50,6 +50,27 @@ function cloneCounterValues(
   return result;
 }
 
+function clonePageGroupPageCounts(source: {
+  [pageType: string]: { [elementOffset: number]: number };
+}): {
+  [pageType: string]: { [elementOffset: number]: number };
+} {
+  const cloned = Object.create(null) as {
+    [pageType: string]: { [elementOffset: number]: number };
+  };
+  Object.keys(source).forEach((pageType) => {
+    const counts = source[pageType];
+    const clonedCounts = Object.create(null) as {
+      [elementOffset: number]: number;
+    };
+    Object.keys(counts).forEach((offset) => {
+      clonedCounts[offset as unknown as number] = counts[offset];
+    });
+    cloned[pageType] = clonedCounts;
+  });
+  return cloned;
+}
+
 export type Position = {
   spineIndex: number;
   pageIndex: number;
@@ -1945,6 +1966,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
             currentPageType: pageCascade.currentPageType,
             previousPageType: pageCascade.previousPageType,
           };
+          const savedPageGroupPageCounts = clonePageGroupPageCounts(
+            targetViewItem.instance.pageGroupPageCounts,
+          );
 
           // Save the scopes and restore them after re-rendering page.
           // This is necessary for :blank page selector to work.
@@ -1988,6 +2012,8 @@ export class OPFView implements Vgen.CustomRendererFactory {
               savedPageCascadePageTypeState.currentPageType;
             pageCascade.previousPageType =
               savedPageCascadePageTypeState.previousPageType;
+            targetViewItem.instance.pageGroupPageCounts =
+              savedPageGroupPageCounts;
             targetViewItem.instance.scopes = scopes;
             this.counterStore.popPageCounters();
             this.counterStore.popReferencesToSolve();

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -314,6 +314,9 @@ export class StyleInstance
   pageSheetSize: { [key: string]: { width: number; height: number } } = {};
   pageSheetHeight: number = 0;
   pageSheetWidth: number = 0;
+  pageGroupPageCounts: {
+    [pageType: string]: { [elementOffset: number]: number };
+  } = Object.create(null);
 
   constructor(
     public readonly style: Style,
@@ -747,6 +750,175 @@ export class StyleInstance
       }
     }
     return { counterOffset, changeOffset };
+  }
+
+  private getPageStartElement(
+    layoutPosition: Vtree.LayoutPosition,
+    pageStartOffset: number = this.getPageStartOffset(layoutPosition),
+  ): Element | null {
+    if (!isFinite(pageStartOffset)) {
+      return null;
+    }
+    const searchRoot = this.xmldoc.body || this.xmldoc.root;
+    if (!searchRoot) {
+      return null;
+    }
+    const startElement = this.getFirstInFlowElementAtOrAfter(
+      searchRoot,
+      pageStartOffset,
+    );
+    const searchRootOffset = this.xmldoc.getElementOffset(searchRoot);
+    const isDocumentStart = pageStartOffset <= searchRootOffset;
+    return startElement === searchRoot && isDocumentStart
+      ? this.getFirstInFlowChildElement(searchRoot)
+      : startElement;
+  }
+
+  private isForcedPageBreakValue(value: string | null): boolean {
+    return (
+      Break.isForcedBreakValue(value) &&
+      value !== "column" &&
+      value !== "region"
+    );
+  }
+
+  private hasForcedPageBreakBefore(style: CssCascade.ElementStyle): boolean {
+    const breakValue = CssCascade.getProp(style, "break-before");
+    if (!breakValue) {
+      return false;
+    }
+    const resolvedBreakValue = breakValue
+      .evaluate(this, "break-before")
+      .toString();
+    return this.isForcedPageBreakValue(resolvedBreakValue);
+  }
+
+  private getExplicitPageType(style: CssCascade.ElementStyle): string | null {
+    const pageValue = CssCascade.getProp(style, "page");
+    if (!pageValue) {
+      return null;
+    }
+    const pageType = pageValue.evaluate(this, "page").toString();
+    if (!pageType || pageType.toLowerCase() === "auto") {
+      return null;
+    }
+    return pageType;
+  }
+
+  private getPageGroupPageType(element: Element): string | null {
+    const style = this.styler.getStyle(element, false);
+    if (!style) {
+      return null;
+    }
+    return this.getExplicitPageType(style);
+  }
+
+  private getPreviousInFlowSibling(element: Element): Element | null {
+    let sibling = element.previousElementSibling;
+    while (sibling) {
+      if (this.isNormalFlowElement(sibling)) {
+        return sibling;
+      }
+      sibling = sibling.previousElementSibling;
+    }
+    return null;
+  }
+
+  private getFirstDocumentFlowElement(): Element | null {
+    const searchRoot = this.xmldoc.body || this.xmldoc.root;
+    if (!searchRoot) {
+      return null;
+    }
+    const searchRootOffset = this.xmldoc.getElementOffset(searchRoot);
+    const startElement = this.getFirstInFlowElementAtOrAfter(
+      searchRoot,
+      searchRootOffset,
+    );
+    return startElement === searchRoot
+      ? this.getFirstInFlowChildElement(searchRoot)
+      : startElement;
+  }
+
+  private shouldStartPageGroup(
+    element: Element,
+    pageType: string,
+    pageStartOffset: number,
+  ): boolean {
+    const style = this.styler.getStyle(element, false);
+    if (!style) {
+      return false;
+    }
+
+    if (this.getFirstDocumentFlowElement() === element) {
+      return true;
+    }
+
+    const elementOffset = this.xmldoc.getElementOffset(element);
+    if (elementOffset !== pageStartOffset) {
+      return false;
+    }
+
+    if (this.hasForcedPageBreakBefore(style)) {
+      return true;
+    }
+
+    const previousSibling = this.getPreviousInFlowSibling(element);
+    if (!previousSibling) {
+      return false;
+    }
+    const previousStyle = this.styler.getStyle(previousSibling, false);
+    if (!previousStyle) {
+      return false;
+    }
+
+    const previousPageType = this.getExplicitPageType(previousStyle);
+    return previousPageType !== pageType;
+  }
+
+  private updatePageGroupPageIndices(
+    layoutPosition: Vtree.LayoutPosition,
+  ): void {
+    const pageCascade = this.pageManager.pageCascadeInstance;
+    pageCascade.pageTypePageIndices = Object.create(null);
+
+    const pageStartOffset = this.getPageStartOffset(layoutPosition);
+    const startElement = this.getPageStartElement(
+      layoutPosition,
+      pageStartOffset,
+    );
+
+    if (!startElement) {
+      return;
+    }
+
+    let currentElement: Element | null = startElement;
+    while (currentElement) {
+      const pageType = this.getPageGroupPageType(currentElement);
+      if (pageType) {
+        const elementOffset = this.xmldoc.getElementOffset(currentElement);
+        const countsByElement =
+          this.pageGroupPageCounts[pageType] ||
+          (this.pageGroupPageCounts[pageType] = Object.create(null));
+        let pageIndex = countsByElement[elementOffset] || 0;
+        if (
+          pageIndex > 0 ||
+          this.shouldStartPageGroup(currentElement, pageType, pageStartOffset)
+        ) {
+          pageIndex += 1;
+          countsByElement[elementOffset] = pageIndex;
+
+          const pageTypeIndices =
+            pageCascade.pageTypePageIndices[pageType] ||
+            (pageCascade.pageTypePageIndices[pageType] = []);
+          pageTypeIndices.push(pageIndex);
+        }
+      }
+
+      if (currentElement === this.xmldoc.root) {
+        break;
+      }
+      currentElement = currentElement.parentElement;
+    }
   }
 
   private getFirstInFlowElementAtOrAfter(
@@ -2169,9 +2341,6 @@ export class StyleInstance
     page.isBlankPage = cp.isBlankPage;
     cp.page++;
 
-    // Save previous page type before it gets updated
-    const prevPageType = this.styler.cascade.previousPageType;
-
     if (page.pageType == null) {
       page.pageType =
         (page.isBlankPage
@@ -2182,17 +2351,8 @@ export class StyleInstance
         this.styler.cascade.currentPageType;
     }
 
-    // Update page type page counts for :nth(An+B of <page-type>) selector
-    // Use pageCascadeInstance which is used for page rule evaluation
-    const pageCascade = this.pageManager.pageCascadeInstance;
-    if (page.pageType) {
-      // If page type changed from the previous page, reset count for the new page type (new page group)
-      if (prevPageType !== page.pageType) {
-        pageCascade.pageTypePageCounts[page.pageType] = 0;
-      }
-      pageCascade.pageTypePageCounts[page.pageType] =
-        (pageCascade.pageTypePageCounts[page.pageType] || 0) + 1;
-    }
+    // Update page group page indices for :nth(An+B of <page-type>) selector
+    this.updatePageGroupPageIndices(cp);
 
     this.clearScope(this.style.pageScope);
     this.layoutPositionAtPageStart = cp.clone();

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -360,11 +360,10 @@ module.exports = [
         file: "named-pages/named-pages.html",
         title: "Named Pages",
       },
-      // Not yet supported:
-      // {
-      //   file: "named-pages/page-groups.html",
-      //   title: "Page Groups",
-      // },
+      {
+        file: "named-pages/page-groups.html",
+        title: "Page Groups",
+      },
     ],
   },
   {

--- a/packages/core/test/files/named-pages/page-groups.html
+++ b/packages/core/test/files/named-pages/page-groups.html
@@ -48,6 +48,16 @@
           content: ":nth(1 of B)";
         }
       }
+      @page :nth(1 of A) {
+        @bottom-right-corner {
+          content: ":nth(1 of A)";
+          text-align: center;
+        }
+      }
+      /* Page group start interpretation used in this test:
+         starts at document first element, page-type boundary, or break-before with forced page value (page|left|right|recto|verso).
+         break-after and forced column/region breaks are not treated as page-group starts. */
+      /* Expected on Page 5: :nth(5 of A), :nth(1 of B), and :nth(5) all match */
       @page :nth(5) {
         @bottom-right {
           content: ":nth(5)";
@@ -142,6 +152,7 @@
       </p>
     </div>
     <div class="A">
+      <!-- Expected: this second Page Group A starts on Page 8 and matches :nth(1 of A). -->
       <p>
         Page Group A (second) start.<br /><br />
         Nunc vulputate enim vitae quam imperdiet, iaculis lobortis turpis
@@ -154,6 +165,18 @@
         luctus. Proin placerat, ante et cursus elementum, est nisl posuere mi,
         at varius sem ante ac nibh. Interdum et malesuada fames ac ante ipsum
         primis in faucibus.<br /><br />
+        Page Group A (second) continue.
+      </p>
+      <!-- Expected: this paragraph is on Page 9, and the second Page Group A ends on Page 9. -->
+      <p>
+        Page Group A (second) second page.<br /><br />
+        Sed imperdiet nisi ac orci bibendum, at porta velit facilisis. Mauris
+        vitae turpis arcu. Duis pharetra sem quis malesuada sodales. Nullam
+        convallis imperdiet nisl, vitae ullamcorper nunc pretium sit amet.
+        Suspendisse potenti. Pellentesque habitant morbi tristique senectus et
+        netus et malesuada fames ac turpis egestas. Nulla facilisi. Etiam et
+        lectus et ipsum porta malesuada quis vel lorem. Donec feugiat ante sed
+        est mollis, nec iaculis neque hendrerit.<br /><br />
         Page Group A (second) end.
       </p>
     </div>


### PR DESCRIPTION
- implement page-group counters per page-type and per element instance
- evaluate `:nth(An+B of <page-type>)` against all active groups on the current page
- allow a page to belong to multiple groups (ancestor/descendant nesting)
- add named-pages/page-groups test case
- document expected results in the test file

Page-group start rules implemented in this change:

- start at the first in-flow element of the document
- start at page-type boundary between adjacent in-flow elements
- start when an element with `page` has `break-before` forced page value (`page | left | right | recto | verso`)
- do not start from `break-after`
- do not treat `column`/`region` forced breaks as page-group starts

closes #1710

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to implement CSS GCPM §3.2 Page groups (`:nth(An+B of <page-type>)`) per issue #1710.
- The human author iterated on the regression test-case format, first asking about a WPT-style Given/When/Then structure, trying it, then reverting to a simpler "Expected:" comment style as clearer.
- After testing with varied CSS, the human author found a problem with the `break-after` handling and provided the exact CSS GCPM draft spec wording so the AI could re-align the implementation, then asked for a clarifying code comment.
- The human author requested a commit message that also explained the implementation approach, then created PR #1745; a reviewer left comments, which the human author asked the AI to check and address.

</details>
