### PR TITLE
feat: Support footnote-display inline and compact

### DIFF
--- a/docs/ja/supported-css-features.md
+++ b/docs/ja/supported-css-features.md
@@ -331,6 +331,8 @@ Vivliostyle は現在、以下の各 CSS 機能（[値](#値)、[セレクタ](#
 
 - [string-set（名前付き文字列）](https://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro)
 - [position: running()（ランニング要素）](https://www.w3.org/TR/css-gcpm-3/#running-elements)
+- [footnote-display](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-display)
+  - [`block`、`inline`、`compact`](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-display) 値をサポートします。
 - [footnote-policy](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-policy)
   - [`auto`、`line`](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-policy) 値をサポートします。
 

--- a/docs/supported-css-features.md
+++ b/docs/supported-css-features.md
@@ -331,6 +331,8 @@ See also: [At-rules in CSS Paged Media 3](#css-paged-media-3)
 
 - [string-set (Named Strings)](https://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro)
 - [position: running() (Running Elements)](https://www.w3.org/TR/css-gcpm-3/#running-elements)
+- [footnote-display](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-display)
+  - Supports [`block`, `inline`, `compact`](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-display) values.
 - [footnote-policy](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-policy)
   - Supports [`auto`, `line`](https://www.w3.org/TR/css-gcpm-3/#propdef-footnote-policy) values.
 

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -653,6 +653,7 @@ background-blend-mode = COMMA( BLEND_MODE+ );
 
 /* CSS GCPM */
 string-set = COMMA( SPACE( IDENT CONTENT_LIST )+ | none );
+footnote-display = block | inline | compact;
 footnote-policy = auto | line;
 
 /* CSS Repeated Headers and Footers */
@@ -1607,6 +1608,13 @@ span[data-viv-leader] {
   font-variant-numeric: tabular-nums;
   white-space: pre;
   text-transform: none;
+}
+[style*="--viv-footnote-inline-separator"]::after {
+  content: var(--viv-footnote-inline-separator);
+  white-space: normal;
+}
+[style*="--viv-footnote-white-space"] {
+  white-space: var(--viv-footnote-white-space);
 }
 [style*="--viv-marker-color"]::marker {
   color: var(--viv-marker-color);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -30,6 +30,7 @@ import * as Logging from "./logging";
 import * as Diff from "./diff";
 import * as Base from "./base";
 import * as BreakPosition from "./break-position";
+import * as CssCascade from "./css-cascade";
 import * as Css from "./css";
 import * as GeometryUtil from "./geometry-util";
 import * as LayoutHelper from "./layout-helper";
@@ -1711,6 +1712,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         .then(() => {
           if (!failed) {
             Asserts.assert(floatArea);
+            if (floatArea.isFootnote) {
+              floatArea.applyCompactFootnoteDisplay();
+            }
             const logicalFloatSide = context.setFloatAreaDimensions(
               floatArea,
               firstFloat.floatReference,
@@ -4875,5 +4879,115 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
         return this.vertical ? margin.left : margin.bottom;
       }),
     );
+  }
+
+  applyCompactFootnoteDisplay(): void {
+    const viewFactory = this.layoutContext as Vgen.ViewFactory | undefined;
+    const styler = viewFactory?.styler;
+    const xmldoc = viewFactory?.xmldoc;
+    const compactFootnotes = this.rootViewNodes.filter((node) => {
+      const offset = node.getAttribute(Base.ELEMENT_OFFSET_ATTR);
+      if (!offset || !styler || !xmldoc) {
+        return false;
+      }
+      const sourceNode = xmldoc.getNodeByOffset(parseInt(offset, 10));
+      if (!sourceNode || sourceNode.nodeType !== Node.ELEMENT_NODE) {
+        return false;
+      }
+      const style = styler.getStyle(sourceNode as Element, false);
+      const footnoteDisplay = CssCascade.getProp(
+        style,
+        "footnote-display",
+      )?.value?.toString();
+      const usesOutsideFootnoteMarker = !!CssCascade.getProp(
+        style,
+        "--viv-marker-content",
+      )?.value;
+      return footnoteDisplay === "compact" && !usesOutsideFootnoteMarker;
+    }) as HTMLElement[];
+    if (compactFootnotes.length === 0) {
+      this.updateInlineFootnoteSeparators();
+      this.updateComputedBlockSizeForFootnoteArea();
+      return;
+    }
+
+    const areaRect = this.element.getBoundingClientRect();
+    const availableMeasure = this.vertical ? areaRect.height : areaRect.width;
+    compactFootnotes.forEach((footnote) => {
+      Base.setCSSProperty(footnote, "display", "inline");
+      footnote.style.setProperty("--viv-footnote-white-space", "nowrap");
+    });
+
+    const tolerance = 1.5 / (this.clientLayout.pixelRatio || 1);
+    const measureCompactInlineSize = (element: HTMLElement): number => {
+      const clone = element.cloneNode(true) as HTMLElement;
+      clone.style.removeProperty("--viv-footnote-inline-separator");
+      Base.setCSSProperty(clone, "display", "inline-block");
+      Base.setCSSProperty(clone, "position", "absolute");
+      Base.setCSSProperty(clone, "visibility", "hidden");
+      Base.setCSSProperty(clone, "white-space", "nowrap");
+      Base.setCSSProperty(clone, "max-width", "none");
+      Base.setCSSProperty(clone, "left", "0");
+      Base.setCSSProperty(clone, "top", "0");
+      this.element.appendChild(clone);
+      const rect = clone.getBoundingClientRect();
+      this.element.removeChild(clone);
+      return this.vertical ? rect.height : rect.width;
+    };
+
+    compactFootnotes.forEach((footnote) => {
+      if (measureCompactInlineSize(footnote) > availableMeasure + tolerance) {
+        Base.setCSSProperty(footnote, "display", "block");
+        footnote.style.removeProperty("--viv-footnote-white-space");
+      }
+    });
+
+    this.updateInlineFootnoteSeparators();
+    this.updateComputedBlockSizeForFootnoteArea();
+  }
+
+  private updateComputedBlockSizeForFootnoteArea(): void {
+    if (this.rootViewNodes.length === 0) {
+      this.computedBlockSize = 0;
+      return;
+    }
+
+    const dir = this.getBoxDir();
+    this.computedBlockSize = Math.max(
+      0,
+      ...this.rootViewNodes.map((node) => {
+        const box = LayoutHelper.getElementClientRectAdjusted(
+          this.clientLayout,
+          node,
+          this.vertical,
+        );
+        const margin = this.getComputedMargin(node);
+        const marginAfter = this.vertical ? margin.left : margin.bottom;
+        return (
+          dir * (this.getAfterEdge(box) - this.beforeEdge) +
+          Math.max(0, marginAfter)
+        );
+      }),
+    );
+  }
+
+  private updateInlineFootnoteSeparators(): void {
+    this.rootViewNodes.forEach((node, index) => {
+      const element = node as HTMLElement;
+      const display =
+        element.ownerDocument.defaultView?.getComputedStyle(element).display;
+      const nextElement = this.rootViewNodes[index + 1] as
+        | HTMLElement
+        | undefined;
+      const nextDisplay =
+        nextElement?.ownerDocument.defaultView?.getComputedStyle(
+          nextElement,
+        ).display;
+      if (display === "inline" && nextDisplay === "inline") {
+        element.style.setProperty("--viv-footnote-inline-separator", '" "');
+      } else {
+        element.style.removeProperty("--viv-footnote-inline-separator");
+      }
+    });
   }
 }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1109,6 +1109,13 @@ export class ViewFactory
         floatSide = null;
         clearSide = null;
       }
+      let footnoteDisplay: Css.Val | null = null;
+      let usesOutsideFootnoteMarker = false;
+      const isFootnoteBodyInFootnoteArea =
+        this.isFootnote &&
+        (!this.nodeContext?.parent ||
+          this.nodeContext.pluginProps["nestedFootnoteDetached"]);
+
       let floating =
         floatSide instanceof Css.SpaceList ||
         floatSide === Css.ident.left ||
@@ -1128,18 +1135,19 @@ export class ViewFactory
         // Don't want to set it in view DOM CSS.
         delete computedStyle["float"];
         if (floatSide === Css.ident.footnote) {
-          if (
-            this.isFootnote &&
-            (!this.nodeContext?.parent ||
-              this.nodeContext.pluginProps["nestedFootnoteDetached"])
-          ) {
+          footnoteDisplay = computedStyle["footnote-display"];
+          usesOutsideFootnoteMarker = !!computedStyle["--viv-marker-content"];
+          if (isFootnoteBodyInFootnoteArea) {
             // Root of the footnote body being rendered in footnote area.
             // Nested footnote inside a footnote area: render as a detached block
             // entry, with call marker handled separately. (Issue #1352)
             floating = false;
-            display = computedStyle["--viv-marker-content"]
+            const footnoteDisplayName = footnoteDisplay?.toString();
+            display = usesOutsideFootnoteMarker
               ? Css.getName("list-item")
-              : Css.ident.block;
+              : footnoteDisplayName === "inline"
+                ? Css.ident.inline
+                : Css.ident.block;
             computedStyle["display"] = display;
           } else {
             // Footnote body in main flow (not yet in footnote area):
@@ -3528,6 +3536,7 @@ export const propertiesNotPassedToDOM = {
   "flow-linger": true,
   "flow-options": true,
   "flow-priority": true,
+  "footnote-display": true,
   "footnote-policy": true,
   "margin-break": true,
   page: true,

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -795,6 +795,10 @@ module.exports = [
         title: "Footnote call/marker counter styles",
       },
       {
+        file: "footnotes/footnote-display.html",
+        title: "footnote-display (Issue #1825)",
+      },
+      {
         file: "footnotes/footnotes-in-table.html",
         title: "Footnotes in table (Issue #438)",
       },

--- a/packages/core/test/files/footnotes/footnote-display.html
+++ b/packages/core/test/files/footnotes/footnote-display.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>footnote-display</title>
+    <style>
+      @page {
+        size: 148mm 210mm;
+        margin: 16mm;
+
+        @bottom-center {
+          font-size: 0.85rem;
+          content: "Page " counter(page);
+        }
+      }
+
+      body {
+        font-family: serif;
+        line-height: 1.4;
+      }
+
+      section {
+        margin-block: 0 1.4rem;
+      }
+
+      h1 {
+        margin-bottom: 0.5rem;
+      }
+
+      h2 {
+        margin-bottom: 0.3rem;
+      }
+
+      p {
+        margin: 0.35rem 0;
+      }
+
+      .keep-together {
+        break-inside: avoid;
+        page-break-inside: avoid;
+      }
+
+      .expected {
+        font-size: 0.9rem;
+        font-style: italic;
+      }
+
+      .footnote {
+        float: footnote;
+        font-size: 0.85rem;
+      }
+
+      .footnote-display-block {
+        color: #800;
+      }
+
+      .footnote-display-block .footnote {
+        footnote-display: block;
+      }
+
+      .footnote-display-inline {
+        color: #080;
+      }
+
+      .footnote-display-inline .footnote {
+        footnote-display: inline;
+      }
+
+      .footnote-display-compact {
+        color: #008;
+      }
+
+      .footnote-display-compact .footnote {
+        footnote-display: compact;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>footnote-display test</h1>
+    <section class="footnote-display-block">
+      <h2>footnote-display: block</h2>
+      <p class="expected">
+        Each footnote body should start on its own line in the footnote area.
+      </p>
+      <p>
+        Block footnotes remain separated<span class="footnote">First block note.</span>
+        even when the note text is short<span class="footnote">Second block note.</span>
+        and could otherwise fit beside another note<span class="footnote">Third block note with a little more text.</span>.
+      </p>
+    </section>
+    <section class="footnote-display-inline">
+      <h2>footnote-display: inline</h2>
+      <p class="expected">
+        Inline footnotes should stay in one inline run even when a longer note wraps, with a normal space between note bodies.
+      </p>
+      <p>
+        Inline footnotes should begin as a loose run of notes<span class="footnote">Short inline note.</span>
+        and then continue through a longer inline note that wraps to the next line in the footnote area<span class="footnote">A longer inline note that should wrap to another line so the example shows that inline footnotes still remain part of one inline sequence after wrapping.</span>
+        before a trailing short note carries on inline rather than becoming a separate block<span class="footnote">Trailing inline note.</span>.
+      </p>
+    </section>
+    <section class="footnote-display-compact">
+      <h2>footnote-display: compact</h2>
+      <p class="expected">
+        Compact footnotes should behave like unbreakable inline notes by default, and only fall back to block when a single note cannot fit on one rendered line.
+      </p>
+      <p class="keep-together">
+        Four short compact notes should wrap as inline nowrap units<span class="footnote">Short compact note.</span>
+        with the next short compact note still on that first line<span class="footnote">Another short compact note.</span>
+        and then continue on the next line with another short compact note<span class="footnote">Another short compact note.</span>
+        plus one more short compact note on that same following line<span class="footnote">Short compact note.</span>.
+      </p>
+      <p>
+        A compact note that is too long to fit as a single unbroken inline note should fall back to block<span class="footnote">A medium-length compact note that is long enough that keeping it as a single unbroken inline note would overflow the footnote measure, so it should become a block footnote.</span>
+        while the following short compact notes can still share a later line inline<span class="footnote">Short compact note.</span>
+        and continue with another short compact note on that same line<span class="footnote">Another short note.</span>
+        before a final longer compact note falls back to block again<span class="footnote">A longer trailing compact note that no longer fits as a single unbroken inline note.</span>.
+      </p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Implement CSS GCPM footnote-display support for footnotes.

- add support for footnote-display values block, inline, and compact
- render inline and compact footnotes appropriately in the footnote area
- make compact footnotes fall back to block only when a note would overflow
- add tests and documentation for footnote-display

closes #1825

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to implement CSS GCPM `footnote-display` (block/inline/compact), providing a test sample HTML.
- Over many iterations, the human author caught several implementation bugs — compact notes all rendering as inline, incorrect page-margin sizing after compacting, and the footnote area's `computedBlockSize` not being updated when content was compacted — and asked for trimmed, non-redundant test examples.
- After creating the PR, the human author disputed one of three Copilot review comments with a specific technical justification (call ordering between `applyCompactFootnoteDisplay()` and `setFloatAreaDimensions()`) and directed responses to the rest; two further regressions (wrong page placement, then compacting not applying) were caught and fixed before the PR was finalized.

</details>
