### PR TITLE
fix: Prevent unexpected column breaking in multi-column box with column-fill:auto

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -387,16 +387,24 @@ export function fixAutoFillMultiColumnBox(
   // If it overflows, find a non-overflow block-size by binary search.
   element.style.columnFill = "auto";
   const blockSize2 = parseFloat(computedStyle.blockSize);
-  const delta = 1 / (column.clientLayout.pixelRatio || 1);
   let blockSize = NaN;
   element.style.blockSize = `${blockSize2}px`;
   if (!checkRootColumnOverflow(column)) {
-    blockSize = blockSize2;
+    blockSize = parseFloat(computedStyle.blockSize);
+    if (blockSize < blockSize2) {
+      // `computedStyle.blockSize` may return a smaller value than the set `blockSize2` due to rounding,
+      // which can cause unexpected column breaking in the multi-column box. So we need to adjust it.
+      // (Issue #1773)
+      const layoutUnitAdj = 1 / column.clientLayout.layoutUnitPerPixel;
+      blockSize = blockSize2 + layoutUnitAdj;
+      element.style.blockSize = `${blockSize}px`;
+    }
   } else {
     element.style.blockSize = `${blockSize1}px`;
     if (!checkRootColumnOverflow(column)) {
       // `blockSize1` is non-overflow and `blockSize2` is overflow.
       // Search the largest non-overflow value in [blockSize1, blockSize2].
+      const delta = 1 / (column.clientLayout.pixelRatio || 1);
       let ok = blockSize1;
       let ng = blockSize2;
       while (ng - ok > delta) {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -491,7 +491,8 @@ module.exports = [
       },
       {
         file: "multi-column/multicol-column-fill-auto.html",
-        title: "column-fill: auto in non-root multicol (Issue #1720, #1758)",
+        title:
+          "column-fill: auto in non-root multicol (Issue #1720, #1758, #1773)",
       },
       {
         file: "multi-column/column-rule-page-floats-footnotes.html",

--- a/packages/core/test/files/multi-column/multicol-column-fill-auto.html
+++ b/packages/core/test/files/multi-column/multicol-column-fill-auto.html
@@ -134,17 +134,7 @@
       tortor sodales in. In hac habitasse platea dictumst. Nullam sapien sapien,
       scelerisque ac volutpat sit amet, vestibulum interdum est. Nunc massa
       turpis, fermentum ac est feugiat, hendrerit varius nibh. Etiam malesuada
-      cursus molestie. Praesent blandit, erat sed faucibus tristique, est nunc
-      viverra orci, eu molestie orci ligula ac risus. Donec massa est, cursus
-      quis ante vulputate, suscipit pellentesque nisl. Praesent pharetra
-      imperdiet elit a iaculis. Sed eu tempor justo. Quisque suscipit venenatis
-      volutpat. Maecenas scelerisque non lectus hendrerit elementum. Mauris id
-      aliquet dui. Phasellus pharetra, massa faucibus porta lobortis, risus leo
-      cursus elit, congue placerat neque nunc eget elit. Donec vel tempus velit.
-      In hac habitasse platea dictumst. Aenean efficitur mollis finibus. In
-      vestibulum tempus dui. Integer fermentum, libero ut tincidunt
-      pellentesque, mi augue lacinia lorem, id lacinia massa sapien a quam.
-      Etiam molestie porta diam, quis pellentesque ipsum efficitur id.
+      cursus molestie.
     </section>
   </body>
 </html>


### PR DESCRIPTION
- Follow-up to PR #1759
- Fix #1773