### PR TITLE
fix: honor break-before at overflowed column starts

### DIFF
--- a/packages/core/src/vivliostyle/break.ts
+++ b/packages/core/src/vivliostyle/break.ts
@@ -175,6 +175,15 @@ export function isSpreadBreakValue(value: string | null): boolean {
   return !!spreadBreakValues[value];
 }
 
+/**
+ * Returns if the value is a page-level forced break value.
+ * That is, one of page/left/right/recto/verso, excluding column/region.
+ * @param value The break value to be judged. Treats null as 'auto'.
+ */
+export function isPageLevelForcedBreak(value: string | null): boolean {
+  return isForcedBreakValue(value) && value !== "column" && value !== "region";
+}
+
 export const avoidBreakValues: { [key: string]: boolean | null } = {
   avoid: true,
   "avoid-page": true,

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -425,6 +425,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   last: Node;
   viewDocument: Document;
   flowRootFormattingContext: Vtree.FormattingContext = null;
+  // Issue #1842: true only for columns reached after automatic column overflow.
+  isNonFirstColumn: boolean = false;
   isFloat: boolean = false;
   isFootnote: boolean = false;
   startEdge: number = 0;
@@ -3253,6 +3255,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       return Task.newResult(nodeContext);
     }
     const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("skipEdges");
+    const column = this;
 
     // If a forced break occurred at the end of the previous column,
     // nodeContext.after should be false.
@@ -3264,17 +3267,108 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let trailingEdgeContexts: Vtree.NodeContext[] = [];
     let onStartEdges = false;
 
+    // Issue #1842: if a stronger page/spread break wins at the page's first
+    // column, drop weaker ancestor column breaks so they do not fire again
+    // later.
+    function suppressWeakerLeadingColumnBreaks(
+      currentNodeContext: Vtree.NodeContext,
+    ): void {
+      if (
+        !leadingEdge ||
+        column.isNonFirstColumn ||
+        forcedBreakValue ||
+        !Break.isPageLevelForcedBreak(breakAtTheEdge)
+      ) {
+        return;
+      }
+      for (let nc = currentNodeContext; nc; nc = nc.parent) {
+        if (nc.breakBefore === "column") {
+          nc.breakBefore = null;
+        }
+        if (nc.viewNode?.nodeType === 1) {
+          const elem = nc.viewNode as HTMLElement;
+          if (elem.style?.breakBefore === "column") {
+            elem.style.breakBefore = "";
+          }
+        }
+      }
+    }
+
+    // Issue #1842: a column break at the start of a follow-up column is already
+    // satisfied by the overflow that moved us into this column.
+    function consumeSatisfiedLeadingColumnBreak(
+      currentNodeContext: Vtree.NodeContext,
+    ): void {
+      if (
+        !leadingEdge ||
+        !column.isNonFirstColumn ||
+        forcedBreakValue ||
+        breakAtTheEdge !== "column"
+      ) {
+        return;
+      }
+      for (let nc = currentNodeContext; nc; nc = nc.parent) {
+        if (nc.breakBefore === "column") {
+          nc.breakBefore = null;
+        }
+        if (nc.viewNode?.nodeType === 1) {
+          const elem = nc.viewNode as HTMLElement;
+          if (elem.style?.breakBefore === "column") {
+            elem.style.breakBefore = "";
+          }
+        }
+      }
+      breakAtTheEdge = null;
+    }
+
+    function suppressWeakerTrailingColumnBreaks(
+      currentNodeContext: Vtree.NodeContext,
+    ): void {
+      if (forcedBreakValue || !Break.isPageLevelForcedBreak(breakAtTheEdge)) {
+        return;
+      }
+      for (let nc = currentNodeContext; nc; nc = nc.parent) {
+        if (nc.breakAfter === "column") {
+          nc.breakAfter = null;
+        }
+        if (nc.viewNode?.nodeType === 1) {
+          const elem = nc.viewNode as HTMLElement;
+          if (elem.style?.breakAfter === "column") {
+            elem.style.breakAfter = "";
+          }
+        }
+      }
+    }
+
+    function setBreakAtTheEdge(nextBreakValue: string | null): void {
+      breakAtTheEdge = Break.resolveEffectiveBreakValue(
+        breakAtTheEdge,
+        nextBreakValue,
+      );
+    }
+
     function needForcedBreak(): boolean {
-      // leadingEdge=true means that we are at the beginning of the new column
-      // and hence must avoid a break (Otherwise leading to an infinite loop)
+      if (forcedBreakValue) {
+        return true;
+      }
+      if (!Break.isForcedBreakValue(breakAtTheEdge)) {
+        return false;
+      }
+      if (leadingEdge) {
+        // Issue #1842: allow page/spread breaks at the start of overflowed
+        // columns, but still suppress column/region breaks already satisfied by
+        // entering that column.
+        return (
+          column.isNonFirstColumn &&
+          breakAtTheEdge !== "column" &&
+          breakAtTheEdge !== "region"
+        );
+      }
       return (
-        !!forcedBreakValue ||
-        (!leadingEdge &&
-          Break.isForcedBreakValue(breakAtTheEdge) &&
-          // prevent unnecessary breaks at the beginning of the column/page
-          // after out-of-flow elements, e.g. position:absolute or running().
-          // (Issue #1176)
-          !atLeadingEdgeIgnoringOutOfFlow())
+        // prevent unnecessary breaks at the beginning of the column/page
+        // after out-of-flow elements, e.g. position:absolute or running().
+        // (Issue #1176)
+        !atLeadingEdgeIgnoringOutOfFlow()
       );
     }
 
