### PR TITLE
fix: avoid empty nested-multicol table fragments at column breaks

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -4569,11 +4569,15 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 export class PseudoColumn {
   startNodeContexts: Vtree.NodeContext[] = [];
   private column: Layout.Column;
+  // Issue #1854: retain the source subtree root so we can detect breaks that
+  // land after the last significant node in a table-cell pseudo column.
+  private readonly flowRootSourceNode: Node;
   constructor(
     column: Layout.Column,
     viewRoot: HTMLElement,
     parentNodeContext: Vtree.NodeContext,
   ) {
+    this.flowRootSourceNode = parentNodeContext.sourceNode;
     this.column = Object.create(column) as Layout.Column;
     this.column.element = viewRoot;
     this.column.layoutContext = column.layoutContext.clone();
@@ -4645,10 +4649,57 @@ export class PseudoColumn {
     );
   }
   isLastAfterNodeContext(nodeContext: Vtree.NodeContext): boolean {
-    return VtreeImpl.isSameNodePosition(
-      nodeContext.toNodePosition(),
-      this.column.lastAfterPosition,
+    return (
+      VtreeImpl.isSameNodePosition(
+        nodeContext.toNodePosition(),
+        this.column.lastAfterPosition,
+      ) || this.isEffectivelyLastAfterNodeContext(nodeContext)
     );
+  }
+
+  private isEffectivelyLastAfterNodeContext(
+    nodeContext: Vtree.NodeContext,
+  ): boolean {
+    // Issue #1854: a table cell can break immediately after its last visible
+    // text node without matching lastAfterPosition exactly; treat that as a
+    // terminal break so table row fragmentation does not create an empty
+    // continuation fragment that only carries borders.
+    const flowRoot = this.flowRootSourceNode;
+    const sourceNode = nodeContext.sourceNode;
+    if (!flowRoot || !sourceNode || !nodeContext.after) {
+      return false;
+    }
+    if (
+      flowRoot !== sourceNode &&
+      !(flowRoot as Element).contains?.(sourceNode)
+    ) {
+      return false;
+    }
+    if (sourceNode.nodeType === Node.TEXT_NODE) {
+      const textNode = sourceNode as Text;
+      if (nodeContext.offsetInNode < textNode.length) {
+        const remainingText = textNode.data.slice(nodeContext.offsetInNode);
+        if (!VtreeImpl.canIgnoreText(remainingText, nodeContext.whitespace)) {
+          return false;
+        }
+      }
+    }
+    for (
+      let node: Node | null = sourceNode;
+      node && node !== flowRoot;
+      node = node.parentNode
+    ) {
+      for (
+        let sibling = node.nextSibling;
+        sibling;
+        sibling = sibling.nextSibling
+      ) {
+        if (!VtreeImpl.canIgnore(sibling, nodeContext.whitespace)) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
   getColumnElement(): Element {
     return this.column.element;

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -287,7 +287,10 @@ export function canIgnore(node: Node, whitespace?: Whitespace): boolean {
   if (node.nodeType == 1) {
     return false;
   }
-  const text = node.textContent;
+  return canIgnoreText(node.textContent, whitespace);
+}
+
+export function canIgnoreText(text: string, whitespace?: Whitespace): boolean {
   switch (whitespace) {
     case Whitespace.PRESERVE:
       return text.length == 0;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -584,6 +584,10 @@ module.exports = [
         file: "table/table-break.html",
         title: "Table page break (auto + forced) (Issue #1492, #1849)",
       },
+      {
+        file: "table/nrmc-table-break-column.html",
+        title: "Table column break in non-root multicol (Issue #1854)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/table/nrmc-table-break-column.html
+++ b/packages/core/test/files/table/nrmc-table-break-column.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Table column break in non-root multicol</title>
+  <style>
+@page {
+  size: 500px;
+  margin: 50px;
+  outline: 1px solid cyan;
+  @bottom-center {
+    content: "Page " counter(page);
+    font-size: 14px;
+    line-height: 1;
+  }
+}
+body {
+  margin: 0;
+  font: 16px/22px serif;
+  widows: 1;
+  orphans: 1;
+}
+.multicol {
+  column-count: 2;
+}
+table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  border: 4px solid;
+}
+td {
+  border: 1px solid;
+  padding: 0 4px;
+  vertical-align: top;
+}
+  </style>
+</head>
+<body>
+  <!--
+    Test: nested multi-column table column breaks
+    - Issue #1854: avoid border-only trailing row fragments at page boundaries
+      and avoid re-firing break-before: column after such an empty fragment.
+
+    Expected: 3 pages
+    Page 1: R1 split across both nested columns with bottom cell borders visible.
+    Page 2: R2 in the first nested column, R3 and R4 in the second nested column.
+    Page 3: R5.
+  -->
+  <div class="multicol">
+    <table>
+      <tr>
+        <td>
+          R1C1 (1)<br>R1C1 (2)<br>R1C1 (3)<br>R1C1 (4)<br>
+          R1C1 (5)<br>R1C1 (6)<br>R1C1 (7)<br>R1C1 (8)<br>
+          R1C1 (9)<br>R1C1 (10)<br>R1C1 (11)<br>R1C1 (12)<br>
+          R1C1 (13)<br>R1C1 (14)<br>R1C1 (15)<br>R1C1 (16)<br>
+          R1C1 (17)<br>R1C1 (18)<br>R1C1 (19)<br>R1C1 (20)<br>
+          R1C1 (21)<br>R1C1 (22)
+        </td>
+        <td>
+          R1C2 (1)<br>R1C2 (2)<br>R1C2 (3)<br>R1C2 (4)<br>
+          R1C2 (5)<br>R1C2 (6)<br>R1C2 (7)<br>R1C2 (8)<br>
+          R1C2 (9)<br>R1C2 (10)<br>R1C2 (11)<br>R1C2 (12)<br>
+          R1C2 (13)<br>R1C2 (14)<br>R1C2 (15)<br>R1C2 (16)<br>
+          R1C2 (17)<br>R1C2 (18)<br>R1C2 (19)<br>R1C2 (20)<br>
+          R1C2 (21)<br>R1C2 (22)
+        </td>
+      </tr>
+      <tr style="break-before: column;">
+        <td>R2C1 -- break-before: column on row</td>
+        <td>R2C2</td>
+      </tr>
+      <tr>
+        <td style="break-before: column;">R3C1 -- break-before: column on cell</td>
+        <td>R3C2</td>
+      </tr>
+      <tr style="break-after: column;">
+        <td>R4C1 -- break-after: column on row</td>
+        <td>R4C2</td>
+      </tr>
+      <tr>
+        <td>R5C1 -- after forced break</td>
+        <td>R5C2</td>
+      </tr>
+    </table>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Treat pseudo-column break positions after the last significant source node as terminal breaks so table row fragmentation does not create border-only continuation fragments in nested multi-column tables.

Add a regression test for non-root multicol table column breaks.

fixes #1854

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix an issue combining Vivliostyle's own page/column split logic with the browser's native column fragmentation, noting this requires understanding both systems together.
- The human author confirmed the fix worked, directed the commit message, created the PR, addressed Copilot review comments, and raised a refactoring question about redundant whitespace-ignore logic in `canIgnore()`.

</details>
