### PR TITLE
fix: Exclude writing-mode and direction from layout box propagation

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2697,11 +2697,16 @@ export class ViewFactory
         // Also propagate to the layout box so that page float areas laid out
         // there (e.g. during stash re-layout before the root element is
         // processed on the new page) inherit the correct values. (Issue #1752)
-        Base.setCSSProperty(
-          this.viewport.layoutBox,
-          propName,
-          value.toString(),
-        );
+        // Exclude writing-mode and direction: these affect page box positioning
+        // inside the layout box (e.g. vertical-rl right-aligns children) and
+        // are already set on the page box when needed.
+        if (propName !== "writing-mode" && propName !== "direction") {
+          Base.setCSSProperty(
+            this.viewport.layoutBox,
+            propName,
+            value.toString(),
+          );
+        }
       } else {
         Base.setCSSProperty(target, propName, value.toString());
       }


### PR DESCRIPTION
Setting writing-mode (e.g. vertical-rl) on the layout box caused page boxes inside it to be right-aligned, breaking layout calculations that assume the page box left edge aligns with the layout box left edge. This resulted in corrupted layouts such as footnotes overlapping body text in vertical writing mode.

Exclude writing-mode and direction from the inherited properties propagated to the layout box. These properties are already set on the page box when needed, so propagation to the layout box is unnecessary.

Follow-up fix for PR #1753 (Issue #1752)

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- After PR #1753 merged, the human author discovered its root-inherited-properties fix broke vertical-writing-mode layout as a side effect, and asked the AI to fix it as a follow-up within the same session.
- The human author ran `/draft-commit` once satisfied with the fix.

</details>
