### PR TITLE
fix: Improve EPUB/DPUB footnote link navigation and backlink styling

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1409,6 +1409,12 @@ aside[role="doc-footnote"]:footnote-content {
   line-height: 1.2;
 }
 
+aside[epub|type="footnote"]:footnote-content a[epub|type="backlink"],
+aside[epub\:type="footnote"]:footnote-content a[epub\:type="backlink"],
+aside[role="doc-footnote"]:footnote-content a[role="doc-backlink"] {
+  text-decoration: none;
+}
+
 /* EPUB-specific */
 epub|trigger {
   display: none;

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -34,6 +34,7 @@ import * as Logging from "./logging";
 import * as Net from "./net";
 import * as OPS from "./ops";
 import * as Plugin from "./plugin";
+import * as SemanticFootnote from "./semantic-footnote";
 import * as Task from "./task";
 import * as Toc from "./toc";
 import * as Vgen from "./vgen";
@@ -2689,6 +2690,38 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return frame.result();
   }
 
+  private resolveSemanticFootnoteNavigationOffset(
+    viewItem: OPFViewItem,
+    target: Element,
+  ): number | null {
+    if (!SemanticFootnote.isSemanticFootnoteElement(target)) {
+      return null;
+    }
+    const targetId = target.getAttribute("id");
+    if (!targetId) {
+      return null;
+    }
+    const targetURL = Base.resolveURL(`#${targetId}`, viewItem.xmldoc.url);
+    const anchors = viewItem.xmldoc.document.getElementsByTagName("a");
+    for (let i = 0; i < anchors.length; i++) {
+      const anchor = anchors.item(i);
+      if (!SemanticFootnote.isSemanticFootnoteNoterefElement(anchor)) {
+        continue;
+      }
+      const anchorHref =
+        anchor.getAttribute("href") ||
+        anchor.getAttributeNS(Base.NS.XLINK, "href");
+      if (!anchorHref) {
+        continue;
+      }
+      if (Base.resolveURL(anchorHref, viewItem.xmldoc.url) !== targetURL) {
+        continue;
+      }
+      return viewItem.xmldoc.getElementOffset(anchor);
+    }
+    return null;
+  }
+
   /**
    * Move to the page specified by the given URL and render it.
    */
@@ -2747,11 +2780,20 @@ export class OPFView implements Vgen.CustomRendererFactory {
           return;
         }
         const target = viewItem.xmldoc.getElement(href);
+        const semanticFootnoteOffset =
+          target &&
+          this.resolveSemanticFootnoteNavigationOffset(viewItem, target);
+        const targetOffset =
+          semanticFootnoteOffset != null
+            ? semanticFootnoteOffset
+            : target
+              ? viewItem.xmldoc.getElementOffset(target)
+              : 0;
         this.findPage(
           {
             spineIndex: item.spineIndex,
             pageIndex: -1,
-            offsetInItem: target ? viewItem.xmldoc.getElementOffset(target) : 0,
+            offsetInItem: targetOffset,
           },
           sync,
         ).thenFinish(frame);

--- a/packages/core/src/vivliostyle/semantic-footnote.ts
+++ b/packages/core/src/vivliostyle/semantic-footnote.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @fileoverview Semantic footnote helper utilities.
+ */
+
+import * as Base from "./base";
+
+function hasToken(value: string | null, token: string): boolean {
+  return !!(value && value.match(new RegExp(`(^|\\s)${token}($|\\s)`)));
+}
+
+export function isSemanticFootnoteElement(element: Element): boolean {
+  if (element.localName !== "aside") {
+    return false;
+  }
+  if (hasToken(element.getAttribute("role"), "doc-footnote")) {
+    return true;
+  }
+  const epubType =
+    element.getAttributeNS(Base.NS.epub, "type") ||
+    element.getAttribute("epub:type");
+  return hasToken(epubType, "footnote");
+}
+
+export function isSemanticFootnoteNoterefElement(element: Element): boolean {
+  if (element.localName !== "a") {
+    return false;
+  }
+  if (hasToken(element.getAttribute("role"), "doc-noteref")) {
+    return true;
+  }
+  const epubType =
+    element.getAttributeNS(Base.NS.epub, "type") ||
+    element.getAttribute("epub:type");
+  return hasToken(epubType, "noteref");
+}

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -39,6 +39,7 @@ import * as Plugin from "./plugin";
 import * as PseudoElement from "./pseudo-element";
 import * as RepetitiveElement from "./repetitive-element";
 import * as Scripts from "./scripts";
