### PR TITLE
fix: Fix float with clear not working correctly

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1370,6 +1370,38 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         floatHorBox.y1 = this.bottommostFloatTop * dir;
         floatHorBox.y2 = floatHorBox.y1 + boxExtent;
       }
+
+      // Handle clear property on inline floats (Issue #1803)
+      if (nodeContext.clearSide) {
+        const clearLR =
+          /^(top|bottom|inside|outside|(block|inline)-(start|end))$/.test(
+            nodeContext.clearSide,
+          )
+            ? PageFloats.resolveInlineFloatDirection(
+                nodeContext.clearSide,
+                nodeContext.vertical,
+                nodeContext.direction,
+                (this.layoutContext as Vgen.ViewFactory).page.side,
+              )
+            : nodeContext.clearSide === "same"
+              ? floatSide
+              : nodeContext.clearSide;
+        let clearEdge = this.beforeEdge;
+        if (clearLR !== "right") {
+          clearEdge = dir * Math.max(clearEdge * dir, this.leftFloatEdge * dir);
+        }
+        if (clearLR !== "left") {
+          clearEdge =
+            dir * Math.max(clearEdge * dir, this.rightFloatEdge * dir);
+        }
+        const clearY = clearEdge * dir;
+        if (floatHorBox.y1 < clearY) {
+          const boxExtent = floatHorBox.y2 - floatHorBox.y1;
+          floatHorBox.y1 = clearY;
+          floatHorBox.y2 = floatHorBox.y1 + boxExtent;
+        }
+      }
+
       GeometryUtil.positionFloat(box, this.bands, floatHorBox, floatSide);
       if (this.vertical) {
         floatBox = GeometryUtil.unrotateBox(floatHorBox);
@@ -3024,6 +3056,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       // For page floats, clearance is handled differently
       return false;
     }
+    if (nodeContext.floatSide) {
+      // Clear on inline floats is handled in layoutFloat()
+      return false;
+    }
 
     // measure where the edge of the element would be without clearance
     const margin = this.getComputedMargin(nodeContext.viewNode as Element);
@@ -3090,9 +3126,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     // edge holds the position where element border "before" edge will be
     // without clearance. clearEdge is the "after" edge of the float to clear.
 
+    // Round clearEdge to the next float unit boundary (+ 1 unit margin) to
+    // account for exclusion float height rounding in createFloats() and
+    // sub-pixel rendering differences. (Issue #1803)
+    const floatUnit = 1 / (this.clientLayout.pixelRatio || 1);
+    clearEdge =
+      dir * (Math.ceil((clearEdge * dir) / floatUnit) + 1) * floatUnit;
+
     // tolerance to avoid unnecessary clearance due to the pixel rounding errors
     // (Issue #1608)
