### PR TITLE
fix: guard against null currentPage in getRunningValue

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -604,6 +604,9 @@ class CounterResolver implements CssCascade.CounterResolver {
       .sort(Base.numberCompare);
 
     const currentPage = this.counterStore.currentPage;
+    if (!currentPage) {
+      return "";
+    }
     const pageStartOffset = currentPage.isBlankPage
       ? currentPage.offset - 1
       : currentPage.offset;


### PR DESCRIPTION
PR #1683 made getStringValueFromCssContentVal eagerly evaluate Css.Expr objects (e.g., string() / element() functions) during string-set processing. This evaluation can trigger getRunningValue via getNamedStringVal/getRunningElementVal, which accesses counterStore.currentPage. However, string-set processing occurs during the cascade phase before setCurrentPage() is called, so currentPage is null, causing a TypeError.

Return empty string early when currentPage is null, since there is no page context to resolve running values against during cascade.

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author diagnosed this `TypeError` as caused by PR #1683's eager `Css.Expr` evaluation reaching `getRunningValue()` before `currentPage` was set, and asked the AI to implement the null guard.
- The human author directed the commit message and ran `/address-pr-comments` across two rounds.

</details>
