### PR TITLE
fix: preserve border-top on table cells outside explicit table-row

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -417,9 +417,16 @@ export class TableFormattingContext
       case "table-cell": {
         // For cells, check if this cell's source node is in cellBreakPositions
         // or if fragmentIndex indicates this is a continuation (issue #1663).
-        const parentFragmentIndex =
-          nodeContext.parent?.fragmentIndex ?? nodeContext.fragmentIndex;
-        if (nodeContext.fragmentIndex > 1 || parentFragmentIndex > 1) {
+        // A table-cell directly under the table participates in an anonymous
+        // row, so a continued table fragment must not make a fresh cell look
+        // like a continuation fragment.
+        if (nodeContext.fragmentIndex > 1) {
+          return false;
+        }
+        if (
+          nodeContext.parent?.display === "table-row" &&
+          nodeContext.parent.fragmentIndex > 1
+        ) {
           return false;
         }
         // Check if this cell's sourceNode is in cellBreakPositions


### PR DESCRIPTION
Fix only problem 2 from Issue #1816: border-top was not rendered on row-less table cells after a page break.

Problem 1 in Issue #1816 is not fixed by this commit, so the issue should remain open.

Refs #1816

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author explained the two distinct problems described in issue #1816 (one long-standing, one caused by PR #1665) and asked the AI to fix them; when the fix broke table layout badly in one test, the human author reported the specifics precisely (cells shifted to the wrong fragment/column).
- The human author decided to scope this PR to problem 2 only, judging problem 1 low priority since it had never caused reported issues, and confirmed the fix matched the stable version's behavior exactly before finalizing.

</details>
