### PR TITLE
chore: Add --export-html and --export-html-diff options to layout regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "archiver": "^7.0.1",
+    "diff": "^8.0.4",
     "doctoc": "^2.0.0",
     "github-release-cli": "^2.0.0",
     "husky": "^4.2.3",

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -1403,30 +1403,36 @@ async function main() {
       screenshotMismatches += 1;
 
       if (opts.exportHtmlDiff) {
-        const baselineHtml = fs.readFileSync(
-          path.join(baselineDir, `${slug}.html`),
-          "utf8",
-        );
-        const actualHtml = fs.readFileSync(
-          path.join(actualDir, `${slug}.html`),
-          "utf8",
-        );
-        const formatOpts = { parser: "html", printWidth: 120 };
-        const baselineFormatted = await prettier.format(
-          baselineHtml,
-          formatOpts,
-        );
-        const actualFormatted = await prettier.format(actualHtml, formatOpts);
-        const patch = createTwoFilesPatch(
-          `baseline/${slug}.html`,
-          `actual/${slug}.html`,
-          baselineFormatted,
-          actualFormatted,
-        );
-        // createTwoFilesPatch always returns a header even if identical;
-        // only write when there are actual changes (lines starting with + or -)
-        if (/^[+-][^+-]/m.test(patch)) {
-          fs.writeFileSync(path.join(diffDir, `${slug}.diff`), patch, "utf8");
+        try {
+          const baselineHtml = fs.readFileSync(
+            path.join(baselineDir, `${slug}.html`),
+            "utf8",
+          );
+          const actualHtml = fs.readFileSync(
+            path.join(actualDir, `${slug}.html`),
+            "utf8",
+          );
+          const formatOpts = { parser: "html", printWidth: 120 };
+          const baselineFormatted = await prettier.format(
+            baselineHtml,
+            formatOpts,
+          );
+          const actualFormatted = await prettier.format(actualHtml, formatOpts);
+          const patch = createTwoFilesPatch(
+            `baseline/${slug}.html`,
+            `actual/${slug}.html`,
+            baselineFormatted,
+            actualFormatted,
+          );
+          // createTwoFilesPatch always returns a header even if identical;
+          // only write when there are actual changes (lines starting with + or -)
+          if (/^[+-][^+-]/m.test(patch)) {
+            fs.writeFileSync(path.join(diffDir, `${slug}.diff`), patch, "utf8");
+          }
+        } catch (error) {
+          console.warn(
+            `  -> skipped HTML diff export for ${slug}: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
       }
     }

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -7,6 +7,8 @@ import { chromium } from "playwright";
 import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
 import yaml from "js-yaml";
+import { createTwoFilesPatch } from "diff";
+import prettier from "prettier";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -32,6 +34,7 @@ const defaults = {
   viewportHeight: 1800,
   skipScreenshots: false,
   exportHtml: false,
+  exportHtmlDiff: false,
   actualViewer: "https://vivliostyle.vercel.app/",
   baselineViewer: "https://vivliostyle.org/viewer/",
   actualLabel: "canary",
@@ -143,6 +146,9 @@ function parseArgs(argv) {
       opts.skipScreenshots = true;
     } else if (a === "--export-html") {
       opts.exportHtml = true;
+    } else if (a === "--export-html-diff") {
+      opts.exportHtmlDiff = true;
+      opts.exportHtml = true;
     } else if (a === "--baseline-viewer") {
       baselineViewerSpec = argv[++i];
     } else if (a === "--actual-viewer") {
@@ -226,6 +232,7 @@ Options:
   --viewport-height <number> Browser viewport height
   --skip-screenshots         Skip image capture/compare, check page counts only
   --export-html              Export rendered HTML snapshot for each entry
+  --export-html-diff         Compare rendered HTML as HAST and write diff
   --actual-viewer <spec>     Actual viewer: URL, version (v2.35.0 or 2019.11.100),
                              or keyword: canary, stable, dev, prod, git-<branch> (default: canary)
   --baseline-viewer <spec>   Baseline viewer: same format as --actual-viewer (default: stable)
@@ -1394,6 +1401,34 @@ async function main() {
 
     if (diffEntry.pages.length > 0) {
       screenshotMismatches += 1;
+
+      if (opts.exportHtmlDiff) {
+        const baselineHtml = fs.readFileSync(
+          path.join(baselineDir, `${slug}.html`),
+          "utf8",
+        );
+        const actualHtml = fs.readFileSync(
+          path.join(actualDir, `${slug}.html`),
+          "utf8",
+        );
+        const formatOpts = { parser: "html", printWidth: 120 };
+        const baselineFormatted = await prettier.format(
+          baselineHtml,
+          formatOpts,
+        );
+        const actualFormatted = await prettier.format(actualHtml, formatOpts);
+        const patch = createTwoFilesPatch(
+          `baseline/${slug}.html`,
+          `actual/${slug}.html`,
+          baselineFormatted,
+          actualFormatted,
+        );
+        // createTwoFilesPatch always returns a header even if identical;
+        // only write when there are actual changes (lines starting with + or -)
+        if (/^[+-][^+-]/m.test(patch)) {
+          fs.writeFileSync(path.join(diffDir, `${slug}.diff`), patch, "utf8");
+        }
+      }
     }
 
     if (diffEntry.pageCountMismatch || diffEntry.pages.length > 0) {

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -232,7 +232,7 @@ Options:
   --viewport-height <number> Browser viewport height
   --skip-screenshots         Skip image capture/compare, check page counts only
   --export-html              Export rendered HTML snapshot for each entry
-  --export-html-diff         Compare rendered HTML as HAST and write diff
+  --export-html-diff         Compare prettified rendered HTML and write diff
   --actual-viewer <spec>     Actual viewer: URL, version (v2.35.0 or 2019.11.100),
                              or keyword: canary, stable, dev, prod, git-<branch> (default: canary)
   --baseline-viewer <spec>   Baseline viewer: same format as --actual-viewer (default: stable)

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -31,6 +31,7 @@ const defaults = {
   viewportWidth: 1800,
   viewportHeight: 1800,
   skipScreenshots: false,
+  exportHtml: false,
   actualViewer: "https://vivliostyle.vercel.app/",
   baselineViewer: "https://vivliostyle.org/viewer/",
   actualLabel: "canary",
@@ -140,6 +141,8 @@ function parseArgs(argv) {
       opts.viewportHeight = Number(argv[++i]);
     } else if (a === "--skip-screenshots") {
       opts.skipScreenshots = true;
+    } else if (a === "--export-html") {
+      opts.exportHtml = true;
     } else if (a === "--baseline-viewer") {
       baselineViewerSpec = argv[++i];
     } else if (a === "--actual-viewer") {
@@ -222,6 +225,7 @@ Options:
   --viewport-width <number>  Browser viewport width
   --viewport-height <number> Browser viewport height
   --skip-screenshots         Skip image capture/compare, check page counts only
+  --export-html              Export rendered HTML snapshot for each entry
   --actual-viewer <spec>     Actual viewer: URL, version (v2.35.0 or 2019.11.100),
                              or keyword: canary, stable, dev, prod, git-<branch> (default: canary)
   --baseline-viewer <spec>   Baseline viewer: same format as --actual-viewer (default: stable)
@@ -686,6 +690,7 @@ async function capturePages({
   dir,
   timeoutMs,
   skipScreenshots,
+  exportHtml,
 }) {
   await page.goto(url, { waitUntil: "domcontentloaded", timeout: timeoutMs });
   await waitForViewerReady(page, timeoutMs);
@@ -696,6 +701,12 @@ async function capturePages({
   }
 
   const totalPages = await getTotalPages(page);
+
+  if (exportHtml) {
+    const html = await page.content();
+    const snapshotPath = path.join(dir, `${key}.html`);
+    fs.writeFileSync(snapshotPath, html, "utf8");
+  }
 
   if (!skipScreenshots) {
     const spreadContainer = page.locator(
@@ -744,6 +755,7 @@ async function captureOneSide({
   dir,
   timeoutMs,
   skipScreenshots,
+  exportHtml,
   viewportWidth,
   viewportHeight,
 }) {
@@ -762,6 +774,7 @@ async function captureOneSide({
       dir,
       timeoutMs,
       skipScreenshots,
+      exportHtml,
     });
     return { ok: true, ...captured };
   } catch (err) {
@@ -1262,6 +1275,7 @@ async function main() {
       dir: baselineDir,
       timeoutMs: opts.timeoutMs,
       skipScreenshots: opts.skipScreenshots,
+      exportHtml: opts.exportHtml,
       viewportWidth: opts.viewportWidth,
       viewportHeight: opts.viewportHeight,
     });
@@ -1273,6 +1287,7 @@ async function main() {
       dir: actualDir,
       timeoutMs: opts.timeoutMs,
       skipScreenshots: opts.skipScreenshots,
+      exportHtml: opts.exportHtml,
       viewportWidth: opts.viewportWidth,
       viewportHeight: opts.viewportHeight,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6640,6 +6640,11 @@ diff-sequences@^29.6.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
+diff@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
+  integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"


### PR DESCRIPTION
VRTさっそく活用しています。画像で差分を検知した際にVivliostyle ViewerのHTMLの差分を確認できるオプションがあると便利だと思いました。`--export-html`はスクリーンショットとともにHTMLも保存するオプション、`--export-html-diff`は`--export-html`を有効にしつつPrettierで整形してdiffを出力するオプションとなっています。

例えばv2.39.1→v2.40.0（CMYKサポート）では以下のような出力を得られます。

```diff
...
@@ -704,31 +705,35 @@
                           Basic CMYK Colors
                         </h2>
                         <p
                           class="cyan"
+                          data-viv-device-cmyk='{"color":"device-cmyk(1 0 0 0)"}'
                           data-adapt-eloff="2377"
-                          style="display: block; margin-top: 16px; margin-bottom: 16px"
+                          style="color: color(srgb 0 1 1); display: block; margin-top: 16px; margin-bottom: 16px"
                         >
                           Cyan text: device-cmyk(1 0 0 0)
                         </p>
...
```
