### PR TITLE
fix: Adjust layout regression test settings

### DIFF
--- a/docs/ja/layout-regression-test.md
+++ b/docs/ja/layout-regression-test.md
@@ -207,10 +207,10 @@ PR 実行時は `--actual-viewer` が自動的に `git-<branch>` に設定され
 --limit <number>             N エントリで停止
 --out-dir <path>             出力ディレクトリ（デフォルト: artifacts/layout-regression）
 --timeout <seconds>          ページあたりのタイムアウト秒数（デフォルト: 30）
---max-diff-ratio <number>    許容する差分ピクセル比率（デフォルト: 0.0008）
+--max-diff-ratio <number>    許容する差分ピクセル比率（デフォルト: 0.0002）
 --pixel-threshold <0..1>     ピクセルごとの色差感度（デフォルト: 0.75）
---viewport-width <number>    ブラウザのビューポート幅（デフォルト: 900）
---viewport-height <number>   ブラウザのビューポート高さ（デフォルト: 900）
+--viewport-width <number>    ブラウザのビューポート幅（デフォルト: 1800）
+--viewport-height <number>   ブラウザのビューポート高さ（デフォルト: 1800）
 --skip-screenshots           スクリーンショットをスキップしてページ数のみ確認
 --actual-viewer <spec>       actual ビューワー指定（デフォルト: canary）
 --baseline-viewer <spec>     baseline ビューワー指定（デフォルト: stable）
@@ -237,7 +237,7 @@ PR 実行時は `--actual-viewer` が自動的に `git-<branch>` に設定され
 差分ありと判定される条件:
 
 - 両サイドのページ数が異なる
-- ページごとのピクセル差分比率が `--max-diff-ratio`（デフォルト `0.0008`）を超える
+- ページごとのピクセル差分比率が `--max-diff-ratio`（デフォルト `0.0002`）を超える
 
 エラーとして記録される条件:
 

--- a/docs/layout-regression-test.md
+++ b/docs/layout-regression-test.md
@@ -221,10 +221,10 @@ category filter, and limit.
 --limit <number>             Stop after N entries
 --out-dir <path>             Output directory (default: artifacts/layout-regression)
 --timeout <seconds>          Timeout per page (default: 30)
---max-diff-ratio <number>    Allowed ratio of diff pixels (default: 0.0008)
+--max-diff-ratio <number>    Allowed ratio of diff pixels (default: 0.0002)
 --pixel-threshold <0..1>     Per-pixel color diff sensitivity (default: 0.75)
---viewport-width <number>    Browser viewport width (default: 900)
---viewport-height <number>   Browser viewport height (default: 900)
+--viewport-width <number>    Browser viewport width (default: 1800)
+--viewport-height <number>   Browser viewport height (default: 1800)
 --skip-screenshots           Skip image capture/compare, check page counts only
 --actual-viewer <spec>       Actual viewer spec (default: canary)
 --baseline-viewer <spec>     Baseline viewer spec (default: stable)
@@ -251,7 +251,7 @@ Results are written to `artifacts/layout-regression/` (by default):
 A difference is reported when either:
 
 - page count differs between the two sides
-- per-page pixel diff ratio exceeds `--max-diff-ratio` (default `0.0008`)
+- per-page pixel diff ratio exceeds `--max-diff-ratio` (default `0.0002`)
 
 An error is reported when either side fails to complete rendering.
 

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -16,13 +16,19 @@ const fileListPath = path.join(
   "packages/core/test/files/file-list.js",
 );
 
+// These params are appended last so that values explicitly specified earlier
+// via --extra-viewer-params take precedence: the viewer always uses the first
+// occurrence of a repeated parameter, so a user-supplied zoom or spread value
+// will win and these fallbacks will be ignored for that parameter.
+const fallbackViewerParams = "&zoom=1&spread=false";
+
 const defaults = {
   outDir: path.join(repoRoot, "artifacts", "layout-regression"),
   timeoutSec: 30,
-  maxDiffRatio: 0.0008,
+  maxDiffRatio: 0.0002,
   pixelThreshold: 0.75,
-  viewportWidth: 900,
-  viewportHeight: 900,
+  viewportWidth: 1800,
+  viewportHeight: 1800,
   skipScreenshots: false,
   actualViewer: "https://vivliostyle.vercel.app/",
   baselineViewer: "https://vivliostyle.org/viewer/",
@@ -144,7 +150,7 @@ Options:
   --limit <number>           Stop after N entries
   --out-dir <path>           Output directory
   --timeout <seconds>        Timeout in seconds for page load/waits (default 30)
-  --max-diff-ratio <number>  Allowed ratio of diff pixels (default 0.0008)
+  --max-diff-ratio <number>  Allowed ratio of diff pixels (default 0.0002)
   --pixel-threshold <0..1>   Pixel diff sensitivity (default 0.75)
   --viewport-width <number>  Browser viewport width
   --viewport-height <number> Browser viewport height
@@ -323,7 +329,7 @@ function buildViewerParams(entry, extraParams) {
     new RegExp(dirLocal, "g"),
     urlOnline,
   );
-  const parameterOnline = `${parameterOnlineBase}${extraParams}`;
+  const parameterOnline = `${parameterOnlineBase}${extraParams}${fallbackViewerParams}`;
   const parameterOld = parameterOnline.replace(
     /\bsrc=/g,
     /\bbookMode=true\b/.test(entry.options) ? "b=" : "x=",
@@ -342,8 +348,8 @@ function buildViewerParamsForTestUrl(testUrl, extraParams) {
   }
 
   // Do NOT percent-encode the URL - the viewer's hash parser expects it as-is.
-  const parameterOnline = `#src=${normalizedUrl}${extraParams}`;
-  const parameterOld = `#x=${normalizedUrl}${extraParams}`;
+  const parameterOnline = `#src=${normalizedUrl}${extraParams}${fallbackViewerParams}`;
+  const parameterOld = `#x=${normalizedUrl}${extraParams}${fallbackViewerParams}`;
 
   return {
     parameterOnline,
@@ -513,7 +519,7 @@ async function getTotalPages(page) {
   return page.evaluate(() => {
     const totalPages =
       document.querySelector(
-        "#vivliostyle-viewer-viewport > * > [data-vivliostyle-spread-container]",
+        "#vivliostyle-viewer-viewport [data-vivliostyle-spread-container]",
       )?.children.length ?? 0;
     if (totalPages > 0) {
       return totalPages;
@@ -576,7 +582,9 @@ async function capturePages({
   const totalPages = await getTotalPages(page);
 
   if (!skipScreenshots) {
-    const viewport = page.locator("#vivliostyle-viewer-viewport");
+    const spreadContainer = page.locator(
+      "#vivliostyle-viewer-viewport [data-vivliostyle-spread-container]",
+    );
     // Detect navigation capability once: prefer input-based jump, fall back to
     // sequential Move-Next clicks for old viewers without the page-number field.
     const useInputNav =
@@ -593,7 +601,7 @@ async function capturePages({
         dir,
         `${key}-p${String(p).padStart(4, "0")}.png`,
       );
-      await viewport.screenshot({ path: imagePath });
+      await spreadContainer.screenshot({ path: imagePath });
     }
   }
 


### PR DESCRIPTION
Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author was addressing Copilot review comments on a `layout-regression.mjs` settings PR and asked the AI to check whether a similar CSS selector fix elsewhere in the file (line 522) should be applied the same way.

</details>
