### PR TITLE
fix: fix footnote markers in list items

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1354,6 +1354,7 @@ m|math[display="block"] {
 /* CSS GCPM footnotes */
 ::footnote-marker {
   content: counter(footnote) ". ";
+  list-style-position: inside;
 }
 ::footnote-call {
   content: counter(footnote);

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3708,9 +3708,13 @@ export class CascadeInstance {
               // list-style-position: outside. When inside (default), use
               // traditional marker span to support properties like
               // vertical-align that ::marker doesn't support.
-              const fnMarkerListStylePos = (
-                pseudoProps["list-style-position"] as CascadeValue
-              )?.value;
+              const fnMarkerListStylePos =
+                this.resolvePseudoelementInheritedPropertyValue(
+                  pseudoProps,
+                  "list-style-position",
+                  styler,
+                  element,
+                );
               if (fnMarkerListStylePos === Css.ident.outside) {
                 // Use native ::marker with CSS custom properties
                 this.processMarkerPseudoelementProps(
@@ -3982,6 +3986,34 @@ export class CascadeInstance {
       styler as AbstractStyler & { validatorSet: CssValidator.ValidatorSet }
     ).validatorSet;
     return validatorSet?.defaultValues[propName] ?? null;
+  }
+
+  resolvePseudoelementInheritedPropertyValue(
+    pseudoProps: ElementStyle,
+    propName: string,
+    styler: CssStyler.AbstractStyler,
+    element: Element,
+  ): Css.Val | null {
+    const prop = pseudoProps[propName] as CascadeValue;
+    if (prop) {
+      const val = prop.evaluate(this.context, propName);
+      if (
+        val !== Css.ident.inherit &&
+        val !== Css.ident.unset &&
+        val !== Css.ident.revert
+      ) {
+        if (val === Css.ident.initial) {
+          const validatorSet = (
+            styler as AbstractStyler & {
+              validatorSet: CssValidator.ValidatorSet;
+            }
+          ).validatorSet;
+          return validatorSet?.defaultValues[propName] ?? null;
+        }
+        return val;
+      }
+    }
+    return this.getInheritedPropertyValue(propName, styler, element);
   }
 
   private applyAttrFilterInner(

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -645,6 +645,14 @@ export class ViewFactory
     let node = this.nodeContext.sourceNode;
     const styles = [];
     let lang: string | null = null;
+    const isFootnoteContentInclude =
+      node instanceof Element &&
+      node.namespaceURI === Base.NS.SHADOW &&
+      node.localName === "include" &&
+      node.classList.contains("-vivliostyle-footnote-content");
+    const shouldSkipAncestorMarkerProps =
+      this.isFootnote &&
+      (!this.nodeContext?.parent || isFootnoteContentInclude);
 
     // TODO: this is hacky. We need to recover the path through the shadow
     // trees, but we do not have the full shadow tree structure at this point.
@@ -775,6 +783,13 @@ export class ViewFactory
       let lineHeight: Css.Val;
 
       for (const name of propList) {
+        if (
+          i > 0 &&
+          shouldSkipAncestorMarkerProps &&
+          name.startsWith("--viv-marker-")
+        ) {
+          continue;
+        }
         if (i > 0 && blockedInheritedByCurrent.has(name)) {
           continue;
         }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -863,6 +863,16 @@ module.exports = [
         title:
           "::footnote-marker with list-style-position: outside (Issue #1702)",
       },
+      {
+        file: "footnotes/footnote-in-list-item.html",
+        title:
+          "Footnote in list item should not inherit list marker (Issue #1838)",
+      },
+      {
+        file: "footnotes/footnote-marker-position-inherit-initial.html",
+        title:
+          "::footnote-marker list-style-position inherit/initial (Issue #1838)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnotes/footnote-in-list-item.html
+++ b/packages/core/test/files/footnotes/footnote-in-list-item.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Footnote in list item</title>
+<style>
+@page {
+  size: A5;
+  margin: 20mm;
+
+  @bottom-center {
+    content: "Page " counter(page);
+  }
+}
+
+body {
+  font: 16px/1.4 serif;
+}
+
+section {
+  break-after: page;
+}
+
+section:last-of-type {
+  break-after: auto;
+}
+
+ol {
+  padding-inline-start: 2em;
+}
+
+li {
+  margin-block: 0.6em;
+}
+
+.footnote {
+  float: footnote;
+  color: initial;
+  text-align: initial;
+  text-align-last: initial;
+  text-indent: initial;
+  font: initial;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  margin-inline-start: 1em;
+}
+
+.outside .footnote::footnote-marker {
+  list-style-position: outside;
+}
+</style>
+</head>
+<body>
+<section class="inside">
+  <h1>Footnote in list item: inside marker</h1>
+  <p>
+    Paragraph one.<span class="footnote">Footnote for paragraph one.</span>
+  </p>
+  <ol>
+    <li>
+      List item one<span class="footnote">Footnote for list item one. It should start with only "2. ".</span>
+    </li>
+    <li>
+      List item two<span class="footnote">Footnote for list item two. It should start with only "3. ", without an inherited list marker prefix.</span>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit.
+    </li>
+  </ol>
+</section>
+
+<section class="outside">
+  <h1>Footnote in list item: outside marker</h1>
+  <p>
+    Paragraph one.<span class="footnote">Footnote for paragraph one.</span>
+  </p>
+  <ol>
+    <li>
+      List item one<span class="footnote">Footnote for list item one. It should have only marker "2. " in the footnote area.</span>
+    </li>
+    <li>
+      List item two<span class="footnote">Footnote for list item two. It should have only marker "3. " in the footnote area, without an extra inherited list marker.</span>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit.
+    </li>
+  </ol>
+</section>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/footnote-marker-position-inherit-initial.html
+++ b/packages/core/test/files/footnotes/footnote-marker-position-inherit-initial.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>::footnote-marker with list-style-position inherit and initial</title>
+<style>
+@page {
+  size: A5;
+  margin: 20mm;
+
+  @bottom-center {
+    content: "Page " counter(page);
+  }
+}
+
+.footnote {
+  float: footnote;
+}
+
+.inherit .footnote::footnote-marker {
+  list-style-position: inherit;
+}
+
+.initial .footnote::footnote-marker {
+  list-style-position: initial;
+}
+
+.list-style-outside {
+  list-style-position: outside;
+  color: #800;
+}
+
+.list-style-inside {
+  list-style-position: inside;
+  color: #080;
+}
+</style>
+</head>
+<body>
+<h1>::footnote-marker with list-style-position inherit and initial</h1>
+
+<section class="list-style-outside inherit">
+  <h2>inherit from outside list</h2>
+  <p>Paragraph one.<span class="footnote">Footnote for paragraph one.</span></p>
+  <ol>
+    <li>List item one<span class="footnote">Footnote for list item one.</span></li>
+    <li>List item two<span class="footnote">Footnote for list item two. This marker should be outside.</span></li>
+  </ol>
+</section>
+
+<section class="list-style-inside inherit">
+  <h2>inherit from inside list</h2>
+  <p>Paragraph one.<span class="footnote">Footnote for paragraph one.</span></p>
+  <ol>
+    <li>List item one<span class="footnote">Footnote for list item one.</span></li>
+    <li>List item two<span class="footnote">Footnote for list item two. This marker should stay inside.</span></li>
+  </ol>
+</section>
+
+<section class="list-style-outside initial">
+  <h2>initial should be outside</h2>
+  <p>Paragraph one.<span class="footnote">Footnote for paragraph one.</span></p>
+  <ol>
+    <li>List item one<span class="footnote">Footnote for list item one.</span></li>
+    <li>List item two<span class="footnote">Footnote for list item two. This marker should be outside because initial value is outside.</span></li>
+  </ol>
+</section>
+</body>
+</html>


### PR DESCRIPTION
Prevent list-item marker custom properties from leaking into footnote content rendered in the footnote area, which caused duplicated markers for footnotes inside list items.

Resolve ::footnote-marker list-style-position using the effective value instead of the raw cascaded token, so inherit and initial behave correctly for outside marker rendering.

Add regression tests covering inside/outside footnote markers in list items and inherit/initial handling for ::footnote-marker.

- Fixes #1838

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author reported that PR #1832 (native `::marker` rendering) leaked list-item marker custom properties into footnote content, suggested the likely root-cause location, and asked the AI to investigate and fix it.
- The human author tested and found the `outside` marker case fixed but `inside` still broken, then found a related bug with `inherit`/`initial` keywords on `::footnote-marker`'s `list-style-position`; the AI fixed both.
- The human author asked the AI to consolidate three separate test files into one, specifying an exact two-page structure (inside on page 1, outside on page 2), verified it manually, then asked for a commit message with implementation details in the body.
- After opening PR #1839, the human author asked the AI to fix a test-case mistake flagged by a Copilot review comment, then separately found that the fix had broken the default (`inside`) marker position, applied a fix themselves in `assets.ts`'s `UserAgentBaseCss`, and asked the AI to verify it was correct.

</details>
