### PR TITLE
fix: prevent duplicate dev server startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "lerna run build",
     "build-dev": "lerna run build-dev",
     "clean": "lerna run clean",
-    "dev": "lerna run dev --parallel --ignore @vivliostyle/react",
+    "dev": "node scripts/dev.mjs",
     "dev:react": "lerna run dev --parallel --ignore @vivliostyle/viewer",
     "format": "lerna run format",
     "lint": "lerna run lint",

--- a/packages/viewer/gulpfile.js
+++ b/packages/viewer/gulpfile.js
@@ -339,13 +339,22 @@ function serve(isDevelopment) {
   gulp.watch(target).on("change", browserSync.reload);
   return true;
 }
-gulp.task(
-  "serve",
-  gulp.series("watch", function (done) {
-    serve(false);
+gulp.task("serve", function (done) {
+  const runningDevServer = findRunningDevServer();
+  if (runningDevServer) {
+    console.log(
+      `[dev] Vivliostyle dev server is already running at ${runningDevServer.url}.`,
+    );
+    console.log("[dev] Skipping a new dev server start.");
     done();
-  }),
-);
+    return;
+  }
+
+  return gulp.series("watch", function (next) {
+    serve(false);
+    next();
+  })(done);
+});
 gulp.task("serve-dev", function (done) {
   const runningDevServer = findRunningDevServer();
   if (runningDevServer) {

--- a/packages/viewer/gulpfile.js
+++ b/packages/viewer/gulpfile.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require("fs");
 const path = require("path");
+const process = require("process");
 // const KarmaServer = require("karma").Server;
 const browserSync = require("browser-sync").create();
 const gulp = require("gulp");
@@ -33,6 +34,8 @@ const VIEWER_JS_FILES = {
   production: path.relative(DEST_DIR, pkg.main),
   development: "js/vivliostyle-viewer-dev.js",
 };
+const DEV_SERVER_LOCK_FILE = path.resolve(".cache", "dev-server.json");
+const DEV_SERVER_DEFAULT_URL = "http://localhost:3000/core/test/files/";
 
 const VIVLIOSTYLE_VERSION = process.env["VIVLIOSTYLE_VERSION"];
 const VERSION =
@@ -48,6 +51,119 @@ function destDir(type) {
   const dirs = RESOURCE_MAP[type];
   const dirName = dirs.dest ? dirs.dest : dirs.src;
   return path.join(DEST_DIR, dirName);
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readDevServerLock() {
+  if (!fs.existsSync(DEV_SERVER_LOCK_FILE)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(DEV_SERVER_LOCK_FILE, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function removeDevServerLock() {
+  fs.rmSync(DEV_SERVER_LOCK_FILE, { force: true });
+}
+
+function cleanupStaleDevServerLock() {
+  const lock = readDevServerLock();
+  if (lock && isProcessAlive(lock.pid)) {
+    return lock;
+  }
+  if (fs.existsSync(DEV_SERVER_LOCK_FILE)) {
+    removeDevServerLock();
+  }
+  return null;
+}
+
+function writeDevServerLock(url) {
+  fs.mkdirSync(path.dirname(DEV_SERVER_LOCK_FILE), { recursive: true });
+  fs.writeFileSync(
+    DEV_SERVER_LOCK_FILE,
+    JSON.stringify({
+      pid: process.pid,
+      url,
+      startedAt: new Date().toISOString(),
+    }),
+  );
+}
+
+let hasRegisteredDevServerCleanup = false;
+function registerDevServerCleanup() {
+  if (hasRegisteredDevServerCleanup) {
+    return;
+  }
+  hasRegisteredDevServerCleanup = true;
+
+  const cleanup = () => {
+    const lock = readDevServerLock();
+    if (lock && lock.pid === process.pid) {
+      removeDevServerLock();
+    }
+  };
+
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+}
+
+function findRunningDevServer() {
+  const lock = cleanupStaleDevServerLock();
+  if (!lock) {
+    return null;
+  }
+  return {
+    url: lock.url || DEV_SERVER_DEFAULT_URL,
+  };
+}
+
+function getLocalServerOrigin(bs) {
+  if (!bs || typeof bs.getOption !== "function") {
+    return "http://localhost:3000";
+  }
+  const urls = bs.getOption("urls");
+  if (urls && typeof urls.get === "function") {
+    const local = urls.get("local");
+    if (local) {
+      return local;
+    }
+  }
+  return "http://localhost:3000";
+}
+
+function getDevServerUrl(localUrl) {
+  if (typeof localUrl !== "string" || !localUrl) {
+    return DEV_SERVER_DEFAULT_URL;
+  }
+
+  if (localUrl.includes("/core/test/files/")) {
+    return localUrl;
+  }
+
+  const normalized = localUrl.endsWith("/") ? localUrl.slice(0, -1) : localUrl;
+  return `${normalized}/core/test/files/`;
 }
 
 const srcPattern = (type) =>
@@ -193,16 +309,35 @@ gulp.task(
 
 // serve
 function serve(isDevelopment) {
-  browserSync.init({
-    server: {
-      baseDir: "../",
+  const runningDevServer = findRunningDevServer();
+  if (runningDevServer) {
+    console.log(
+      `[dev] Vivliostyle dev server is already running at ${runningDevServer.url}.`,
+    );
+    console.log("[dev] Skipping a new dev server start.");
+    return false;
+  }
+
+  browserSync.init(
+    {
+      server: {
+        baseDir: "../",
+      },
+      startPath: "/core/test/files/",
+      ghostMode: false, // do not mirror clicks, scrolls etc. between multiple browsers
+      notify: false, // do not show any notifications in the browser
+      port: 3000,
     },
-    startPath: "/core/test/files/",
-    ghostMode: false, // do not mirror clicks, scrolls etc. between multiple browsers
-    notify: false, // do not show any notifications in the browser
-  });
+    (_, bs) => {
+      const localOrigin = getLocalServerOrigin(bs);
+      const devServerUrl = getDevServerUrl(localOrigin);
+      writeDevServerLock(devServerUrl);
+      registerDevServerCleanup();
+    },
+  );
   const target = [DEST_DIR + "/**/*"];
   gulp.watch(target).on("change", browserSync.reload);
+  return true;
 }
 gulp.task(
   "serve",
@@ -211,12 +346,21 @@ gulp.task(
     done();
   }),
 );
-gulp.task(
-  "serve-dev",
-  gulp.series("watch-dev", function (done) {
-    serve(true);
+gulp.task("serve-dev", function (done) {
+  const runningDevServer = findRunningDevServer();
+  if (runningDevServer) {
+    console.log(
+      `[dev] Vivliostyle dev server is already running at ${runningDevServer.url}.`,
+    );
+    console.log("[dev] Skipping a new dev server start.");
     done();
-  }),
-);
+    return;
+  }
+
+  return gulp.series("watch-dev", function (next) {
+    serve(true);
+    next();
+  })(done);
+});
 
 gulp.task("default", gulp.task("serve-dev"));

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,69 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+const DEV_SERVER_LOCK_FILE = resolve(
+  process.cwd(),
+  "packages/viewer/.cache/dev-server.json",
+);
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getExistingDevServerUrl() {
+  if (!existsSync(DEV_SERVER_LOCK_FILE)) {
+    return null;
+  }
+
+  try {
+    const lock = JSON.parse(readFileSync(DEV_SERVER_LOCK_FILE, "utf8"));
+    if (isProcessAlive(lock.pid)) {
+      return lock.url || "http://localhost:3000/core/test/files/";
+    }
+  } catch {
+    // Ignore parse/read errors and remove broken lock file below.
+  }
+
+  rmSync(DEV_SERVER_LOCK_FILE, { force: true });
+  return null;
+}
+
+const existingUrl = getExistingDevServerUrl();
+if (existingUrl) {
+  console.log(
+    `[dev] Vivliostyle dev server is already running at ${existingUrl}.`,
+  );
+  console.log("[dev] Skipping a new dev server start.");
+  process.exit(0);
+}
+
+const child = spawn(
+  "lerna",
+  ["run", "dev", "--parallel", "--ignore", "@vivliostyle/react"],
+  {
+    stdio: "inherit",
+    shell: true,
+  },
+);
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+
+child.on("error", (err) => {
+  console.error("[dev] Failed to start lerna:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to prevent `yarn dev` from starting a duplicate dev server when one was already running, proposing two possible approaches; after discussion, directed the AI to implement the simpler one (exit 0 and show the existing URL, no forced-restart option) and helped debug an error encountered while testing it.
- The human author asked for the branch to be renamed to match the commit message convention, then had the AI push and create the PR, and asked it to address a Copilot review comment.

</details>
