### PR TITLE
fix: Accept legacy cmyk() as an alias for device-cmyk()

### DIFF
--- a/packages/core/src/vivliostyle/cmyk-store.ts
+++ b/packages/core/src/vivliostyle/cmyk-store.ts
@@ -221,7 +221,8 @@ function getNumValue(v: Css.Val): number | null {
 export function parseDeviceCmyk(
   func: Css.Func,
 ): { cmyk: CMYKValue; alpha: number | null } | null {
-  if (func.name !== "device-cmyk") {
+  // Also accept legacy cmyk() as an alias for device-cmyk()
+  if (func.name !== "device-cmyk" && func.name !== "cmyk") {
     return null;
   }
 

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -513,7 +513,7 @@ export class PrimitiveValidator extends PropertyValidator {
 
   override visitFunc(func: Css.Func): Css.Val {
     if (this.allowed & ALLOW_COLOR) {
-      if (func.name === "device-cmyk") {
+      if (func.name === "device-cmyk" || func.name === "cmyk") {
         if (
           CSS.supports("color", "color(srgb 0 0 0)") &&
           CmykStore.parseDeviceCmyk(func) !== null


### PR DESCRIPTION
- closes #1806

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to add legacy `cmyk()` as an alias for the already-supported `device-cmyk()`, specifying the exact external test HTML/CSS URLs to use directly (without copying them locally) and directing verification via Chrome DevTools MCP.
- The AI located the `device-cmyk` handling in `css-validator.ts` and implemented the alias.

</details>
