### PR TITLE
fix: Fix text disappearance after full-page CSS float element

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3263,6 +3263,27 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   ).modify();
                   nodeContext.overflow = true;
                 } else {
+                  // When lastAfterNodeContext is null (no in-flow trailing
+                  // edge before this content, e.g. after CSS floats
+                  // converted to position:absolute) and no block-level
+                  // leading edges were encountered (bare inline text
+                  // directly after the float), save a break position at
+                  // the content start. This parallels the block-level
+                  // break opportunity saved for Issue #611 below.
+                  // The leadingEdge guard prevents break positions at the
+                  // very start of a column (first layoutNext call).
+                  // (Issue #1786)
+                  if (
+                    !lastAfterNodeContext &&
+                    !leadingEdge &&
+                    leadingEdgeContexts.length === 0
+                  ) {
+                    this.saveEdgeBreakPosition(
+                      nodeContext,
+                      breakAtTheEdge,
+                      false,
+                    );
+                  }
                   nodeContext = nodeContext.modify();
                   nodeContext.breakBefore = breakAtTheEdge;
                 }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -187,6 +187,11 @@ module.exports = [
         title: "z-index on @page and page-margin boxes",
       },
       {
+        file: "z-index-at-page-bare-text.html",
+        title:
+          "z-index on @page and page-margin boxes (bare text after float, Issue #1786)",
+      },
+      {
         file: "inset-shorthand.html",
         title: "inset shorthand property",
       },

--- a/packages/core/test/files/z-index-at-page-bare-text.html
+++ b/packages/core/test/files/z-index-at-page-bare-text.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>z-index on @page and page-margin boxes (bare text)</title>
+    <style>
+@page {
+  size: 14cm 14cm;
+  margin: 2cm;
+  z-index: -2;
+  background: yellow;
+  @top-center {
+    content: "Page Header, displayed on all pages";
+  }
+  @bottom-center {
+    content: "Page Footer, displayed on the second and subsequent pages";
+    z-index: -1;
+  }
+}
+
+body {
+  margin: 0;
+}
+
+header {
+  float: left;
+  margin: -2cm;
+  padding: 2cm;
+  width: 100vw;
+  height: 100vh;
+  background: lime;
+}
+    </style>
+  </head>
+  <body>
+    <header>
+      <p>This is the first page, background color is lime, with Page Header, and hidden Page Footer.</p>
+      <p>The rest pages will be yellow, and with both Page Header and Page Footer.</p>
+    </header>
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Modi eligendi ad nulla? Laboriosam natus in et ipsum molestias id explicabo ad corporis alias eum voluptatum obcaecati, ullam nobis minima, voluptates.
+    <p>Voluptatem quasi sunt dignissimos!</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Fix text disappearance after a full-page CSS float element (Issue #1786).

When a CSS float element fills the entire page (converted to `position:absolute`), text following the float becomes invisible because it is positioned behind the float and no break position exists to push it to the next page.

## Root Cause

For **block-level elements** (`<p>`, etc.) after such floats, the existing Issue #611 fix (line 3325 in `layout.ts`) saves a break position at the block edge, allowing overflow detection to defer content to the next page.

For **bare inline text** directly after the float, no block-level edge exists, so no break position is saved and the text remains stuck on the overflowed page.

## Fix

Add a targeted break position save in `skipEdges` for the specific case of bare inline text after a CSS float. The condition `!lastAfterNodeContext && !leadingEdge && leadingEdgeContexts.length === 0` precisely identifies this scenario:

- `!lastAfterNodeContext`: No in-flow trailing edge processed (float trailing edges are skipped by `isCssOutOfFlow()` from PR #1792)
- `!leadingEdge`: Not the first `layoutNext` call (excludes column start)
- `leadingEdgeContexts.length === 0`: No block element start edges encountered (excludes cases like running elements where `<h2>` elements populate this array)

## Test Cases Verified

- `z-index-at-page.html` — text after full-page float: 2 pages
- `z-index-at-page-bare-text.html` (new) — bare inline text after full-page float: 2 pages
- `running-elements.html` — page 7 margin boxes correct
- `page-float-spacing.html?fontSize=18` — 18 pages, no overflow
- `block-start-out-of-flow-break.html` — 3 pages, correct pagination

Closes #1786