+import * as SemanticFootnote from "./semantic-footnote";
 import * as Task from "./task";
 import * as TaskUtil from "./task-util";
 import * as Urls from "./urls";
@@ -171,17 +172,6 @@ export class ViewFactory
     );
   }
 
-  private isSemanticFootnoteNoteref(element: Element): boolean {
-    const role = element.getAttribute("role");
-    if (role && role.match(/(^|\s)doc-noteref($|\s)/)) {
-      return true;
-    }
-    const epubType =
-      element.getAttributeNS(Base.NS.epub, "type") ||
-      element.getAttribute("epub:type");
-    return !!(epubType && epubType.match(/(^|\s)noteref($|\s)/));
-  }
-
   private initializeSemanticFootnoteFirstRefOffsets(ownerDocument: Document) {
     if (this.semanticFootnoteFirstRefOffsetsInitialized.value) {
       return;
@@ -189,7 +179,7 @@ export class ViewFactory
     const anchorElements = ownerDocument.getElementsByTagName("a");
     for (let i = 0; i < anchorElements.length; i++) {
       const anchor = anchorElements.item(i);
-      if (!this.isSemanticFootnoteNoteref(anchor)) {
+      if (!SemanticFootnote.isSemanticFootnoteNoterefElement(anchor)) {
         continue;
       }
       const anchorHref =
@@ -217,7 +207,10 @@ export class ViewFactory
    * True only for the first semantic footnote reference to the same target.
    */
   private shouldGenerateSemanticFootnote(element: Element): boolean {
-    if (element.localName !== "a" || !this.isSemanticFootnoteNoteref(element)) {
+    if (
+      element.localName !== "a" ||
+      !SemanticFootnote.isSemanticFootnoteNoterefElement(element)
+    ) {
       return true;
     }
     const href =
@@ -2488,17 +2481,10 @@ export class ViewFactory
    */
   private isSemanticFootnoteElement(footnoteNodeContext: Vtree.NodeContext) {
     const sourceNode = footnoteNodeContext.sourceNode;
-    if (!(sourceNode instanceof Element) || sourceNode.localName !== "aside") {
-      return false;
-    }
-    const role = sourceNode.getAttribute("role");
-    if (role && role.match(/(^|\s)doc-footnote($|\s)/)) {
-      return true;
-    }
-    const epubType =
-      sourceNode.getAttributeNS(Base.NS.epub, "type") ||
-      sourceNode.getAttribute("epub:type");
-    return !!(epubType && epubType.match(/(^|\s)footnote($|\s)/));
+    return (
+      sourceNode instanceof Element &&
+      SemanticFootnote.isSemanticFootnoteElement(sourceNode)
+    );
   }
 
   /**


### PR DESCRIPTION
- fix semantic footnote navigation to the displayed footnote location
- remove underline from EPUB/DPUB footnote backlink
- follow-up to #1767

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- After fixing issue #1767 (duplicate footnote bodies) earlier in the same session, the human author asked the AI to design a fix for a related footnote-link navigation problem, and questioned duplicated role/epub:type-checking logic between `epub.ts` and `vgen.ts`, suggesting a shared helper in `vgen.ts` be used instead.
- The human author asked for a repository-convention-matching file header comment (including `@fileoverview`), directed the commit to be separate from the earlier fix (covering only the navigation change), then reconsidered and asked to fold in an unrelated backlink-underline style change they had made directly, retitling the commit to describe both together.

</details>
