### PR TITLE
fix: Fix inline float with clear not positioned correctly near column boundary

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1417,6 +1417,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         }
       }
 
+      // Extend box after-edge slightly so positionFloat() does not reject a
+      // float that barely overflows due to sub-pixel rounding when clear
+      // pushes it near the column boundary. (Issue #1803)
+      box.y2 += 1 / (this.clientLayout.pixelRatio || 1);
+
       GeometryUtil.positionFloat(box, this.bands, floatHorBox, floatSide);
       if (this.vertical) {
         floatBox = GeometryUtil.unrotateBox(floatHorBox);


### PR DESCRIPTION
When clear pushes an inline float (e.g., float:right with clear:right in vertical-rl) close to the column's after-edge, sub-pixel rounding can cause positionFloat() to reject it as overflowing by a fraction of a pixel, leaving the float at its anchor position instead of the cleared edge.

Add a 1-device-pixel tolerance to the box boundary passed to positionFloat() so that floats pushed near the edge by clear are not incorrectly rejected.

- Closes #1803

Test case:
- packages/core/test/files/float-clear-vertical.html

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author found a remaining issue #1803 problem in the vertical-writing-mode test case after PR #1805 (a float not reaching the page's after-edge as expected) and asked the AI to investigate and fix it.
- The human author confirmed the fix worked and asked for a commit message.

</details>
