### PR TITLE
fix: Fix clearEdge rounding side effect on page/column float clearance

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3106,6 +3106,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       clearLogical,
       this,
     );
+    const pageFloatClearEdge = clearEdge;
 
     switch (clearLR) {
       case "left":
@@ -3126,12 +3127,20 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     // edge holds the position where element border "before" edge will be
     // without clearance. clearEdge is the "after" edge of the float to clear.
 
-    // Round clearEdge to the next float unit boundary (+ 1 unit margin) to
-    // account for exclusion float height rounding in createFloats() and
-    // sub-pixel rendering differences. (Issue #1803)
+    // Round clearEdge to the next float unit boundary to account for
+    // exclusion float height rounding in createFloats(). Add an extra unit
+    // margin only when the clear edge comes from inline float edges
+    // (leftFloatEdge/rightFloatEdge), which are subject to sub-pixel
+    // rendering differences with exclusion floats. Page/column float clear
+    // edges from getPageFloatClearEdge() are accurate DOM measurements and
+    // don't need the extra margin. (Issue #1803)
     const floatUnit = 1 / (this.clientLayout.pixelRatio || 1);
+    const inlineFloatEdgeDominates = clearEdge * dir > pageFloatClearEdge * dir;
     clearEdge =
-      dir * (Math.ceil((clearEdge * dir) / floatUnit) + 1) * floatUnit;
+      dir *
+      (Math.ceil((clearEdge * dir) / floatUnit) +
+        (inlineFloatEdgeDominates ? 1 : 0)) *
+      floatUnit;
 
     // tolerance to avoid unnecessary clearance due to the pixel rounding errors
     // (Issue #1608)


### PR DESCRIPTION
The extra unit margin (+1 floatUnit) added in applyClearance() to prevent sub-pixel overlap with exclusion floats (PR #1805, Issue #1803) was applied unconditionally, causing unnecessary gaps when clearing page/column floats. This broke the layout of existing test cases page_floats/clear_page_floats.html and its vertical writing-mode variant.

The extra margin is only needed when inline float edges (leftFloatEdge/rightFloatEdge) dominate the clear edge, as they are subject to exclusion float height rounding in createFloats(). Page/column float clear edges from getPageFloatClearEdge() are accurate DOM measurements and don't need the extra margin.

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- After PR #1805 merged, the human author discovered it broke two existing page/column-float test cases as a side effect, and asked the AI to investigate and fix it as a follow-up within the same session.
- The human author directed the commit message to explicitly note it addressed a side effect of PR #1805 (issue #1803).

</details>
