### PR TITLE
fix: Fix column-rule length with page floats

### DIFF
--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1675,20 +1675,36 @@ export class PageFloatLayoutContext
   }
 
   getBlockStartEdgeOfBlockEndFloats(): number {
-    const isVertical = this.getContainer().vertical;
-    return this.floatFragments
+    let context: PageFloatLayoutContext = this;
+    let container: Vtree.Container | null = null;
+    while (context && !container) {
+      container = context.container;
+      context = context.parent;
+    }
+    const isVertical = !!container?.vertical;
+    let edge = NaN;
+    this.floatFragments
       .filter((fragment) => fragment.floatSide === "block-end")
-      .reduce(
-        (edge, fragment) => {
-          const rect = fragment.getOuterRect();
-          if (isVertical) {
-            return Math.max(edge, rect.x2);
-          } else {
-            return Math.min(edge, rect.y1);
-          }
-        },
-        isVertical ? 0 : Infinity,
-      );
+      .forEach((fragment) => {
+        const rect = fragment.getOuterRect();
+        const fragmentEdge = isVertical ? rect.x2 : rect.y1;
+        edge = isFinite(edge)
+          ? isVertical
+            ? Math.max(edge, fragmentEdge)
+            : Math.min(edge, fragmentEdge)
+          : fragmentEdge;
+      });
+    if (this.parent) {
+      const parentEdge = this.parent.getBlockStartEdgeOfBlockEndFloats();
+      if (isFinite(parentEdge)) {
+        edge = isFinite(edge)
+          ? isVertical
+            ? Math.max(edge, parentEdge)
+            : Math.min(edge, parentEdge)
+          : parentEdge;
+      }
+    }
+    return edge;
   }
 
   getPageFloatClearEdge(clear: string, column: LayoutType.Column): number {

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1511,26 +1511,29 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
             ? (column?.element.style.left ?? "")
             : (column?.element.style.top ?? ""),
         );
-        const basePaddingRect = column?.getPaddingRect
-          ? column.getPaddingRect()
-          : container.getPaddingRect();
+        const basePaddingRect = container.getPaddingRect();
         const columnLike = column as Vtree.Container & {
           pageFloatLayoutContext?: {
             parent?: {
               getBlockEndEdgeOfBlockStartFloats?: () => number;
+              getBlockStartEdgeOfBlockEndFloats?: () => number;
             };
           };
         };
         const blockStartFloatEndEdge =
           columnLike.pageFloatLayoutContext?.parent?.getBlockEndEdgeOfBlockStartFloats?.();
-        const blockStartReduction = isFinite(blockStartFloatEndEdge)
-          ? Math.max(
-              0,
-              this.vertical
-                ? basePaddingRect.x2 - blockStartFloatEndEdge
-                : blockStartFloatEndEdge - basePaddingRect.y1,
-            )
-          : 0;
+        const blockEndFloatStartEdge =
+          columnLike.pageFloatLayoutContext?.parent?.getBlockStartEdgeOfBlockEndFloats?.();
+        const blockStartLimit = isFinite(blockStartFloatEndEdge)
+          ? this.vertical
+            ? blockStartFloatEndEdge - basePaddingRect.x1
+            : blockStartFloatEndEdge - basePaddingRect.y1
+          : NaN;
+        const blockEndLimit = isFinite(blockEndFloatStartEdge)
+          ? this.vertical
+            ? blockEndFloatStartEdge - basePaddingRect.x1
+            : blockEndFloatStartEdge - basePaddingRect.y1
+          : NaN;
         const border = this.vertical ? "border-top" : "border-left";
         for (let i = 1; i < columnCount; i++) {
           const pos = this.vertical
@@ -1558,12 +1561,19 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
             0,
           );
           const renderedEnd = renderedStart + size;
