### PR TITLE
fix: Don't hide aside[role="doc-footnote"] unless referenced by a noteref anchor

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1390,9 +1390,9 @@ a[role="doc-noteref"]:href-role-type(doc-footnote, aside) {
   text-decoration: none;
 }
 
-aside[epub|type="footnote"],
-aside[epub\:type="footnote"],
-aside[role="doc-footnote"] {
+aside[epub|type="footnote"][data-vivliostyle-footnote-referenced],
+aside[epub\:type="footnote"][data-vivliostyle-footnote-referenced],
+aside[role="doc-footnote"][data-vivliostyle-footnote-referenced] {
   display: none;
 }
 

--- a/packages/core/src/vivliostyle/semantic-footnote.ts
+++ b/packages/core/src/vivliostyle/semantic-footnote.ts
@@ -18,6 +18,7 @@
  */
 
 import * as Base from "./base";
+import * as Plugin from "./plugin";
 
 function hasToken(value: string | null, token: string): boolean {
   return !!(value && value.match(new RegExp(`(^|\\s)${token}($|\\s)`)));
@@ -48,3 +49,38 @@ export function isSemanticFootnoteNoterefElement(element: Element): boolean {
     element.getAttribute("epub:type");
   return hasToken(epubType, "noteref");
 }
+
+/**
+ * Mark aside elements that are referenced by semantic footnote noteref anchors
+ * with the `data-vivliostyle-footnote-referenced` attribute.
+ * This is used by the UA stylesheet to apply `display: none` only to asides
+ * that are actually referenced (so unreferenced asides with `float: footnote`
+ * set by the author stylesheet are not hidden). (Issue #1823)
+ */
+function markReferencedFootnoteElements(document: Document): void {
+  const anchorElements = document.getElementsByTagName("a");
+  for (let i = 0; i < anchorElements.length; i++) {
+    const anchor = anchorElements.item(i);
+    if (!isSemanticFootnoteNoterefElement(anchor)) {
+      continue;
+    }
+    // Only handle same-document fragment references, same as :href-role-type()
+    if (
+      !(anchor instanceof HTMLAnchorElement) ||
+      !anchor.hash ||
+      anchor.href !== anchor.baseURI.replace(/#.*$/, "") + anchor.hash
+    ) {
+      continue;
+    }
+    const id = anchor.hash.substring(1);
+    const target = document.getElementById(id);
+    if (target && isSemanticFootnoteElement(target)) {
+      target.setAttribute("data-vivliostyle-footnote-referenced", "true");
+    }
+  }
+}
+
+Plugin.registerHook(
+  Plugin.HOOKS.PREPROCESS_SINGLE_DOCUMENT,
+  markReferencedFootnoteElements,
+);


### PR DESCRIPTION
- fixes #1823

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author described the issue in detail: semantic footnote support hides `aside[role="doc-footnote"]` via `display: none` to remove it from normal flow, but this incorrectly hides such elements even when no `a[role="doc-noteref"]` links to them, and asked the AI for a good approach to only hide referenced footnote asides.
- The AI proposed and implemented marking referenced footnote asides with a `data-vivliostyle-footnote-referenced` attribute during document preprocessing (`PREPROCESS_SINGLE_DOCUMENT`), restricting the `display: none` UA rule to elements carrying that attribute.

</details>