-    const tolerance = 1 / (this.clientLayout.pixelRatio || 1);
+    const tolerance = floatUnit;
     if (edge * dir + tolerance > clearEdge * dir) {
       // No need for clearance
       nodeContext.viewNode.parentNode.removeChild(spacer);

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1174,8 +1174,9 @@ export class ViewFactory
         ) {
           delete computedStyle["clear"];
           if (
-            computedStyle["display"] &&
-            computedStyle["display"] != Css.ident.inline
+            floating ||
+            (computedStyle["display"] &&
+              computedStyle["display"] != Css.ident.inline)
           ) {
             this.nodeContext.clearSide = clearSide.toString();
           }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -77,6 +77,14 @@ module.exports = [
       { file: "clear-bug-test.html", title: "Float clear bug" },
       { file: "float-text-offset-bug.html", title: "Float text offset bug" },
       {
+        file: "float-clear.html",
+        title: "Float with clear (Issue #1803)",
+      },
+      {
+        file: "float-clear-vertical.html",
+        title: "Float with clear, vertical-rl (Issue #1803)",
+      },
+      {
         file: "float-lh-rlh.html",
         title: "Float with lh/rlh height (Issue #1494, #1738)",
       },

--- a/packages/core/test/files/float-clear-vertical.html
+++ b/packages/core/test/files/float-clear-vertical.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Float with clear, vertical-rl (Issue #1803)</title>
+<style>
+@page {
+  size: 514px 600px;
+}
+:root {
+  writing-mode: vertical-rl;
+}
+
+h3 {
+  clear: both;
+  background: #eee;
+  margin: 0.5em 0;
+  padding: 0.2em;
+}
+
+/* Test 1: clear on block after floats with larger font-size */
+.test1 p {
+  clear: both;
+}
+.test1 .FL {
+  float: left;
+  clear: left;
+  background: cyan;
+}
+.test1 .FR {
+  float: right;
+  clear: right;
+  background: magenta;
+}
+.test1 .FL, .test1 .FR {
+  font-size: 1.25em;
+}
+
+/* Test 2: clear on inline floats with same font-size as line */
+.test2 p {
+  clear: both;
+}
+.test2 .FL {
+  float: left;
+  clear: left;
+  background: cyan;
+}
+.test2 .FR {
+  float: right;
+  clear: right;
+  background: magenta;
+}
+</style>
+</head>
+<body>
+<h3>Test 1: clear:both on block after floats (with larger font-size floats)</h3>
+<div class="test1">
+<p>Aaaa<span class="FL">FloatLeft1</span> bbbb<span class="FL">FloatLeft2</span> cccc<span class="FL">FloatLeft3</span>.</p>
+<p>Dddd<span class="FR">FloatRight1</span> eeee<span class="FR">FloatRight2</span> ffff<span class="FR">FloatRight3</span>.</p>
+</div>
+
+<h3>Test 2: clear:left/right on inline floats (with same font-size as line)</h3>
+<div class="test2">
+<p>Aaaa<span class="FL">FloatLeft1</span> bbbb<span class="FL">FloatLeft2</span> cccc<span class="FL">FloatLeft3</span>.</p>
+<p>Dddd<span class="FR">FloatRight1</span> eeee<span class="FR">FloatRight2</span> ffff<span class="FR">FloatRight3</span>.</p>
+</div>
+</body>
+</html>

--- a/packages/core/test/files/float-clear.html
+++ b/packages/core/test/files/float-clear.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Float with clear (Issue #1803)</title>
+<style>
+h3 {
+  clear: both;
+  background: #eee;
+  margin: 0.5em 0;
+  padding: 0.2em;
+}
+
+/* Test 1: clear on block after floats with larger font-size */
+.test1 p {
+  clear: both;
+}
+.test1 .FL {
+  float: left;
+  clear: left;
+  background: cyan;
+}
+.test1 .FR {
+  float: right;
+  clear: right;
+  background: magenta;
+}
+.test1 .FL, .test1 .FR {
+  font-size: 1.25em;
+}
+
+/* Test 2: clear on inline floats with same font-size as line */
+.test2 p {
+  clear: both;
+}
+.test2 .FL {
+  float: left;
+  clear: left;
+  background: cyan;
+}
+.test2 .FR {
+  float: right;
+  clear: right;
+  background: magenta;
+}
+</style>
+</head>
+<body>
+<h3>Test 1: clear:both on block after floats (with larger font-size floats)</h3>
+<div class="test1">
+<p>Aaaa<span class="FL">FloatLeft1</span> bbbb<span class="FL">FloatLeft2</span> cccc<span class="FL">FloatLeft3</span>.</p>
+<p>Dddd<span class="FR">FloatRight1</span> eeee<span class="FR">FloatRight2</span> ffff<span class="FR">FloatRight3</span>.</p>
+</div>
+
+<h3>Test 2: clear:left/right on inline floats (with same font-size as line)</h3>
+<div class="test2">
+<p>Aaaa<span class="FL">FloatLeft1</span> bbbb<span class="FL">FloatLeft2</span> cccc<span class="FL">FloatLeft3</span>.</p>
+<p>Dddd<span class="FR">FloatRight1</span> eeee<span class="FR">FloatRight2</span> ffff<span class="FR">FloatRight3</span>.</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Fix applyClearance() to round clearEdge to the next float unit boundary with an extra unit margin, to account for exclusion float height rounding in createFloats() and sub-pixel rendering differences that caused cleared content to overlap with exclusion floats, resulting in text being shifted unexpectedly. This affected both horizontal and vertical writing modes.

- Fix layoutFloat() to handle the clear property on inline float elements by adjusting the initial y position before calling positionFloat(). Without this, floats with clear:left/right whose block size was smaller than the line height were placed side-by-side instead of being stacked.

- Fix clearSide not being set on floating inline elements in vgen.ts.

Closes #1803

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix a `clear` property clearance-calculation bug (issue #1803); found and reported an additional vertical-writing-mode-specific coordinate issue during testing, and asked for horizontal and vertical test variants to be consolidated into single HTML files with improved content.
- The human author connected the bug to a longstanding, previously-suspected regression (PR #1739) that turned out to be a pre-existing issue merely made more visible by that PR, and confirmed this understanding with the AI before committing.
- After creating the PR, the human author reported a layout-regression side effect from CI on an unrelated test case, which the AI addressed as part of the same PR.

</details>
