### PR TITLE
fix: Tighten column block-sizes after balancing and fix float overlap regression

### DIFF
--- a/packages/core/src/vivliostyle/columns.ts
+++ b/packages/core/src/vivliostyle/columns.ts
@@ -18,6 +18,7 @@
  * @fileoverview Columns - Control column layout.
  */
 import * as Asserts from "./asserts";
+import * as Base from "./base";
 import * as Css from "./css";
 import * as MathUtil from "./math-util";
 import * as PageFloats from "./page-floats";
@@ -101,6 +102,7 @@ export abstract class ColumnBalancer {
           candidates[0],
         );
         this.restoreContents(result.layoutResult);
+        this.tightenColumnBlockSizes(result.layoutResult.columns);
         this.postBalance();
         frame.finish(result.layoutResult);
       });
@@ -128,6 +130,63 @@ export abstract class ColumnBalancer {
 
   protected postBalance() {
     setBlockSize(this.layoutContainer, this.originalContainerBlockSize);
+  }
+
+  /**
+   * After column balancing, the column elements' CSS block-size may be larger
+   * than the actual content (computedBlockSize) due to browser multi-column
+   * layout constraints. Tighten them to match the content so that column rules
+   * rendered in finishContainer use the correct, content-matching height.
+   */
+  private tightenColumnBlockSizes(columns: Layout.Column[]): void {
+    if (columns.length <= 1) {
+      return;
+    }
+    const maxComputedBlockSize = Math.max.apply(
+      null,
+      columns.map((c) => c.computedBlockSize),
+    );
+    if (maxComputedBlockSize <= 0) {
+      return;
+    }
+    for (const column of columns) {
+      if (column.vertical) {
+        // In vertical-rl, block-size = width, block-start = right edge.
+        // adjustColumnBlockSizeForBlockEndFloats may have already reduced
+        // CSS width without updating JS properties, so read CSS values.
+        const cssWidth = parseFloat(column.element.style.width);
+        const cssLeft = parseFloat(column.element.style.left);
+        if (
+          isFinite(cssWidth) &&
+          isFinite(cssLeft) &&
+          cssWidth > maxComputedBlockSize
+        ) {
+          // Preserve the right edge (block-start) while reducing width
+          const rightEdge = cssLeft + cssWidth;
+          const newLeft = rightEdge - maxComputedBlockSize;
+          Base.setCSSProperty(
+            column.element,
+            "width",
+            `${maxComputedBlockSize}px`,
+          );
+          Base.setCSSProperty(column.element, "left", `${newLeft}px`);
+          column.width = maxComputedBlockSize;
+          column.left = newLeft;
+        }
+      } else {
+        // In horizontal, block-size = height. Read CSS value because
+        // adjustColumnBlockSizeForBlockEndFloats may have reduced it.
+        const cssHeight = parseFloat(column.element.style.height);
+        if (isFinite(cssHeight) && cssHeight > maxComputedBlockSize) {
+          Base.setCSSProperty(
+            column.element,
+            "height",
+            `${maxComputedBlockSize}px`,
+          );
+          column.height = maxComputedBlockSize;
+        }
+      }
+    }
   }
 
   savePageFloatLayoutContexts(layoutResult: ColumnLayoutResult | null) {

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1369,39 +1369,30 @@ export class PageFloatLayoutContext
     const blockSideForInlineLimit = logicalFloatSides.find((s) =>
       s.includes("block"),
     );
-    const includeParentLimits = anchorEdge !== null;
 
     let blockStart = this.getLimitValue(
       "block-start",
       inlineSideForBlockLimit,
       area.layoutContext,
       area.clientLayout,
-      undefined,
-      includeParentLimits,
     );
     let blockEnd = this.getLimitValue(
       "block-end",
       inlineSideForBlockLimit,
       area.layoutContext,
       area.clientLayout,
-      undefined,
-      includeParentLimits,
     );
     let inlineStart = this.getLimitValue(
       "inline-start",
       blockSideForInlineLimit,
       area.layoutContext,
       area.clientLayout,
-      undefined,
-      includeParentLimits,
     );
     let inlineEnd = this.getLimitValue(
       "inline-end",
       blockSideForInlineLimit,
       area.layoutContext,
       area.clientLayout,
-      undefined,
-      includeParentLimits,
     );
     const blockOffset = area.vertical ? area.originX : area.originY;
     const inlineOffset = area.vertical ? area.originY : area.originX;


### PR DESCRIPTION
Follow-up to PR #1761 (Issue #1493) and PR #1766 (Issue #1764).

After column balancing, the column elements' CSS block-size could be larger than the actual content due to browser multi-column layout constraints, causing column rules to extend beyond the text area. Add tightenColumnBlockSizes() post-processing in ColumnBalancer to cap each column's CSS block-size to the maximum computedBlockSize across columns. For vertical-rl, the right edge (block-start) is preserved when reducing width.

Revert the includeParentLimits change from PR #1766 that skipped parent context limits for deferred floats. This caused column-level floats (float-reference: column) to ignore page-level float boundaries, resulting in overlapping floats. The CSS dimension compensation in getLimitValuesInner() already handles the coordinate space mismatch during column balancing that the skipped parent limits were meant to address.

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to further improve the column-rule-length fix from PR #1761, describing precisely how column-balancing left a visible gap between the rule length and the actual (shortened) column content.
- The human author pushed back when the AI's first approach added a workaround in `page-master.ts`, asking it to instead find and fix the root cause in `columns.ts`'s balance-search logic; questioned whether some of the proposed changes were redundant given a later one; and, testing with vertical writing-mode variants, repeatedly caught cases where a fix was reported as working but a related overlap/misalignment remained.
- The human author identified that a specific line added in PR #1766 (`includeParentLimits`) was itself a mistake and suggested removing it entirely rather than keeping it defaulted to `true`; directed the commit message to reference both PR #1761 and PR #1766 as the fixes being built upon.

</details>
