### PR TITLE
fix: wait for page-margin box images before sizing auto widths

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -2162,6 +2162,7 @@ export class StyleInstance
     let cont: Task.Result<boolean>;
     let removed = false;
     if (!flowName || !flowName.isIdent()) {
+      const fetchers: TaskUtil.Fetcher<string>[] = [];
       const contentVal = boxInstance.getProp(this, "content");
       if (
         contentVal instanceof Css.Expr &&
@@ -2206,6 +2207,30 @@ export class StyleInstance
           page,
           this.faces,
         );
+        const images = innerContainer.querySelectorAll("img[src]");
+        for (let i = 0; i < images.length; i++) {
+          const image = images[i] as HTMLImageElement;
+          const src = image.getAttribute("src");
+          if (!src) {
+            continue;
+          }
+          const fetcher = Net.loadElement(image, src);
+          fetchers.push(fetcher);
+          page.fetchers.push(fetcher);
+        }
+
+        const rootSrc = innerContainer.getAttribute("src");
+        if (rootSrc) {
+          let image = innerContainer.querySelector(
+            "img",
+          ) as HTMLImageElement | null;
+          if (!image) {
+            image = innerContainer as HTMLImageElement;
+          }
+          const fetcher = Net.loadElement(image, rootSrc);
+          fetchers.push(fetcher);
+          page.fetchers.push(fetcher);
+        }
         if (innerContainerTag == "span") {
           // text-spacing & hanging-punctuation on margin boxes
           TextPolyfill.processGeneratedContent(
@@ -2232,7 +2257,9 @@ export class StyleInstance
           this.faces,
         );
       }
-      cont = Task.newResult(true);
+      cont = fetchers.length
+        ? TaskUtil.waitForFetchers(fetchers).thenReturn(true)
+        : Task.newResult(true);
     } else if (!this.pageBreaks[flowName.toString()]) {
       const innerFrame: Task.Frame<boolean> = Task.newFrame(
         "layoutContainer.inner",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -166,6 +166,10 @@ module.exports = [
         title: "Content in page margin box",
       },
       {
+        file: "page-margin-box-images.html",
+        title: "Page margin box images (Issue #1867)",
+      },
+      {
         file: "counters-function-in-page-margin-box.html",
         title: "counters() in page margin boxes",
       },

--- a/packages/core/test/files/page-margin-box-images.html
+++ b/packages/core/test/files/page-margin-box-images.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page Margin Box Images</title>
+    <style>
+      @page {
+        size: A4;
+        margin: 80mm 20mm 20mm;
+
+        @top-left {
+          content: url("./img/45x45.png");
+          padding: 2mm;
+          border: 1px solid #c33;
+          background: rgba(255, 224, 224, 0.8);
+        }
+
+        @top-right {
+          content: url("./img/200x200.png");
+          padding: 2mm;
+          border: 1px solid #369;
+          background: rgba(224, 240, 255, 0.8);
+        }
+      }
+
+      body {
+        margin: 0;
+        font: 16px/1.5 sans-serif;
+      }
+
+      main {
+        padding: 12mm;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p>
+        The left and right top margin boxes should have different widths that
+        match the intrinsic widths of the two images.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Wait for generated images in page-margin boxes before adjusting page layout, so auto-sized margin boxes can use the intrinsic image widths on first render.

Add a manual regression testcase for image content in page-margin boxes.

fixes #1867

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix an issue about incorrect margin-box widths when containing images; tested the fix themselves and added the issue number to the test's registered title.
- The human author created the PR and asked the AI to check and address Copilot review comments.

</details>
