### PR TITLE
fix: Fix infinite page count with page floats (regression)

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -667,6 +667,16 @@ export function isOutOfFlow(node: Node): boolean {
   if (!(node?.nodeType === 1)) return false;
   const e = node as HTMLElement;
   if (isSpecial(e)) return true;
+  return isCssOutOfFlow(node);
+}
+
+/**
+ * Check if element is out-of-flow due to CSS positioning or float.
+ * Unlike isOutOfFlow(), this does not check for special marker elements.
+ */
+export function isCssOutOfFlow(node: Node): boolean {
+  if (!(node?.nodeType === 1)) return false;
+  const e = node as HTMLElement;
   const position = e.style?.position;
   if (position === "absolute" || position === "fixed") {
     return true;

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3440,11 +3440,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 breakAtTheEdge = null;
               }
               onStartEdges = false; // we are now on end edges.
-              // Do not use out-of-flow elements (including absolute/fixed
-              // positioned and floated elements) as lastAfterNodeContext,
-              // since their edge positions are not in the block flow and
-              // would prevent correct overflow detection. (Issue #1775)
-              if (!LayoutHelper.isOutOfFlow(nodeContext.viewNode)) {
+              // Do not use CSS-positioned out-of-flow elements
+              // (absolute/fixed positioned and CSS floated elements) as
+              // lastAfterNodeContext, since their edge positions are not
+              // in the block flow and would prevent correct overflow
+              // detection. (Issue #1775)
+              // Note: Use isCssOutOfFlow() instead of isOutOfFlow() to
+              // allow special marker elements (e.g. page float anchors)
+              // which are positioned in normal flow and are needed for
+              // break position tracking. (Issue #1790)
+              if (!LayoutHelper.isCssOutOfFlow(nodeContext.viewNode)) {
                 lastAfterNodeContext = nodeContext.copy();
                 trailingEdgeContexts.push(lastAfterNodeContext);
               }


### PR DESCRIPTION
The `isOutOfFlow()` guard added in #1777 (Issue #1775 fix) excluded all out-of-flow elements from `lastAfterNodeContext` tracking in `skipEdges`. This included page float anchor elements (`<span data-adapt-spec="1">`), which are special marker elements positioned in normal flow.

When only page float anchors preceded a forced column/page break (e.g. `break-after: column` with `clear: all` on paragraphs), `lastAfterNodeContext` stayed null, causing `atLeadingEdgeIgnoringOutOfFlow()` to return false. This made `needForcedBreak()` fire at what was effectively a leading edge, resulting in infinite forced page breaks.

The fix adds isCssOutOfFlow() which checks only CSS positioning and float, not special markers. The lastAfterNodeContext guard uses this instead of isOutOfFlow(), allowing page float anchors while still excluding CSS out-of-flow elements (Issue #1775).

Closes #1790

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author diagnosed that this infinite-page-count regression came from PR #1777's `isOutOfFlow()` guard and asked the AI to fix it without reintroducing issue #1775, explaining Vivliostyle's page-float anchor implementation (`<span data-adapt-spec="1">` marker elements) in detail to guide the fix.
- The human author found an additional infinite-loop case in a different test file during verification; after the fix worked, they asked for a commit message, created the PR, and asked the AI to address review comments.
- The human author asked for an amend commit to fix a formatting problem in the commit message, then pushed and merged.

</details>
