### PR TITLE
fix: resolve named @page rule on first page when running element has child elements

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -843,6 +843,24 @@ export class StyleInstance
       : startElement;
   }
 
+  /**
+   * Resolve the page type for the first page by examining the first in-flow
+   * element's CSS `page` property. This is needed because `currentPageType`
+   * is only set during layout (in ViewFactory), but the first page's type
+   * must be known before layout begins for correct @page rule matching.
+   */
+  private resolveFirstPageType(): string | null {
+    const firstElement = this.getFirstDocumentFlowElement();
+    if (!firstElement) {
+      return null;
+    }
+    const pageType = this.getPageGroupPageType(firstElement);
+    if (pageType) {
+      this.styler.cascade.currentPageType = pageType;
+    }
+    return pageType;
+  }
+
   private shouldStartPageGroup(
     element: Element,
     pageType: string,
@@ -2403,7 +2421,9 @@ export class StyleInstance
       page.pageType =
         (page.isBlankPage
           ? this.styler.cascade.previousPageType
-          : this.styler.cascade.currentPageType) ?? "";
+          : this.styler.cascade.currentPageType) ??
+        (cp.page === 1 ? this.resolveFirstPageType() : null) ??
+        "";
       // Fix for issue #1309
       this.styler.cascade.previousPageType =
         this.styler.cascade.currentPageType;

--- a/packages/core/test/files/named-pages/page-child-element.html
+++ b/packages/core/test/files/named-pages/page-child-element.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Named Page on Child Element with Running Element</title>
+    <style>
+      @page {
+        size: 18cm 18cm;
+        margin: 2cm;
+        border: 2px dotted;
+        @top-center {
+          content: "default page";
+        }
+        @bottom-center {
+          content: counter(page);
+        }
+      }
+      @page content {
+        margin: 3cm 2cm;
+        border-style: dashed;
+        @top-center {
+          content: element(runHeader);
+        }
+        @bottom-center {
+          content: "content page " counter(page);
+        }
+      }
+      .running {
+        position: running(runHeader);
+      }
+      .content {
+        page: content;
+      }
+      body {
+        margin: 0;
+      }
+      .test {
+        border: 4px outset gray;
+        padding: 4px;
+        margin: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="running"><strong>Running Header</strong></div>
+    <div class="test content">
+      <p>This text is rendered on a 'content' page.</p>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Reprehenderit,
+        esse facilis. Ut, illum, totam voluptatum dolorum neque commodi eum amet
+        eligendi sequi ad facilis quasi. Ipsam illo neque sunt corporis.
+      </p>
+      <p>
+        Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure
+        cupiditate numquam enim hic sequi commodi, maxime quia nam illum ullam
+        perspiciatis maiores laudantium voluptas minima officiis error, quas qui
+        tenetur!
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Possimus quod
+        quisquam, recusandae porro dolorem eaque laborum nam quam provident quos
+        corrupti voluptatem ducimus quasi odit nihil autem officia sequi.
+        Molestias.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque tenetur
+        eum necessitatibus provident, voluptatem ullam sequi iste aut ipsam
+        nostrum esse ad enim porro, inventore placeat maiores numquam corporis
+        animi.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Error quas eos
+        dicta quidem modi dolores aperiam numquam omnis laborum voluptas
+        corporis tempore porro, illum tempora illo facilis odit! Harum, labore.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
I just created issue #1833 which this PR should fix. We're using vivliostyle in an internal tool with the purpose of replacing word processing applications like Word or Pages and it works like charm, except for this little problem. Thanks for your work!

## Summary

When a `position: running()` element contains child elements (e.g. `<strong>`), the first page falls back to the unnamed `@page` rule instead of the named one. Pages 2+ render correctly.

The existing `firstPageType` detection in `css-styler.ts:1120-1135` (#770/#1405) checks `style["page"]` for elements at `blockStartOffset === 0`. A child element inside the running element shifts `blockStartOffset`, so the first in-flow element's `page` property is missed.

This PR adds a fallback at the `page.pageType` assignment in `ops.ts` that uses the existing `getFirstDocumentFlowElement()` and `getPageGroupPageType()` methods to resolve the page type when `currentPageType` is null.

## Changes

- `packages/core/src/vivliostyle/ops.ts` — add `resolveFirstPageType()` method and wire it as a fallback
- `packages/core/test/files/named-pages/page-child-element.html` — minimal reproduction file

## Test plan

- Open `packages/core/test/files/named-pages/page-child-element.html` in the viewer
- Verify page 1 shows "Running Header" in top margin and "content page 1" in bottom margin (not "default page")
- Verify all pages have 3cm/2cm margins (not uniform 2cm)

Fixes #1833 