### PR TITLE
fix: prevent running elements from causing blank first page with named page rules

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3329,6 +3329,19 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // Ignorable text content, skip
                 break;
               }
+              // Text inside out-of-flow elements (e.g. position:running()
+              // rendered as position:fixed) should not be treated as
+              // in-flow content for break detection. (Issue #1833)
+              let hasOutOfFlowAncestor = false;
+              for (let nc = nodeContext; nc; nc = nc.parent) {
+                if (nc.viewNode && LayoutHelper.isOutOfFlow(nc.viewNode)) {
+                  hasOutOfFlowAncestor = true;
+                  break;
+                }
+              }
+              if (hasOutOfFlowAncestor) {
+                break;
+              }
               if (!nodeContext.after) {
                 // Leading edge of non-empty block -> finished going through
                 // all starting edges of the box
@@ -3538,6 +3551,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
               // Trailing edge
               if (onStartEdges) {
+                // Out-of-flow elements (e.g. position:running() rendered as
+                // position:fixed) should not end the leading edge sequence.
+                // Their trailing edges must not reset leadingEdge, otherwise
+                // the next in-flow element's forced break would be incorrectly
+                // treated as a mid-page break. (Issue #1833)
+                if (LayoutHelper.isCssOutOfFlow(nodeContext.viewNode)) {
+                  break;
+                }
                 // finished going through all starting edges of the box.
                 // check if a forced break must occur before the block.
                 if (needForcedBreak()) {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -388,6 +388,10 @@ module.exports = [
         ],
         title: "Page Groups across concatenated docs with boundary blank page",
       },
+      {
+        file: "named-pages/page-child-element.html",
+        title: "Named Page on Child Element with Running Element (Issue #1833)",
+      },
     ],
   },
   {


### PR DESCRIPTION
Running elements (`position: running()` rendered as `position: fixed`) with child elements caused the first page to be blank when used with named `@page` rules. In `skipEdges()`, text nodes inside out-of-flow ancestors were incorrectly treated as in-flow content, and trailing edges of out-of-flow elements reset the leadingEdge flag. This caused the next in-flow element's forced page break to be treated as a mid-page break instead of being suppressed at the page start.

Follow-up to PR #1834 and Issue #1833

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author first asked the AI to review PR #1834 (a prior fix) for correctness and explain why it was right, then approved it with a short thank-you comment for the contributor.
- As a follow-up, the human author registered a new test case and reported unusual first-page-blank behavior; reminded the AI that the running `yarn dev` auto-rebuilds, so `yarn build-dev` alone was enough to check for build errors.
- The human author questioned two specific code changes and asked what would happen if each were reverted individually, directed the commit message (framed as a follow-up to PR #1834 / Issue #1833), and after creating the PR asked the AI to address review comments.

</details>
