### PR TITLE
fix: Fix text disappearance after CSS float when content is in block-level elements

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3331,7 +3331,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     )
                   : this.breakPositions[
                       this.breakPositions.length - 1
-                    ] instanceof BoxBreakPosition)
+                    ] instanceof BoxBreakPosition ||
+                    // When lastAfterNodeContext is null (no in-flow
+                    // trailing edge, e.g. after CSS floats converted to
+                    // position:absolute) and no block-level leading edges
+                    // were encountered, save a break position at the
+                    // block-level element. This parallels the inline text
+                    // break opportunity above. (Issue #1786)
+                    (!leadingEdge && leadingEdgeContexts.length === 0))
               ) {
                 this.saveEdgeBreakPosition(
                   nodeContext.copy(),


### PR DESCRIPTION
The previous fix for Issue #1786 (PR #1793) only handled bare inline text nodes after CSS floats. When the content after the float was wrapped in block-level elements (e.g. `<p>` tags), the Issue #611 break position check did not save a break position because lastAfterNodeContext was null (CSS floats excluded by isCssOutOfFlow) and no BoxBreakPosition existed yet.

Extended the Issue #611 condition to also save a break position when lastAfterNodeContext is null and no block-level leading edges were encountered, paralleling the inline text fix.

Closes #1786

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author noticed after merging PR #1793 that a related test case (`z-index-at-page.html`) had regressed back to the original bug — the fix in #1793 had actually been verified against a modified copy of the test (`z-index-at-page-bare-text.html`) and the original case's continued failure had been overlooked — and asked the AI to extend the fix to cover block-wrapped content too.
- The human author directed the commit message and created the PR, then asked the AI to check and address a Copilot review comment about a code comment wording suggestion.

</details>
