### PR TITLE
fix: Fix column balancing misjudging balanced columns as unbalanced

### DIFF
--- a/packages/core/src/vivliostyle/columns.ts
+++ b/packages/core/src/vivliostyle/columns.ts
@@ -363,12 +363,15 @@ function isLastColumnLongerThanAnyOtherColumn(
   const lastColumnBlockSize = columns[columns.length - 1].computedBlockSize;
   const otherColumns = columns.slice(0, columns.length - 1);
 
-  // The computedBlockSize of the last column may be a little larger than
-  // the others even though columns are balanced, because of the issue
-  // that only the last column's computedBlockSize includes the last
-  // half-leading space.
-  // To work around this, we add an error margin to the other columns.
-  const errorMargin = 6;
+  // When a column is broken mid-paragraph, its computedBlockSize is measured
+  // from line content-area edges (excluding trailing half-leading). But the
+  // last column, where a paragraph ends naturally, includes the trailing
+  // half-leading. This causes a discrepancy of up to half the line-height
+  // between columns with the same number of lines.
+  // Use the line stride (≈ line-height) from broken columns to compute a
+  // proper error margin. (Issue #1828)
+  const maxLineStride = Math.max(...columns.map((c) => c.lastLineStride || 0));
+  const errorMargin = maxLineStride > 0 ? maxLineStride / 2 : 6;
   return otherColumns.every(
     (c) => lastColumnBlockSize > c.computedBlockSize + errorMargin,
   );

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -448,6 +448,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   nodeContextOverflowingDueToRepetitiveElements: Vtree.NodeContext | null =
     null;
   blockDistanceToBlockEndFloats: number = NaN;
+  lastLineStride: number = 0;
   breakAtTheEdgeBeforeFloat: string | null = null;
 
   constructor(
@@ -2770,6 +2771,18 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       }
       this.computedBlockSize =
         dir * (edge - this.beforeEdge) + repetitiveElementsOffset;
+      // Store line stride for column balancing half-leading correction.
+      // Use the stride around the actual break line instead of always
+      // assuming the first two lines have the representative stride.
+      if (linePositions.length >= 2) {
+        const strideIndex = Math.max(
+          1,
+          Math.min(lineIndex - 1, linePositions.length - 1),
+        );
+        this.lastLineStride = Math.abs(
+          linePositions[strideIndex] - linePositions[strideIndex - 1],
+        );
+      }
     }
     return nodeContext;
   }
@@ -3982,6 +3995,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     this.overflown = false;
     this.pageBreakType = null;
     this.lastAfterPosition = null;
+    this.lastLineStride = 0;
   }
 
   /**
@@ -4596,6 +4610,7 @@ export class ColumnLayoutRetryer extends LayoutRetryers.AbstractLayoutRetryer {
   private initialPageBreakType: string | null = null;
   initialComputedBlockSize: number = 0;
   private initialOverflown: boolean = false;
+  private initialLastLineStride: number = 0;
   context: { overflownNodeContext: Vtree.NodeContext } = {
     overflownNodeContext: null,
   };
@@ -4645,6 +4660,7 @@ export class ColumnLayoutRetryer extends LayoutRetryers.AbstractLayoutRetryer {
     this.initialPageBreakType = column.pageBreakType;
     this.initialComputedBlockSize = column.computedBlockSize;
     this.initialOverflown = column.overflown;
+    this.initialLastLineStride = column.lastLineStride;
   }
 
   override restoreState(nodeContext: Vtree.NodeContext, column: Layout.Column) {
@@ -4652,6 +4668,7 @@ export class ColumnLayoutRetryer extends LayoutRetryers.AbstractLayoutRetryer {
     column.pageBreakType = this.initialPageBreakType;
     column.computedBlockSize = this.initialComputedBlockSize;
     column.overflown = this.initialOverflown;
+    column.lastLineStride = this.initialLastLineStride;
   }
 }
 

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -169,6 +169,7 @@ export namespace Layout {
     pseudoParent: Column;
     nodeContextOverflowingDueToRepetitiveElements: Vtree.NodeContext | null;
     blockDistanceToBlockEndFloats: number;
+    lastLineStride: number;
     computedBlockSize: number;
 
     layoutContext: Vtree.LayoutContext;

--- a/packages/core/test/spec/vivliostyle/column-spec.js
+++ b/packages/core/test/spec/vivliostyle/column-spec.js
@@ -60,6 +60,7 @@ describe("column", function () {
     return {
       element: { parentNode: parentNode },
       computedBlockSize: computedBlockSize || 1000,
+      lastLineStride: 0,
       getMaxBlockSizeOfPageFloats: jasmine
         .createSpy("getMaxBlockSizeOfPageFloats")
         .and.returnValue(pageFloatBlockSize || 0),
@@ -235,6 +236,35 @@ describe("column", function () {
         };
 
         expect(balancer.calculatePenalty(layoutResult)).toBe(800);
+      });
+
+      it("does not return Infinity when last column exceeds others by half-leading within line stride margin", function () {
+        var balancer = createBalancer(2, false);
+        spyOn(balancer, "checkPosition").and.returnValue(true);
+        // Simulate: col0 broken mid-paragraph (384px, excludes trailing
+        // half-leading), col1 ends naturally (400px, includes half-leading).
+        // With line-height=50, the half-leading is 17px, so 400-384=16 < 25.
+        var layoutResult = {
+          columns: [384, 400].map(createDummyColumn),
+          position: {},
+        };
+        // Set lastLineStride (≈ line-height) on the broken column
+        layoutResult.columns[0].lastLineStride = 50;
+
+        expect(balancer.calculatePenalty(layoutResult)).toBe(400);
+      });
+
+      it("returns Infinity when last column genuinely exceeds others beyond half line stride", function () {
+        var balancer = createBalancer(2, false);
+        spyOn(balancer, "checkPosition").and.returnValue(true);
+        // col0=350, col1=400 → diff=50 > 50/2=25 → last column is genuinely longer
+        var layoutResult = {
+          columns: [350, 400].map(createDummyColumn),
+          position: {},
+        };
+        layoutResult.columns[0].lastLineStride = 50;
+
+        expect(balancer.calculatePenalty(layoutResult)).toBe(Infinity);
       });
     });
 


### PR DESCRIPTION
When a column is broken mid-paragraph, computedBlockSize excludes trailing half-leading, but the last column (where the paragraph ends naturally) includes it. The fixed errorMargin (6px) in isLastColumnLongerThanAnyOtherColumn was too small for large line-heights, causing balanced columns to be rejected as "last column longer".

Use the actual line stride (≈ line-height) recorded during column breaking to compute a proper error margin of half the line stride.

closes #1828

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author described issue #1828 (column balancing misjudging balanced columns as unbalanced) along with a detailed hypothesis about the half-leading discrepancy between columns broken mid-paragraph versus the last column, and asked the AI to investigate and fix it.
- The human author built a simplified repro test case to confirm the hypothesis, then confirmed the fix worked, directed the commit message, and after creating the PR asked the AI to check and address Copilot review comments.

</details>
