### PR TITLE
fix: Fix wrong text-spacing behavior in list-item

### DIFF
--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -470,7 +470,7 @@ class TextSpacingPolyfill {
         prevNode = p.viewNode?.previousSibling;
         if (prevNode) {
           if (
-            prevNode.nodeType === 3 &&
+            prevNode.nodeType === Node.TEXT_NODE &&
             /^[ \t\r\n\f]*$/.test(prevNode.textContent) &&
             p.whitespace !== Vtree.Whitespace.PRESERVE
           ) {
@@ -484,7 +484,7 @@ class TextSpacingPolyfill {
       }
 
       while (prevNode) {
-        if (prevNode.nodeType === 1) {
+        if (prevNode.nodeType === Node.ELEMENT_NODE) {
           if ((prevNode as Element).localName === "br") {
             return true;
           }
@@ -492,7 +492,7 @@ class TextSpacingPolyfill {
           if (display && display !== "inline") {
             return !/^(inline|ruby)\b/.test(display);
           }
-        } else if (prevNode.nodeType === 3) {
+        } else if (prevNode.nodeType === Node.TEXT_NODE) {
           if (p.whitespace === Vtree.Whitespace.PRESERVE) {
             if (/\n$/.test(prevNode.textContent)) {
               return true;
@@ -559,27 +559,32 @@ class TextSpacingPolyfill {
         let isLastBeforeForcedLineBreak = false;
         let isLastInBlock = false;
 
+        // Check list marker with `list-style-position: outside` which should
+        // be treated like a forced line break. (Issue #1763)
+        function isOutsideListMarker(element: Element): boolean {
+          return element.classList.contains("_viv-marker-outside");
+        }
+
         function checkIfFirstAfterForcedLineBreak(
           prevP: Vtree.NodeContext,
         ): boolean {
-          if (prevP.viewNode?.nodeType === 1) {
-            return (prevP.viewNode as Element).localName === "br";
+          if (prevP.viewNode?.nodeType === Node.ELEMENT_NODE) {
+            const prevElem = prevP.viewNode as Element;
+            return prevElem.localName === "br" || isOutsideListMarker(prevElem);
           }
-          if (prevP.viewNode?.nodeType === 3) {
+          if (prevP.viewNode?.nodeType === Node.TEXT_NODE) {
+            const prevTextNode = prevP.viewNode as Text;
             if (prevP.whitespace === Vtree.Whitespace.PRESERVE) {
-              if (/\n$/.test(prevP.viewNode.textContent)) {
+              if (/\n$/.test(prevTextNode.textContent)) {
                 return true;
               }
             } else if (prevP.whitespace === Vtree.Whitespace.NEWLINE) {
-              if (/\n[ \t\r\n\f]*$/.test(prevP.viewNode.textContent)) {
+              if (/\n[ \t\r\n\f]*$/.test(prevTextNode.textContent)) {
                 return true;
               }
             }
-            if (
-              (prevP.viewNode as Element).previousElementSibling?.localName ===
-              "br"
-            ) {
-              return Vtree.canIgnore(prevP.viewNode, prevP.whitespace);
+            if (prevTextNode.previousElementSibling?.localName === "br") {
+              return Vtree.canIgnore(prevTextNode, prevP.whitespace);
             }
           }
           return false;
@@ -588,23 +593,23 @@ class TextSpacingPolyfill {
         function checkIfLastBeforeForcedLineBreak(
           nextP: Vtree.NodeContext,
         ): boolean {
-          if (nextP.viewNode?.nodeType === 1) {
-            return (nextP.viewNode as Element).localName === "br";
+          if (nextP.viewNode?.nodeType === Node.ELEMENT_NODE) {
+            const nextElem = nextP.viewNode as Element;
+            return nextElem.localName === "br" || isOutsideListMarker(nextElem);
           }
-          if (nextP.viewNode?.nodeType === 3) {
+          if (nextP.viewNode?.nodeType === Node.TEXT_NODE) {
+            const nextTextNode = nextP.viewNode as Text;
             if (nextP.whitespace === Vtree.Whitespace.PRESERVE) {
-              if (/^\n/.test(nextP.viewNode.textContent)) {
+              if (/^\n/.test(nextTextNode.textContent)) {
                 return true;
               }
             } else if (nextP.whitespace === Vtree.Whitespace.NEWLINE) {
-              if (/^[ \t\r\n\f]*\n/.test(nextP.viewNode.textContent)) {
+              if (/^[ \t\r\n\f]*\n/.test(nextTextNode.textContent)) {
                 return true;
               }
             }
-            if (
-              (nextP.viewNode as Element).nextElementSibling?.localName === "br"
-            ) {
-              return Vtree.canIgnore(nextP.viewNode, nextP.whitespace);
+            if (nextTextNode.nextElementSibling?.localName === "br") {
+              return Vtree.canIgnore(nextTextNode, nextP.whitespace);
             }
           }
           return false;
@@ -644,7 +649,7 @@ class TextSpacingPolyfill {
           }
           if (
             (prevP.display && !/^(inline|ruby)\b/.test(prevP.display)) ||
-            (prevP.viewNode?.nodeType === 1 &&
+            (prevP.viewNode?.nodeType === Node.ELEMENT_NODE &&
               ((prevP.viewNode as Element).localName === "br" ||
                 Base.mediaTags[(prevP.viewNode as Element).localName]))
           ) {
@@ -675,7 +680,7 @@ class TextSpacingPolyfill {
           }
           if (
             (nextP.display && !/^(inline|ruby)\b/.test(nextP.display)) ||
-            (nextP.viewNode?.nodeType === 1 &&
+            (nextP.viewNode?.nodeType === Node.ELEMENT_NODE &&
               ((nextP.viewNode as Element).localName === "br" ||
                 Base.mediaTags[(nextP.viewNode as Element).localName]))
           ) {
@@ -1068,7 +1073,7 @@ class TextSpacingPolyfill {
       node1: Node,
       node2: Node,
     ): boolean {
-      if (node1.nodeType === 1) {
+      if (node1.nodeType === Node.ELEMENT_NODE) {
         const style = document.defaultView.getComputedStyle(node1 as Element);
         if (
           parseFloat(style.marginInlineEnd) ||
@@ -1082,7 +1087,7 @@ class TextSpacingPolyfill {
       if (parent1 && !parent1.contains(node2)) {
         return checkNonZeroMarginBorderPadding(parent1, node2);
       }
-      if (node2.nodeType === 1) {
+      if (node2.nodeType === Node.ELEMENT_NODE) {
         const style = document.defaultView.getComputedStyle(node2 as Element);
         if (
           parseFloat(style.marginInlineStart) ||

--- a/packages/core/test/files/counter-style/list-item-text-spacing.html
+++ b/packages/core/test/files/counter-style/list-item-text-spacing.html
@@ -22,6 +22,14 @@
   </head>
 
   <body>
+    <h1>List items with text-spacing trim-start</h1>
+    <p>
+      This page tests that opening parentheses at the start of list items do not have extra leading spacing
+      when <code>text-spacing-trim: trim-start</code> is applied and markers are outside. For each list below,
+      items beginning with <code>（</code> (or with an opening quote followed by <code>（</code>) should appear
+      directly after the marker, with no additional space between the marker and the opening parenthesis.
+    </p>
+
     <ul>
       <li>ああああ</li>
       <li>「あああああああああああああああ。」「（あああああああああああ。）」</li>

--- a/packages/core/test/files/counter-style/list-item-text-spacing.html
+++ b/packages/core/test/files/counter-style/list-item-text-spacing.html
@@ -8,6 +8,10 @@
         text-spacing-trim: trim-start;
         text-autospace: normal;
       }
+      ul,
+      ol {
+        list-style-position: outside;
+      }
       .cjk-decimal {
         list-style: cjk-decimal;
       }

--- a/packages/core/test/files/counter-style/list-item-text-spacing.html
+++ b/packages/core/test/files/counter-style/list-item-text-spacing.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <title>List-item with text-spacing</title>
+    <style>
+      :root {
+        text-spacing-trim: trim-start;
+        text-autospace: normal;
+      }
+      .cjk-decimal {
+        list-style: cjk-decimal;
+      }
+      .custom-marker {
+        list-style: "マーカー";
+      }
+    </style>
+  </head>
+
+  <body>
+    <ul>
+      <li>ああああ</li>
+      <li>「あああああああああああああああ。」「（あああああああああああ。）」</li>
+      <li>（ああ）ああ</li>
+      <li>Lorem ipsum dolor sit amet consectetur adipisicing elit. Velit tempora enim ratione consectetur totam.</li>
+    </ul>
+
+    <ol>
+      <li>ああああ</li>
+      <li>「あああああああああああああああ。」「（あああああああああああ。）」</li>
+      <li>（ああ）ああ</li>
+      <li>Lorem ipsum dolor sit amet consectetur adipisicing elit. Velit tempora enim ratione consectetur totam.</li>
+    </ol>
+
+    <ol class="cjk-decimal">
+      <li>ああああ</li>
+      <li>「あああああああああああああああ。」「（あああああああああああ。）」</li>
+      <li>（ああ）ああ</li>
+      <li>Lorem ipsum dolor sit amet consectetur adipisicing elit. Velit tempora enim ratione consectetur totam.</li>
+    </ol>
+
+    <ul class="custom-marker">
+      <li>ああああ</li>
+      <li>「あああああああああああああああ。」「（あああああああああああ。）」</li>
+      <li>（ああ）ああ</li>
+      <li>Lorem ipsum dolor sit amet consectetur adipisicing elit. Velit tempora enim ratione consectetur totam.</li>
+    </ul>
+  </body>
+
+</html>

--- a/packages/core/test/files/counter-style/list-item-text-spacing.html
+++ b/packages/core/test/files/counter-style/list-item-text-spacing.html
@@ -18,6 +18,9 @@
       .custom-marker {
         list-style: "マーカー";
       }
+      code {
+        background-color: #eee;
+      }
     </style>
   </head>
 
@@ -25,8 +28,8 @@
     <h1>List items with text-spacing trim-start</h1>
     <p>
       This page tests that opening parentheses at the start of list items do not have extra leading spacing
-      when <code>text-spacing-trim: trim-start</code> is applied and markers are outside. For each list below,
-      items beginning with <code>（</code> (or with an opening quote followed by <code>（</code>) should appear
+      when <code>text-spacing-trim: trim-start</code> is applied and markers are outside.
+      For each list below, items beginning with <code>「</code> or <code>（</code> should appear
       directly after the marker, with no additional space between the marker and the opening parenthesis.
     </p>
 

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -943,6 +943,10 @@ module.exports = [
         file: "counter-style/list-style-type-bullet-vertical.html",
         title: "list-style-type bullet marker (vertical writing-mode)",
       },
+      {
+        file: "counter-style/list-item-text-spacing.html",
+        title: "List-item with text-spacing (Issue #1763)",
+      },
     ],
   },
 ];


### PR DESCRIPTION
- Fix wrong text-spacing behavior in list-item with outside marker, where the boundary between the marker and the list-item text should be treated like a forced line break, so that `text-spacing-trim: trim-start` can be applied to the list-item text.
- Add a test case for this issue.
- Close #1763.