### PR TITLE
fix: Prevent duplicate EPUB/DPUB footnote body generation for repeated noteref targets

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -314,6 +314,9 @@ export class StyleInstance
   pageSheetSize: { [key: string]: { width: number; height: number } } = {};
   pageSheetHeight: number = 0;
   pageSheetWidth: number = 0;
+  private semanticFootnoteFirstRefOffsets: Map<string, number | null> =
+    new Map();
+  private semanticFootnoteFirstRefOffsetsInitialized = { value: false };
   pageGroupPageCounts: {
     [pageType: string]: Map<Element, number>;
   } = Object.create(null);
@@ -1973,6 +1976,8 @@ export class StyleInstance
       this.documentURLTransformer,
       this.style.pageProps,
       this.currentCascadedPageStyle,
+      this.semanticFootnoteFirstRefOffsets,
+      this.semanticFootnoteFirstRefOffsetsInitialized,
     );
     let columnIndex = 0;
     let column: LayoutType.Column = null;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -135,6 +135,13 @@ export class ViewFactory
     public readonly documentURLTransformer: Base.DocumentURLTransformer,
     public readonly pageProps?: { [key: string]: CssCascade.ElementStyle },
     public readonly cascadedPageStyle?: CssCascade.ElementStyle,
+    private readonly semanticFootnoteFirstRefOffsets: Map<
+      string,
+      number | null
+    > = new Map(),
+    private readonly semanticFootnoteFirstRefOffsetsInitialized: {
+      value: boolean;
+    } = { value: false },
   ) {
     super();
     this.document = viewport.document;
@@ -159,7 +166,76 @@ export class ViewFactory
       this.documentURLTransformer,
       this.pageProps,
       this.cascadedPageStyle,
+      this.semanticFootnoteFirstRefOffsets,
+      this.semanticFootnoteFirstRefOffsetsInitialized,
     );
