### PR TITLE
fix: fix multi-column text and page block-end float overlap

### DIFF
--- a/packages/core/src/vivliostyle/columns.ts
+++ b/packages/core/src/vivliostyle/columns.ts
@@ -74,6 +74,13 @@ export abstract class ColumnBalancer {
     const frame: Task.Frame<ColumnLayoutResult> = Task.newFrame(
       "ColumnBalancer#balanceColumns",
     );
+    // Suppress block-size adjustment during column balancing trials so trial
+    // break positions are not affected by block-end floats. (Issue #1787,
+    // #1826)
+    this.layoutContainer.element.setAttribute(
+      "data-vivliostyle-in-column-balancing",
+      "true",
+    );
     this.preBalance(layoutResult);
     this.savePageFloatLayoutContexts(layoutResult);
     this.layoutContainer.clear();
@@ -100,6 +107,9 @@ export abstract class ColumnBalancer {
         const result = candidates.reduce(
           (prev, curr) => (curr.penalty < prev.penalty ? curr : prev),
           candidates[0],
+        );
+        this.layoutContainer.element.removeAttribute(
+          "data-vivliostyle-in-column-balancing",
         );
         this.restoreContents(result.layoutResult);
         this.tightenColumnBlockSizes(result.layoutResult.columns);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1065,8 +1065,17 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   private adjustColumnBlockSizeForBlockEndFloats(): void {
-    if (!this.element.hasAttribute("data-vivliostyle-page-area")) {
-      // This adjustment is only for the page area. (Issue #1787, #1789)
+    // During column balancing, this column is a child of the page-area
+    // container re-laid out by ColumnBalancer. Skip CSS block-size adjustment
+    // for those trial columns so balancing is based on the original fragmentainer
+    // size, while keeping the adjustment for the final layout pass to avoid the
+    // half-leading overlap regression. (Issue #1787, #1826)
+    if (
+      this.element.hasAttribute("data-vivliostyle-in-column-balancing") ||
+      this.element.parentElement?.hasAttribute(
+        "data-vivliostyle-in-column-balancing",
+      )
+    ) {
       return;
     }
     const initialBlockSize = this.vertical ? this.width : this.height;
@@ -1082,6 +1091,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         const left = this.left + (initialBlockSize - blockSize);
         Base.setCSSProperty(this.element, "left", `${left}px`);
       }
+      this.element.setAttribute(
+        "data-vivliostyle-column-block-size-adjusted",
+        "true",
+      );
     }
   }
 
@@ -4093,7 +4106,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               LayoutHelper.unsetBrowserColumnBreaking(this);
 
               // Restore root column block-size if it was reduced by Chromium
-              // table fragmentation workaround. (Issue #1812)
+              // table fragmentation workaround (Issue #1812),
+              // or by footnotes/block-end-page-floats and table/multicol issue
+              // workaround (Issue #1662, #1460).
               if (
                 this.element.hasAttribute(
                   "data-vivliostyle-column-block-size-adjusted",
@@ -4101,6 +4116,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               ) {
                 if (this.vertical) {
                   Base.setCSSProperty(this.element, "width", `${this.width}px`);
+                  Base.setCSSProperty(this.element, "left", `${this.left}px`);
                 } else {
                   Base.setCSSProperty(
                     this.element,

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -525,6 +525,10 @@ module.exports = [
         title:
           "Column rule with page floats and footnotes (vertical writing-mode) (Issue #1493, #1764)",
       },
+      {
+        file: "multi-column/multicol-page-block-end-float.html",
+        title: "Multi-column text and page block-end float (Issue #1826)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/multi-column/multicol-page-block-end-float.html
+++ b/packages/core/test/files/multi-column/multicol-page-block-end-float.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Multi-column text and page block-end float</title>
+    <style>
+      @page {
+        size: 500px;
+        margin: 50px;
+        outline: 1px solid cyan;
+
+        @bottom-center {
+          font-size: 12px;
+          line-height: 1;
+          content: "Page " counter(page);
+        }
+      }
+
+      :root {
+        font-size: 16px;
+        line-height: 50px;
+        column-count: 2;
+        column-rule: 4px solid orange;
+        widows: 1;
+        orphans: 1;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      p {
+        margin: 0;
+        background: orange;
+      }
+
+      .page-float {
+        float: block-end;
+        float-reference: page;
+        block-size: 64px;
+        text-align: center;
+        background: #f0f8;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page-float">Page Float</div>
+
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tortor
+      lorem, rhoncus a ex et, aliquam vulputate ex. Maecenas fermentum nunc quis
+      ligula eleifend venenatis. Nullam egestas mi eget turpis iaculis, at
+      varius ex ultrices. Proin consectetur, nisi id aliquet elementum, felis
+      massa auctor ex, ac rhoncus mi turpis vel nulla. Mauris sed ornare ligula.
+      Quisque lectus ante, pretium hendrerit magna tincidunt, dignissim pretium
+      metus. Aenean gravida fermentum sapien quis sagittis.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Restore adjustColumnBlockSizeForBlockEndFloats() for non-page-area columns and revert the temporary CSS block-size adjustment after column layout finishes.

Skip that adjustment only while column balancing trials are running, so balancing keeps using the original fragmentainer size and does not regress on balance-all multi-column layout.

Also add a regression test case for the multi-column text and block-end page float scenario.

Fixes #1826

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author, mid-way through fixing issue #1826 (half-leading gap overlapping a page float), traced the bug to PR #1796 and asked the AI to continue the fix; provided a minimal repro URL and later corrected the AI's read of the test results (a line had actually moved to the next column, not stayed).
- The human author questioned whether a proposed constant-name refactor was consistent with the rest of the codebase's conventions and decided against it.
- The human author asked to rename the new test's registered title to drop "overlap" (since the test also covers a related column-rule issue), directed the commit message and title, and after creating the PR reviewed Copilot's comments.

</details>
