### PR TITLE
fix: Use browser's native `::marker` pseudo-element for list markers

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1353,7 +1353,6 @@ m|math[display="block"] {
 /* CSS GCPM footnotes */
 ::footnote-marker {
   content: counter(footnote) ". ";
-  list-style-position: inside;
 }
 ::footnote-call {
   content: counter(footnote);
@@ -1594,37 +1593,53 @@ span[data-viv-leader] {
 }
 
 /* ::marker */
-/* Mozilla Bullet font (https://github.com/mozilla/gecko-dev/blob/master/layout/style/res/Mozilla_Bullet.woff2) */
-@font-face {
-  font-family: "-viv-moz-bullet";
-  src: url("data:font/woff2;base64,d09GMgABAAAAAAScAAsAAAAACfAAAARNAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAAhBIRCAqGMIRJATYCJAMsCxgABCAFhF4HaBsuCMgehXEsLOlXaXd7sgbPQ172fjLwdhYFM92mABaiTuRVdO5/mx9I5UJiJom3phLRQw/TSF2M/vo25+pNyWkNws81NrUDAAf0QOdfcf7nmPEyBPZtCbbZEDuosskKZG922ZhBenh05qcSXktf6s3Oy9dAkWsyDzMoM5QTKcwKNjFayUPSREGFhUMrdE8MJsH052qGcYNO3pbEaYIBoDTItIKGAqhDdKHRD0kkKg6QGSCWEfueTNr3P6OvYaIbDH/8ULEAbjQtUt+hT/qmX/SH/twwMLDqN4jxzXjy4PHtltSA6lINqkpRd7N7onVBP20y7YBWyDIHFEBjqKBFMmECfQcTZtD3MmEB/SATVtCPM2ED/TQTdtCfS0/pEsN4ySin3r8q8xHE+0D0XMg8gJi4YrNpNv3qetXuDyeo6OBNZrq5gi7ouC1zcmB2Fd+FewIhcUIfszpF1hzXhrmMCwxaznRyZjig6Y2W7+bBn2DL8fJu/2oHbWc6X80+LUTXcVzv8O3IOy4qKVyFw/DHaMtfzNQEi5gbFT/EDpiofbpkYq2dQui6WcpfxrVBEJ/KxbLA4ZroZoVx+iE+QeTIiI7oKuoUIk/a1ekEOoNFjozm0suYYUelq13/88K1c3PTH9O9Q0d5LZbu7+J2aT7XP23KyQs+34WTU7r8d/k0l6dLl98Dn+/BSUZc7U0mm7FqhSMO9EHV/j5FB4qYX4aXNaKwz/4RRfAWsW8xGW+hvr8PTAf6IP9mRpkDwwv7QFz9HRuOeGWfd8rkyYsWTVy4vpG/pgVNWzBx0aTeIgeq58XFVfZXVduwuOq51a77aT0XLVw4v1PBFjRsQzO+tVeVp3KIwqfKbd6sdjzGvFSuPMquGpMT29lkrhwbE5uz6cGHhIETB06oUk+6tHLJgfnu/3nVnJzYxiXNjQNjYqsu+vCgYKDla5uUOzTNDZg46eCBd3d3gSk9Kz/bFiv8hvOzCT5eqyjBGerT+EiG/JGqwbC+UQ6Bv9bmKGWMj8Yn+fPVRJxKBGqTFXQyM9DhHSlvEHmLVxyYjY/Fdd3hACfLyP3VVZLvVR7B0pxSsGIBqHhwT5sSMOMkRG0BJhpsWMkEO24KwE0pqp3tIYTWCIjJjuBiGNTKTj8JoBLKAn4TmPFnj9oywZwFGx4egp1g3oObeLHdwUO2pFcYTITZCa2c1GQbNg6RCsu9bpikThhAWnLaBi3LM8+5VbMU6rUn30owOC83ULcfBlClb5BBre46BinaWRal85SUvlCbUx1Nbyj2HWCxBTkEgWScQKzsTioJW0IanAYRZqET4mZLSKU2JABII9np01lQ7lOt3srtM1KAeqgQPhYJSMCZJRuAukRZB1CF35gB1MJBr4ilIPZchNyIlDkpRt+3s96cz9K8XKQvCdZfcqWxgtLoXZ2AoKAyVSRRxSRmsYjVOriP089q3z6gdMjE5KI7kzumWzpnAwAAAA==") format("woff2");
-}
-[data-adapt-pseudo="marker"],
-[data-adapt-pseudo="footnote-marker"] {
+[style*="--viv-marker-content"]::marker {
+  content: var(--viv-marker-content);
   unicode-bidi: isolate;
   font-variant-numeric: tabular-nums;
   white-space: pre;
   text-transform: none;
 }
-[data-adapt-pseudo="marker"]._viv-marker-bullet {
-  font-family: "-viv-moz-bullet";
-  font-style: normal;
-  font-weight: normal;
+/* ::footnote-marker inherits --viv-marker-content from the footnote element */
+.-vivliostyle-footnote-content::marker {
+  content: var(--viv-marker-content);
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  white-space: pre;
+  text-transform: none;
 }
-[data-adapt-pseudo="marker"]._viv-marker-outside,
-[data-adapt-pseudo="footnote-marker"]._viv-marker-outside {
-  position: relative;
-  text-indent: 0;
-  line-height: 1;
+[style*="--viv-marker-color"]::marker {
+  color: var(--viv-marker-color);
 }
-[data-adapt-pseudo="marker"] > ._viv-marker-outside-content,
-[data-adapt-pseudo="footnote-marker"] > ._viv-marker-outside-content {
-  position: absolute;
-  inset-inline-end: 0;
-  inset-block-start: 0;
-  inset-block-end: 0;
-  display: flex !important;
-  align-items: center;
+[style*="--viv-marker-font-size"]::marker {
+  font-size: var(--viv-marker-font-size);
+}
+[style*="--viv-marker-font-family"]::marker {
+  font-family: var(--viv-marker-font-family);
+}
+[style*="--viv-marker-font-style"]::marker {
+  font-style: var(--viv-marker-font-style);
+}
+[style*="--viv-marker-font-weight"]::marker {
+  font-weight: var(--viv-marker-font-weight);
+}
+[style*="--viv-marker-font-variant"]::marker {
+  font-variant: var(--viv-marker-font-variant);
+}
+[style*="--viv-marker-unicode-bidi"]::marker {
+  unicode-bidi: var(--viv-marker-unicode-bidi);
+}
+[style*="--viv-marker-direction"]::marker {
+  direction: var(--viv-marker-direction);
+}
+[style*="--viv-marker-white-space"]::marker {
+  white-space: var(--viv-marker-white-space);
+}
+[style*="--viv-marker-text-transform"]::marker {
+  text-transform: var(--viv-marker-text-transform);
+}
+[style*="--viv-marker-text-combine-upright"]::marker {
+  text-combine-upright: var(--viv-marker-text-combine-upright);
 }
 
 /* initial-letter */

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -41,6 +41,19 @@ function cloneCounterValues(
 }
 
 /**
+ * Decode CSS string escape sequences.
+ * e.g., `\22` → `"`, `\A` → newline, `\\` → `\`
+ */
+function decodeCssString(s: string): string {
+  return s.replace(/\\([0-9a-fA-F]{1,6})\s?|\\(.)/g, (_, hex, ch) => {
+    if (hex) {
+      return String.fromCodePoint(parseInt(hex, 16));
+    }
+    return ch;
+  });
+}
+
+/**
  * Extract text content from an element for a specific pseudo-element.
  * @param element The DOM element to extract text from
  * @param pseudoElement The pseudo-element type: "content", "before", "after" or "marker"
@@ -56,6 +69,33 @@ function extractPseudoElementText(
     const pseudos = clone.querySelectorAll("[data-adapt-pseudo]");
     pseudos.forEach((pseudo) => pseudo.remove());
     return clone.textContent || "";
+  } else if (pseudoElement === "marker") {
+    // First check for traditional marker span (e.g., footnote-marker inside)
+    const pseudoElem = element.querySelector(
+      `[data-adapt-pseudo="marker"], [data-adapt-pseudo="footnote-marker"]`,
+    );
+    if (pseudoElem) {
+      return pseudoElem.textContent || "";
+    }
+    // Native ::marker: read from --viv-marker-content CSS custom property.
+    // Use getComputedStyle to capture inherited values (e.g., footnote-content
+    // inheriting from the footnote wrapper).
+    const markerContent = element.ownerDocument.defaultView
+      ?.getComputedStyle(element)
+      ?.getPropertyValue("--viv-marker-content");
+    if (markerContent) {
+      // Extract only string components from the CSS content value.
+      // e.g., url(icon.png) "1. " → "1. " (url() tokens are ignored)
+      const stringMatches = markerContent.match(
+        /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g,
+      );
+      if (stringMatches && stringMatches.length > 0) {
+        return stringMatches
+          .map((s) => decodeCssString(s.substring(1, s.length - 1)))
+          .join("");
+      }
+    }
+    return "";
   } else {
     // Extract ::before or ::after content
     const pseudoElem = element.querySelector(

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2567,7 +2567,20 @@ export class ContentPropVisitor extends Css.FilterVisitor {
             const pseudos = getStyleMap(this.cascade.currentStyle, "_pseudos");
             const val = (pseudos?.[pseudoName]?.["content"] as CascadeValue)
               ?.value;
-            stringValue = this.evaluateAndGetString(val);
+            if (val) {
+              stringValue = this.evaluateAndGetString(val);
+            } else if (pseudoName === "marker") {
+              // Native ::marker: content was extracted to --viv-marker-content
+              const markerVal = (
+                this.cascade.currentStyle[
+                  "--viv-marker-content"
+                ] as CascadeValue
+              )?.value;
+              stringValue = getStringValueFromCssContentVal(
+                markerVal,
+                this.cascade.context,
+              );
+            }
           }
         }
         break;
@@ -3680,12 +3693,52 @@ export class CascadeInstance {
             this.processPseudoelementProps(pseudoProps, element, pseudoName);
 
             if (pseudoName === "marker") {
-              // Make marker content from list-style-* properties
+              // Extract ::marker properties into CSS custom properties on the
+              // parent element, then remove the pseudo-element so the browser's
+              // native ::marker is used instead.
               this.processMarkerPseudoelementProps(
                 pseudoProps,
                 element,
                 styler,
               );
+              // Delete the pseudo to prevent fake element generation
+              delete pseudos[pseudoName];
+            } else if (pseudoName === "footnote-marker") {
+              // For ::footnote-marker, use native ::marker only when
+              // list-style-position: outside. When inside (default), use
+              // traditional marker span to support properties like
+              // vertical-align that ::marker doesn't support.
+              const fnMarkerListStylePos = (
+                pseudoProps["list-style-position"] as CascadeValue
+              )?.value;
+              if (fnMarkerListStylePos === Css.ident.outside) {
+                // Use native ::marker with CSS custom properties
+                this.processMarkerPseudoelementProps(
+                  pseudoProps,
+                  element,
+                  styler,
+                );
+                // Set display: list-item for native ::marker to work
+                this.currentStyle["display"] = new CascadeValue(
+                  Css.getName("list-item"),
+                  0,
+                );
+                this.currentStyle["list-style-position"] = new CascadeValue(
+                  Css.ident.outside,
+                  0,
+                );
+                this.currentStyle["list-style-type"] = new CascadeValue(
+                  Css.ident.none,
+                  0,
+                );
+                this.currentStyle["list-style-image"] = new CascadeValue(
+                  Css.ident.none,
+                  0,
+                );
+                // Delete the pseudo to prevent fake element generation
+                delete pseudos[pseudoName];
+              }
+              // else: keep the pseudo for traditional span-based rendering
             } else if (
               pseudoName === "first-letter" &&
               pseudoProps["initial-letter"]
@@ -3726,19 +3779,49 @@ export class CascadeInstance {
     }
   }
 
+  /**
+   * Properties that are valid on ::marker and should be extracted
+   * to CSS custom properties on the parent element.
+   */
+  static readonly markerAllowedProps: string[] = [
+    "color",
+    "font-family",
+    "font-size",
+    "font-style",
+    "font-weight",
+    "font-variant",
+    "unicode-bidi",
+    "direction",
+    "white-space",
+    "text-transform",
+    "text-combine-upright",
+  ];
+
+  /**
+   * Extract ::marker or ::footnote-marker properties into CSS custom
+   * properties (--viv-marker-*) on the parent element's currentStyle,
+   * so that the browser's native ::marker can be controlled via polyfill CSS.
+   *
+   * For ::marker: the content is resolved from list-style-type/list-style-image
+   * if not explicitly set.  For ::footnote-marker: the content comes from
+   * ::footnote-marker { content: ... } declarations.
+   */
   processMarkerPseudoelementProps(
     pseudoProps: ElementStyle,
     element: Element,
     styler: CssStyler.AbstractStyler,
   ): void {
+    const isListItem = Display.isListItem(
+      (this.currentStyle["display"] as CascadeValue)?.value,
+    );
+
+    // Resolve marker content from list-style-* if no explicit content
     if (
       !Vtree.nonTrivialContent(
         (pseudoProps["content"] as CascadeValue)?.value,
       ) &&
-      Display.isListItem((this.currentStyle["display"] as CascadeValue)?.value)
+      isListItem
     ) {
-      // If no ::marker content is specified and the element is a list-item,
-      // make content from list-style-type or list-style-image.
       const listStyleType = this.getInheritedPropertyValue(
         "list-style-type",
         styler,
@@ -3750,8 +3833,7 @@ export class CascadeInstance {
         element,
       );
       if (listStyleImage instanceof Css.URL) {
-        // list-style-image: <URL>
-        // -> content: <URL> " "
+        // list-style-image: <URL> -> content: <URL> " "
         pseudoProps["content"] = new CascadeValue(
           new Css.SpaceList([listStyleImage, new Css.Str(" ")]),
           0,
@@ -3769,19 +3851,56 @@ export class CascadeInstance {
             ?.value as Css.Num
         )?.num;
         if (listItemCount != null) {
-          pseudoProps["content"] = new CascadeValue(
-            new Css.Str(
-              this.counterStyleStore.formatMarker(
-                listStyleType.name,
-                listItemCount,
+          const lowerName = listStyleType.name.toLowerCase();
+          if (
+            lowerName === "disc" ||
+            lowerName === "circle" ||
+            lowerName === "square" ||
+            lowerName === "disclosure-open" ||
+            lowerName === "disclosure-closed"
+          ) {
+            // Bullet types: let the browser handle natively via
+            // list-style-type. Don't set --viv-marker-content.
+          } else {
+            pseudoProps["content"] = new CascadeValue(
+              new Css.Str(
+                this.counterStyleStore.formatMarker(
+                  listStyleType.name,
+                  listItemCount,
+                ),
               ),
-            ),
+              0,
+            );
+          }
+        }
+      }
+    }
+
+    // Now extract the resolved content to CSS custom property
+    const contentCasc = pseudoProps["content"] as CascadeValue;
+    if (contentCasc) {
+      const contentVal = contentCasc.value;
+      if (Vtree.nonTrivialContent(contentVal)) {
+        // Resolve any Css.Expr nodes (e.g., from counter()) to strings
+        const resolvedContent = this.resolveMarkerContentVal(contentVal);
+        this.currentStyle["--viv-marker-content"] = new CascadeValue(
+          resolvedContent,
+          0,
+        );
+      }
+    }
+
+    // Extract allowed ::marker properties to CSS custom properties
+    for (const propName of CascadeInstance.markerAllowedProps) {
+      const prop = pseudoProps[propName] as CascadeValue;
+      if (prop) {
+        const val = prop.evaluate(this.context, propName);
+        if (val && !Css.isDefaultingValue(val)) {
+          this.currentStyle[`--viv-marker-${propName}`] = new CascadeValue(
+            val,
             0,
           );
         }
-        // This is used in the marker layout processing in
-        // `PseudoelementStyler.processMarker()` in pseudo-element.ts.
-        pseudoProps["list-style-type"] = new CascadeValue(listStyleType, 0);
       }
     }
 
@@ -3792,15 +3911,39 @@ export class CascadeInstance {
         styler,
         element,
       );
-      if (listStylePosition) {
-        // This is used in the marker layout processing in
-        // `PseudoelementStyler.processMarker()` in pseudo-element.ts.
-        pseudoProps["list-style-position"] = new CascadeValue(
+      if (
+        listStylePosition &&
+        listStylePosition !== Css.ident.outside &&
+        !Css.isDefaultingValue(listStylePosition)
+      ) {
+        this.currentStyle["list-style-position"] = new CascadeValue(
           listStylePosition,
           0,
         );
       }
     }
+  }
+
+  /**
+   * Resolve Css.Expr nodes in marker content to static values.
+   * counter() functions are evaluated to strings; URLs are kept as-is.
+   */
+  private resolveMarkerContentVal(val: Css.Val): Css.Val {
+    if (val instanceof Css.Expr) {
+      const result = val.expr.evaluate(this.context);
+      if (typeof result === "string") {
+        return new Css.Str(result);
+      }
+      if (typeof result === "number") {
+        return new Css.Str(String(result));
+      }
+      return val;
+    }
+    if (val instanceof Css.SpaceList) {
+      const resolved = val.values.map((v) => this.resolveMarkerContentVal(v));
+      return new Css.SpaceList(resolved);
+    }
+    return val;
   }
 
   /**

--- a/packages/core/src/vivliostyle/pseudo-element.ts
+++ b/packages/core/src/vivliostyle/pseudo-element.ts
@@ -106,16 +106,11 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
     const pseudoName = getPseudoName(element);
     if (!this.contentProcessed[pseudoName]) {
       this.contentProcessed[pseudoName] = true;
-      if (pseudoName === "marker" || pseudoName === "footnote-marker") {
-        this.processMarker(element, styles, nodeContext);
-      }
       const contentVal = styles["content"];
       if (Vtree.nonTrivialContent(contentVal)) {
         contentVal.visit(
           new Vtree.ContentPropertyHandler(
-            (element.classList.contains("_viv-marker-outside") &&
-              element.firstElementChild?.firstElementChild) ||
-              element,
+            element,
             this.context,
             contentVal,
             this.exprContentListener,
@@ -125,103 +120,5 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
         TextPolyfill.preprocessForTextSpacing(element);
       }
     }
-  }
-
-  /**
-   * ::marker and ::footnote-marker support
-   */
-  private processMarker(
-    element: Element,
-    styles: { [key: string]: Css.Val },
-    nodeContext: Vtree.NodeContext,
-  ): void {
-    const content = styles["content"];
-    const listStylePosition = styles["list-style-position"];
-    const listStyleType = styles["list-style-type"];
-
-    if (Vtree.nonTrivialContent(content)) {
-      if (content instanceof Css.URL) {
-        // content: <URL>
-        //
-        // Wrap URL in a SpaceList to ensure that img element is generated as
-        // a child of the marker pseudo-element.
-        styles["content"] = new Css.SpaceList([content]);
-      } else if (content instanceof Css.Str) {
-        // content: <string>
-        //
-        // The content string may have been made from list-style-type in
-        // `CascadeInstance.processMarkerPseudoelementProps()` in css-cascade.ts.
-        if (listStyleType instanceof Css.Ident) {
-          const lowerName = listStyleType.name.toLowerCase();
-          if (
-            lowerName === "disc" ||
-            lowerName === "circle" ||
-            lowerName === "square" ||
-            lowerName === "disclosure-open" ||
-            lowerName === "disclosure-closed"
-          ) {
-            // Use special font for bullet symbols.
-            element.classList.add("_viv-marker-bullet");
-            if (
-              lowerName === "disclosure-open" ||
-              lowerName === "disclosure-closed"
-            ) {
-              const rtl = nodeContext.direction === "rtl";
-              const vertical = nodeContext.vertical;
-              // Change disclosure triangles for rtl or vertical text.
-              styles["content"] = new Css.Str(
-                lowerName === "disclosure-open"
-                  ? vertical
-                    ? "◂ "
-                    : "▾ "
-                  : vertical
-                    ? rtl
-                      ? "▴ "
-                      : "▾ "
-                    : rtl
-                      ? "◂ "
-                      : "▸ ",
-              );
-            }
-          }
-        }
-      }
-    }
-
-    if (listStylePosition === Css.ident.outside) {
-      // Use special styling to simulate outside markers.
-      element.classList.add("_viv-marker-outside");
-      // Create a flex container for centering and an inner span to keep
-      // marker content as a single flex item even when it mixes images/text.
-      const contentContainer = element.ownerDocument.createElementNS(
-        Base.NS.XHTML,
-        "span",
-      );
-      contentContainer.classList.add("_viv-marker-outside-content");
-      const contentInner = element.ownerDocument.createElementNS(
-        Base.NS.XHTML,
-        "span",
-      );
-      contentInner.classList.add("_viv-marker-outside-content-inner");
-      contentContainer.appendChild(contentInner);
-      element.appendChild(contentContainer);
-
-      // Prevent text-spacing-trim and hanging-punctuation from trimming or
-      // hanging the suffix "、" of counter styles such as "cjk-decimal".
-      const textSpacingTrim = nodeContext.inheritedProps["text-spacing-trim"];
-      if (textSpacingTrim && textSpacingTrim !== "space-all") {
-        styles["text-spacing-trim"] = Css.ident.normal;
-      }
-      const hangingPunctuation =
-        nodeContext.inheritedProps["hanging-punctuation"];
-      if (hangingPunctuation) {
-        styles["hanging-punctuation"] = Css.ident.none;
-      }
-    }
-
-    // These are used only temporarily to generate content from list-style-*,
-    // so remove them after processing.
-    delete styles["list-style-position"];
-    delete styles["list-style-type"];
   }
 }

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -559,18 +559,11 @@ class TextSpacingPolyfill {
         let isLastBeforeForcedLineBreak = false;
         let isLastInBlock = false;
 
-        // Check list marker with `list-style-position: outside` which should
-        // be treated like a forced line break. (Issue #1763)
-        function isOutsideListMarker(element: Element): boolean {
-          return element.classList.contains("_viv-marker-outside");
-        }
-
         function checkIfFirstAfterForcedLineBreak(
           prevP: Vtree.NodeContext,
         ): boolean {
           if (prevP.viewNode?.nodeType === Node.ELEMENT_NODE) {
-            const prevElem = prevP.viewNode as Element;
-            return prevElem.localName === "br" || isOutsideListMarker(prevElem);
+            return (prevP.viewNode as Element).localName === "br";
           }
           if (prevP.viewNode?.nodeType === Node.TEXT_NODE) {
             const prevTextNode = prevP.viewNode as Text;
@@ -594,8 +587,7 @@ class TextSpacingPolyfill {
           nextP: Vtree.NodeContext,
         ): boolean {
           if (nextP.viewNode?.nodeType === Node.ELEMENT_NODE) {
-            const nextElem = nextP.viewNode as Element;
-            return nextElem.localName === "br" || isOutsideListMarker(nextElem);
+            return (nextP.viewNode as Element).localName === "br";
           }
           if (nextP.viewNode?.nodeType === Node.TEXT_NODE) {
             const nextTextNode = nextP.viewNode as Text;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -289,18 +289,13 @@ export class ViewFactory
             }
           }
         }
-        if (name === "before" || name === "after" || name === "marker") {
+        if (
+          name === "before" ||
+          name === "after" ||
+          name === "footnote-marker"
+        ) {
           const content = pseudoMap[name]["content"] as CssCascade.CascadeValue;
           if (!content || !Vtree.nonTrivialContent(content.value)) {
-            continue;
-          }
-          if (
-            name === "marker" &&
-            (!Display.isListItem(computedStyle["display"]) ||
-              // Disable ::marker for "toc-node" in the TOC box
-              CssCascade.getProp(cascStyle, "behavior")?.value ===
-                Css.getName("toc-node"))
-          ) {
             continue;
           }
         }
@@ -1142,8 +1137,15 @@ export class ViewFactory
             // Nested footnote inside a footnote area: render as a detached block
             // entry, with call marker handled separately. (Issue #1352)
             floating = false;
-            computedStyle["display"] = Css.ident.block;
+            display = computedStyle["--viv-marker-content"]
+              ? Css.getName("list-item")
+              : Css.ident.block;
+            computedStyle["display"] = display;
           } else {
+            // Footnote body in main flow (not yet in footnote area):
+            // render inline (only the call marker is visible), but keep
+            // the blockified display variable so nodeContext.inline stays
+            // false — layout needs this to collect the float properly.
             computedStyle["display"] = Css.ident.inline;
           }
         }
@@ -1183,7 +1185,11 @@ export class ViewFactory
         }
       }
       const isListItem =
-        Display.isListItem(display) && !!computedStyle["ua-list-item-count"];
+        Display.isListItem(display) &&
+        !!(
+          computedStyle["ua-list-item-count"] ||
+          computedStyle["--viv-marker-content"]
+        );
       const breakInside = computedStyle["break-inside"];
       if (
         floating ||
@@ -1441,16 +1447,21 @@ export class ViewFactory
         custom = !!this.customRenderer;
       }
       if (isListItem) {
-        // We don't use browser's list item rendering, so we change
-        // `display: list-item` to `display: block` and
-        // `display: inline list-item` to `display: inline`.
-        display = Display.isInlineLevel(display)
-          ? Css.ident.inline
-          : Css.ident.block;
-        computedStyle["display"] = display;
+        // Keep display: list-item so the browser's native ::marker is used.
         if (firstTime) {
           tag = "li";
+          if (computedStyle["--viv-marker-content"]) {
+            // We control marker content via --viv-marker-content CSS custom
+            // property, so suppress the browser's default marker.
+            computedStyle["list-style-type"] = Css.ident.none;
+            computedStyle["list-style-image"] = Css.ident.none;
+          }
         } else {
+          // Subsequent fragments: no marker
+          display = Display.isInlineLevel(display)
+            ? Css.ident.inline
+            : Css.ident.block;
+          computedStyle["display"] = display;
           tag = "div";
         }
       } else if (tag == "body" || tag == "li") {
@@ -1777,11 +1788,22 @@ export class ViewFactory
           }
         }
         delete computedStyle["content"];
-        const listStyleImage = computedStyle["list-style-image"];
-        if (listStyleImage && listStyleImage instanceof Css.URL) {
-          const listStyleURL = (listStyleImage as Css.URL).url;
-          fetchers.push(Net.loadElement(new Image(), listStyleURL));
+
+        // Preload marker images referenced via --viv-marker-content so that
+        // pagination waits for them, avoiding late reflow.
+        const markerContent = computedStyle["--viv-marker-content"];
+        if (markerContent) {
+          const markerValues =
+            markerContent instanceof Css.SpaceList
+              ? markerContent.values
+              : [markerContent];
+          for (const v of markerValues) {
+            if (v instanceof Css.URL && v.url) {
+              fetchers.push(Net.loadElement(new Image(), v.url));
+            }
+          }
         }
+
         this.preprocessElementStyle(computedStyle);
         this.applyComputedStyles(result, computedStyle);
 
@@ -1835,25 +1857,11 @@ export class ViewFactory
           }
         }
         if (isListItem) {
-          result.setAttribute(
-            "value",
-            computedStyle["ua-list-item-count"].stringValue(),
-          );
-        }
-        if (result.classList.contains("_viv-marker-outside-content")) {
-          // Adjust marker position for outside markers
-          if (Display.isListItem(this.nodeContext.parent?.parent?.display)) {
-            const style = this.viewport.window.getComputedStyle(
-              this.nodeContext.parent.parent.viewNode as Element,
+          if (computedStyle["ua-list-item-count"]) {
+            result.setAttribute(
+              "value",
+              computedStyle["ua-list-item-count"].stringValue(),
             );
-            const markerOffset =
-              parseFloat(style.borderInlineStartWidth) +
-              parseFloat(style.paddingInlineStart) +
-              parseFloat(style.textIndent);
-            if (markerOffset) {
-              (result as HTMLElement).style.insetInlineEnd =
-                `${markerOffset}px`;
-            }
           }
         }
 

--- a/packages/core/test/files/counter-style/marker-block-child.html
+++ b/packages/core/test/files/counter-style/marker-block-child.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>::marker - block child in list item</title>
+    <style>
+      body { font-size: 16px; }
+    </style>
+  </head>
+  <body>
+    <h1>li with block child — marker should align with first line of text</h1>
+
+    <h2>disc (default)</h2>
+    <ul>
+      <li><p>Text inside p element. Marker should align with this line.</p></li>
+      <li><p>Second item.</p></li>
+      <li><p>Third item.</p></li>
+    </ul>
+
+    <h2>decimal</h2>
+    <ol>
+      <li><p>Text inside p element. Marker should align with this line.</p></li>
+      <li><p>Second item.</p></li>
+      <li><p>Third item.</p></li>
+    </ol>
+
+    <h2>inline text (reference)</h2>
+    <ul>
+      <li>Text without p element. Marker should align with this line.</li>
+      <li>Second item.</li>
+      <li>Third item.</li>
+    </ul>
+    <ol>
+      <li>Text without p element. Marker should align with this line.</li>
+      <li>Second item.</li>
+      <li>Third item.</li>
+    </ol>
+  </body>
+</html>

--- a/packages/core/test/files/counter-style/marker-empty-li.html
+++ b/packages/core/test/files/counter-style/marker-empty-li.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>::marker - empty list items</title>
+    <style>
+      body {
+        font-size: 16px;
+      }
+      ol.large-image li::marker {
+        content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="48"><path d="M50,3l12,36h38l-30,22l11,36l-31-21l-31,21l11-36l-30-22h38z" fill="%23FF0" stroke="%2300F" stroke-width="10"/></svg>')
+          " ";
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Empty list items — markers should not overlap</h1>
+
+    <h2>disc (default bullet)</h2>
+    <ul>
+      <li></li>
+      <li></li>
+      <li></li>
+    </ul>
+
+    <h2>decimal</h2>
+    <ol>
+      <li></li>
+      <li></li>
+      <li></li>
+    </ol>
+
+    <h2>large image (48px)</h2>
+    <ol class="large-image">
+      <li></li>
+      <li></li>
+      <li></li>
+    </ol>
+
+    <p>In all lists above, markers of each item should appear on separate lines and not overlap each other.</p>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -974,6 +974,14 @@ module.exports = [
         title: "::marker pseudo-element",
       },
       {
+        file: "counter-style/marker-block-child.html",
+        title: "::marker with block child in list item (Issue #1831)",
+      },
+      {
+        file: "counter-style/marker-empty-li.html",
+        title: "::marker on empty list items",
+      },
+      {
         file: "counter-style/list-style-position.html",
         title: "list-style-position",
       },


### PR DESCRIPTION
Redesign the list marker implementation to use the browser's native ::marker pseudo-element instead of generating fake DOM elements with position:absolute. This fixes Issue #1831 where large marker images overlap with the previous line, as the browser now handles marker sizing and line-height automatically.

The new approach uses CSS custom properties (`--viv-marker-*`) set on the list item element, which are picked up by polyfill CSS rules targeting `[style*="--viv-marker-content"]::marker`. Bullet types (disc, circle, square, disclosure-open, disclosure-closed) are left entirely to the browser's native handling.

- css-cascade.ts: Rewrite processMarkerPseudoelementProps() to resolve marker content (list-style-type/image, counter styles) into CSS custom properties. Bullet types skip this and use the browser's native list-style-type directly. For ::footnote-marker, use native ::marker only when list-style-position:outside; keep traditional span for inside (default) to support vertical-align etc.
- assets.ts: Replace old `[data-adapt-pseudo="marker"]` rules with native `::marker` polyfill CSS. Restore `display:block` for EPUB footnote-content to prevent unwanted bullets.
- vgen.ts: Keep `display:list-item` with `<li>` tag. Only suppress browser's default marker (`list-style-type:none`) when `--viv-marker-content` is set; otherwise let the browser use the inherited list-style-type natively.
- pseudo-element.ts: Remove processMarker() (~90 lines) and related content redirection logic.
- text-polyfill.ts: Remove isOutsideListMarker() workaround for Issue #1763, no longer needed with native ::marker.
- counters.ts: Update extractPseudoElementText() to read marker text from `--viv-marker-content` via getComputedStyle for target-text(), extracting only string components from CSS content values.
- css-cascade.ts visitFuncContent(): Add `--viv-marker-content` fallback for `content(marker)` in string-set.
- Add test files marker-block-child.html and marker-empty-li.html.

Closes #1831

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author, while investigating issue #1831, found the existing list-marker implementation had broader problems (empty list items, block-element children) and asked the AI to redesign it around the browser's native `::marker` pseudo-element.
- Across a long implementation session, the human author found and directed fixes for several regressions the redesign introduced: broken vertical-writing-mode disclosure marker orientation, `content(marker)` in `string-set` no longer working, `target-text(attr(href url), marker)` no longer working, and a footnote-in-table regression; the human author also decided a now-unnecessary workaround (`isOutsideListMarker()`) could be deleted outright since a future regression would be caught by its own test.
- The human author asked for the two new test files to be registered in `file-list.js`, directed the commit message, and after creating the PR reviewed multiple rounds of Copilot comments, testing one reviewer's specific claim (`::marker { content: '"'; }` producing `\22` in `target-text()`) themselves before directing the response.

</details>
