### PR TITLE
fix: preserve ::before/::after with view-conditional content

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3677,8 +3677,10 @@ export class CascadeInstance {
         if (pseudoProps) {
           if (
             ((pseudoName === "before" || pseudoName === "after") &&
-              !Vtree.nonTrivialContent(
-                (pseudoProps["content"] as CascadeValue)?.value,
+              !(
+                Vtree.nonTrivialContent(
+                  (pseudoProps["content"] as CascadeValue)?.value,
+                ) || this.hasNonTrivialViewConditionalPseudoContent(pseudoProps)
               )) ||
             (pseudoName === "marker" &&
               !Display.isListItem(
@@ -3781,6 +3783,20 @@ export class CascadeInstance {
     if (itemToPushLast) {
       this.stack[this.stack.length - 2].push(itemToPushLast);
     }
+  }
+
+  private hasNonTrivialViewConditionalPseudoContent(
+    pseudoProps: ElementStyle,
+  ): boolean {
+    const viewConditionalStyles = pseudoProps["_viewConditionalStyles"] as
+      | { matcher: Matchers.Matcher; styles: ElementStyle }[]
+      | undefined;
+    if (!viewConditionalStyles || viewConditionalStyles.length <= 0) {
+      return false;
+    }
+    return viewConditionalStyles.some((entry) =>
+      Vtree.nonTrivialContent((entry.styles["content"] as CascadeValue)?.value),
+    );
   }
 
   /**


### PR DESCRIPTION
- Keep pseudo-elements when content is defined via `_viewConditionalStyles`, not only direct `content`
- Fix regression where `nth-fragment` based labels (page1: ... page8:) were dropped
- refs #1844

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author noticed the long-supported `nth-fragment` selector's test case no longer matched its expected output and asked the AI to fix it, deciding to split out an unrelated page-4 content discrepancy into a separate issue.
- The human author created the PR, asked the AI to check Copilot review comments, and judged that adding spec-level unit tests wasn't important given the existing layout-regression coverage.

</details>
