### PR TITLE
fix: follow up page group support for root/body page type and concatenated docs

### DIFF
--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -787,6 +787,16 @@ export class Styler implements AbstractStyler {
     if (offset < rootOffset) {
       const rootStyle = this.getStyle(this.root, false);
       Asserts.assert(rootStyle);
+      if (!this.cascade.firstPageType) {
+        const rootPageCV = rootStyle["page"] as CssCascade.CascadeValue;
+        const rootPageType =
+          rootPageCV &&
+          !Css.isDefaultingValue(rootPageCV.value) &&
+          rootPageCV.value.toString();
+        if (rootPageType && rootPageType.toLowerCase() !== "auto") {
+          this.cascade.firstPageType = rootPageType;
+        }
+      }
       const flowName = CssCascade.getProp(rootStyle, "flow-into");
       const flowNameStr = flowName
         ? flowName.evaluate(context, "flow-into").toString()
@@ -1109,14 +1119,18 @@ export class Styler implements AbstractStyler {
         }
         const blockStartOffset = this.boxStack.nearestBlockStartOffset(box);
 
-        if (blockStartOffset === 0) {
+        if (blockStartOffset === 0 || elem === this.xmldoc.body) {
           // Named page type at first page
           const pageCV = style["page"] as CssCascade.CascadeValue;
           const pageType =
             pageCV &&
             !Css.isDefaultingValue(pageCV.value) &&
             pageCV.value.toString();
-          if (pageType && pageType.toLowerCase() !== "auto") {
+          if (
+            !this.cascade.firstPageType &&
+            pageType &&
+            pageType.toLowerCase() !== "auto"
+          ) {
             this.cascade.firstPageType = pageType;
           }
         }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -51,22 +51,15 @@ function cloneCounterValues(
 }
 
 function clonePageGroupPageCounts(source: {
-  [pageType: string]: { [elementOffset: number]: number };
+  [pageType: string]: Map<Element, number>;
 }): {
-  [pageType: string]: { [elementOffset: number]: number };
+  [pageType: string]: Map<Element, number>;
 } {
   const cloned = Object.create(null) as {
-    [pageType: string]: { [elementOffset: number]: number };
+    [pageType: string]: Map<Element, number>;
   };
   Object.keys(source).forEach((pageType) => {
-    const counts = source[pageType];
-    const clonedCounts = Object.create(null) as {
-      [elementOffset: number]: number;
-    };
-    Object.keys(counts).forEach((offset) => {
-      clonedCounts[offset as unknown as number] = counts[offset];
-    });
-    cloned[pageType] = clonedCounts;
+    cloned[pageType] = new Map(source[pageType]);
   });
   return cloned;
 }
@@ -1969,6 +1962,8 @@ export class OPFView implements Vgen.CustomRendererFactory {
           const savedPageGroupPageCounts = clonePageGroupPageCounts(
             targetViewItem.instance.pageGroupPageCounts,
           );
+          const savedCurrentPageGroupDocument =
+            targetViewItem.instance.currentPageGroupDocument;
 
           // Save the scopes and restore them after re-rendering page.
           // This is necessary for :blank page selector to work.
@@ -2014,6 +2009,8 @@ export class OPFView implements Vgen.CustomRendererFactory {
               savedPageCascadePageTypeState.previousPageType;
             targetViewItem.instance.pageGroupPageCounts =
               savedPageGroupPageCounts;
+            targetViewItem.instance.currentPageGroupDocument =
+              savedCurrentPageGroupDocument;
             targetViewItem.instance.scopes = scopes;
             this.counterStore.popPageCounters();
             this.counterStore.popReferencesToSolve();

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -315,8 +315,9 @@ export class StyleInstance
   pageSheetHeight: number = 0;
   pageSheetWidth: number = 0;
   pageGroupPageCounts: {
-    [pageType: string]: { [elementOffset: number]: number };
+    [pageType: string]: Map<Element, number>;
   } = Object.create(null);
+  currentPageGroupDocument: Document | null = null;
 
   constructor(
     public readonly style: Style,
@@ -854,6 +855,23 @@ export class StyleInstance
     }
 
     const elementOffset = this.xmldoc.getElementOffset(element);
+    const searchRoot = this.xmldoc.body || this.xmldoc.root;
+    const searchRootOffset = this.xmldoc.getElementOffset(searchRoot);
+    const isDocumentStart = pageStartOffset <= searchRootOffset;
+
+    // Root/body page groups can start at document start even when the first
+    // in-flow element is a descendant.
+    if (isDocumentStart && element === searchRoot) {
+      return true;
+    }
+
+    if (
+      !this.getPreviousInFlowSibling(element) &&
+      pageStartOffset === elementOffset
+    ) {
+      return true;
+    }
+
     if (elementOffset !== pageStartOffset) {
       return false;
     }
@@ -880,7 +898,24 @@ export class StyleInstance
   ): void {
     const pageCascade = this.pageManager.pageCascadeInstance;
     pageCascade.pageTypePageIndices = Object.create(null);
-    const canStartNewPageGroup = !layoutPosition.isBlankPage;
+    const startSide = layoutPosition.startSideOfFlow("body");
+    const bodyFlowPosition = layoutPosition.flowPositions["body"];
+    const hasBodyFlowContent = !!(
+      bodyFlowPosition && bodyFlowPosition.positions.length
+    );
+    const isSpreadDeferredBlankPage =
+      Break.isSpreadBreakValue(startSide) &&
+      !this.matchPageSide(startSide) &&
+      !hasBodyFlowContent;
+    // A synthetic blank first page can be inserted between concatenated
+    // documents for spread alignment (issue #666). It must not consume
+    // :nth(An+B of <page-type>) page-group indices.
+    const isBlankPageAtDocumentStart =
+      this.blankPageAtStart && layoutPosition.page === 1;
+    const canStartNewPageGroup =
+      !isBlankPageAtDocumentStart &&
+      !layoutPosition.isBlankPage &&
+      !isSpreadDeferredBlankPage;
 
     const pageStartOffset = this.getPageStartOffset(layoutPosition);
     const startElement = this.getPageStartElement(
@@ -892,26 +927,38 @@ export class StyleInstance
       return;
     }
 
+    const startDocument = startElement.ownerDocument;
+    const isNewPageGroupDocument =
+      this.currentPageGroupDocument !== startDocument;
+    // Do not consume new-document boundary on synthetic blank pages at start;
+    // keep it for the first real content page.
+    const shouldActivateNewPageGroupDocument =
+      isNewPageGroupDocument && canStartNewPageGroup;
+    if (shouldActivateNewPageGroupDocument) {
+      this.pageGroupPageCounts = Object.create(null);
+      this.currentPageGroupDocument = startDocument;
+    }
+
     let currentElement: Element | null = startElement;
     while (currentElement) {
       const pageType = this.getPageGroupPageType(currentElement);
       if (pageType) {
-        const elementOffset = this.xmldoc.getElementOffset(currentElement);
         const countsByElement =
           this.pageGroupPageCounts[pageType] ||
-          (this.pageGroupPageCounts[pageType] = Object.create(null));
-        let pageIndex = countsByElement[elementOffset] || 0;
+          (this.pageGroupPageCounts[pageType] = new Map());
+        let pageIndex = countsByElement.get(currentElement) || 0;
         if (
           pageIndex > 0 ||
           (canStartNewPageGroup &&
-            this.shouldStartPageGroup(
-              currentElement,
-              pageType,
-              pageStartOffset,
-            ))
+            (shouldActivateNewPageGroupDocument ||
+              this.shouldStartPageGroup(
+                currentElement,
+                pageType,
+                pageStartOffset,
+              )))
         ) {
           pageIndex += 1;
-          countsByElement[elementOffset] = pageIndex;
+          countsByElement.set(currentElement, pageIndex);
 
           const pageTypeIndices =
             pageCascade.pageTypePageIndices[pageType] ||

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -368,6 +368,13 @@ module.exports = [
         file: "named-pages/page-groups-spread-breaks.html",
         title: "Page Groups with spread breaks",
       },
+      {
+        file: [
+          "named-pages/page-groups-concat-blank-first.html",
+          "named-pages/page-groups-concat-blank-second.html",
+        ],
+        title: "Page Groups across concatenated docs with boundary blank page",
+      },
     ],
   },
   {

--- a/packages/core/test/files/named-pages/page-groups-concat-blank-first.html
+++ b/packages/core/test/files/named-pages/page-groups-concat-blank-first.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page Groups across concatenated docs - first</title>
+    <style>
+      @page {
+        size: 16cm 16cm;
+        margin: 2cm;
+        @top-left {
+          content: "Page " counter(page);
+        }
+      }
+      @page A {
+        @top-center {
+          content: "Named Page A";
+        }
+      }
+      @page :nth(n of A) {
+        @top-right {
+          content: "Page Group A";
+        }
+      }
+      @page :nth(1 of A) {
+        @bottom-left {
+          content: ":nth(1 of A)";
+        }
+      }
+      @page :nth(2 of A) {
+        @bottom-left {
+          content: ":nth(2 of A)";
+        }
+      }
+
+      .A {
+        page: A;
+        break-before: right;
+      }
+
+      .probe {
+        border: 1px solid #333;
+        padding: 8mm;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="A probe">
+      <h1>Doc 1 / Page Group A</h1>
+      <p>
+        This file is the first source in a concatenated test.
+        Expected on this page: Named Page A, Page Group A, and :nth(1 of A).
+      </p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/named-pages/page-groups-concat-blank-second.html
+++ b/packages/core/test/files/named-pages/page-groups-concat-blank-second.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en" class="A">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page Groups across concatenated docs - second</title>
+    <style>
+      @page {
+        size: 16cm 16cm;
+        margin: 2cm;
+        @top-left {
+          content: "Page " counter(page);
+        }
+      }
+      @page A {
+        @top-center {
+          content: "Named Page A";
+        }
+      }
+      @page :nth(n of A) {
+        @top-right {
+          content: "Page Group A";
+        }
+      }
+      @page :nth(1 of A) {
+        @bottom-left {
+          content: ":nth(1 of A)";
+        }
+      }
+      @page :nth(2 of A) {
+        @bottom-left {
+          content: ":nth(2 of A)";
+        }
+      }
+
+      .A {
+        page: A;
+        break-before: right;
+      }
+
+      .probe {
+        border: 1px solid #333;
+        padding: 8mm;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="probe">
+      <h1>Doc 2 / Page Group A restart</h1>
+      <p>
+        This second source starts with break-before:right and creates a blank
+        page at document boundary in concatenated rendering.
+      </p>
+      <p>
+        Expected on this page: Named Page A, Page Group A, and :nth(1 of A).
+        It must not show :nth(2 of A).
+      </p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Follow up page-group support for CSS GCPM `:nth(... of <page-type>)` in edge cases found after the initial implementation.

- Handle page type specified on root/body consistently: ensure firstPageType is initialized from root/body page declarations so page-group matching starts correctly from the first page.

- Fix page-group index tracking across concatenated HTML sources: avoid carrying indices between documents by tracking counts per element and handling document boundaries explicitly.

- Prevent synthetic boundary blank pages (issue #666 behavior) from consuming page-group indices: treat inserted blank pages between concatenated documents as non-counting for `:nth(... of <page-type>)` progression.

- Preserve page-group tracking state during target-counter rerender paths to avoid accidental double counting/regression.

- Add regression coverage for concatenated documents with a boundary blank page to verify that the second document restarts page-group counting at `:nth(1 of A)` and still matches Named Page A / Page Group A correctly.

follow-up for issue #1710, PR #1745, and PR #1746

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- After PR #1745 merged, the human author found further edge cases (root/body page-type handling, a forced page-break test variant using left/right) and directed the fix, citing the exact CSS GCPM draft spec wording for `break-after` handling when the AI's first attempt needed correction.
- The human author found a page-group indexing regression when concatenating HTML documents with a synthetic blank page, pointed the AI to the related issue #666 / PR #694 code as a hint, and asked for a regression test once the fix worked — catching that page 5's `:nth(1 of A)` and "Page Group A" header were missing before the fix was complete.
- The human author decided to combine this fix with an earlier not-yet-committed root/body page-type fix into one PR and directed the commit message content; the AI implemented per that direction.

</details>