+  }
+
+  private isSemanticFootnoteNoteref(element: Element): boolean {
+    const role = element.getAttribute("role");
+    if (role && role.match(/(^|\s)doc-noteref($|\s)/)) {
+      return true;
+    }
+    const epubType =
+      element.getAttributeNS(Base.NS.epub, "type") ||
+      element.getAttribute("epub:type");
+    return !!(epubType && epubType.match(/(^|\s)noteref($|\s)/));
+  }
+
+  private initializeSemanticFootnoteFirstRefOffsets(ownerDocument: Document) {
+    if (this.semanticFootnoteFirstRefOffsetsInitialized.value) {
+      return;
+    }
+    const anchorElements = ownerDocument.getElementsByTagName("a");
+    for (let i = 0; i < anchorElements.length; i++) {
+      const anchor = anchorElements.item(i);
+      if (!this.isSemanticFootnoteNoteref(anchor)) {
+        continue;
+      }
+      const anchorHref =
+        anchor.getAttribute("href") ||
+        anchor.getAttributeNS(Base.NS.XLINK, "href");
+      if (!anchorHref) {
+        continue;
+      }
+      const resolvedHref = Base.resolveURL(anchorHref, this.xmldoc.url);
+      if (resolvedHref === "#") {
+        continue;
+      }
+      if (this.semanticFootnoteFirstRefOffsets.has(resolvedHref)) {
+        continue;
+      }
+      this.semanticFootnoteFirstRefOffsets.set(
+        resolvedHref,
+        this.xmldoc.getElementOffset(anchor),
+      );
+    }
+    this.semanticFootnoteFirstRefOffsetsInitialized.value = true;
+  }
+
+  /**
+   * True only for the first semantic footnote reference to the same target.
+   */
+  private shouldGenerateSemanticFootnote(element: Element): boolean {
+    if (element.localName !== "a" || !this.isSemanticFootnoteNoteref(element)) {
+      return true;
+    }
+    const href =
+      element.getAttribute("href") ||
+      element.getAttributeNS(Base.NS.XLINK, "href");
+    if (!href) {
+      return true;
+    }
+    const resolvedHref = Base.resolveURL(href, this.xmldoc.url);
+    if (resolvedHref === "#") {
+      return true;
+    }
+    this.initializeSemanticFootnoteFirstRefOffsets(element.ownerDocument);
+    const firstOffset = this.semanticFootnoteFirstRefOffsets.get(resolvedHref);
+    if (firstOffset == null) {
+      return true;
+    }
+    return this.xmldoc.getElementOffset(element) === firstOffset;
   }
 
   createPseudoelementShadow(
@@ -360,17 +436,24 @@ export class ViewFactory
       templateURLVal instanceof Css.URL ||
       templateURLVal === Css.ident.footnote
     ) {
-      const url =
-        templateURLVal instanceof Css.URL
-          ? templateURLVal.url
-          : Base.resolveURL("user-agent.xml#footnote", Base.resourceBaseURL);
-      cont = this.createRefShadow(
-        url,
-        Vtree.ShadowType.ROOTLESS,
-        element,
-        shadowContext,
-        shadow,
-      );
+      if (
+        templateURLVal !== Css.ident.footnote ||
+        this.shouldGenerateSemanticFootnote(element)
+      ) {
+        const url =
+          templateURLVal instanceof Css.URL
+            ? templateURLVal.url
+            : Base.resolveURL("user-agent.xml#footnote", Base.resourceBaseURL);
+        cont = this.createRefShadow(
+          url,
+          Vtree.ShadowType.ROOTLESS,
+          element,
+          shadowContext,
+          shadow,
+        );
+      } else {
+        cont = Task.newResult(shadow);
+      }
     } else {
       cont = Task.newResult(shadow);
     }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -801,8 +801,18 @@ module.exports = [
         title: "DPUB footnotes with target-counter() (Issue #1700)",
       },
       {
+        file: "footnotes/dpub-footnote-duplicate-reference.html",
+        title:
+          "DPUB noteref duplicate reference should not duplicate footnote body (Issue #1767)",
+      },
+      {
         file: "footnotes/epub-footnotes-static-number.html",
         title: "EPUB footnotes (static numbering)",
+      },
+      {
+        file: "footnotes/epub-footnote-duplicate-reference.xhtml",
+        title:
+          "EPUB noteref duplicate reference should not duplicate footnote body (Issue #1767)",
       },
       {
         file: "footnotes/default-footnote-pseudo-styles.html",

--- a/packages/core/test/files/footnotes/dpub-footnote-duplicate-reference.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-duplicate-reference.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB footnote duplicate reference</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    @page {
+      size: 500px 300px;
+      @bottom-center {
+        content: "Page " counter(page);
+      }
+    }
+    body {
+      font-family: serif;
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <p>
+    Expected result: the footnote bodies "1 Aaaaaa" and "2 Bbbbbb" should appear once.
+    If "1 Aaaaaa" appears twice, this test fails.
+  </p>
+
+  <p>
+    Aaa<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a>
+    bbb<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.
+  </p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>
+    Ccc aaa<a id="fnref1-1" href="#fn1" role="doc-noteref"><sup>1</sup></a>.
+    This second reference must not create another footnote body.
+  </p>
+
+  <aside id="fn1" role="doc-footnote">
+    <a href="#fnref1" role="doc-backlink"><sup>1</sup></a>Aaaaaa
+  </aside>
+  <aside id="fn2" role="doc-footnote">
+    <a href="#fnref2" role="doc-backlink"><sup>2</sup></a>Bbbbbb
+  </aside>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/epub-footnote-duplicate-reference.xhtml
+++ b/packages/core/test/files/footnotes/epub-footnote-duplicate-reference.xhtml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:epub="http://www.idpf.org/2007/ops"
+  xmlns:ops="http://www.idpf.org/2007/ops">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EPUB footnote duplicate reference</title>
+    <style>
+      @page {
+        size: 500px 300px;
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+      }
+      body {
+        font-family: serif;
+        line-height: 1.4;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Expected result: the footnote bodies "1 Aaaaaa" and "2 Bbbbbb" should
+      appear once. If "1 Aaaaaa" appears twice, this test fails.
+    </p>
+
+    <p>
+      Aaa<a id="fnref1" href="#fn1" epub:type="noteref"><sup>1</sup></a> bbb<a
+        id="fnref2"
+        href="#fn2"
+        epub:type="noteref"
+        ><sup>2</sup></a
+      >.
+    </p>
+    <p>Dummy text.</p>
+    <p>Dummy text.</p>
+    <p>Dummy text.</p>
+    <p>Dummy text.</p>
+    <p>Dummy text.</p>
+    <p>Dummy text.</p>
+    <p>Dummy text.</p>
+    <p>Dummy text.</p>
+    <p>
+      Ccc aaa<a id="fnref1-1" href="#fn1" epub:type="noteref"><sup>1</sup></a
+      >. This second reference must not create another footnote body.
+    </p>
+
+    <aside id="fn1" epub:type="footnote">
+      <a href="#fnref1" epub:type="backlink"><sup>1</sup></a
+      >Aaaaaa
+    </aside>
+    <aside id="fn2" epub:type="footnote">
+      <a href="#fnref2" epub:type="backlink"><sup>2</sup></a
+      >Bbbbbb
+    </aside>
+  </body>
+</html>


### PR DESCRIPTION
- render semantic footnote body only for the first noteref in source order per target
- avoid retry-sensitive state that could suppress footnote rendering
- add regression tests for both DPUB role-based and EPUB type-based duplicate noteref cases
- fixes #1767

Assisted-by: GitHub Copilot Chat

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1767 (duplicate footnote bodies for repeated noterefs referencing the same footnote); across several rounds, one attempt initially broke footnote rendering entirely, which was diagnosed and fixed using the Chrome DevTools MCP for verification.
- The human author asked for regression tests to be registered in `file-list.js` with self-descriptive titles, questioned an apparently redundant DOM scan the AI had added (leading to a simplification using a shared helper), and asked for a `@fileoverview`-style header comment matching repository conventions.
- After this fix was committed, the human author asked the AI to prepare a separate follow-up commit bundling an unrelated internal-link-navigation fix with a footnote-backlink underline style change the human author had made directly, framed as a follow-up to the (already-closed) issue #1767.

</details>