@@ -3283,7 +3377,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         return false;
       }
       // Exclude if itself is a float (Issue #1288)
-      if (nodeContext.floatSide) {
+      if (!nodeContext || nodeContext.floatSide) {
         return false;
       }
       for (let nc = lastAfterNodeContext; nc?.parent; nc = nc.parent) {
@@ -3468,10 +3562,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // new formatting context, or float or flex container,
                 // or empty block box (unbreakable)
                 leadingEdgeContexts.push(nodeContext.copy());
-                breakAtTheEdge = Break.resolveEffectiveBreakValue(
-                  breakAtTheEdge,
-                  nodeContext.breakBefore,
-                );
+                setBreakAtTheEdge(nodeContext.breakBefore);
+                suppressWeakerLeadingColumnBreaks(nodeContext);
+                consumeSatisfiedLeadingColumnBreak(nodeContext);
 
                 // check if a forced break must occur before the block.
                 if (needForcedBreak()) {
@@ -3525,10 +3618,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 onStartEdges = false;
                 lastAfterNodeContext = nodeContext.copy();
                 trailingEdgeContexts.push(lastAfterNodeContext);
-                breakAtTheEdge = Break.resolveEffectiveBreakValue(
-                  null,
-                  nodeContext.breakAfter,
-                );
+                breakAtTheEdge = null;
+                setBreakAtTheEdge(nodeContext.breakAfter);
+                suppressWeakerTrailingColumnBreaks(nodeContext);
                 this.checkOverflowAndSaveEdgeAndBreakPosition(
                   lastAfterNodeContext,
                   null,
@@ -3593,10 +3685,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 lastAfterNodeContext = nodeContext.copy();
                 trailingEdgeContexts.push(lastAfterNodeContext);
               }
-              breakAtTheEdge = Break.resolveEffectiveBreakValue(
-                breakAtTheEdge,
-                nodeContext.breakAfter,
-              );
+              setBreakAtTheEdge(nodeContext.breakAfter);
+              suppressWeakerTrailingColumnBreaks(nodeContext);
               if (
                 style &&
                 !LayoutHelper.isOutOfFlow(nodeContext.viewNode) &&
@@ -3612,10 +3702,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             } else {
               // Leading edge
               leadingEdgeContexts.push(nodeContext.copy());
-              breakAtTheEdge = Break.resolveEffectiveBreakValue(
-                breakAtTheEdge,
-                nodeContext.breakBefore,
-              );
+              setBreakAtTheEdge(nodeContext.breakBefore);
+              suppressWeakerLeadingColumnBreaks(nodeContext);
+              consumeSatisfiedLeadingColumnBreak(nodeContext);
 
               // Prevent unnecessary blank pages by removing unnecessary forced column breaks
               if (

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1736,6 +1736,9 @@ export class StyleInstance
             layoutConstraint,
             columnPageFloatLayoutContext,
           );
+          // Issue #1842: mark columns created after the first one so layout can
+          // treat already-satisfied leading column breaks differently.
+          column.isNonFirstColumn = currentColumnIndex > 0;
           column.forceNonfitting = forceNonFitting;
           column.vertical = layoutContainer.vertical;
           column.rtl = layoutContainer.rtl;
@@ -1777,6 +1780,8 @@ export class StyleInstance
             layoutConstraint,
             columnPageFloatLayoutContext,
           );
+          // Single-column layout always behaves like the first column on a page.
+          column.isNonFirstColumn = false;
           column.copyFrom(layoutContainer);
         }
         column.exclusions = dontApplyExclusions ? [] : exclusions.concat();

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -137,6 +137,9 @@ export namespace Layout {
     last: Node;
     viewDocument: Document;
     flowRootFormattingContext: Vtree.FormattingContext;
+    // Issue #1842: distinguishes auto-advanced follow-up columns from the first
+    // column on a page so leading-edge forced breaks can be handled differently.
+    isNonFirstColumn: boolean;
     isFloat: boolean;
     isFootnote: boolean;
     startEdge: number;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -442,6 +442,10 @@ module.exports = [
         title: "Combine forced break values",
       },
       {
+        file: "page_breaks/combine_breaks_2.html",
+        title: "Combine break value regressions (Issue #1842)",
+      },
+      {
         file: "page_breaks/break_left_right.html",
         title: "break-before/after: left/right",
       },

--- a/packages/core/test/files/page_breaks/combine_breaks_2.html
+++ b/packages/core/test/files/page_breaks/combine_breaks_2.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>combine break regressions</title>
+    <style>
+      @page {
+        size: 900px 300px;
+        margin: 20px;
+        @bottom-center {
+          content: counter(page);
+        }
+      }
+      html {
+        column-count: 3;
+        orphans: 1;
+        widows: 1;
+      }
+      body {
+        margin: 0;
+      }
+      .column-break-before {
+        break-before: column;
+      }
+      .page-break-before {
+        break-before: page;
+      }
+      .page-break-after {
+        break-after: page;
+      }
+      .empty {
+        height: 100px;
+        background: #dfd;
+      }
+      svg {
+        width: 100px;
+        height: 100px;
+        background: #fdd;
+      }
+      .high-empty {
+        height: 261px;
+        background: #dfd;
+      }
+      .scenario-start {
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      This should be on the 1st page.
+      <div class="high-empty"></div>
+    </div>
+    <div>
+      <div class="page-break-before empty"></div>
+    </div>
+    <div>
+      This should be on the 2nd page.
+    </div>
+
+    <div class="scenario-start">
+      This should be on the 3rd page.
+      <div class="high-empty"></div>
+    </div>
+    <div class="page-break-before">
+      <div class="page-break-before empty"></div>
+    </div>
+    <div>
+      This should be on the 4th page.
+    </div>
+
+    <div class="scenario-start">
+      This should be on the 5th page.
+      <div class="high-empty"></div>
+    </div>
+    <div class="page-break-before">
+      <div class="column-break-before empty"></div>
+    </div>
+    <div>
+      This should be on the 6th page.
+    </div>
+
+    <div class="scenario-start">This should be on the 7th page.</div>
+    <div class="page-break-after">
+      This should be on the 7th page too.<svg style="height:300px"></svg>
+    </div>
+    This should be on the 8th page.
+    <div>
+      This should be on the 8th page too.<svg style="height:300px"></svg>
+    </div>
+    <div>
+      This should be in the 3rd column of the 8th page.
+    </div>
+
+    <div class="scenario-start">
+      This should be on the 9th page.
+      <div class="high-empty"></div>
+    </div>
+    <div>
+      <div class="column-break-before empty"></div>
+    </div>
+    <div>
+      This should be in the 3rd column of the 9th page.
+    </div>
+
+    <div class="scenario-start">
+      This should be on the 10th page.
+      <div class="high-empty"></div>
+    </div>
+    <div class="column-break-before">
+      <div class="column-break-before empty"></div>
+    </div>
+    <div>
+      This should be in the 3rd column of the 10th page.
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Handle Issue #1842 by allowing forced page breaks at the start of non-first columns while avoiding duplicate column breaks, and preserve page/spread break propagation for existing page-break regressions.

fixes #1842

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1842; the first attempt was incomplete, demonstrated with a modified test case, and the human author found further edge cases across several more test variations (including one specifically designed to check for spurious empty-column creation).
- The human author asked to reorganize and rename test files for consistency with existing naming conventions, ran a full layout-regression test and found 2 existing test regressions to resolve, and asked for clarifying code comments referencing issue #1842.
- The human author directed the commit message, created the PR, addressed Copilot review comments, and suggested relocating a new helper function into the existing `break.ts` helpers for consistency.

</details>
