### PR TITLE
fix: prevent false overflow from ancestor block-end padding/border during page breaking

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2244,12 +2244,19 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
         // Record the height
         // TODO: should this be done after first-line calculation?
+        // Suppress ancestor block-end padding/border during edge
+        // calculation to prevent false overflow from browser column
+        // breaking. (Issue #1846)
+        const restoreInset = this.suppressOpenAncestorBlockEndInset(
+          resNodeContext ?? nodeContext,
+        );
         let edge = this.calculateEdge(
           resNodeContext,
           checkPoints,
           checkPointIndex,
           checkPoints[checkPointIndex].boxOffset,
         );
+        restoreInset();
         let overflown = false;
         if (
           !resNodeContext ||
@@ -3007,6 +3014,49 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   /**
+   * Temporarily suppress block-end padding/border on ancestor containers
+   * that are still being laid out (not yet complete) when using browser
+   * column breaking for overflow detection. This prevents the browser's
+   * column-breaking layout from incorrectly accounting for padding that
+   * will be removed at actual break points due to box-decoration-break:
+   * slice (the default). (Issue #1846)
+   *
+   * Returns a cleanup function that restores the original state.
+   */
+  private suppressOpenAncestorBlockEndInset(
+    nodeContext: Vtree.NodeContext,
+  ): () => void {
+    if (!LayoutHelper.isUsingBrowserColumnBreaking(this)) {
+      return () => {};
+    }
+    const saved: { element: Element; original: string | null }[] = [];
+    for (let nc = nodeContext?.parent; nc; nc = nc.parent) {
+      if (nc.after || nc.inline) {
+        continue;
+      }
+      const element = nc.viewNode as Element;
+      if (!element || element.nodeType !== 1) {
+        continue;
+      }
+      if (Break.isCloneBoxDecorationBreak(element)) {
+        continue;
+      }
+      const original = element.getAttribute("data-viv-box-break");
+      Break.setBoxBreakFlag(element, "block-end");
+      saved.push({ element, original });
+    }
+    return () => {
+      for (const { element, original } of saved) {
+        if (original === null) {
+          element.removeAttribute("data-viv-box-break");
+        } else {
+          element.setAttribute("data-viv-box-break", original);
+        }
+      }
+    };
+  }
+
+  /**
    * @return true if overflows
    */
   checkOverflowAndSaveEdge(
@@ -3024,12 +3074,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     if (LayoutHelper.isOrphan(nodeContext.viewNode)) {
       return false;
     }
+    const restoreInset = this.suppressOpenAncestorBlockEndInset(nodeContext);
     let edge = LayoutHelper.calculateEdge(
       nodeContext,
       this.clientLayout,
       0,
       this.vertical,
     );
+    restoreInset();
     const offsets = BreakPosition.calculateOffset(
       nodeContext,
       this.collectElementsOffset(),

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -478,6 +478,10 @@ module.exports = [
         title:
           "Block-start out-of-flow break (vertical writing-mode) (Issue #1775)",
       },
+      {
+        file: "page_breaks/page-breaking-with-container-padding-border.html",
+        title: "Page breaking with container padding/border (Issue #1846)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/page_breaks/page-breaking-with-container-padding-border.html
+++ b/packages/core/test/files/page_breaks/page-breaking-with-container-padding-border.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page breaking with container padding/border</title>
+    <!--
+      Test: When a container with padding/border is fragmented across pages,
+      the block-end padding/border (removed by box-decoration-break: slice)
+      should not cause incorrect overflow detection.
+
+      Page content area: 200px (= 300px page height - 50px*2 margins)
+      Each .content item: 60px (= 40px height + 10px*2 padding)
+
+      Expected page layout (3 pages):
+        Page 1: 1-1, 1-2, 1-3  (container1: 5+5 inset + 3*60 = 190px)
+        Page 2: 1-4, 1-5, 2-1  (60*2 + 5pad + 5+5margin + 5inset + 60 = 200px)
+        Page 3: 2-2, 2-3, 2-4  (60*3 + 5pad = 185px)
+
+      Bug (before fix): content 2-1 falsely overflows because container2's
+      block-end border+padding (5px) is included in the browser's column
+      layout, making the total 205px > 200px. This pushes content 2-1 to
+      page 3, wasting space on page 2 and creating a 4th page.
+    -->
+    <style>
+      @page {
+        size: 500px 300px;
+        margin: 50px;
+        border: rgba(0, 0, 255, 0.2) solid 1px;
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+      }
+      :root {
+        font-size: 14px;
+        widows: 1;
+        orphans: 1;
+      }
+      body {
+        margin: 0 10px;
+      }
+      .content {
+        height: 40px;
+        padding: 10px;
+      }
+      /* Container with padding only */
+      .container1 {
+        margin: 5px;
+        padding: 5px;
+        background-color: #eee;
+      }
+      /* Container with border + padding (same total inset as container1) */
+      .container2 {
+        margin: 5px;
+        padding: 3px;
+        border: 2px solid gray;
+        background-color: #dde;
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <div class="container1">
+        <div class="content">content 1-1</div>
+        <div class="content">content 1-2</div>
+        <div class="content">content 1-3</div>
+        <div class="content">content 1-4</div>
+        <div class="content">content 1-5</div>
+      </div>
+      <div class="container2">
+        <div class="content">content 2-1</div>
+        <div class="content">content 2-2</div>
+        <div class="content">content 2-3</div>
+        <div class="content">content 2-4</div>
+      </div>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
When using browser-native multicol for page break detection, the block-end padding/border of ancestor containers was incorrectly included in the overflow calculation. Since box-decoration-break defaults to slice, these insets are removed at actual break points, but the browser's column layout still counted them because subsequent siblings had not yet been added to the view tree. This caused content that should fit on the page to be pushed to the next page.

Fix by temporarily suppressing block-end padding/border on open ancestor containers (via the existing `data-viv-box-break` attribute) during edge measurement in `checkOverflowAndSaveEdge()` and `layoutBreakableBlock()`.

closes #1846

Assisted-by: GitHub Copilot Chat:gpt-5.3-codex

<details>
<summary>How the AI was used</summary>

- The human author described the false-overflow bug in technical detail (why ancestor block-end padding/border was being double-counted against `box-decoration-break: slice` semantics) and asked the AI to implement the fix.
- The human author asked for the test case to be simplified to a minimal, clear repro, adjusted the test's title/filename themselves to match recent naming conventions, and after creating the PR asked the AI to evaluate a Copilot review suggestion about `try`/`finally` usage, sharing their own reasoning for why it likely wasn't necessary.

</details>
