### PR TITLE
fix: fix page navigation freeze with target-text reflow

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1159,6 +1159,126 @@ export class CounterStore {
   }
 
   /**
+   * Adjust page counter snapshots for elements in spines after the specified
+   * spine. Called when a preceding spine's page count changes (e.g. TOC
+   * expands after target-text resolution), shifting all subsequent pages.
+   */
+  adjustPageCountersOfLaterSpines(
+    expandedSpineIndex: number,
+    pageDelta: number,
+  ): void {
+    if (pageDelta <= 0) return;
+    // Multiple IDs on the same page share the same counter object reference
+    // (assigned in finishPage). Use a Set to avoid adjusting the same object
+    // multiple times.
+    const adjusted = new Set<CssCascade.CounterValues>();
+    for (const id of Object.keys(this.pageIndicesById)) {
+      const idx = this.pageIndicesById[id];
+      if (idx.spineIndex > expandedSpineIndex) {
+        const counters = this.pageCountersById[id];
+        if (counters && counters["page"] && !adjusted.has(counters)) {
+          adjusted.add(counters);
+          counters["page"] = counters["page"].map((v) => v + pageDelta);
+        }
+      }
+    }
+  }
+
+  /**
+   * Walk through target-counter DOM nodes in the given page containers and
+   * update their text content from the current pageCountersById snapshots.
+   */
+  updateTargetCounterNodesInPages(pages: Vtree.Page[]): void {
+    for (const page of pages) {
+      if (!page || !page.container) continue;
+      const nodes = page.container.querySelectorAll(`[${TARGET_COUNTER_ATTR}]`);
+      for (const node of nodes) {
+        const key = node.getAttribute(TARGET_COUNTER_ATTR);
+        const expr = this.targetCounterExprs.find((o) => o.expr.key === key);
+        if (expr && expr.transformedId) {
+          const counterValue = this.pageCountersById[expr.transformedId];
+          if (counterValue) {
+            const arr: number[] = counterValue[expr.name];
+            if (arr) {
+              node.textContent = expr.format(arr[arr.length - 1]);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Resolve page-level counter values for a page.
+   *
+   * Prefer an explicit per-page snapshot when one is supplied. Otherwise fall
+   * back to looking up tracked element IDs on the page via pageCountersById.
+   *
+   * Note: explicitCounters are pageCounterStarts (pre-increment snapshots),
+   * while pageCountersById stores post-increment values. When using
+   * explicitCounters as a fallback, the caller should be aware of this
+   * distinction. For the "page" counter the difference is +1, but this
+   * method returns whichever snapshot it finds without adjustment.
+   */
+  private getPageCountersForPage(
+    page: Vtree.Page,
+    explicitCounters?: CssCascade.CounterValues | null,
+  ): CssCascade.CounterValues | null {
+    // First try pageCountersById (post-render values) via any tracked element
+    const elementIds = Object.keys(page.elementsById);
+    for (const elementId of elementIds) {
+      const counters = this.pageCountersById[elementId];
+      if (counters) {
+        return counters;
+      }
+    }
+    // Fall back to explicit per-page counters (e.g. pageCounterStarts)
+    if (explicitCounters) {
+      return explicitCounters;
+    }
+    return null;
+  }
+
+  /**
+   * Walk through page-counter DOM nodes in the given page containers and
+   * update their text content from the adjusted pageCountersById snapshots.
+   * Called after adjustPageCountersOfLaterSpines has shifted the counters.
+   *
+   * When available, pass explicit per-page counter snapshots aligned with the
+   * given pages so pages without tracked element IDs are also updated.
+   */
+  updatePageCounterNodesInPages(
+    pages: Vtree.Page[],
+    pageCountersByPage?: Array<CssCascade.CounterValues | null>,
+  ): void {
+    for (let i = 0; i < pages.length; i++) {
+      const page = pages[i];
+      if (!page?.container) continue;
+
+      const counters = this.getPageCountersForPage(
+        page,
+        pageCountersByPage?.[i],
+      );
+      if (!counters) continue;
+
+      const nodes = page.container.querySelectorAll(`[${PAGE_COUNTER_ATTR}]`);
+      for (const node of nodes) {
+        const key = node.getAttribute(PAGE_COUNTER_ATTR);
+        const counterExpr = this.pageCounterExprs.find(
+          (o) => o.expr.key === key,
+        );
+        if (!counterExpr) continue;
+        const str = (counterExpr.expr as Exprs.Native)?.str;
+        const counterName = str?.replace(/^page-counters?-/, "");
+        const counterValues = counters[counterName];
+        if (counterValues) {
+          node.textContent = counterExpr.format(counterValues);
+        }
+      }
+    }
+  }
+
+  /**
    * Returns unresolved references pointing to the specified page.
    */
   getUnresolvedRefsToPage(page: Vtree.Page): {

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2028,6 +2028,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
             targetViewItem.instance.currentPageGroupDocument =
               savedCurrentPageGroupDocument;
             targetViewItem.instance.scopes = scopes;
+            // Save the counter state BEFORE popping. After renderSinglePage,
+            // currentPageCounters reflects the correct end state for the
+            // target page within the pushed scope. This is the correct
+            // starting state for any pending page created by cascade blocking.
+            // After popPageCounters, this state is lost (restored to the
+            // source spine's counters), so save it now.
+            const counterStateAfterTargetRender = cloneCounterValues(
+              this.counterStore.currentPageCounters,
+            );
             this.counterStore.popPageCounters();
             this.counterStore.popReferencesToSolve();
             if (
@@ -2054,6 +2063,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             // layout slot (layoutPositions has next page) without an actual
             // rendered page in pages[]. Materialize that pending page here so
             // later navigation/render loops do not stop one page early.
+            const isCrossSpine = targetViewItem !== viewItem;
             const firstPendingPageIndex = targetViewItem.pages.length;
             const pendingLayoutPosition =
               targetViewItem.layoutPositions[firstPendingPageIndex];
@@ -2065,12 +2075,90 @@ export class OPFView implements Vgen.CustomRendererFactory {
               pendingLayoutPosition &&
               !hasActiveRootPageFloatLayoutContextAfterRerender
             ) {
+              // For cross-spine cases, save/restore counter state around the
+              // pending page render and use the counter state saved before
+              // popPageCounters, because the global state after pop reflects
+              // the source spine, not the target spine.
+              const savedCountersBeforePending = isCrossSpine
+                ? cloneCounterValues(this.counterStore.currentPageCounters)
+                : null;
+              if (isCrossSpine) {
+                this.counterStore.currentPageCounters =
+                  counterStateAfterTargetRender;
+              }
+              const pageCountBeforePending = firstPendingPageIndex;
               this.renderSinglePage(targetViewItem, pendingLayoutPosition).then(
                 () => {
+                  if (isCrossSpine) {
+                    this.markSpineItemCompleteIfReady(targetViewItem);
+                  }
+                  // After the pending page expanded the target spine,
+                  // pageCountersById snapshots for elements in later spines
+                  // are stale (page counter is off by the added pages).
+                  // Adjust those snapshots, shift the saved source-spine
+                  // counter state so subsequent pages start from the
+                  // corrected offset, and patch already-rendered
+                  // target-counter DOM nodes in the expanded spine's pages.
+                  const pageDelta =
+                    targetViewItem.pages.length - pageCountBeforePending;
+                  if (isCrossSpine && pageDelta > 0) {
+                    this.counterStore.adjustPageCountersOfLaterSpines(
+                      targetViewItem.item.spineIndex,
+                      pageDelta,
+                    );
+                    this.counterStore.updateTargetCounterNodesInPages(
+                      targetViewItem.pages,
+                    );
+                    // Adjust pageCounterStarts and page-counter DOM nodes
+                    // for all already-rendered later-spine viewItems so
+                    // their counter(page) margins show the corrected value
+                    // and future re-renders start from the right offset.
+                    const expandedIdx = targetViewItem.item.spineIndex;
+                    for (
+                      let si = expandedIdx + 1;
+                      si < this.spineItems.length;
+                      si++
+                    ) {
+                      const laterItem = this.spineItems[si];
+                      if (!laterItem) continue;
+                      laterItem.item.epage += pageDelta;
+                      for (const pcs of laterItem.pageCounterStarts) {
+                        if (pcs?.["page"]) {
+                          pcs["page"] = pcs["page"].map((v) => v + pageDelta);
+                        }
+                      }
+                      this.counterStore.updatePageCounterNodesInPages(
+                        laterItem.pages,
+                        laterItem.pageCounterStarts,
+                      );
+                    }
+                    // Shift the saved source-spine counter state so that
+                    // when it is restored below, subsequent pages of the
+                    // source spine continue with the corrected page offset.
+                    if (savedCountersBeforePending) {
+                      const srcPage = savedCountersBeforePending["page"];
+                      if (srcPage) {
+                        savedCountersBeforePending["page"] = srcPage.map(
+                          (v) => v + pageDelta,
+                        );
+                      }
+                    }
+                  }
+                  if (savedCountersBeforePending) {
+                    this.counterStore.currentPageCounters =
+                      savedCountersBeforePending;
+                  }
                   loopFrame.continueLoop();
                 },
               );
               return;
+            }
+            // The target spine's re-render (or cascade inside the resolve
+            // scope) may have set complete=false even when no pending page
+            // was created. Re-check completeness so navigation can advance
+            // past this spine. Only for cross-spine cases.
+            if (isCrossSpine) {
+              this.markSpineItemCompleteIfReady(targetViewItem);
             }
             loopFrame.continueLoop();
           });
@@ -2244,6 +2332,22 @@ export class OPFView implements Vgen.CustomRendererFactory {
               resultPage = viewItem.pages[pageIndex];
               loopFrame.breakLoop();
             } else if (sync) {
+              this.renderPage(normalizedPosition).then((result) => {
+                if (result) {
+                  resultPage = result.page;
+                  pageIndex = result.position.pageIndex;
+                }
+                loopFrame.breakLoop();
+              });
+            } else if (
+              pageIndex < viewItem.layoutPositions.length &&
+              !viewItem.pages[pageIndex]
+            ) {
+              // The page has a pending layout position that was never
+              // materialized (e.g. created during target-text resolution
+              // but blocked from cascading, or the spine was recreated
+              // during navigation). Render it now instead of polling
+              // forever waiting for a nonexistent concurrent task.
               this.renderPage(normalizedPosition).then((result) => {
                 if (result) {
                   resultPage = result.page;
@@ -3089,11 +3193,36 @@ export class OPFView implements Vgen.CustomRendererFactory {
             ? previousViewItem.instance.pageNumberOffset +
               previousViewItem.pages.length
             : 0;
-          const counters = this.counterStore.currentPageCounters["page"];
-          pageCounterOffset =
-            !counters || !counters.length
-              ? pageNumberOffset
-              : counters[counters.length - 1];
+          // Derive the page counter offset from the previous spine's last
+          // rendered page counter start rather than the global
+          // currentPageCounters, which may reflect stale state from a later
+          // spine that has been destroyed and is being recreated (e.g. after
+          // target-text reflow expanded an earlier spine).
+          // Note: pageCounterStarts is captured BEFORE updatePageCounters()
+          // applies counter-increment, so +1 is added for the standard page
+          // auto-increment. Using pageCounterStarts instead of
+          // pageCountersById because the latter can be overwritten during
+          // resolve-scope cascade re-renders (finishPage), making it
+          // unreliable for offset derivation.
+          const prevLastPageCounterStarts =
+            previousViewItem &&
+            previousViewItem.pageCounterStarts[
+              previousViewItem.pages.length - 1
+            ];
+          const prevLastPageCounters =
+            prevLastPageCounterStarts && prevLastPageCounterStarts["page"];
+          if (prevLastPageCounters && prevLastPageCounters.length) {
+            // pageCounterStarts stores the counter BEFORE auto-increment,
+            // so add 1 for the page's own increment.
+            pageCounterOffset =
+              prevLastPageCounters[prevLastPageCounters.length - 1] + 1;
+          } else {
+            const counters = this.counterStore.currentPageCounters["page"];
+            pageCounterOffset =
+              !counters || !counters.length
+                ? pageNumberOffset
+                : counters[counters.length - 1];
+          }
 
           // Note: The "page" counter value differs to the "page-number" value
           // if the "page" counter has been reset by counter-reset/increment.

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -122,7 +122,8 @@ module.exports = [
       },
       {
         file: "target-text-reflow-navigation/publication.json",
-        title: "target-text() reflow across WebPub spine navigation",
+        title:
+          "target-text() reflow across WebPub spine navigation (Issue #1856)",
       },
       {
         file: "target-text-vs-named-strings.html",


### PR DESCRIPTION
When cross-document target-text() resolution causes a preceding spine (e.g. TOC) to expand by one or more pages, several issues occurred:

- Navigation from the expanded spine to the next spine froze the viewer because the pending layout position was never materialized into a page.
- Page counter values (counter(page)) in page margins of later spines were stale, showing incorrect numbers.
- target-counter() values in the TOC did not reflect the corrected page numbers after spine expansion.
- The viewer toolbar page slider showed wrong page numbers on direct navigation via TOC click or epubcfi.

Fix by:
- Saving counter state before popPageCounters in the cross-spine resolve path and restoring it for pending page rendering.
- Falling through to renderPage when a pending layout position exists but no page has been materialized.
- Deriving pageCounterOffset from the previous spine's last pageCounterStarts rather than the potentially stale global counter.
- After spine expansion, adjusting pageCountersById snapshots for later spines, shifting pageCounterStarts, patching counter(page) and target-counter() DOM nodes in already-rendered pages, and updating item.epage so the viewer slider reflects the correct position.

Closes #1856

Assisted-by: GitHub Copilot Chat

<details>
<summary>How the AI was used</summary>

- The human author described a page-navigation freeze and incorrect-page-number bug from `target-text()` reflow in detail, clarifying it was not a regression (it had never worked correctly, even in the older stable release) and pointing to a series of prior `target-text`/counter PRs as likely relevant context.
- Layout-regression testing surfaced a regression in existing target-counter/text tests from the first fix attempt; the human author worked with the AI to correct the counter values, catching a stale page-footer number after a TOC click, and later catching that TOC/epubcfi navigation had regressed further ("this is worse than before") — requiring another round of fixes.
- The human author accepted a cosmetic remaining limitation (toolbar page-slider off-by-one on direct navigation) flagged by a reviewer, directed the commit message, created the PR, addressed review comments, and reported and had fixed one more footer-page-number regression discovered after the fix was live.

</details>