-          const adjustedStart = this.vertical
-            ? renderedStart
-            : Math.max(renderedStart, blockStartReduction);
-          const adjustedSize = this.vertical
-            ? Math.max(0, size - blockStartReduction)
-            : Math.max(0, renderedEnd - adjustedStart);
+          const adjustedStart = Math.max(
+            renderedStart,
+            isFinite(this.vertical ? blockEndLimit : blockStartLimit)
+              ? Math.max(0, this.vertical ? blockEndLimit : blockStartLimit)
+              : 0,
+          );
+          const adjustedEnd = Math.min(
+            renderedEnd,
+            isFinite(this.vertical ? blockStartLimit : blockEndLimit)
+              ? Math.max(0, this.vertical ? blockStartLimit : blockEndLimit)
+              : renderedEnd,
+          );
+          const adjustedSize = Math.max(0, adjustedEnd - adjustedStart);
           const rule = container.element.ownerDocument.createElement("div");
           Base.setCSSProperty(rule, "position", "absolute");
           Base.setCSSProperty(

--- a/packages/core/test/spec/vivliostyle/page-floats-spec.js
+++ b/packages/core/test/spec/vivliostyle/page-floats-spec.js
@@ -1781,5 +1781,128 @@ describe("page-floats", function () {
         ]);
       });
     });
+
+    describe("float edge helpers", function () {
+      function container(vertical) {
+        return {
+          vertical: vertical,
+          clear: jasmine.createSpy("clear"),
+        };
+      }
+
+      function addFragment(context, floatReference, floatSide, rect) {
+        var float = new PageFloat(
+          dummyNodePosition(),
+          floatReference,
+          floatSide,
+          null,
+          "body",
+        );
+        context.addPageFloat(float);
+        var fragment = new PageFloatFragment(
+          float.floatReference,
+          float.floatSide,
+          null,
+          [new PageFloatContinuation(float, {})],
+          {
+            getOuterRect: jasmine
+              .createSpy("getOuterRect")
+              .and.returnValue(rect),
+          },
+          false,
+        );
+        context.addPageFloatFragment(fragment);
+      }
+
+      it("includes ancestor block-end floats when getting block-start edge of block-end floats", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          container(false),
+          null,
+          null,
+          null,
+          null,
+        );
+        var regionContext = new PageFloatLayoutContext(
+          pageContext,
+          FloatReference.REGION,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var columnContext = new PageFloatLayoutContext(
+          regionContext,
+          FloatReference.COLUMN,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+        addFragment(pageContext, FloatReference.PAGE, "block-end", {
+          x1: 0,
+          x2: 0,
+          y1: 520,
+          y2: 600,
+        });
+        addFragment(regionContext, FloatReference.REGION, "block-end", {
+          x1: 0,
+          x2: 0,
+          y1: 480,
+          y2: 500,
+        });
+
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats()).toBe(480);
+      });
+
+      it("includes ancestor block-end floats in vertical contexts", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          container(true),
+          null,
+          null,
+          null,
+          null,
+        );
+        var regionContext = new PageFloatLayoutContext(
+          pageContext,
+          FloatReference.REGION,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var columnContext = new PageFloatLayoutContext(
+          regionContext,
+          FloatReference.COLUMN,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+        addFragment(pageContext, FloatReference.PAGE, "block-end", {
+          x1: 100,
+          x2: 180,
+          y1: 0,
+          y2: 0,
+        });
+        addFragment(regionContext, FloatReference.REGION, "block-end", {
+          x1: 200,
+          x2: 260,
+          y1: 0,
+          y2: 0,
+        });
+
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats()).toBe(260);
+      });
+    });
   });
 });


### PR DESCRIPTION
Fix column-rule clipping when page floats and footnotes reduce the available column block-size.

The previous fix shortened column rules for block-start page floats, but it did not fully handle block-end floats. It also used a column-based coordinate conversion that breaks in vertical writing mode after column balancing updates the column's CSS left/width.

This change:

- clips column rules against both block-start and block-end ancestor page floats
- makes block-end float edge lookup include ancestor page-float contexts
- uses the page-area container coordinate space for rule clipping so balanced
- vertical columns do not shorten the rule incorrectly
- adds tests for ancestor block-end float edges in horizontal and vertical cases

As a result, column rules no longer overlap page floats or footnote areas, and the vertical writing-mode case on the second page is rendered correctly after column balancing.

Fixes #1797.