### PR TITLE
fix: Adjust column-rule geometry for balanced columns with page floats and footnotes

### DIFF
--- a/packages/core/src/vivliostyle/columns.ts
+++ b/packages/core/src/vivliostyle/columns.ts
@@ -203,7 +203,9 @@ export function reduceContainerSize(
   }
   if (container.vertical) {
     const outerWidth = parseFloat(container.element.style?.width);
-    container.originX = outerWidth - container.width;
+    if (isFinite(outerWidth)) {
+      container.originX = outerWidth - container.width;
+    }
   }
 }
 

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1615,6 +1615,39 @@ export class PageFloatLayoutContext
     );
   }
 
+  getBlockEndEdgeOfBlockStartFloats(): number {
+    let context: PageFloatLayoutContext = this;
+    let container: Vtree.Container | null = null;
+    while (context && !container) {
+      container = context.container;
+      context = context.parent;
+    }
+    const isVertical = !!container?.vertical;
+    let edge = NaN;
+    this.floatFragments
+      .filter((fragment) => fragment.floatSide.includes("block-start"))
+      .forEach((fragment) => {
+        const rect = fragment.getOuterRect();
+        const fragmentEdge = isVertical ? rect.x1 : rect.y2;
+        edge = isFinite(edge)
+          ? isVertical
+            ? Math.min(edge, fragmentEdge)
+            : Math.max(edge, fragmentEdge)
+          : fragmentEdge;
+      });
+    if (this.parent) {
+      const parentEdge = this.parent.getBlockEndEdgeOfBlockStartFloats();
+      if (isFinite(parentEdge)) {
+        edge = isFinite(edge)
+          ? isVertical
+            ? Math.min(edge, parentEdge)
+            : Math.max(edge, parentEdge)
+          : parentEdge;
+      }
+    }
+    return edge;
+  }
+
   getBlockStartEdgeOfBlockEndFloats(): number {
     const isVertical = this.getContainer().vertical;
     return this.floatFragments

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1506,6 +1506,31 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
         const containerSize = this.vertical
           ? container.height
           : container.width;
+        const renderedPhysicalStartOffset = parseFloat(
+          this.vertical
+            ? (column?.element.style.left ?? "")
+            : (column?.element.style.top ?? ""),
+        );
+        const basePaddingRect = column?.getPaddingRect
+          ? column.getPaddingRect()
+          : container.getPaddingRect();
+        const columnLike = column as Vtree.Container & {
+          pageFloatLayoutContext?: {
+            parent?: {
+              getBlockEndEdgeOfBlockStartFloats?: () => number;
+            };
+          };
+        };
+        const blockStartFloatEndEdge =
+          columnLike.pageFloatLayoutContext?.parent?.getBlockEndEdgeOfBlockStartFloats?.();
+        const blockStartReduction = isFinite(blockStartFloatEndEdge)
+          ? Math.max(
+              0,
+              this.vertical
+                ? basePaddingRect.x2 - blockStartFloatEndEdge
+                : blockStartFloatEndEdge - basePaddingRect.y1,
+            )
+          : 0;
         const border = this.vertical ? "border-top" : "border-left";
         for (let i = 1; i < columnCount; i++) {
           const pos = this.vertical
@@ -1517,18 +1542,41 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
               columnGap / 2 +
               container.paddingLeft -
               ruleWidth / 2;
-          const size = this.vertical
-            ? container.width + container.paddingLeft + container.paddingRight
-            : container.height + container.paddingTop + container.paddingBottom;
+          const renderedBlockSize = parseFloat(
+            this.vertical
+              ? (column?.element.style.width ?? "")
+              : (column?.element.style.height ?? ""),
+          );
+          const size =
+            renderedBlockSize > 0
+              ? renderedBlockSize
+              : this.vertical
+                ? column.width
+                : column.height;
+          const renderedStart = Math.max(
+            renderedPhysicalStartOffset > 0 ? renderedPhysicalStartOffset : 0,
+            0,
+          );
+          const renderedEnd = renderedStart + size;
+          const adjustedStart = this.vertical
+            ? renderedStart
+            : Math.max(renderedStart, blockStartReduction);
+          const adjustedSize = this.vertical
+            ? Math.max(0, size - blockStartReduction)
+            : Math.max(0, renderedEnd - adjustedStart);
           const rule = container.element.ownerDocument.createElement("div");
           Base.setCSSProperty(rule, "position", "absolute");
-          Base.setCSSProperty(rule, this.vertical ? "left" : "top", "0px");
+          Base.setCSSProperty(
+            rule,
+            this.vertical ? "left" : "top",
+            `${adjustedStart}px`,
+          );
           Base.setCSSProperty(rule, this.vertical ? "top" : "left", `${pos}px`);
           Base.setCSSProperty(rule, this.vertical ? "height" : "width", "0px");
           Base.setCSSProperty(
             rule,
             this.vertical ? "width" : "height",
-            `${size}px`,
+            `${adjustedSize}px`,
           );
           Base.setCSSProperty(
             rule,

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -766,6 +766,7 @@ export namespace PageFloats {
     ): string | null;
     getFloatFragmentExclusions(): GeometryUtil.Shape[];
     getMaxReachedAfterEdge(): number;
+    getBlockEndEdgeOfBlockStartFloats(): number;
     getBlockStartEdgeOfBlockEndFloats(): number;
     getPageFloatClearEdge(clear: string, column: Layout.Column): number;
     getPageFloatPlacementCondition(

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -493,6 +493,15 @@ module.exports = [
         file: "multi-column/multicol-column-fill-auto.html",
         title: "column-fill: auto in non-root multicol (Issue #1720, #1758)",
       },
+      {
+        file: "multi-column/column-rule-page-floats-footnotes.html",
+        title: "Column rule with page floats and footnotes (Issue #1493)",
+      },
+      {
+        file: "multi-column/column-rule-page-floats-footnotes-vertical.html",
+        title:
+          "Column rule with page floats and footnotes (vertical writing-mode) (Issue #1493)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/multi-column/column-rule-page-floats-footnotes-vertical.html
+++ b/packages/core/test/files/multi-column/column-rule-page-floats-footnotes-vertical.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Column rule with page floats and footnotes (vertical writing-mode)</title>
+<style>
+@page {
+  size: A5 landscape;
+  margin: 20mm;
+}
+:root {
+  writing-mode: vertical-rl;
+  font: 1rem/1.25 "Times New Roman", serif;
+  column-count: 3;
+  column-gap: 20px;
+  column-rule: 2px solid maroon;
+}
+p {
+  text-indent: 1em;
+  widows: 1;
+  orphans: 1;
+  margin-block: 0;
+}
+.footnote {
+  float: footnote;
+  font: 0.85rem/1.25 "Times New Roman", serif;
+  text-indent: 0;
+}
+.float-page-top {
+  float-reference: page;
+  float: block-start;
+  text-align: center;
+  padding: 5px;
+  border: solid 3px olive;
+  margin-block-end: 3px;
+}
+.float-page-bottom {
+  float-reference: page;
+  float: block-end;
+  text-align: center;
+  padding: 5px;
+  border: solid 3px olive;
+  margin-block-start: 3px;
+}
+.float-column-top {
+  float-reference: column;
+  float: block-start;
+  text-align: center;
+  padding: 5px;
+  border: solid 3px orange;
+  margin-block-end: 3px;
+}
+</style>
+</head>
+
+<body>
+<p>The quick, brown fox jumps over a lazy dog<span class="footnote">Fox nymphs grab quick-jived waltz. Brick quiz whangs jumpy veldt fox. Bright vixens jump; dozy fowl quack.</span>. DJs flock by when MTV ax quiz prog. Junk MTV quiz graced by fox whelps. Bawds jog, flick quartz, vex nymphs. Waltz, bad nymph, for quick jigs vex!</p>
+
+<div class="float-page-top">Float on page top</div>
+
+<p>Flummoxed by job, kvetching W. zaps Iraq. Cozy sphinx waves quart jug of bad milk.<span class="footnote">A very bad quack might jinx zippy fowls. Few quips galvanized the mock jury box. Quick brown dogs jump over the lazy fox.</span> DJs flock by when MTV ax quiz prog. Junk MTV quiz graced by fox whelps. Bawds jog, flick quartz, vex nymphs. Waltz, bad nymph, for quick jigs vex! Fox nymphs grab quick-jived waltz. Brick quiz whangs jumpy veldt fox. Bright vixens jump; dozy fowl quack. Quick wafting zephyrs vex bold Jim.</p>
+
+<div class="float-page-bottom">Float on page bottom</div>
+
+<p>How quickly daft jumping zebras vex. Two driven jocks help fax my big quiz. Quick, Baz, get my woven flax jodhpurs! "Now fax quiz Jack! " my brave ghost pled. Five quacking zephyrs jolt my wax bed.</p>
+
+<div class="float-column-top">Float on column top</div>
+
+<p>The jay, pig, fox, zebra, and my wolves quack! Blowzy red vixens fight for a quick jump. A wizard's job is to vex chumps quickly in fog. Watch "Jeopardy!"<span class="footnote">Joaquin Phoenix was gazed by MTV for luck.</span>, Alex Trebek's fun TV quiz game. Woven silk pyjamas exchanged for olive quartz. Brawny gods just flocked up to quiz and vex him. Adjusting quiver and bow, Zompyc killed the fox. My faxed joke won a pager in the cable TV quiz show.<span class="footnote">My girl wove six dozen plaid jackets before she quit. Six big devils from Japan quickly forgot how to waltz. Big July earthquakes confound zany experimental vow.</span></p>
+
+<div class="float-column-top">Another float on column top</div>
+
+<p>Amazingly few discotheques provide jukeboxes. Six big devils from Japan quickly forgot how to waltz. Big July earthquakes confound zany experimental vow.</p>
+
+<div class="float-page-top">Another float on page top</div>
+
+<p>Foxy parsons quiz and cajole the lovably dim wiki-girl. Have a pick<span class="footnote">Sixty zippers were quickly picked from the woven jute bag.</span>: twenty six letters - no forcing a jumbled quiz! Crazy<span class="footnote">All questions asked by five watch experts amazed the judge. Jack quietly moved up front and seized the big ball of wax. The quick, brown fox jumps over a lazy dog.</span> Fredericka bought many very exquisite opal jewels.</p>
+
+<p>A quick movement of the enemy will jeopardize six gunboats. My girl wove six dozen plaid jackets before she quit. Six big devils from Japan quickly forgot how to waltz. Big July earthquakes confound zany experimental vow.</p>
+</body>
+</html>

--- a/packages/core/test/files/multi-column/column-rule-page-floats-footnotes.html
+++ b/packages/core/test/files/multi-column/column-rule-page-floats-footnotes.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Column rule with page floats and footnotes</title>
+<style>
+@page {
+  size: A5;
+  margin: 20mm;
+}
+:root {
+  font: 1rem/1.25 "Times New Roman", serif;
+  column-count: 3;
+  column-gap: 20px;
+  column-rule: 2px solid maroon;
+}
+p {
+  text-indent: 1em;
+  widows: 1;
+  orphans: 1;
+  margin-block: 0;
+}
+.footnote {
+  float: footnote;
+  font: 0.85rem/1.25 "Times New Roman", serif;
+  text-indent: 0;
+}
+.float-page-top {
+  float-reference: page;
+  float: block-start;
+  text-align: center;
+  padding: 5px;
+  border: solid 3px olive;
+  margin-block-end: 3px;
+}
+.float-page-bottom {
+  float-reference: page;
+  float: block-end;
+  text-align: center;
+  padding: 5px;
+  border: solid 3px olive;
+  margin-block-start: 3px;
+}
+.float-column-top {
+  float-reference: column;
+  float: block-start;
+  text-align: center;
+  padding: 5px;
+  border: solid 3px orange;
+  margin-block-end: 3px;
+}
+</style>
+</head>
+
+<body>
+<p>The quick, brown fox jumps over a lazy dog<span class="footnote">Fox nymphs grab quick-jived waltz. Brick quiz whangs jumpy veldt fox. Bright vixens jump; dozy fowl quack.</span>. DJs flock by when MTV ax quiz prog. Junk MTV quiz graced by fox whelps. Bawds jog, flick quartz, vex nymphs. Waltz, bad nymph, for quick jigs vex!</p>
+
+<div class="float-page-top">Float on page top</div>
+
+<p>Flummoxed by job, kvetching W. zaps Iraq. Cozy sphinx waves quart jug of bad milk.<span class="footnote">A very bad quack might jinx zippy fowls. Few quips galvanized the mock jury box. Quick brown dogs jump over the lazy fox.</span> DJs flock by when MTV ax quiz prog. Junk MTV quiz graced by fox whelps. Bawds jog, flick quartz, vex nymphs. Waltz, bad nymph, for quick jigs vex! Fox nymphs grab quick-jived waltz. Brick quiz whangs jumpy veldt fox. Bright vixens jump; dozy fowl quack. Quick wafting zephyrs vex bold Jim.</p>
+
+<div class="float-page-bottom">Float on page bottom</div>
+
+<p>How quickly daft jumping zebras vex. Two driven jocks help fax my big quiz. Quick, Baz, get my woven flax jodhpurs! "Now fax quiz Jack! " my brave ghost pled. Five quacking zephyrs jolt my wax bed.</p>
+
+<div class="float-column-top">Float on column top</div>
+
+<p>The jay, pig, fox, zebra, and my wolves quack! Blowzy red vixens fight for a quick jump. A wizard's job is to vex chumps quickly in fog. Watch "Jeopardy!"<span class="footnote">Joaquin Phoenix was gazed by MTV for luck.</span>, Alex Trebek's fun TV quiz game. Woven silk pyjamas exchanged for olive quartz. Brawny gods just flocked up to quiz and vex him. Adjusting quiver and bow, Zompyc killed the fox. My faxed joke won a pager in the cable TV quiz show.<span class="footnote">My girl wove six dozen plaid jackets before she quit. Six big devils from Japan quickly forgot how to waltz. Big July earthquakes confound zany experimental vow.</span></p>
+
+<div class="float-column-top">Another float on column top</div>
+
+<p>Amazingly few discotheques provide jukeboxes. Six big devils from Japan quickly forgot how to waltz. Big July earthquakes confound zany experimental vow.</p>
+
+<div class="float-page-top">Another float on page top</div>
+
+<p>Foxy parsons quiz and cajole the lovably dim wiki-girl. Have a pick<span class="footnote">Sixty zippers were quickly picked from the woven jute bag.</span>: twenty six letters - no forcing a jumbled quiz! Crazy<span class="footnote">All questions asked by five watch experts amazed the judge. Jack quietly moved up front and seized the big ball of wax. The quick, brown fox jumps over a lazy dog.</span> Fredericka bought many very exquisite opal jewels.</p>
+
+<p>A quick movement of the enemy will jeopardize six gunboats. My girl wove six dozen plaid jackets before she quit. Six big devils from Japan quickly forgot how to waltz. Big July earthquakes confound zany experimental vow.</p>
+</body>
+</html>


### PR DESCRIPTION
- make column-rule length follow the rendered balanced column size
- avoid overlap with block-start and footnote/page-float areas
- refine vertical writing-mode placement and sizing logic
- limit shortening behavior to relevant float context cases
- add horizontal and vertical multi-column regression test samples
- register both new samples in the test file list
- closes #1493

Assisted-by: GitHub Copilot Chat

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1493 (column-rule length not accounting for page floats/footnotes shortening the column), directing verification via the dev server and Chrome DevTools MCP.
- The AI investigated column balancing and column-rule rendering in `columns.ts`/`page-master.ts` and implemented the fix, adding horizontal and vertical writing-mode regression samples.

</details>
