### PR TITLE
fix: limit adjustColumnBlockSizeForBlockEndFloats workaround to the page area

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1065,6 +1065,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   private adjustColumnBlockSizeForBlockEndFloats(): void {
+    if (!this.element.hasAttribute("data-vivliostyle-page-area")) {
+      // This adjustment is only for the page area. (Issue #1787, #1789)
+      return;
+    }
     const initialBlockSize = this.vertical ? this.width : this.height;
     const blockSize = this.getBoxDir() * (this.footnoteEdge - this.beforeEdge);
     if (


### PR DESCRIPTION
The adjustColumnBlockSizeForBlockEndFloats workaround was added to fix for footnotes/block-end-page-floats and table/multicol issues (PR #1664 for issue #1662, and revised in PR #1460 for #1460).

However, it caused side effects:
- issue #1787
  - column block-end float positioning and column balancing changed in root multi-column
- issue #1789
  - region block-size changed when footnot area exists (when using EPUB Adaptive Layout)

To avoid these issues, we decide to limit this adjustment to the page area, i.e., no region (page-partition in EPUB Adaptive Layout), and no root multi-column.

Fixes #1787
Fixes #1789

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix two side effects (issues #1787 and #1789) of the `adjustColumnBlockSizeForBlockEndFloats` workaround from PR #1761, explaining the workaround's origin (PR #1664 for issue #1662, revised in PR #1460) and the decision to limit its scope to the page area only, excluding regions/EPUB page-partitions and root multi-column contexts.
- The AI implemented the scoping restriction and verified both reported issues were resolved.

</details>
