### PR TITLE
fix: restore column block-size after table fragmentation workaround

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -4091,6 +4091,27 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
               // Unset browser's multi-column (Issue #1637, #1747)
               LayoutHelper.unsetBrowserColumnBreaking(this);
+
+              // Restore root column block-size if it was reduced by Chromium
+              // table fragmentation workaround. (Issue #1812)
+              if (
+                this.element.hasAttribute(
+                  "data-vivliostyle-column-block-size-adjusted",
+                )
+              ) {
+                if (this.vertical) {
+                  Base.setCSSProperty(this.element, "width", `${this.width}px`);
+                } else {
+                  Base.setCSSProperty(
+                    this.element,
+                    "height",
+                    `${this.height}px`,
+                  );
+                }
+                this.element.removeAttribute(
+                  "data-vivliostyle-column-block-size-adjusted",
+                );
+              }
             }
             if (this.pageFloatLayoutContext.isInvalidated()) {
               frame.finish(null);


### PR DESCRIPTION
- fixes #1812

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author diagnosed issue #1812 themselves (a table-containing page partition's block size becoming 1px too small, caused by the Chromium table-split-bug workaround in `layout-helper.ts`) and directed the exact fix: after `LayoutHelper.unsetBrowserColumnBreaking(this)` in `layout.ts`, restore the original block size when the column element carries the `data-vivliostyle-column-block-size-adjusted` attribute.
- The AI implemented the fix exactly as specified and verified it built and lint-checked cleanly.

</details>
