### PR TITLE
fix: Prevent page break right after out-of-flow element at block start

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -668,7 +668,16 @@ export function isOutOfFlow(node: Node): boolean {
   const e = node as HTMLElement;
   if (isSpecial(e)) return true;
   const position = e.style?.position;
-  return position === "absolute" || position === "fixed";
+  if (position === "absolute" || position === "fixed") {
+    return true;
+  }
+  const float = e.style?.float;
+  return (
+    float === "left" ||
+    float === "right" ||
+    float === "inline-start" ||
+    float === "inline-end"
+  );
 }
 
 export function isSpecialNodeContext(nodeContext: Vtree.NodeContext): boolean {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2135,6 +2135,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let minNeg = 0;
     for (let i = trailingEdgeContexts.length - 1; i >= 0; i--) {
       const nodeContext = trailingEdgeContexts[i];
+      if (!nodeContext) {
+        break;
+      }
       if (
         !nodeContext.after ||
         !nodeContext.viewNode ||
@@ -3401,8 +3404,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 breakAtTheEdge = null;
               }
               onStartEdges = false; // we are now on end edges.
-              lastAfterNodeContext = nodeContext.copy();
-              trailingEdgeContexts.push(lastAfterNodeContext);
+              // Do not use out-of-flow (absolute/fixed) elements as
+              // lastAfterNodeContext, since their edge positions are not
+              // in the block flow and would prevent correct overflow
+              // detection. (Issue #1775)
+              if (!LayoutHelper.isOutOfFlow(nodeContext.viewNode)) {
+                lastAfterNodeContext = nodeContext.copy();
+                trailingEdgeContexts.push(lastAfterNodeContext);
+              }
               breakAtTheEdge = Break.resolveEffectiveBreakValue(
                 breakAtTheEdge,
                 nodeContext.breakAfter,
@@ -3417,7 +3426,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // Non-zero trailing inset.
                 // Margins don't collapse across non-zero borders and
                 // paddings.
-                trailingEdgeContexts = [lastAfterNodeContext];
+                trailingEdgeContexts = lastAfterNodeContext
+                  ? [lastAfterNodeContext]
+                  : [];
               }
             } else {
               // Leading edge

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -447,6 +447,10 @@ module.exports = [
         file: "page_breaks/class_C_break_point.html",
         title: "Class C break point",
       },
+      {
+        file: "page_breaks/block-start-out-of-flow-break.html",
+        title: "Block-start out-of-flow break (Issue #1775)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/page_breaks/block-start-out-of-flow-break.html
+++ b/packages/core/test/files/page_breaks/block-start-out-of-flow-break.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Block-start out-of-flow break (Issue #1775)</title>
+  <style>
+    @page {
+      size: a7 landscape;
+      margin: 8mm;
+    }
+
+    body {
+      font: 12px/1.4 sans-serif;
+    }
+
+    h2 {
+      font-size: 12px;
+      margin: 0 0 4px;
+      break-after: avoid;
+    }
+
+    .list p {
+      margin: 0 0 2px 1em;
+      orphans: 2;
+      widows: 2;
+    }
+
+    .abs p > span {
+      position: absolute;
+      left: 0;
+    }
+
+    .flt p > span {
+      float: left;
+      margin-left: -1em;
+    }
+  </style>
+</head>
+
+<body>
+  <h2>position: absolute</h2>
+  <section class="list abs">
+    <p><span>•</span>Item 1<br />Item 1</p>
+    <p><span>•</span>Item 2<br />Item 2</p>
+    <p><span>•</span>Item 3<br />Item 3</p>
+    <p><span>•</span>Item 4<br />Item 4</p>
+    <p><span>•</span>Item 5<br />Item 5</p>
+    <p><span>•</span>Item 6<br />Item 6</p>
+    <p><span>•</span>Item 7<br />Item 7</p>
+    <p><span>•</span>Item 8<br />Item 8</p>
+  </section>
+
+  <h2>float: left</h2>
+  <section class="list flt">
+    <p><span>•</span>Item 1<br />Item 1</p>
+    <p><span>•</span>Item 2<br />Item 2</p>
+    <p><span>•</span>Item 3<br />Item 3</p>
+    <p><span>•</span>Item 4<br />Item 4</p>
+    <p><span>•</span>Item 5<br />Item 5</p>
+    <p><span>•</span>Item 6<br />Item 6</p>
+    <p><span>•</span>Item 7<br />Item 7</p>
+    <p><span>•</span>Item 8<br />Item 8</p>
+  </section>
+</body>
+
+</html>


### PR DESCRIPTION
Fix page-break handling when a block starts with an out-of-flow marker (e.g. absolutely-positioned bullet span), where the marker could be left alone on the previous page.

Changes:
- In `skipEdges`, do not record out-of-flow nodes as `lastAfterNodeContext`, so overflow checks use the nearest in-flow edge.
- Guard trailing-edge margin handling against null contexts to avoid regressions when out-of-flow edges are skipped.
- Update `isOutOfFlow()` to treat actual floated values as out-of-flow (`left`, `right`, `inline-start`, `inline-end`) in addition to `position:absolute/fixed` and special nodes.

This also covers non-root multi-column float cases where float may remain as float in the view tree instead of being converted to absolute.

closes #1775

Assisted-by: GitHub Copilot Chat

<details>
<summary>How the AI was used</summary>

- The human author described the bug (an absolutely-positioned marker at the start of a block causing an incorrect page break) with a minimal repro, caught a mistake in the AI's test selector, and asked the AI to verify the fix reproduced correctly using the Chrome DevTools MCP.
- The human author manually debugged in Chrome DevTools and reported that only one of several code changes actually mattered, prompting the AI to trim the fix down; the human author then noticed `isOutOfFlow()` was missing a `float` property check and corrected the AI's first attempt, which would have wrongly matched `float: unset`.
- The human author created the PR and asked the AI to check and respond to Copilot review comments, then afterward raised follow-up concerns about the fix's writing-mode assumptions and a `zeroIndent()` helper, ultimately deciding the helper could be removed entirely.

</details>
