### PR TITLE
fix: fix table overflow and support forced breaks inside tables

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -182,11 +182,21 @@ export function getElementClientRectAdjusted(
 
   if (columnOver > 0) {
     let style = clientLayout.getElementComputedStyle(element);
-    if (Base.browserType === "firefox" && style.display === "table") {
-      // Workaround for Firefox bug: Tables do not break (fragment) in CSS Multi-column Layout
+    if (
+      style.display.startsWith("table") &&
+      !findAncestorNonRootMultiColumn(element)
+    ) {
+      // For now, browser's column breaking for tables does not work well,
+      // so we disable it and use our own fragmentation logic for tables
+      // unless the table is inside a non-root multi-column element, which
+      // requires the browser's column breaking.
+      //
+      // Firefox bug: Tables do not break (fragment) in CSS Multi-column Layout
       //   https://bugzilla.mozilla.org/show_bug.cgi?id=888257
-      // We cannot use the browser's column breaking for tables in Firefox,
-      // so we disable it and use our own fragmentation logic.
+      //
+      // Chromium also has a bug on table fragmentation:
+      //   https://issues.chromium.org/issues/458852795
+
       const columnElem = element.closest(
         "[data-vivliostyle-column]",
       ) as HTMLElement;
@@ -195,53 +205,6 @@ export function getElementClientRectAdjusted(
 
         const rect2 = clientLayout.getElementClientRect(element);
         return rect2;
-      }
-    } else if (
-      Base.browserType === "chromium" &&
-      (style.display === "table-cell" ||
-        (element.className === "-vivliostyle-table-cell-container" &&
-          element.parentElement?.parentElement &&
-          (style = clientLayout.getElementComputedStyle(
-            element.parentElement.parentElement,
-          )).display === "table-cell"))
-    ) {
-      // Workaround for Chromium bug on table fragmentation:
-      //   https://issues.chromium.org/issues/458852795
-      // To prevent the table cell from moving to the next column without breaking inside the cell due to the bug,
-      // we try to reduce the column height so that a column break inside the cell can occur.
-      const columnElem = element.closest(
-        "[data-vivliostyle-column]",
-      ) as HTMLElement;
-      const columnStyle = columnElem?.style;
-      const blockSizeP = vertical ? "width" : "height";
-      const columnHeight = columnStyle && parseFloat(columnStyle[blockSizeP]);
-      if (columnHeight) {
-        let columnHeight2 = columnHeight;
-        let columnOver2 = columnOver;
-        const paddingBlockEnd = parseFloat(style.paddingBlockEnd);
-        const borderBlockEndWidth = parseFloat(style.borderBlockEndWidth);
-        let count = Math.ceil(paddingBlockEnd + borderBlockEndWidth);
-        while (
-          count-- > 0 &&
-          columnOver2 === columnOver &&
-          --columnHeight2 > 0
-        ) {
-          columnStyle[blockSizeP] = `${columnHeight2}px`;
-          const rect2 = clientLayout.getElementClientRect(element);
-          columnOver2 = adjustRectForColumnBreaking(rect2, vertical);
-          if (
-            columnOver2 < columnOver ||
-            (columnOver2 === columnOver &&
-              (vertical ? rect2.right > rect.right : rect2.top < rect.top))
-          ) {
-            columnElem.setAttribute(
-              "data-vivliostyle-column-block-size-adjusted",
-              "true",
-            );
-            return rect2;
-          }
-        }
-        columnStyle[blockSizeP] = `${columnHeight}px`;
       }
     }
   }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -4293,30 +4293,24 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
               // Unset browser's multi-column (Issue #1637, #1747)
               LayoutHelper.unsetBrowserColumnBreaking(this);
-
-              // Restore root column block-size if it was reduced by Chromium
-              // table fragmentation workaround (Issue #1812),
-              // or by footnotes/block-end-page-floats and table/multicol issue
-              // workaround (Issue #1662, #1460).
-              if (
-                this.element.hasAttribute(
-                  "data-vivliostyle-column-block-size-adjusted",
-                )
-              ) {
-                if (this.vertical) {
-                  Base.setCSSProperty(this.element, "width", `${this.width}px`);
-                  Base.setCSSProperty(this.element, "left", `${this.left}px`);
-                } else {
-                  Base.setCSSProperty(
-                    this.element,
-                    "height",
-                    `${this.height}px`,
-                  );
-                }
-                this.element.removeAttribute(
-                  "data-vivliostyle-column-block-size-adjusted",
-                );
+            }
+            // Restore root column block-size if it was reduced by
+            // footnotes/block-end-page-floats and table/multicol issue
+            // workaround (Issue #1662, #1460).
+            if (
+              this.element.hasAttribute(
+                "data-vivliostyle-column-block-size-adjusted",
+              )
+            ) {
+              if (this.vertical) {
+                Base.setCSSProperty(this.element, "width", `${this.width}px`);
+                Base.setCSSProperty(this.element, "left", `${this.left}px`);
+              } else {
+                Base.setCSSProperty(this.element, "height", `${this.height}px`);
               }
+              this.element.removeAttribute(
+                "data-vivliostyle-column-block-size-adjusted",
+              );
             }
             if (this.pageFloatLayoutContext.isInvalidated()) {
               frame.finish(null);

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -19,6 +19,7 @@
  */
 import * as Asserts from "./asserts";
 import * as Base from "./base";
+import * as Break from "./break";
 import * as BreakPosition from "./break-position";
 import * as Css from "./css";
 import * as LayoutHelper from "./layout-helper";
@@ -43,6 +44,8 @@ import {
 
 export class TableRow {
   cells: TableCell[] = [];
+  breakBefore: string | null = null;
+  breakAfter: string | null = null;
 
   constructor(
     public readonly rowIndex: number,
@@ -869,6 +872,11 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             this.rowIndex,
             new TableRow(this.rowIndex, nodeContext.sourceNode),
           );
+          // Capture row's own breakBefore for forced break detection
+          if (nodeContext.breakBefore) {
+            formattingContext.rows[this.rowIndex].breakBefore =
+              nodeContext.breakBefore;
+          }
           if (!repetitiveElements.firstContentSourceNode) {
             repetitiveElements.firstContentSourceNode =
               nodeContext.sourceNode as Element;
@@ -911,6 +919,14 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
           if (!this.inHeaderOrFooter) {
             formattingContext.lastRowViewNode = nodeContext.viewNode as Element;
             this.inRow = false;
+            // Capture row's own breakAfter for forced break detection
+            const row = formattingContext.rows[this.rowIndex];
+            if (row && nodeContext.breakAfter) {
+              row.breakAfter = Break.resolveEffectiveBreakValue(
+                row.breakAfter,
+                nodeContext.breakAfter,
+              );
+            }
           }
           break;
         case "table-cell":
@@ -926,6 +942,22 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
               new TableCell(this.rowIndex, this.columnIndex, elem),
             );
             this.columnIndex++;
+            // Propagate cell break values to the row for forced break detection
+            const cellRow = formattingContext.rows[this.rowIndex];
+            if (cellRow) {
+              if (nodeContext.breakBefore) {
+                cellRow.breakBefore = Break.resolveEffectiveBreakValue(
+                  cellRow.breakBefore,
+                  nodeContext.breakBefore,
+                );
+              }
+              if (nodeContext.breakAfter) {
+                cellRow.breakAfter = Break.resolveEffectiveBreakValue(
+                  cellRow.breakAfter,
+                  nodeContext.breakAfter,
+                );
+              }
+            }
           }
           break;
       }
@@ -1231,11 +1263,55 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     return this.layoutRowSpanningCellsFromPreviousFragment(state).thenAsync(
       () => {
         this.registerCellFragmentIndex();
+
+        // Merge pre-collected cell/row break values with state.breakAtTheEdge
+        let breakAtEdge = state.breakAtTheEdge;
+        if (this.currentRowIndex > 0) {
+          const prevRow = formattingContext.rows[this.currentRowIndex - 1];
+          if (prevRow?.breakAfter) {
+            breakAtEdge = Break.resolveEffectiveBreakValue(
+              breakAtEdge,
+              prevRow.breakAfter,
+            );
+          }
+        }
+        const currentRow = formattingContext.rows[this.currentRowIndex];
+        if (currentRow?.breakBefore) {
+          breakAtEdge = Break.resolveEffectiveBreakValue(
+            breakAtEdge,
+            currentRow.breakBefore,
+          );
+        }
+
+        // Check for forced break before this row
+        if (!state.leadingEdge && Break.isForcedBreakValue(breakAtEdge)) {
+          this.column.checkOverflowAndSaveEdgeAndBreakPosition(
+            state.lastAfterNodeContext,
+            null,
+            true,
+            breakAtEdge,
+          );
+          if (nodeContext.viewNode?.parentNode) {
+            nodeContext.viewNode.parentNode.removeChild(nodeContext.viewNode);
+          }
+          // Set block-end box-break flags on the table and its ancestors
+          // since doFinishBreak skips finishBreak when pageBreakType is set
+          if (state.lastAfterNodeContext) {
+            this.column.layoutContext.processFragmentedBlockEdge(
+              state.lastAfterNodeContext,
+            );
+          }
+          this.column.pageBreakType = breakAtEdge;
+          this.resetColumn();
+          state.break = true;
+          return Task.newResult(true);
+        }
+
         const overflown = this.column.checkOverflowAndSaveEdgeAndBreakPosition(
           state.lastAfterNodeContext,
           null,
           true,
-          state.breakAtTheEdge,
+          breakAtEdge,
         );
         if (
           overflown &&
@@ -1669,7 +1745,9 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
         ).current;
       if (
         !column.isOverflown(edge) &&
-        (!tableLayoutOption || !tableLayoutOption.calculateBreakPositionsInside)
+        (!tableLayoutOption ||
+          !tableLayoutOption.calculateBreakPositionsInside) &&
+        !this.hasForcedBreakInRows(formattingContext)
       ) {
         column.breakPositions.push(
           new EntireTableBreakPosition(initialNodeContext),
@@ -1682,6 +1760,31 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
       frame.finish(null);
     });
     return frame.result();
+  }
+
+  /**
+   * Check if any row inside the table has a forced break value
+   * (propagated from cells or set on the row itself).
+   */
+  private hasForcedBreakInRows(
+    formattingContext: TableFormattingContext,
+  ): boolean {
+    for (let i = 0; i < formattingContext.rows.length; i++) {
+      const row = formattingContext.rows[i];
+      if (!row) continue;
+      // Skip the first row's breakBefore (break before the table, not inside)
+      if (i > 0 && Break.isForcedBreakValue(row.breakBefore)) {
+        return true;
+      }
+      // Skip the last row's breakAfter (break after the table, not inside)
+      if (
+        i < formattingContext.rows.length - 1 &&
+        Break.isForcedBreakValue(row.breakAfter)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   addCaptions(

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -580,6 +580,10 @@ module.exports = [
         title: "Table repeating header/footer (vertical writing-mode)",
       },
       { file: "table/break_after_table.html", title: "Break after table" },
+      {
+        file: "table/table-break.html",
+        title: "Table page break (auto + forced) (Issue #1492, #1849)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/table/table-break.html
+++ b/packages/core/test/files/table/table-break.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Table page break test</title>
+  <style>
+@page {
+  size: 500px;
+  margin: 50px;
+  outline: 1px solid cyan;
+  @bottom-center {
+    content: "Page " counter(page);
+    font-size: 14px;
+    line-height: 1;
+  }
+}
+body {
+  margin: 0;
+  font: 16px/22px serif;
+  widows: 1;
+  orphans: 1;
+}
+table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  border: 4px solid;
+}
+td {
+  border: 1px solid;
+  padding: 0 4px;
+  vertical-align: top;
+}
+  </style>
+</head>
+<body>
+  <!--
+    Test: Table page breaking (auto + forced)
+    - Issue #1849: Auto page breaking inside cells without overflow
+    - Issue #1492: Forced page breaks on table rows and cells
+
+    Expected: 5 pages
+    Page 1: R1 auto-broken (lines 1-18 in each cell)
+    Page 2: R1 continued (lines 19-22)
+    Page 3: R2 (forced break-before: page on row)
+    Page 4: R3 + R4 (forced break-before: page on cell)
+    Page 5: R5 (forced break-after: page on R4)
+  -->
+  <table>
+    <tr>
+      <td>
+        R1C1 (1)<br>R1C1 (2)<br>R1C1 (3)<br>R1C1 (4)<br>
+        R1C1 (5)<br>R1C1 (6)<br>R1C1 (7)<br>R1C1 (8)<br>
+        R1C1 (9)<br>R1C1 (10)<br>R1C1 (11)<br>R1C1 (12)<br>
+        R1C1 (13)<br>R1C1 (14)<br>R1C1 (15)<br>R1C1 (16)<br>
+        R1C1 (17)<br>R1C1 (18)<br>R1C1 (19)<br>R1C1 (20)<br>
+        R1C1 (21)<br>R1C1 (22)
+      </td>
+      <td>
+        R1C2 (1)<br>R1C2 (2)<br>R1C2 (3)<br>R1C2 (4)<br>
+        R1C2 (5)<br>R1C2 (6)<br>R1C2 (7)<br>R1C2 (8)<br>
+        R1C2 (9)<br>R1C2 (10)<br>R1C2 (11)<br>R1C2 (12)<br>
+        R1C2 (13)<br>R1C2 (14)<br>R1C2 (15)<br>R1C2 (16)<br>
+        R1C2 (17)<br>R1C2 (18)<br>R1C2 (19)<br>R1C2 (20)<br>
+        R1C2 (21)<br>R1C2 (22)
+      </td>
+    </tr>
+    <tr style="break-before: page;">
+      <td>R2C1 — break-before: page on row</td>
+      <td>R2C2</td>
+    </tr>
+    <tr>
+      <td style="break-before: page;">R3C1 — break-before: page on cell</td>
+      <td>R3C2</td>
+    </tr>
+    <tr style="break-after: page;">
+      <td>R4C1 — break-after: page on row</td>
+      <td>R4C2</td>
+    </tr>
+    <tr>
+      <td>R5C1 — after forced break</td>
+      <td>R5C2</td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
- Disable browser's column breaking for tables (except inside non-root multi-column elements) to fix table cell overflow and incorrect page breaking (Issue #1849).
- Remove Chromium-specific column height adjustment workaround that was insufficient to fix the issue.
- Implement forced page break detection (break-before/break-after) on table rows and cells without relying on browser's column breaking (Issue #1492).
  - Collect break values from rows and cells during initial table layout
  - Detect and process forced breaks in TableLayoutStrategy.startTableRow()
  - Force fragmented layout when internal forced breaks exist
- Add test case for table page breaking (auto + forced).

closes #1849

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1849 (table overflow) and, once resolved, asked for a combined regression test also covering the related forced-break issue #1492, specifying that a single test file should cover both.
- The human author refined the test case iteratively (adjusting page size, adding an outline for visual clarity, adding explicit `widows`/`orphans` values so break positions would be easy to verify) and adjusted the reproduction sample themselves to make the pre-fix bug clearly visible against canary/stable.
- The human author noted that non-root multi-column tables still had unrelated issues (deferred to a separate issue) and relocated the new test file into the `table` directory before finalizing.

</details>
