### PR TITLE
fix: Fix page float spacing with padding, border, and margin-bottom

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1626,6 +1626,21 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return count;
   }
 
+  /**
+   * Mark a spine item as complete if all layout positions have corresponding
+   * rendered pages (Issue #1498).  When the item becomes complete, clean up
+   * inherited CSS properties that were propagated to the layout box during
+   * page float rendering so they don't leak into the next spine item or
+   * remain in the DOM after layout (Issue #1752).
+   */
+  private markSpineItemCompleteIfReady(viewItem: OPFViewItem): void {
+    viewItem.complete =
+      viewItem.layoutPositions.length === viewItem.pages.length;
+    if (viewItem.complete) {
+      viewItem.instance.viewport.layoutBox.removeAttribute("style");
+    }
+  }
+
   private getTotalOffsetForViewItem(viewItem: OPFViewItem): number {
     const spineIndex = viewItem.item.spineIndex;
     let totalOffset = this.paginationProgress.totalOffsetsBySpine[spineIndex];
@@ -2304,8 +2319,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
               // Issue #1498: do not mark complete if layoutPositions and pages
               // are out of sync. A pending layout position means additional
               // page rendering is still required.
-              viewItem.complete =
-                viewItem.layoutPositions.length === viewItem.pages.length;
+              this.markSpineItemCompleteIfReady(viewItem);
               loopFrame.breakLoop();
             }
           });
@@ -2321,8 +2335,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             if (!result.nextLayoutPosition) {
               // Issue #1498: keep complete=false while there are pending
               // layout positions without corresponding rendered pages.
-              viewItem.complete =
-                viewItem.layoutPositions.length === viewItem.pages.length;
+              this.markSpineItemCompleteIfReady(viewItem);
             }
             frame.finish(result.pageAndPosition);
           });
@@ -3090,6 +3103,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
           pageCounterStarts: [],
         };
         this.spineItems[spineIndex] = viewItem;
+
         frame.finish(viewItem);
         loadingContinuations.forEach((c) => {
           c.schedule(viewItem);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -4771,4 +4771,17 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
       }),
     );
   }
+
+  getContentBlockMarginAfter(): number {
+    if (this.rootViewNodes.length === 0) {
+      return 0;
+    }
+    return Math.max.apply(
+      null,
+      this.rootViewNodes.map((r, i) => {
+        const margin = this.floatMargins[i];
+        return this.vertical ? margin.left : margin.bottom;
+      }),
+    );
+  }
 }

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1456,7 +1456,15 @@ export class PageFloatLayoutContext
         return null;
       }
     } else {
-      blockSize = area.computedBlockSize;
+      // computedBlockSize already includes the border-box size (padding +
+      // border) of the root float elements and any positive trailing margin.
+      // However, negative trailing margin is not reflected, so only add the
+      // negative part of margin-after here. (Issue #1752)
+      const marginAfter = area.getContentBlockMarginAfter();
+      blockSize = Math.max(
+        0,
+        area.computedBlockSize + Math.min(0, marginAfter),
+      );
       outerBlockSize = blockSize + area.getInsetBefore() + area.getInsetAfter();
       const availableBlockSize = (blockEnd - blockStart) * area.getBoxDir();
       if (logicalFloatSides[0] === "snap-block") {

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -570,6 +570,7 @@ export namespace Layout {
 
     convertPercentageSizesToPx(target: Element): void;
     fixFloatSizeAndPosition(nodeContext: Vtree.NodeContext): void;
+    getContentBlockMarginAfter(): number;
     getContentInlineSize(): number;
   }
 }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2673,6 +2673,14 @@ export class ViewFactory
           propName,
           value.toString(),
         );
+        // Also propagate to the layout box so that page float areas laid out
+        // there (e.g. during stash re-layout before the root element is
+        // processed on the new page) inherit the correct values. (Issue #1752)
+        Base.setCSSProperty(
+          this.viewport.layoutBox,
+          propName,
+          value.toString(),
+        );
       } else {
         Base.setCSSProperty(target, propName, value.toString());
       }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -697,6 +697,17 @@ module.exports = [
         file: "page_floats/page-float-in-page-float.html",
         title: "Page float in page float (Issue #1675)",
       },
