### PR TITLE
chore: Add --concurrency option for parallel capture in layout regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "js-yaml": "^4.1.1",
     "lerna": "^8.1.9",
     "npm-run-all": "^4.1.5",
+    "p-limit": "^7.3.0",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.52.0",
     "pngjs": "^7.0.0",

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
@@ -34,7 +35,7 @@ const defaults = {
   viewportWidth: 1800,
   viewportHeight: 1800,
   skipScreenshots: false,
-  concurrency: 1,
+  concurrency: os.availableParallelism(),
   exportHtml: false,
   exportHtmlDiff: false,
   actualViewer: "https://vivliostyle.vercel.app/",
@@ -239,7 +240,7 @@ Options:
   --viewport-width <number>  Browser viewport width
   --viewport-height <number> Browser viewport height
   --skip-screenshots         Skip image capture/compare, check page counts only
-  --concurrency <number>     Number of entries to capture in parallel (default 1)
+  --concurrency <number>     Number of entries to capture in parallel (default: os.availableParallelism())
   --export-html              Export rendered HTML snapshot for each entry
   --export-html-diff         Compare prettified rendered HTML and write diff
   --actual-viewer <spec>     Actual viewer: URL, version (v2.35.0 or 2019.11.100),

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -7,6 +7,7 @@ import { chromium } from "playwright";
 import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
 import yaml from "js-yaml";
+import pLimit from "p-limit";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,6 +32,7 @@ const defaults = {
   viewportWidth: 1800,
   viewportHeight: 1800,
   skipScreenshots: false,
+  concurrency: 1,
   actualViewer: "https://vivliostyle.vercel.app/",
   baselineViewer: "https://vivliostyle.org/viewer/",
   actualLabel: "canary",
@@ -140,6 +142,8 @@ function parseArgs(argv) {
       opts.viewportHeight = Number(argv[++i]);
     } else if (a === "--skip-screenshots") {
       opts.skipScreenshots = true;
+    } else if (a === "--concurrency") {
+      opts.concurrency = Number(argv[++i]);
     } else if (a === "--baseline-viewer") {
       baselineViewerSpec = argv[++i];
     } else if (a === "--actual-viewer") {
@@ -195,6 +199,10 @@ function parseArgs(argv) {
   ) {
     throw new Error("--pixel-threshold must be between 0 and 1");
   }
+  if (!Number.isFinite(opts.concurrency) || opts.concurrency < 1) {
+    throw new Error("--concurrency must be a positive integer");
+  }
+  opts.concurrency = Math.floor(opts.concurrency);
   if (!opts.baselineViewer || !opts.actualViewer) {
     throw new Error("--baseline-viewer and --actual-viewer are required");
   }
@@ -222,6 +230,7 @@ Options:
   --viewport-width <number>  Browser viewport width
   --viewport-height <number> Browser viewport height
   --skip-screenshots         Skip image capture/compare, check page counts only
+  --concurrency <number>     Number of entries to capture in parallel (default 1)
   --actual-viewer <spec>     Actual viewer: URL, version (v2.35.0 or 2019.11.100),
                              or keyword: canary, stable, dev, prod, git-<branch> (default: canary)
   --baseline-viewer <spec>   Baseline viewer: same format as --actual-viewer (default: stable)
@@ -1247,35 +1256,46 @@ async function main() {
   let screenshotMismatches = 0;
   let timeoutEntries = 0;
 
-  for (let i = 0; i < targets.length; i++) {
-    const target = targets[i];
+  // Dispatch all captures into a bounded concurrency pool.
+  // Each entry produces a Promise that resolves with [baseline, actual].
+  const limit = pLimit(opts.concurrency);
+  const entryPromises = targets.map((target, i) => {
     const id = String(i + 1).padStart(4, "0");
     const slug = `${id}-${sanitizeName(target.category)}-${sanitizeName(target.title)}`;
+    const captureOpts = {
+      browser,
+      timeoutMs: opts.timeoutMs,
+      skipScreenshots: opts.skipScreenshots,
+      viewportWidth: opts.viewportWidth,
+      viewportHeight: opts.viewportHeight,
+    };
+    const baselineP = limit(() =>
+      captureOneSide({
+        ...captureOpts,
+        url: target.baselineUrl,
+        key: slug,
+        dir: baselineDir,
+      }),
+    );
+    const actualP = limit(() =>
+      captureOneSide({
+        ...captureOpts,
+        url: target.actualUrl,
+        key: slug,
+        dir: actualDir,
+      }),
+    );
+    return { id, slug, target, pair: Promise.all([baselineP, actualP]) };
+  });
+
+  // Process results in order: logs stay sequential while captures run ahead.
+  for (let i = 0; i < entryPromises.length; i++) {
+    const { id, slug, target, pair } = entryPromises[i];
     console.log(
       `[${i + 1}/${targets.length}] ${target.category} :: ${target.title}`,
     );
 
-    const baseline = await captureOneSide({
-      browser,
-      url: target.baselineUrl,
-      key: slug,
-      dir: baselineDir,
-      timeoutMs: opts.timeoutMs,
-      skipScreenshots: opts.skipScreenshots,
-      viewportWidth: opts.viewportWidth,
-      viewportHeight: opts.viewportHeight,
-    });
-
-    const actual = await captureOneSide({
-      browser,
-      url: target.actualUrl,
-      key: slug,
-      dir: actualDir,
-      timeoutMs: opts.timeoutMs,
-      skipScreenshots: opts.skipScreenshots,
-      viewportWidth: opts.viewportWidth,
-      viewportHeight: opts.viewportHeight,
-    });
+    const [baseline, actual] = await pair;
 
     if (!baseline.ok || !actual.ok) {
       if (!baseline.ok) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12806,6 +12806,13 @@ p-limit@^4.0.0:
   dependencies:
     yocto-queue "^1.0.0"
 
+p-limit@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-7.3.0.tgz#821398d91491c6b6a1340ecd09cdc402a9c8d0ee"
+  integrity sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==
+  dependencies:
+    yocto-queue "^1.2.1"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -18141,6 +18148,11 @@ yocto-queue@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+
+yocto-queue@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
+  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
 
 zip-stream@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
VRTにページのキャプチャを並列化する機能`--concurrency`オプションを追加します。

v2.39.1→v2.40.0の250番目から最後までを回すとこれくらい差が出ます。差分画像まで一致することを確認済みです。

||master|feat/parallel-capture<br>(concurrency=13)|
| --- | --- | --- |
|**所要時間**|1:02|0:10|
