### PR TITLE
fix: preserve semantic footnote references for data URL src

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -159,6 +159,18 @@ export function resolveURL(relURL: string, baseURL: string): string {
 }
 
 /**
+ * Resolve a URL while preserving the document URL for fragment-only
+ * references. This is needed when the base URL is a data URL because
+ * resolveURL("#id", data:...) intentionally returns just "#id".
+ */
+export function resolveReferenceURL(relURL: string, baseURL: string): string {
+  if (relURL.match(/^#/) && baseURL) {
+    return stripFragment(baseURL) + relURL;
+  }
+  return resolveURL(relURL, baseURL);
+}
+
+/**
  * Convert special URLs (e.g. GitHub, Gist) to their raw equivalents.
  * This is useful for fetching content from these services in a format
  * that can be easily processed by Vivliostyle.js.
@@ -168,6 +180,7 @@ export function resolveURL(relURL: string, baseURL: string): string {
  */
 export function convertSpecialURL(url: string): string {
   let r: RegExpMatchArray;
+
   if (
     (r =
       /^(https?:)\/\/github\.com\/([^/]+\/[^/]+)\/(blob\/|tree\/|raw\/)?(.*)$/.exec(

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -188,7 +188,10 @@ export class ViewFactory
       if (!anchorHref) {
         continue;
       }
-      const resolvedHref = Base.resolveURL(anchorHref, this.xmldoc.url);
+      const resolvedHref = Base.resolveReferenceURL(
+        anchorHref,
+        this.xmldoc.url,
+      );
       if (resolvedHref === "#") {
         continue;
       }
@@ -219,7 +222,7 @@ export class ViewFactory
     if (!href) {
       return true;
     }
-    const resolvedHref = Base.resolveURL(href, this.xmldoc.url);
+    const resolvedHref = Base.resolveReferenceURL(href, this.xmldoc.url);
     if (resolvedHref === "#") {
       return true;
     }
@@ -469,7 +472,7 @@ export class ViewFactory
               : this.xmldoc;
           }
           if (href) {
-            href = Base.resolveURL(href, xmldoc.url);
+            href = Base.resolveReferenceURL(href, xmldoc.url);
             cont1 = this.createRefShadow(
               href,
               Vtree.ShadowType.ROOTED,
@@ -673,7 +676,7 @@ export class ViewFactory
           owner.getAttribute("href") ||
           owner.getAttributeNS(Base.NS.XLINK, "href");
         if (href) {
-          const resolvedHref = Base.resolveURL(href, this.xmldoc.url);
+          const resolvedHref = Base.resolveReferenceURL(href, this.xmldoc.url);
           const target = this.xmldoc.getElement(resolvedHref);
           if (
             target &&

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -20,6 +20,26 @@ import * as adapt_base from "../../../src/vivliostyle/base";
 describe("base", function () {
   var module = adapt_base;
 
+  describe("resolveReferenceURL", function () {
+    it("preserves the base document URL for fragment references on data URLs", function () {
+      expect(
+        module.resolveReferenceURL(
+          "#fn1",
+          "data:,%3Cp%3Edpub%20test%3C%2Fp%3E",
+        ),
+      ).toBe("data:,%3Cp%3Edpub%20test%3C%2Fp%3E#fn1");
+    });
+
+    it("matches resolveURL for non-fragment references", function () {
+      expect(
+        module.resolveReferenceURL(
+          "chapter-2.html#fn1",
+          "https://example.com/book/chapter-1.html",
+        ),
+      ).toBe("https://example.com/book/chapter-2.html#fn1");
+    });
+  });
+
   describe("escapeCharToHex", function () {
     it("escape the first character to a 4-digit hex code and add the specified prefix", function () {
       expect(module.escapeCharToHex("a", ":")).toBe(":0061");


### PR DESCRIPTION
- fix #1801

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to investigate and fix issue #1801 (semantic footnote references not preserved for data URL `src`); once the fix worked, the human author reviewed the root cause the AI identified (comparing an earlier attempted fix in `css-cascade.ts` that turned out ineffective against the actual working fix in `vgen.ts`/`base.ts`) and asked for the unnecessary change to be reverted, keeping the fix minimal.
- The human author asked for a commit message once satisfied, and separately asked whether this fix was related to a different unreproducible issue (#1794) they had been investigating.

</details>