+      {
+        file: "page_floats/page-float-spacing.html",
+        title:
+          "Page float padding, border, and margin-bottom cases (Issue #1752)",
+      },
+      {
+        file: "page_floats/page-float-spacing.html",
+        title:
+          "Page float padding, border, and margin-bottom cases with fontSize=18 (Issue #1752)",
+        options: "&fontSize=18",
+      },
     ],
   },
   {

--- a/packages/core/test/files/page_floats/page-float-spacing.html
+++ b/packages/core/test/files/page_floats/page-float-spacing.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page float spacing cases</title>
+    <style>
+      @page {
+        size: 500px;
+        outline: 1px solid aqua;
+
+        @bottom-center {
+          writing-mode: horizontal-tb;
+          content: "Page " counter(page);
+        }
+      }
+
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+
+      section {
+        break-before: page;
+      }
+
+      h1 {
+        margin-block: 0 0.25em;
+      }
+
+      h2 {
+        margin-block-end: 0.4em;
+      }
+
+      .expectation {
+        font-style: italic;
+        margin-block: 0 0.6em;
+      }
+
+      .pfloat {
+        float-reference: page;
+        padding: 10px;
+        border: 5px dashed green;
+      }
+
+      .top {
+        float: block-start;
+      }
+
+      .bottom {
+        float: block-end;
+      }
+
+      .margin-positive {
+        margin-block-end: 10px;
+      }
+
+      .margin-negative {
+        margin-block-end: -10px;
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h1>Page top float with padding and border</h1>
+      <p class="expectation">
+        Expected result: the page float appears at the top of the next page,
+        and the following paragraph starts immediately below the float's
+        painted bottom edge without overlap or extra trailing gap.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non
+        sollicitudin lectus. In tempus porta lacus, ac bibendum ante sagittis
+        non. Proin vitae auctor nibh. Praesent id orci id nibh suscipit
+        pellentesque.
+      </p>
+      Page float anchor ->
+      <aside class="pfloat top">
+        <h2>Page Float</h2>
+        <p>This is a page float box.</p>
+        <p>
+          Ut vitae tempor metus. Aliquam vitae neque dui. In ipsum risus,
+          aliquam a orci in, molestie tempor lectus. Duis fringilla tortor eu
+          mi rhoncus, et vehicula orci luctus. Duis cursus urna ac convallis
+          ornare. Vivamus finibus condimentum elit, ac vestibulum massa congue
+          a. Suspendisse quis interdum turpis. Nam pretium id tortor eget.
+        </p>
+      </aside>
+      <- Page float anchor
+      <p>
+        Phasellus malesuada non nunc ut imperdiet. Sed non ex quam. Proin sed
+        volutpat velit, ut dictum dolor. Sed interdum justo et tellus venenatis
+        efficitur quis eget eros. Integer bibendum ante eu nunc iaculis
+        dapibus. Ut id nibh nisl. Aenean hendrerit feugiat laoreet. Nam in
+        pharetra mauris, quis dapibus purus. Interdum et malesuada fames ac
+        ante ipsum primis in faucibus.
+      </p>
+    </section>
+
+    <section>
+      <h1>Page bottom float with padding and border</h1>
+      <p class="expectation">
+        Expected result: the page float appears at the bottom of the next page,
+        stays within the page area, and its border and padding are not clipped
+        or pushed outside the page.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non
+        sollicitudin lectus. In tempus porta lacus, ac bibendum ante sagittis
+        non. Proin vitae auctor nibh. Praesent id orci id nibh suscipit
+        pellentesque.
+      </p>
+      Page float anchor ->
+      <aside class="pfloat bottom">
+        <h2>Page Float</h2>
+        <p>This is a page float box.</p>
+        <p>
+          Ut vitae tempor metus. Aliquam vitae neque dui. In ipsum risus,
+          aliquam a orci in, molestie tempor lectus. Duis fringilla tortor eu
+          mi rhoncus, et vehicula orci luctus. Duis cursus urna ac convallis
+          ornare. Vivamus finibus condimentum elit, ac vestibulum massa congue
+          a. Suspendisse quis interdum turpis. Nam pretium id tortor eget.
+        </p>
+      </aside>
+      <- Page float anchor
+      <p>
+        Phasellus malesuada non nunc ut imperdiet. Sed non ex quam. Proin sed
+        volutpat velit, ut dictum dolor. Sed interdum justo et tellus venenatis
+        efficitur quis eget eros. Integer bibendum ante eu nunc iaculis
+        dapibus. Ut id nibh nisl. Aenean hendrerit feugiat laoreet. Nam in
+        pharetra mauris, quis dapibus purus. Interdum et malesuada fames ac
+        ante ipsum primis in faucibus.
+      </p>
+    </section>
+
+    <section>
+      <h1>Page top float with positive margin-bottom</h1>
+      <p class="expectation">
+        Expected result: the page float appears at the top of the next page,
+        and the following paragraph starts lower than in the baseline top-float
+        case by the additional positive bottom margin, without doubling that
+        spacing.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non
+        sollicitudin lectus. In tempus porta lacus, ac bibendum ante sagittis
+        non. Proin vitae auctor nibh. Praesent id orci id nibh suscipit
+        pellentesque.
+      </p>
+      Page float anchor ->
+      <aside class="pfloat top margin-positive">
+        <h2>Page Float</h2>
+        <p>This is a page float box.</p>
+        <p>
+          Ut vitae tempor metus. Aliquam vitae neque dui. In ipsum risus,
+          aliquam a orci in, molestie tempor lectus. Duis fringilla tortor eu
+          mi rhoncus, et vehicula orci luctus. Duis cursus urna ac convallis
+          ornare. Vivamus finibus condimentum elit, ac vestibulum massa congue
+          a. Suspendisse quis interdum turpis. Nam pretium id tortor eget.
+        </p>
+      </aside>
+      <- Page float anchor
+      <p>
+        Phasellus malesuada non nunc ut imperdiet. Sed non ex quam. Proin sed
+        volutpat velit, ut dictum dolor. Sed interdum justo et tellus venenatis
+        efficitur quis eget eros. Integer bibendum ante eu nunc iaculis
+        dapibus. Ut id nibh nisl. Aenean hendrerit feugiat laoreet. Nam in
+        pharetra mauris, quis dapibus purus. Interdum et malesuada fames ac
+        ante ipsum primis in faucibus.
+      </p>
+    </section>
+
+    <section>
+      <h1>Page bottom float with positive margin-bottom</h1>
+      <p class="expectation">
+        Expected result: the page float remains inside the page area while the
+        positive bottom margin moves the float upward relative to the baseline
+        bottom-float case.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non
+        sollicitudin lectus. In tempus porta lacus, ac bibendum ante sagittis
+        non. Proin vitae auctor nibh. Praesent id orci id nibh suscipit
+        pellentesque.
+      </p>
+      Page float anchor ->
+      <aside class="pfloat bottom margin-positive">
+        <h2>Page Float</h2>
+        <p>This is a page float box.</p>
+        <p>
+          Ut vitae tempor metus. Aliquam vitae neque dui. In ipsum risus,
+          aliquam a orci in, molestie tempor lectus. Duis fringilla tortor eu
+          mi rhoncus, et vehicula orci luctus. Duis cursus urna ac convallis
+          ornare. Vivamus finibus condimentum elit, ac vestibulum massa congue
+          a. Suspendisse quis interdum turpis. Nam pretium id tortor eget.
+        </p>
+      </aside>
+      <- Page float anchor
+      <p>
+        Phasellus malesuada non nunc ut imperdiet. Sed non ex quam. Proin sed
+        volutpat velit, ut dictum dolor. Sed interdum justo et tellus venenatis
+        efficitur quis eget eros. Integer bibendum ante eu nunc iaculis
+        dapibus. Ut id nibh nisl. Aenean hendrerit feugiat laoreet. Nam in
+        pharetra mauris, quis dapibus purus. Interdum et malesuada fames ac
+        ante ipsum primis in faucibus.
+      </p>
+    </section>
+
+    <section>
+      <h1>Page top float with negative margin-bottom</h1>
+      <p class="expectation">
+        Expected result: the page float appears at the top of the next page,
+        and the following paragraph moves upward relative to the baseline
+        top-float case because the negative bottom margin reduces the trailing
+        gap.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non
+        sollicitudin lectus. In tempus porta lacus, ac bibendum ante sagittis
+        non. Proin vitae auctor nibh. Praesent id orci id nibh suscipit
+        pellentesque.
+      </p>
+      Page float anchor ->
+      <aside class="pfloat top margin-negative">
+        <h2>Page Float</h2>
+        <p>This is a page float box.</p>
+        <p>
+          Ut vitae tempor metus. Aliquam vitae neque dui. In ipsum risus,
+          aliquam a orci in, molestie tempor lectus. Duis fringilla tortor eu
+          mi rhoncus, et vehicula orci luctus. Duis cursus urna ac convallis
+          ornare. Vivamus finibus condimentum elit, ac vestibulum massa congue
+          a. Suspendisse quis interdum turpis. Nam pretium id tortor eget.
+        </p>
+      </aside>
+      <- Page float anchor
+      <p>
+        Phasellus malesuada non nunc ut imperdiet. Sed non ex quam. Proin sed
+        volutpat velit, ut dictum dolor. Sed interdum justo et tellus venenatis
+        efficitur quis eget eros. Integer bibendum ante eu nunc iaculis
+        dapibus. Ut id nibh nisl. Aenean hendrerit feugiat laoreet. Nam in
+        pharetra mauris, quis dapibus purus. Interdum et malesuada fames ac
+        ante ipsum primis in faucibus.
+      </p>
+    </section>
+
+    <section>
+      <h1>Page bottom float with negative margin-bottom</h1>
+      <p class="expectation">
+        Expected result: the page float moves downward relative to the baseline
+        bottom-float case, but the visible float fragment still stays within a
+        reasonable page-bound position rather than jumping far past the page
+        bottom.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non
+        sollicitudin lectus. In tempus porta lacus, ac bibendum ante sagittis
+        non. Proin vitae auctor nibh. Praesent id orci id nibh suscipit
+        pellentesque.
+      </p>
+      Page float anchor ->
+      <aside class="pfloat bottom margin-negative">
+        <h2>Page Float</h2>
+        <p>This is a page float box.</p>
+        <p>
+          Ut vitae tempor metus. Aliquam vitae neque dui. In ipsum risus,
+          aliquam a orci in, molestie tempor lectus. Duis fringilla tortor eu
+          mi rhoncus, et vehicula orci luctus. Duis cursus urna ac convallis
+          ornare. Vivamus finibus condimentum elit, ac vestibulum massa congue
+          a. Suspendisse quis interdum turpis. Nam pretium id tortor eget.
+        </p>
+      </aside>
+      <- Page float anchor
+      <p>
+        Phasellus malesuada non nunc ut imperdiet. Sed non ex quam. Proin sed
+        volutpat velit, ut dictum dolor. Sed interdum justo et tellus venenatis
+        efficitur quis eget eros. Integer bibendum ante eu nunc iaculis
+        dapibus. Ut id nibh nisl. Aenean hendrerit feugiat laoreet. Nam in
+        pharetra mauris, quis dapibus purus. Interdum et malesuada fames ac
+        ante ipsum primis in faucibus.
+      </p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
- Propagate root element inherited CSS properties (e.g. font-size, line-height) to the layout box so that page float areas inherit correct values during stash re-layout on new pages
- Adjust page float block size for negative margin-bottom on float root elements (computedBlockSize already includes border-box size and positive margins)
- Add test cases for page float padding, border, and margin-bottom

closes #1752

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author was investigating issue #1752 (page float padding/border overlapping body text) and continued the investigation with the AI.
- The human author caught the AI misjudging a multi-font-size test result as passing when it was not, and asked for the test file name to be changed to match existing naming conventions (no "issue-NNNN" prefix) before committing.
- The human author raised a design concern about a stale root-inherited style being left on the layout box after layout completed; after creating PR #1753 and addressing 3 reviewer comments, they asked the AI to add a proper cleanup step once `viewItem.complete` becomes true, iterating on where the cleanup should live and removing redundant copies.
- The human author then discovered this same PR caused a vertical-writing-mode layout regression as a side effect, and had the AI prepare a follow-up fix in the same session.

</details>
