### PR TITLE
fix: correct text-spacing trim after inline code

### DIFF
--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -520,6 +520,9 @@ class TextSpacingPolyfill {
         p.viewNode.nodeType === Node.TEXT_NODE &&
         !Vtree.canIgnore(p.viewNode, p.whitespace)
       ) {
+        if (iFirst < 0) {
+          iFirst = i;
+        }
         const lang = normalizeLang(
           p.lang ??
             p.parent.lang ??
@@ -545,10 +548,6 @@ class TextSpacingPolyfill {
         if (/\b(flex|grid)\b/.test(p.parent.display)) {
           // Cannot process if parent is flex or grid. (Issue #926)
           continue;
-        }
-
-        if (iFirst < 0) {
-          iFirst = i;
         }
         let prevNode: Node = null;
         let nextNode: Node = null;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -319,6 +319,10 @@ module.exports = [
         file: "text-spacing/ts-generated-content-vertical.html",
         title: "Text-spacing on generated content (vertical writing-mode)",
       },
+      {
+        file: "text-spacing/text-spacing-trim-start-code.html",
+        title: "text-spacing-trim after code element (Issue #1863)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/text-spacing/text-spacing-trim-start-code.html
+++ b/packages/core/test/files/text-spacing/text-spacing-trim-start-code.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <title>text-spacing-trim after code element</title>
+    <style>
+      p {
+        text-spacing-trim: trim-start;
+      }
+
+      code {
+        text-spacing: none;
+        hanging-punctuation: none;
+        background: #eee;
+      }
+
+      .frame {
+        border: 1px solid #999;
+        padding: 0.4em 0.6em;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>text-spacing-trim with inline code</h1>
+    <p>In the framed box below, the first line should keep spacing after <code>CODE</code>, while the second line should trim the opening quote at the true line start.</p>
+
+    <div class="frame">
+      <p id="after-code"><code>CODE</code>「コード」</p>
+      <p id="plain-start">「コード」</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
- fixes #1863

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author had already diagnosed the likely cause of issue #1863 (a `continue` statement around line 543 of `text-polyfill.ts` causing text after a `code` element to be misjudged as being at the start of a line) and asked the AI to implement the fix.
- The human author simplified the test case themselves (removing a `font-size` override that pushed content to a second page) and added the issue number to the test's registered title before confirming the fix was complete.

</details>
