### PR TITLE
fix: avoid shortening column rules when page floats do not overlap

### DIFF
--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1641,7 +1641,7 @@ export class PageFloatLayoutContext
     );
   }
 
-  getBlockEndEdgeOfBlockStartFloats(): number {
+  getBlockEndEdgeOfBlockStartFloats(inlinePos?: number): number {
     let context: PageFloatLayoutContext = this;
     let container: Vtree.Container | null = null;
     while (context && !container) {
@@ -1652,6 +1652,15 @@ export class PageFloatLayoutContext
     let edge = NaN;
     this.floatFragments
       .filter((fragment) => fragment.floatSide.includes("block-start"))
+      .filter((fragment) => {
+        if (!isFinite(inlinePos)) {
+          return true;
+        }
+        const rect = fragment.getOuterRect();
+        return isVertical
+          ? rect.y1 <= inlinePos && inlinePos <= rect.y2
+          : rect.x1 <= inlinePos && inlinePos <= rect.x2;
+      })
       .forEach((fragment) => {
         const rect = fragment.getOuterRect();
         const fragmentEdge = isVertical ? rect.x1 : rect.y2;
@@ -1662,7 +1671,8 @@ export class PageFloatLayoutContext
           : fragmentEdge;
       });
     if (this.parent) {
-      const parentEdge = this.parent.getBlockEndEdgeOfBlockStartFloats();
+      const parentEdge =
+        this.parent.getBlockEndEdgeOfBlockStartFloats(inlinePos);
       if (isFinite(parentEdge)) {
         edge = isFinite(edge)
           ? isVertical
@@ -1674,7 +1684,7 @@ export class PageFloatLayoutContext
     return edge;
   }
 
-  getBlockStartEdgeOfBlockEndFloats(): number {
+  getBlockStartEdgeOfBlockEndFloats(inlinePos?: number): number {
     let context: PageFloatLayoutContext = this;
     let container: Vtree.Container | null = null;
     while (context && !container) {
@@ -1684,7 +1694,16 @@ export class PageFloatLayoutContext
     const isVertical = !!container?.vertical;
     let edge = NaN;
     this.floatFragments
-      .filter((fragment) => fragment.floatSide === "block-end")
+      .filter((fragment) => fragment.floatSide.includes("block-end"))
+      .filter((fragment) => {
+        if (!isFinite(inlinePos)) {
+          return true;
+        }
+        const rect = fragment.getOuterRect();
+        return isVertical
+          ? rect.y1 <= inlinePos && inlinePos <= rect.y2
+          : rect.x1 <= inlinePos && inlinePos <= rect.x2;
+      })
       .forEach((fragment) => {
         const rect = fragment.getOuterRect();
         const fragmentEdge = isVertical ? rect.x2 : rect.y1;
@@ -1695,7 +1714,8 @@ export class PageFloatLayoutContext
           : fragmentEdge;
       });
     if (this.parent) {
-      const parentEdge = this.parent.getBlockStartEdgeOfBlockEndFloats();
+      const parentEdge =
+        this.parent.getBlockStartEdgeOfBlockEndFloats(inlinePos);
       if (isFinite(parentEdge)) {
         edge = isFinite(edge)
           ? isVertical

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1515,25 +1515,15 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
         const columnLike = column as Vtree.Container & {
           pageFloatLayoutContext?: {
             parent?: {
-              getBlockEndEdgeOfBlockStartFloats?: () => number;
-              getBlockStartEdgeOfBlockEndFloats?: () => number;
+              getBlockEndEdgeOfBlockStartFloats?: (
+                inlinePos?: number,
+              ) => number;
+              getBlockStartEdgeOfBlockEndFloats?: (
+                inlinePos?: number,
+              ) => number;
             };
           };
         };
-        const blockStartFloatEndEdge =
-          columnLike.pageFloatLayoutContext?.parent?.getBlockEndEdgeOfBlockStartFloats?.();
-        const blockEndFloatStartEdge =
-          columnLike.pageFloatLayoutContext?.parent?.getBlockStartEdgeOfBlockEndFloats?.();
-        const blockStartLimit = isFinite(blockStartFloatEndEdge)
-          ? this.vertical
-            ? blockStartFloatEndEdge - basePaddingRect.x1
-            : blockStartFloatEndEdge - basePaddingRect.y1
-          : NaN;
-        const blockEndLimit = isFinite(blockEndFloatStartEdge)
-          ? this.vertical
-            ? blockEndFloatStartEdge - basePaddingRect.x1
-            : blockEndFloatStartEdge - basePaddingRect.y1
-          : NaN;
         const border = this.vertical ? "border-top" : "border-left";
         for (let i = 1; i < columnCount; i++) {
           const pos = this.vertical
@@ -1545,6 +1535,29 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
               columnGap / 2 +
               container.paddingLeft -
               ruleWidth / 2;
+          // pos is the rule box start; overlap filtering should use
+          // the rendered rule stroke center.
+          const physicalInlinePos = this.vertical
+            ? basePaddingRect.y1 + pos + ruleWidth / 2
+            : basePaddingRect.x1 + pos + ruleWidth / 2;
+          const blockStartFloatEndEdge =
+            columnLike.pageFloatLayoutContext?.parent?.getBlockEndEdgeOfBlockStartFloats?.(
+              physicalInlinePos,
+            );
+          const blockEndFloatStartEdge =
+            columnLike.pageFloatLayoutContext?.parent?.getBlockStartEdgeOfBlockEndFloats?.(
+              physicalInlinePos,
+            );
+          const blockStartLimit = isFinite(blockStartFloatEndEdge)
+            ? this.vertical
+              ? blockStartFloatEndEdge - basePaddingRect.x1
+              : blockStartFloatEndEdge - basePaddingRect.y1
+            : NaN;
+          const blockEndLimit = isFinite(blockEndFloatStartEdge)
+            ? this.vertical
+              ? blockEndFloatStartEdge - basePaddingRect.x1
+              : blockEndFloatStartEdge - basePaddingRect.y1
+            : NaN;
           const renderedBlockSize = parseFloat(
             this.vertical
               ? (column?.element.style.width ?? "")

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -762,8 +762,8 @@ export namespace PageFloats {
     ): string | null;
     getFloatFragmentExclusions(): GeometryUtil.Shape[];
     getMaxReachedAfterEdge(): number;
-    getBlockEndEdgeOfBlockStartFloats(): number;
-    getBlockStartEdgeOfBlockEndFloats(): number;
+    getBlockEndEdgeOfBlockStartFloats(inlinePos?: number): number;
+    getBlockStartEdgeOfBlockEndFloats(inlinePos?: number): number;
     getPageFloatClearEdge(clear: string, column: Layout.Column): number;
     getPageFloatPlacementCondition(
       float: PageFloat,

--- a/packages/core/test/spec/vivliostyle/page-floats-spec.js
+++ b/packages/core/test/spec/vivliostyle/page-floats-spec.js
@@ -1859,6 +1859,156 @@ describe("page-floats", function () {
         expect(columnContext.getBlockStartEdgeOfBlockEndFloats()).toBe(480);
       });
 
+      it("filters block-end floats by inlinePos when getting block-start edge", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          container(false),
+          null,
+          null,
+          null,
+          null,
+        );
+        var regionContext = new PageFloatLayoutContext(
+          pageContext,
+          FloatReference.REGION,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var columnContext = new PageFloatLayoutContext(
+          regionContext,
+          FloatReference.COLUMN,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+        // Overlaps inlinePos=50 only
+        addFragment(pageContext, FloatReference.PAGE, "block-end", {
+          x1: 0,
+          x2: 100,
+          y1: 520,
+          y2: 600,
+        });
+        // Overlaps inlinePos=250 only
+        addFragment(regionContext, FloatReference.REGION, "block-end", {
+          x1: 200,
+          x2: 300,
+          y1: 480,
+          y2: 500,
+        });
+
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats()).toBe(480);
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats(50)).toBe(520);
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats(250)).toBe(480);
+      });
+
+      it("treats block-end inline-* floats as block-end floats", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          container(false),
+          null,
+          null,
+          null,
+          null,
+        );
+        var regionContext = new PageFloatLayoutContext(
+          pageContext,
+          FloatReference.REGION,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var columnContext = new PageFloatLayoutContext(
+          regionContext,
+          FloatReference.COLUMN,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+        addFragment(pageContext, FloatReference.PAGE, "block-end inline-end", {
+          x1: 0,
+          x2: 150,
+          y1: 540,
+          y2: 600,
+        });
+        addFragment(
+          regionContext,
+          FloatReference.REGION,
+          "block-end inline-start",
+          {
+            x1: 200,
+            x2: 350,
+            y1: 500,
+            y2: 560,
+          },
+        );
+
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats()).toBe(500);
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats(50)).toBe(540);
+        expect(columnContext.getBlockStartEdgeOfBlockEndFloats(250)).toBe(500);
+      });
+
+      it("filters block-start floats by inlinePos when getting block-end edge", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          container(false),
+          null,
+          null,
+          null,
+          null,
+        );
+        var regionContext = new PageFloatLayoutContext(
+          pageContext,
+          FloatReference.REGION,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var columnContext = new PageFloatLayoutContext(
+          regionContext,
+          FloatReference.COLUMN,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+        // Overlaps inlinePos=50 only
+        addFragment(pageContext, FloatReference.PAGE, "block-start", {
+          x1: 0,
+          x2: 100,
+          y1: 0,
+          y2: 80,
+        });
+        // Overlaps inlinePos=250 only
+        addFragment(regionContext, FloatReference.REGION, "block-start", {
+          x1: 200,
+          x2: 300,
+          y1: 0,
+          y2: 120,
+        });
+
+        expect(columnContext.getBlockEndEdgeOfBlockStartFloats()).toBe(120);
+        expect(columnContext.getBlockEndEdgeOfBlockStartFloats(50)).toBe(80);
+        expect(columnContext.getBlockEndEdgeOfBlockStartFloats(250)).toBe(120);
+      });
+
       it("includes ancestor block-end floats in vertical contexts", function () {
         var pageContext = new PageFloatLayoutContext(
           rootContext,
@@ -1902,6 +2052,54 @@ describe("page-floats", function () {
         });
 
         expect(columnContext.getBlockStartEdgeOfBlockEndFloats()).toBe(260);
+      });
+
+      it("filters block-start floats by inlinePos in vertical contexts", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          container(true),
+          null,
+          null,
+          null,
+          null,
+        );
+        var regionContext = new PageFloatLayoutContext(
+          pageContext,
+          FloatReference.REGION,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var columnContext = new PageFloatLayoutContext(
+          regionContext,
+          FloatReference.COLUMN,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+        // In vertical writing, inline axis is Y.
+        addFragment(pageContext, FloatReference.PAGE, "block-start", {
+          x1: 300,
+          x2: 360,
+          y1: 0,
+          y2: 120,
+        });
+        addFragment(regionContext, FloatReference.REGION, "block-start", {
+          x1: 260,
+          x2: 320,
+          y1: 200,
+          y2: 300,
+        });
+
+        expect(columnContext.getBlockEndEdgeOfBlockStartFloats()).toBe(260);
+        expect(columnContext.getBlockEndEdgeOfBlockStartFloats(50)).toBe(300);
+        expect(columnContext.getBlockEndEdgeOfBlockStartFloats(250)).toBe(260);
       });
     });
   });


### PR DESCRIPTION
- calculate block-start/block-end float limits per column-rule inline position
- clip column-rule start/end only when the rule line actually intersects page floats
- keep existing column balancing behavior (issue #1493) unchanged
- update PageFloatLayoutContext method signatures to accept optional inline position

fixes #1813

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author described the bug (column rules were shortened around page floats even when the float's inline size was too small to actually overlap the rule) and asked the AI to fix it; when a build error appeared, the human author asked for it to be fixed first.
- The human author clarified that a related column-balancing behavior (from the issue #1493 fix) should remain unchanged even though it produces a different result from the stable version, and asked the AI to discard an incorrect change made to `columns.ts` along the way.
- After creating the PR, the human author reported and reproduced an additional column-rule/page-float overlap case raised by a reviewer, and asked for a more concise English reply to reviewers.

</details>
