### PR TITLE
fix: Make semantic footnote inherit from source parent and simplify default footnote style

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1400,13 +1400,7 @@ aside[epub|type="footnote"]:footnote-content,
 aside[epub\:type="footnote"]:footnote-content,
 aside[role="doc-footnote"]:footnote-content {
   display: block;
-  color: initial;
-  text-align: initial;
-  text-align-last: initial;
-  text-indent: initial;
-  font: initial;
-  font-size: 0.9rem;
-  line-height: 1.2;
+  font-size: 0.9em;
 }
 
 aside[epub|type="footnote"]:footnote-content a[epub|type="backlink"],

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -653,10 +653,52 @@ export class ViewFactory
     // This code handles coming out of the shadow trees, but does not go back in
     // (through shadow:content element).
     let shadowContext = this.nodeContext.shadowContext;
+
+    // For semantic footnotes, the wrapper generated from
+    // <s:include class="-vivliostyle-footnote-content"> should inherit from
+    // the referenced footnote's source parent, not from the noteref owner.
+    // (Issue #1770)
+    if (
+      node instanceof Element &&
+      node.namespaceURI === Base.NS.SHADOW &&
+      node.localName === "include" &&
+      node.classList.contains("-vivliostyle-footnote-content")
+    ) {
+      const owner = shadowContext?.owner;
+      if (
+        owner instanceof Element &&
+        SemanticFootnote.isSemanticFootnoteNoterefElement(owner)
+      ) {
+        const href =
+          owner.getAttribute("href") ||
+          owner.getAttributeNS(Base.NS.XLINK, "href");
+        if (href) {
+          const resolvedHref = Base.resolveURL(href, this.xmldoc.url);
+          const target = this.xmldoc.getElement(resolvedHref);
+          if (
+            target &&
+            SemanticFootnote.isSemanticFootnoteElement(target) &&
+            target.parentNode?.nodeType === 1
+          ) {
+            node = target.parentNode;
+            shadowContext = null;
+          }
+        }
+      }
+    }
+
     let steps = -1;
     while (node && node.nodeType == 1) {
       const shadowRoot = shadowContext && shadowContext.root == node;
-      if (!shadowRoot || shadowContext.type == Vtree.ShadowType.ROOTLESS) {
+      const semanticFootnoteRootInRootedShadow =
+        !!shadowRoot &&
+        shadowContext.type == Vtree.ShadowType.ROOTED &&
+        SemanticFootnote.isSemanticFootnoteElement(node as Element);
+      if (
+        !shadowRoot ||
+        shadowContext.type == Vtree.ShadowType.ROOTLESS ||
+        semanticFootnoteRootInRootedShadow
+      ) {
         const styler = shadowContext
           ? (shadowContext.styler as CssStyler.AbstractStyler)
           : this.styler;
@@ -664,7 +706,7 @@ export class ViewFactory
         styles.push(nodeStyle);
         lang = lang || Base.getLangAttribute(node as Element);
       }
-      if (shadowRoot) {
+      if (shadowRoot && !semanticFootnoteRootInRootedShadow) {
         node = shadowContext.owner;
         shadowContext = shadowContext.parentShadow;
       } else {
@@ -672,6 +714,38 @@ export class ViewFactory
         steps++;
       }
     }
+
+    // When reconstructing inherited values for detached/transcluded nodes,
+    // keep declarations on the current element (including region-specific
+    // rules such as :footnote-content) authoritative over ancestor-derived
+    // inherited values.
+    const blockedInheritedByCurrent = new Set<string>();
+    if (styles.length > 0) {
+      const currentStyle = styles[0];
+      const flattenedCurrentStyle = CssCascade.flattenCascadedStyle(
+        currentStyle,
+        this.context,
+        this.regionIds,
+        this.isFootnote,
+        this.nodeContext,
+      );
+      for (const name in flattenedCurrentStyle) {
+        if (!CssCascade.isInherited(name)) {
+          continue;
+        }
+        const value = flattenedCurrentStyle[name].evaluate(this.context, name);
+        if (
+          value &&
+          value !== Css.ident.inherit &&
+          value !== Css.ident.unset &&
+          value !== Css.ident.revert &&
+          value !== Css.empty
+        ) {
+          blockedInheritedByCurrent.add(name);
+        }
+      }
+    }
+
     const isRoot = steps === 0;
     const fontSize = this.context.queryUnitSize("em", isRoot);
     const props = {
@@ -703,6 +777,9 @@ export class ViewFactory
       let lineHeight: Css.Val;
 
       for (const name of propList) {
+        if (i > 0 && blockedInheritedByCurrent.has(name)) {
+          continue;
+        }
         inheritanceVisitor.setPropName(name);
         const prop = CssCascade.getProp(style, name);
         let prop1 = prop;
@@ -905,13 +982,18 @@ export class ViewFactory
       !Css.isDefaultingValue(floatReferenceCV.value)
         ? PageFloats.floatReferenceOf(floatReferenceCV.value.toString())
         : null;
+    const isSemanticFootnoteInRootedShadow =
+      !!this.nodeContext.shadowContext &&
+      this.nodeContext.shadowContext.type === Vtree.ShadowType.ROOTED &&
+      SemanticFootnote.isSemanticFootnoteElement(element);
     if (
       this.nodeContext.parent &&
       (Display.isRunning(positionCV?.value) ||
-        (floatReference && PageFloats.isPageFloat(floatReference)))
+        (floatReference && PageFloats.isPageFloat(floatReference)) ||
+        isSemanticFootnoteInRootedShadow)
     ) {
-      // Since a page float will be detached from a view node of its parent,
-      // inherited properties need to be inherited from its source parent.
+      // Detached or transcluded content should inherit from the source tree,
+      // not from the synthetic view parent.
       const inheritedValues = this.inheritFromSourceParent(elementStyle);
       elementStyle = inheritedValues.elementStyle;
       this.nodeContext.lang = inheritedValues.lang;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -806,6 +806,11 @@ module.exports = [
           "DPUB noteref duplicate reference should not duplicate footnote body (Issue #1767)",
       },
       {
+        file: "footnotes/dpub-footnote-inherit.html",
+        title:
+          "DPUB footnote should inherit from source parent, not noteref (Issue #1770)",
+      },
+      {
         file: "footnotes/epub-footnotes-static-number.html",
         title: "EPUB footnotes (static numbering)",
       },

--- a/packages/core/test/files/footnotes/dpub-footnote-inherit.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-inherit.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB footnote inherit from source parent</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    @page {
+      size: 540px 360px;
+    }
+
+    body {
+      margin: 1.5em;
+      font-family: sans-serif;
+      line-height: 1.4;
+    }
+
+    .source-parent {
+      color: rgb(0, 128, 0);
+      font-size: 26px;
+      line-height: 1.5;
+    }
+
+    a[role="doc-noteref"] {
+      color: rgb(180, 0, 0);
+      font-size: 11px;
+      line-height: 1;
+      text-decoration: none;
+    }
+
+    aside[role="doc-footnote"] {
+      color: inherit;
+      font-size: inherit;
+      line-height: inherit;
+    }
+  </style>
+</head>
+<body>
+  <p>
+    Expected: the footnote body text is green and large (inherited from
+    .source-parent), not red and tiny (from noteref).
+  </p>
+
+  <section class="source-parent">
+    Parent styled text with footnote<a id="fnref1" href="#fn1" role="doc-noteref">1</a>.
+    <aside id="fn1" role="doc-footnote">
+      This footnote should inherit from the section, not from the noteref anchor.
+    </aside>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
- fix inheritance source for semantic footnote content so it no longer inherits from noteref
- keep current/region winning declarations when reconstructing inherited values
- simplify default footnote-content UA style to:
  - display: block
  - font-size: 0.9em
- add regression test for issue #1770

fixes #1770

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1770 (footnote content should inherit from its source parent, not noteref), and asked for a test's red/green colors to be swapped to match the standard WPT convention (green = correct, red = incorrect).
- The human author found that removing a non-public `:footnote-content` pseudo-class from a test broke an unrelated expectation about default font-size reset, and guided the AI to investigate; the human author then decided to simplify the default footnote UA style down to just `display: block; font-size: 0.9em`.
- The human author directed the commit message, created the PR, and pushed back on a reviewer's `Css.empty` concern by asking the AI to construct a concrete example proving whether it was actually an issue.

</details>
