### PR TITLE
fix: Fix non-root column-fill:auto overflow and disappearing text

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -349,6 +349,93 @@ export function fixOverflowAtForcedColumnBreak(node: Node): void {
 }
 
 /**
+ * Check if the root column's content overflows.
+ *
+ * Note: This check is based on the root column's trailing content
+ * (lastElementChild), not only on a specific target element.
+ */
+export function checkRootColumnOverflow(column: Layout.Column): number {
+  const element = column.element.lastElementChild;
+  const rect = element && column.clientLayout.getElementClientRect(element);
+  if (!rect) {
+    return 0;
+  }
+  const columnOver = checkIfBeyondColumnBreaks(rect, column.vertical);
+  return columnOver;
+}
+
+/**
+ * Fix multi-column box with `column-fill: auto` that was changed to `column-fill: balance`
+ * for layout processing, by restoring `column-fill: auto` and setting block-size to prevent overflow.
+ */
+export function fixAutoFillMultiColumnBox(
+  element: HTMLElement,
+  column: Layout.Column,
+): void {
+  if (element.getAttribute("data-viv-saved-column-fill") !== "auto") {
+    return;
+  }
+  if (checkRootColumnOverflow(column)) {
+    // Do not restore `column-fill: auto` if root-column overflow already exists
+    // even with `column-fill: balance`.
+    return;
+  }
+  const computedStyle = column.clientLayout.getElementComputedStyle(element);
+  const blockSize1 = parseFloat(computedStyle.blockSize);
+
+  // Restore `column-fill: auto` and check if it overflows.
+  // If it overflows, find a non-overflow block-size by binary search.
+  element.style.columnFill = "auto";
+  const blockSize2 = parseFloat(computedStyle.blockSize);
+  const delta = 1 / (column.clientLayout.pixelRatio || 1);
+  let blockSize = NaN;
+  element.style.blockSize = `${blockSize2}px`;
+  if (!checkRootColumnOverflow(column)) {
+    blockSize = blockSize2;
+  } else {
+    element.style.blockSize = `${blockSize1}px`;
+    if (!checkRootColumnOverflow(column)) {
+      // `blockSize1` is non-overflow and `blockSize2` is overflow.
+      // Search the largest non-overflow value in [blockSize1, blockSize2].
+      let ok = blockSize1;
+      let ng = blockSize2;
+      while (ng - ok > delta) {
+        const mid = (ok + ng) / 2;
+        element.style.blockSize = `${mid}px`;
+        if (checkRootColumnOverflow(column)) {
+          ng = mid;
+        } else {
+          ok = mid;
+        }
+      }
+      blockSize = ok;
+      element.style.blockSize = `${blockSize}px`;
+    }
+  }
+  if (isNaN(blockSize)) {
+    // Fallback for unexpected cases where overflow is not resolved while reducing
+    // block-size down to the original balanced size.
+    // Restore the stable `balance` state and keep data-viv-saved-column-fill="auto"
+    // for diagnostics and possible later retry.
+    element.style.blockSize = "";
+    element.style.columnFill = "balance";
+    return;
+  }
+  // Successfully restored `column-fill: auto`.
+  element.removeAttribute("data-viv-saved-column-fill");
+}
+
+export function fixAutoFillMultiColumnBoxes(column: Layout.Column): void {
+  // Restore `column-fill: auto` and set block-size for elements with data-viv-saved-column-fill="auto"
+  const elements = column.element.querySelectorAll(
+    '[data-viv-saved-column-fill="auto"]',
+  );
+  for (const element of elements) {
+    fixAutoFillMultiColumnBox(element as HTMLElement, column);
+  }
+}
+
+/**
  * Calculate the position of the "after" edge in the block-progression.
  * Returns the edge position in pixels if it was determined successfully,
  * and returns NaN if the position could not be determined and the node

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1081,94 +1081,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     }
   }
 
-  private setMaxBlockSizeForNonRootMultiColumn(element: HTMLElement): void {
-    if (Base.browserType !== "chromium") {
-      // On Firefox/Safari, overflow columns in nested multicol are handled
-      // inside the same multicol container, so this Chromium-specific
-      // workaround causes horizontal overflow.
-      return;
-    }
-
-    if (element.hasAttribute("data-vivliostyle-column")) {
-      // Root column element.
-      return;
-    }
-
-    const style = this.clientLayout.getElementComputedStyle(element);
-    if (style.columnFill !== "auto") {
-      return;
-    }
-    const authorSpecifiedMaxBlockSize = this.vertical
-      ? element.style.maxWidth
-      : element.style.maxHeight;
-    if (authorSpecifiedMaxBlockSize && authorSpecifiedMaxBlockSize !== "none") {
-      // Respect author-specified max-block-size.
-      return;
-    }
-
-    const isMultiColumn =
-      !isNaN(parseFloat(style.columnCount)) ||
-      !isNaN(parseFloat(style.columnWidth));
-    if (!isMultiColumn) {
-      return;
-    }
-
-    const rect = this.clientLayout.getElementClientRect(element);
-    if (!rect) {
-      return;
-    }
-
-    let maxBlockSize =
-      this.getBoxDir() * (this.footnoteEdge - this.getBeforeEdge(rect));
-
-    if (style.boxSizing !== "border-box") {
-      const blockInsets = this.vertical
-        ? this.parseComputedLength(style.borderRightWidth) +
-          this.parseComputedLength(style.paddingRight) +
-          this.parseComputedLength(style.borderLeftWidth) +
-          this.parseComputedLength(style.paddingLeft)
-        : this.parseComputedLength(style.borderTopWidth) +
-          this.parseComputedLength(style.paddingTop) +
-          this.parseComputedLength(style.borderBottomWidth) +
-          this.parseComputedLength(style.paddingBottom);
-      maxBlockSize -= blockInsets;
-    }
-
-    // Subtract 1 pixel to prevent overflow due to precision issue.
-    // (Issue #1720 case 3)
-    maxBlockSize -= 1 / (this.clientLayout.pixelRatio || 1);
-
-    if (maxBlockSize > 0 && isFinite(maxBlockSize)) {
-      Base.setCSSProperty(element, "max-block-size", `${maxBlockSize}px`);
-    }
-  }
-
-  private adjustMaxBlockSizeForAncestorNonRootMultiColumn(
-    nodeContext: Vtree.NodeContext,
-  ): void {
-    if (nodeContext.after || !nodeContext.viewNode) {
-      return;
-    }
-
-    const node =
-      nodeContext.viewNode.nodeType === 1
-        ? (nodeContext.viewNode as Element)
-        : nodeContext.viewNode.parentElement;
-    if (!node) {
-      return;
-    }
-
-    const nonRootMultiColumn =
-      LayoutHelper.findAncestorNonRootMultiColumn(node);
-    if (!nonRootMultiColumn) {
-      return;
-    }
-
-    this.setMaxBlockSizeForNonRootMultiColumn(
-      nonRootMultiColumn as HTMLElement,
-    );
-  }
-
   /**
    * @param nodeContext position after the block
    * @param checkPoints array of possible breaking points.
@@ -3269,8 +3181,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     frame
       .loopWithFrame((loopFrame) => {
         while (nodeContext) {
-          this.adjustMaxBlockSizeForAncestorNonRootMultiColumn(nodeContext);
-
           Asserts.assert(nodeContext.formattingContext);
           const layoutProcessor =
             new LayoutProcessor.LayoutProcessorResolver().find(
@@ -3423,6 +3333,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             const viewElement = nodeContext.viewNode as HTMLElement;
             const style = viewElement.style;
             if (nodeContext.after) {
+              // Fix multi-column box with `column-fill: auto` (Issue #1720, #1758)
+              LayoutHelper.fixAutoFillMultiColumnBox(viewElement, this);
+
               if (nodeContext.floatSide) {
                 // Restore break-after:avoid* value at before the float
                 // (Fix for issue #904)
@@ -3508,10 +3421,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               }
             } else {
               // Leading edge
-              this.setMaxBlockSizeForNonRootMultiColumn(
-                nodeContext.viewNode as HTMLElement,
-              );
-
               leadingEdgeContexts.push(nodeContext.copy());
               breakAtTheEdge = Break.resolveEffectiveBreakValue(
                 breakAtTheEdge,
@@ -4033,17 +3942,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             cont = Task.newResult(null);
           }
           cont.then(() => {
-            // Unset browser's multi-column if it caused column overflow.
-            // (Fix for issue #1637)
-            const rect =
-              this.element.lastElementChild &&
-              this.clientLayout.getElementClientRect(
-                this.element.lastElementChild,
-              );
-            const columnOver =
-              rect &&
-              LayoutHelper.checkIfBeyondColumnBreaks(rect, this.vertical);
-            if (columnOver) {
+            if (LayoutHelper.isUsingBrowserColumnBreaking(this)) {
+              // Fix multi-column boxes with `column-fill: auto` (Issue #1720, #1758)
+              LayoutHelper.fixAutoFillMultiColumnBoxes(this);
+
+              // Unset browser's multi-column (Issue #1637, #1747)
               LayoutHelper.unsetBrowserColumnBreaking(this);
             }
             if (this.pageFloatLayoutContext.isInvalidated()) {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1345,6 +1345,27 @@ export class ViewFactory
           result = this.createElement(ns, tag);
         }
 
+        if (
+          !isRoot &&
+          isMultiColumn &&
+          computedStyle["column-fill"] === Css.ident.auto
+        ) {
+          const blockSize = this.nodeContext.vertical
+            ? computedStyle["width"]
+            : computedStyle["height"];
+          if (
+            !blockSize ||
+            blockSize === Css.ident.auto ||
+            Css.isDefaultingValue(blockSize)
+          ) {
+            // To make `column-fill: auto` with auto block size work on non-root multi-column,
+            // we change it to `balance` here, and after layout, we change it back.
+            // (Issue #1720, #1758)
+            result.setAttribute("data-viv-saved-column-fill", "auto");
+            computedStyle["column-fill"] = Css.ident.balance;
+          }
+        }
+
         if (tag != originalTag) {
           result.setAttribute("data-vivliostyle-original-tag", originalTag);
           if (originalTag === "html" || originalTag === "body") {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -489,6 +489,10 @@ module.exports = [
         file: "multi-column/multicol-in-page-float.html",
         title: "Multi-column in page float (Issue #1751)",
       },
+      {
+        file: "multi-column/multicol-column-fill-auto.html",
+        title: "column-fill: auto in non-root multicol (Issue #1720, #1758)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/multi-column/multicol-column-fill-auto.html
+++ b/packages/core/test/files/multi-column/multicol-column-fill-auto.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Multi-column with column-fill: auto</title>
+    <style>
+      @page {
+        size: 800px 600px;
+        margin: 50px;
+        outline: 1px solid aqua;
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+      }
+      :root {
+        font-family: "Times New Roman", serif;
+      }
+      p {
+        margin: 0;
+      }
+      p + p {
+        text-indent: 1em;
+      }
+      section {
+        background-color: beige;
+        margin: 5mm;
+        border: 1mm solid maroon;
+        padding: 2mm;
+        break-after: page;
+      }
+
+      .multicol {
+        columns: 3;
+        column-fill: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Test column-fill: auto</h1>
+    <p>
+      The next section is a multi-column container with column-fill: auto. No
+      forced page break after this paragraph, so the next section should start
+      just after this one, on the same page.
+    </p>
+    <section class="multicol">
+      <h2>Multi-column section with column-fill:auto</h2>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras in neque
+        vel mi aliquam auctor eu sit amet orci. Ut scelerisque pulvinar lacinia.
+        Ut eget facilisis augue. Ut vitae arcu sed ipsum varius sagittis nec a
+        tortor. Cras condimentum quam enim, nec posuere nisi imperdiet et.
+        Suspendisse lectus sem, congue vel purus at, efficitur semper tellus.
+        Nulla scelerisque aliquam massa, vel ornare elit bibendum in.
+      </p>
+      <p>
+        Sed sed quam congue, condimentum neque eu, pellentesque ex. Praesent ac
+        purus mollis, egestas erat eu, porttitor augue. Aliquam lectus quam,
+        vehicula sit amet consectetur non, iaculis ut justo. Phasellus congue
+        porta lorem, quis faucibus enim iaculis sit amet. Fusce auctor feugiat
+        quam, id posuere elit fringilla eu. Integer justo elit, varius ut elit
+        vitae, mollis auctor neque. Curabitur feugiat ut eros eu fermentum.
+        Vivamus iaculis, massa sit amet facilisis bibendum, ipsum odio rhoncus
+        orci, at consectetur dolor purus et felis. Cras commodo nulla ex, vel
+        maximus nulla finibus vel. Nunc condimentum purus dui, ut dapibus augue
+        sagittis sit amet. Nullam ac tellus malesuada, ultrices odio vitae,
+        dignissim nunc. Mauris elementum diam imperdiet ex porta, ac ultrices
+        justo ultrices. Nam hendrerit blandit pretium. Suspendisse aliquet, enim
+        at tempor rhoncus, sem mauris sollicitudin nisl, vitae pharetra neque
+        ipsum ac felis. In hac habitasse platea dictumst. Morbi mollis orci
+        rutrum ligula viverra, a aliquam nibh porta.
+      </p>
+      <p>
+        Morbi justo magna, viverra a porta quis, facilisis sit amet dolor. Morbi
+        ullamcorper massa eget est dignissim, id lacinia nisl luctus. Quisque
+        pulvinar tempor mi, non iaculis erat. Nulla bibendum, elit at pharetra
+        porta, lectus lorem faucibus ex, a maximus neque ex in sapien. Nulla
+        commodo maximus ligula, tincidunt euismod nulla congue ac. Nam quam
+        felis, mollis id luctus quis, vulputate nec enim. Integer dolor risus,
+        facilisis ac metus sit amet, suscipit finibus lectus.
+      </p>
+      <p>
+        Morbi porta diam nec tincidunt porttitor. Quisque efficitur tortor
+        libero, tincidunt eleifend tortor sodales in. In hac habitasse platea
+        dictumst. Nullam sapien sapien, scelerisque ac volutpat sit amet,
+        vestibulum interdum est. Nunc massa turpis, fermentum ac est feugiat,
+        hendrerit varius nibh. Etiam malesuada cursus molestie. Praesent
+        blandit, erat sed faucibus tristique, est nunc viverra orci, eu molestie
+        orci ligula ac risus. Donec massa est, cursus quis ante vulputate,
+        suscipit pellentesque nisl. Praesent pharetra imperdiet elit a iaculis.
+        Sed eu tempor justo. Quisque suscipit venenatis volutpat.
+      </p>
+      <p>
+        Maecenas scelerisque non lectus hendrerit elementum. Mauris id aliquet
+        dui. Phasellus pharetra, massa faucibus porta lobortis, risus leo cursus
+        elit, congue placerat neque nunc eget elit. Donec vel tempus velit. In
+        hac habitasse platea dictumst. Aenean efficitur mollis finibus. In
+        vestibulum tempus dui. Integer fermentum, libero ut tincidunt
+        pellentesque, mi augue lacinia lorem, id lacinia massa sapien a quam.
+        Etiam molestie porta diam, quis pellentesque ipsum efficitur id.
+      </p>
+    </section>
+
+    <section class="multicol">
+      This is another multi-column section with column-fill:auto. This
+      multi-column section contains only one long text node. Lorem ipsum dolor
+      sit amet, consectetur adipiscing elit. Cras in neque vel mi aliquam auctor
+      eu sit amet orci. Ut scelerisque pulvinar lacinia. Ut eget facilisis
+      augue. Ut vitae arcu sed ipsum varius sagittis nec a tortor. Cras
+      condimentum quam enim, nec posuere nisi imperdiet et. Suspendisse lectus
+      sem, congue vel purus at, efficitur semper tellus. Nulla scelerisque
+      aliquam massa, vel ornare elit bibendum in. Sed sed quam congue,
+      condimentum neque eu, pellentesque ex. Praesent ac purus mollis, egestas
+      erat eu, porttitor augue. Aliquam lectus quam, vehicula sit amet
+      consectetur non, iaculis ut justo. Phasellus congue porta lorem, quis
+      faucibus enim iaculis sit amet. Fusce auctor feugiat quam, id posuere elit
+      fringilla eu. Integer justo elit, varius ut elit vitae, mollis auctor
+      neque. Curabitur feugiat ut eros eu fermentum. Vivamus iaculis, massa sit
+      amet facilisis bibendum, ipsum odio rhoncus orci, at consectetur dolor
+      purus et felis. Cras commodo nulla ex, vel maximus nulla finibus vel. Nunc
+      condimentum purus dui, ut dapibus augue sagittis sit amet. Nullam ac
+      tellus malesuada, ultrices odio vitae, dignissim nunc. Mauris elementum
+      diam imperdiet ex porta, ac ultrices justo ultrices. Nam hendrerit blandit
+      pretium. Suspendisse aliquet, enim at tempor rhoncus, sem mauris
+      sollicitudin nisl, vitae pharetra neque ipsum ac felis. In hac habitasse
+      platea dictumst. Morbi mollis orci rutrum ligula viverra, a aliquam nibh
+      porta. Morbi justo magna, viverra a porta quis, facilisis sit amet dolor.
+      Morbi ullamcorper massa eget est dignissim, id lacinia nisl luctus.
+      Quisque pulvinar tempor mi, non iaculis erat. Nulla bibendum, elit at
+      pharetra porta, lectus lorem faucibus ex, a maximus neque ex in sapien.
+      Nulla commodo maximus ligula, tincidunt euismod nulla congue ac. Nam quam
+      felis, mollis id luctus quis, vulputate nec enim. Integer dolor risus,
+      facilisis ac metus sit amet, suscipit finibus lectus. Morbi porta diam nec
+      tincidunt porttitor. Quisque efficitur tortor libero, tincidunt eleifend
+      tortor sodales in. In hac habitasse platea dictumst. Nullam sapien sapien,
+      scelerisque ac volutpat sit amet, vestibulum interdum est. Nunc massa
+      turpis, fermentum ac est feugiat, hendrerit varius nibh. Etiam malesuada
+      cursus molestie. Praesent blandit, erat sed faucibus tristique, est nunc
+      viverra orci, eu molestie orci ligula ac risus. Donec massa est, cursus
+      quis ante vulputate, suscipit pellentesque nisl. Praesent pharetra
+      imperdiet elit a iaculis. Sed eu tempor justo. Quisque suscipit venenatis
+      volutpat. Maecenas scelerisque non lectus hendrerit elementum. Mauris id
+      aliquet dui. Phasellus pharetra, massa faucibus porta lobortis, risus leo
+      cursus elit, congue placerat neque nunc eget elit. Donec vel tempus velit.
+      In hac habitasse platea dictumst. Aenean efficitur mollis finibus. In
+      vestibulum tempus dui. Integer fermentum, libero ut tincidunt
+      pellentesque, mi augue lacinia lorem, id lacinia massa sapien a quam.
+      Etiam molestie porta diam, quis pellentesque ipsum efficitur id.
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Non-root multi-column elements with column-fill:auto could fail to fragment correctly, causing overflow or disappearing text in some cases.

This change reworks the previous workaround and stabilizes the layout flow:

- Remove the max-block-size workaround added for #1720 in the column layout path.
- For non-root multicol with column-fill:auto and auto block-size, temporarily switch to balance during view generation and mark the element for later restoration.
- Add a restoration step that switches marked elements back to column-fill:auto and adjusts block-size to avoid root-column overflow.
- Apply the restoration both during node finalization and at root-column layout finalization.
- Unset browser column breaking again at the end of root-column layout to avoid the regression where content could disappear after root-column size fitting.
- Add/update multi-column test coverage for the column-fill:auto regression scenarios.

<br>

- Fixes #1720
- Fixes #1758
- Fixes #1747

Assisted-by: GitHub Copilot Chat

<details>
<summary>How the AI was used</summary>

- The human author investigated and implemented this fix for issue #1758 themselves before this session, and asked the AI only to review the code and code comments for correctness and suggest improvements.
- The human author pushed back on several of the AI's suggested changes — questioning whether a `getBoundingClientRect()` fallback was actually necessary (citing their own research), whether a style re-fetch was needed, and whether a specific defensive condition could ever be true — and the AI's role was mostly to validate or refine the human author's own reasoning and improve code comments accordingly.
- The human author wrote a combined regression test case covering both issues #1720 and #1758 and asked the AI to add it to `file-list.js` after checking it.
- The human author tested manually, confirmed no problems, created PR #1759, and directed how to respond to three reviewer comments (dismissing two, accepting the third with a request to keep the implementation simple).

</details>
