### PR TITLE
fix: Correct outside marker alignment for superscripted list items

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1613,13 +1613,18 @@ span[data-viv-leader] {
 }
 [data-adapt-pseudo="marker"]._viv-marker-outside,
 [data-adapt-pseudo="footnote-marker"]._viv-marker-outside {
-  position: absolute;
+  position: relative;
   text-indent: 0;
+  line-height: 1;
 }
 [data-adapt-pseudo="marker"] > ._viv-marker-outside-content,
 [data-adapt-pseudo="footnote-marker"] > ._viv-marker-outside-content {
   position: absolute;
   inset-inline-end: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  display: flex !important;
+  align-items: center;
 }
 
 /* initial-letter */

--- a/packages/core/src/vivliostyle/pseudo-element.ts
+++ b/packages/core/src/vivliostyle/pseudo-element.ts
@@ -114,7 +114,7 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
         contentVal.visit(
           new Vtree.ContentPropertyHandler(
             (element.classList.contains("_viv-marker-outside") &&
-              element.firstElementChild) ||
+              element.firstElementChild?.firstElementChild) ||
               element,
             this.context,
             contentVal,
@@ -191,10 +191,20 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
     if (listStylePosition === Css.ident.outside) {
       // Use special styling to simulate outside markers.
       element.classList.add("_viv-marker-outside");
-      // Create a span to hold the marker content.
-      const span = element.ownerDocument.createElementNS(Base.NS.XHTML, "span");
-      span.classList.add("_viv-marker-outside-content");
-      element.appendChild(span);
+      // Create a flex container for centering and an inner span to keep
+      // marker content as a single flex item even when it mixes images/text.
+      const contentContainer = element.ownerDocument.createElementNS(
+        Base.NS.XHTML,
+        "span",
+      );
+      contentContainer.classList.add("_viv-marker-outside-content");
+      const contentInner = element.ownerDocument.createElementNS(
+        Base.NS.XHTML,
+        "span",
+      );
+      contentInner.classList.add("_viv-marker-outside-content-inner");
+      contentContainer.appendChild(contentInner);
+      element.appendChild(contentContainer);
 
       // Prevent text-spacing-trim and hanging-punctuation from trimming or
       // hanging the suffix "、" of counter styles such as "cjk-decimal".

--- a/packages/core/test/files/counter-style/list-style-position-super.html
+++ b/packages/core/test/files/counter-style/list-style-position-super.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>outside marker alignment with superscript content</title>
+    <style>
+      @page {
+        size: A5;
+        margin: 12mm;
+      }
+
+      :root {
+        line-height: 1.8;
+      }
+
+      body {
+        font-size: 16px;
+      }
+
+      section {
+        break-inside: avoid;
+        margin-block: 1em;
+      }
+
+      h1 {
+        font-size: 1.25em;
+        margin-block: 0 0.5em;
+      }
+
+      h2 {
+        font-size: 1em;
+        margin-block: 0 0.25em;
+      }
+
+      ul,
+      ol {
+        list-style-position: outside;
+        margin: 0;
+        padding-inline-start: 2.5em;
+      }
+
+      li + li {
+        margin-block-start: 0.2em;
+      }
+
+      .wrap {
+        max-inline-size: 22em;
+      }
+
+      .super {
+        vertical-align: super;
+      }
+
+      .big {
+        font-size: 200%;
+      }
+
+      .marker-string li::marker {
+        content: "※ ";
+      }
+
+      .marker-alpha li::marker {
+        content: counter(list-item, upper-alpha) ") ";
+      }
+
+      .marker-image-text li::marker {
+        content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="16"><path d="M50,3l12,36h38l-30,22l11,36l-31-21l-31,21l11-36l-30-22h38z" fill="%23FF0" stroke="%2300F" stroke-width="10"/></svg>')
+          counter(list-item, upper-alpha) "👉 ";
+      }
+
+      .cjk {
+        list-style-type: cjk-decimal;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>outside marker alignment with superscript content</h1>
+
+    <section>
+      <h2>disc</h2>
+      <ul class="wrap">
+        <li>ORCID</li>
+        <li>ORCID<sup>M</sup></li>
+        <li>ORCID<span class="super"><sup>M</sup></span></li>
+        <li>ORCID<span class="super">M</span></li>
+        <li>
+          ORCID<span class="super big">M</span> with wrapped text to check a
+          taller superscripted inline box over multiple lines in the same list
+          item.
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>decimal</h2>
+      <ol class="wrap">
+        <li>ORCID</li>
+        <li>ORCID<sup>M</sup></li>
+        <li>ORCID<span class="super"><sup>M</sup></span></li>
+        <li>ORCID<span class="super">M</span></li>
+        <li>
+          ORCID<span class="super big">M</span> with wrapped text to check a
+          taller superscripted inline box over multiple lines in the same list
+          item.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>custom ::marker string</h2>
+      <ul class="marker-string wrap">
+        <li>Marker string</li>
+        <li>Marker string<sup>M</sup></li>
+        <li>Marker string<span class="super"><sup>M</sup></span></li>
+        <li>Marker string<span class="super">M</span></li>
+        <li>
+          Marker string<span class="super big">M</span> with wrapped text to
+          check a taller superscripted inline box over multiple lines in the
+          same list item.
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>custom counter and counter-style suffix</h2>
+      <ol class="marker-alpha wrap">
+        <li>Alpha marker</li>
+        <li>Alpha marker<sup>M</sup></li>
+        <li>Alpha marker<span class="super"><sup>M</sup></span></li>
+        <li>Alpha marker<span class="super">M</span></li>
+      </ol>
+      <ol class="cjk wrap">
+        <li>CJK decimal marker</li>
+        <li>CJK decimal marker<sup>M</sup></li>
+        <li>CJK decimal marker<span class="super"><sup>M</sup></span></li>
+        <li>
+          CJK decimal marker<span class="super big">M</span> with wrapped text
+          to check a taller superscripted inline box over multiple lines.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>mixed image and text ::marker content</h2>
+      <ol class="marker-image-text wrap">
+        <li>Image marker</li>
+        <li>Image marker<sup>M</sup></li>
+        <li>Image marker<span class="super"><sup>M</sup></span></li>
+        <li>
+          Image marker<span class="super big">M</span> with wrapped text to
+          check centering when the marker contains an image and text.
+        </li>
+      </ol>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -966,6 +966,11 @@ module.exports = [
         title: "list-style-position",
       },
       {
+        file: "counter-style/list-style-position-super.html",
+        title:
+          "Outside marker alignment with superscript content (Issue #1780)",
+      },
+      {
         file: "counter-style/list-style-type-bullet.html",
         title: "list-style-type bullet marker",
       },


### PR DESCRIPTION
When a list item contains superscripted inline content, the simulated outside marker could become vertically misaligned relative to the item content. This changes the outside marker styling so the marker content is positioned within a slightly expanded block area and centered in that area, which keeps bullets and other outside markers visually aligned more consistently.

Add a regression test based on issue #1780 and extend it to cover multiple outside marker cases, including disc, decimal, custom ::marker content, and cjk-decimal markers with superscripted and enlarged superscripted content.

Fixes #1780.

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author was working through issue #1780's outside-marker alignment bug and asked the AI to draft the commit message once satisfied with the fix, specifying the exact title and asking for an English body covering the fix and test additions.
- After creating the PR, the human author disputed a Copilot review comment (about `align-content: center` being a no-op without a flex/grid context), citing that it functions correctly on block containers per current CSS/browser behavior, and asked the AI to respond accordingly.

</details>
