### PR TITLE
fix: Fix infinite loop with page floats containing repeating elements

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3712,6 +3712,27 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       PageFloats.isPageFloat(nodeContext.floatReference) ||
       nodeContext.floatSide === "footnote"
     ) {
+      // When inside a page float area, the float element that generated
+      // this area is laid out as content. Its float/footnote CSS properties
+      // must not trigger another page float layout (which would create
+      // infinite recursion). Only skip processing for the generating element
+      // itself; genuinely nested floats/footnotes are allowed. (Issue #1784)
+      const generatingNodePosition =
+        this.pageFloatLayoutContext.generatingNodePosition;
+      if (
+        generatingNodePosition &&
+        nodeContext.sourceNode === generatingNodePosition.steps[0].node
+      ) {
+        const nodeContextMod = nodeContext.modify();
+        nodeContextMod.floatSide = null;
+        nodeContextMod.floatReference = PageFloats.FloatReference.INLINE;
+        nodeContextMod.clearSide = null;
+        if (this.isBreakable(nodeContextMod)) {
+          return this.layoutBreakableBlock(nodeContextMod);
+        } else {
+          return this.layoutUnbreakable(nodeContextMod);
+        }
+      }
       return this.layoutPageFloat(nodeContext);
     } else {
       return this.layoutFloat(nodeContext);


### PR DESCRIPTION
When a page float element (e.g. `float: top`) contains children with `repeat-on-break: header/footer`, an infinite loop occurred because the float element's own CSS float properties triggered `layoutPageFloat` recursively inside its own page float area.

This was a regression introduced by #1737 (support for nested page floats/footnotes inside page float areas), which removed a workaround that prevented float processing inside page float areas.

The fix checks whether the current source node is the same element that generated the containing page float area. If so, it is laid out as a regular block instead of being processed as a page float. Genuinely nested page floats and footnotes (#1675) continue to work normally.

Closes #1784

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author reported an infinite-loop bug they had traced to PR #1737 and asked for a fix; when the AI's diagnostic logging didn't get hit despite a successful build, the human author clarified that the running `yarn dev` auto-rebuilds and a separate build wasn't needed.
- The human author caught the AI misjudging that a minimal test case was already passing when it was not, and continued debugging together until resolved, then identified and removed a redundant duplicate test file before committing.
- The human author created the PR and asked the AI to check and address Copilot review comments.

</details>
