### PR TITLE
fix: Fix abspos boxes moved to next page and text duplication caused by PR #1837

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -653,6 +653,16 @@ export function isCssOutOfFlow(node: Node): boolean {
   );
 }
 
+/**
+ * Check if element has position:fixed. Used to identify running elements
+ * (position:running() rendered as position:fixed) without matching
+ * position:absolute elements. (Issue #1833, #1869, #1870)
+ */
+export function isFixedPositioned(node: Node): boolean {
+  if (!(node?.nodeType === 1)) return false;
+  return (node as HTMLElement).style?.position === "fixed";
+}
+
 export function isSpecialNodeContext(nodeContext: Vtree.NodeContext): boolean {
   const viewNode = nodeContext?.viewNode;
   return viewNode?.nodeType === 1 && isSpecial(viewNode as Element);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3295,6 +3295,20 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   /**
+   * Check if the nodeContext has a position:fixed ancestor in the view tree.
+   * Used to detect text inside running elements (position:running() rendered
+   * as position:fixed). (Issue #1833)
+   */
+  hasFixedPositionAncestor(nodeContext: Vtree.NodeContext): boolean {
+    for (let nc = nodeContext; nc; nc = nc.parent) {
+      if (LayoutHelper.isFixedPositioned(nc.viewNode)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Skips positions until either the start of unbreakable block or inline
    * content. Also sets breakBefore on the result combining break-before and
    * break-after properties from all elements that meet at the edge.
@@ -3437,6 +3451,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         return false;
       }
       for (let nc = lastAfterNodeContext; nc?.parent; nc = nc.parent) {
+        // Skip levels inside out-of-flow ancestors (e.g. position:running()
+        // rendered as position:fixed). Child nodes of out-of-flow elements
+        // should not prevent break suppression at the page start.
+        // (Issue #1833)
+        if (
+          nc.parent.viewNode &&
+          LayoutHelper.isOutOfFlow(nc.parent.viewNode)
+        ) {
+          continue;
+        }
         let node = nc.after ? nc.viewNode : nc.viewNode?.previousSibling;
         while (
           node &&
@@ -3484,17 +3508,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // Ignorable text content, skip
                 break;
               }
-              // Text inside out-of-flow elements (e.g. position:running()
-              // rendered as position:fixed) should not be treated as
-              // in-flow content for break detection. (Issue #1833)
-              let hasOutOfFlowAncestor = false;
-              for (let nc = nodeContext; nc; nc = nc.parent) {
-                if (nc.viewNode && LayoutHelper.isOutOfFlow(nc.viewNode)) {
-                  hasOutOfFlowAncestor = true;
-                  break;
-                }
-              }
-              if (hasOutOfFlowAncestor) {
+              // Text inside running elements (position:running() rendered
+              // as position:fixed) should not be treated as in-flow content
+              // for break detection. Only check position:fixed ancestors,
+              // not position:absolute, to avoid breaking abspos layout.
+              // (Issue #1833, #1869, #1870)
+              if (this.hasFixedPositionAncestor(nodeContext)) {
                 break;
               }
               if (!nodeContext.after) {
@@ -3704,12 +3723,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
               // Trailing edge
               if (onStartEdges) {
-                // Out-of-flow elements (e.g. position:running() rendered as
+                // Running elements (position:running() rendered as
                 // position:fixed) should not end the leading edge sequence.
                 // Their trailing edges must not reset leadingEdge, otherwise
-                // the next in-flow element's forced break would be incorrectly
-                // treated as a mid-page break. (Issue #1833)
-                if (LayoutHelper.isCssOutOfFlow(nodeContext.viewNode)) {
+                // the next in-flow element's forced break would be treated
+                // as a mid-page break. Only skip position:fixed, not
+                // position:absolute. (Issue #1833, #1869, #1870)
+                if (LayoutHelper.isFixedPositioned(nodeContext.viewNode)) {
                   break;
                 }
                 // finished going through all starting edges of the box.

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -848,17 +848,20 @@ export class StyleInstance
    * element's CSS `page` property. This is needed because `currentPageType`
    * is only set during layout (in ViewFactory), but the first page's type
    * must be known before layout begins for correct @page rule matching.
+   *
+   * Note: This must NOT set `currentPageType` as a side effect. Setting it
+   * early would cause intermediate wrapper elements (whose page type is
+   * null/auto) to get unwanted `breakBefore: "page"` during view tree
+   * construction, since their page type would differ from `currentPageType`.
+   * The `currentPageType` will be set naturally when the content element
+   * is processed during layout. (Issue #1869, #1870)
    */
   private resolveFirstPageType(): string | null {
     const firstElement = this.getFirstDocumentFlowElement();
     if (!firstElement) {
       return null;
     }
-    const pageType = this.getPageGroupPageType(firstElement);
-    if (pageType) {
-      this.styler.cascade.currentPageType = pageType;
-    }
-    return pageType;
+    return this.getPageGroupPageType(firstElement);
   }
 
   private shouldStartPageGroup(

--- a/packages/core/test/files/abspos-page-break-bug.html
+++ b/packages/core/test/files/abspos-page-break-bug.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>abspos page break bug</title>
+  <style>
+  @page {
+    size: 500px;
+    margin: 50px;
+    @bottom-center {
+      content: "Page " counter(page);
+    }
+  }
+  .abspos {
+    position: absolute;
+    top: 220px;
+    left: 50px;
+  }
+  h2 {
+    break-before: page;
+  }
+  </style>
+</head>
+<body>
+  <h1>First Page</h1>
+  <div class="abspos">Absolute Positioned</div>
+  <h2>Second Page</h2>
+</body>
+</html>

--- a/packages/core/test/files/abspos-page-break-test.html
+++ b/packages/core/test/files/abspos-page-break-test.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>abspos page break test</title>
+  <style>
+  @page {
+    size: 500px;
+    margin: 50px;
+    @bottom-center {
+      content: "Page " counter(page);
+    }
+  }
+  .chapter-head {
+    font-size: 50px;
+  }
+  .chapter-title {
+    position: absolute;
+    top: 100px;
+    left: 50px;
+    font-size: 50px;
+  }
+  .chapter-lead {
+    position: absolute;
+    top: 220px;
+    left: 50px;
+    font-size: 20px;
+  }
+  .section {
+    break-before: page;
+  }
+  .section-title {
+    font-size: 30px;
+  }
+  .chapter-body {
+    border: 1px solid magenta;
+  }
+  </style>
+</head>
+<body>
+  <h1 class="chapter-head">Chapter 1</h1>
+  <div class="chapter-body">
+    <h2 class="chapter-title">Chapter Title</h2>
+    <div class="chapter-lead">
+      Chapter lead text.
+    </div>
+    <section class="section">
+      <h2 class="section-title">Section Title</h2>
+      <p>Section content.</p>
+    </section>
+  </div>
+</body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -36,6 +36,15 @@ module.exports = [
       },
       { file: "absolute_positioning.html", title: "Absolute positioning" },
       {
+        file: "abspos-page-break-bug.html",
+        title:
+          "Absolute positioned box with page break - no duplication (Issue #1870)",
+      },
+      {
+        file: "abspos-page-break-test.html",
+        title: "Absolute positioned boxes not moved to next page (Issue #1869)",
+      },
+      {
         file: "relative_positioning_pagination.html",
         title: "Relative positioning pagination",
       },


### PR DESCRIPTION
PR #1837 (fix for Issue #1833) modified skipEdges() to skip text nodes and trailing edges inside all out-of-flow elements. This was too broad and caused two regressions:

- Issue #1869
- Issue #1870

The root cause was that position:absolute elements were incorrectly treated the same as position:fixed (running elements). The fix scopes the PR #1837 checks to position:fixed only, since only running elements (position:running() rendered as position:fixed) need special handling in break detection.

Changes:
- Scope text-in-out-of-flow and trailing-edge skip checks in skipEdges() to position:fixed only, not position:absolute
- Add isFixedPositioned() helper in layout-helper.ts
- Add hasFixedPositionAncestor() method to Column class
- Remove currentPageType side-effect from resolveFirstPageType() in ops.ts to prevent unwanted breakBefore on wrapper elements
- Add out-of-flow ancestor skipping in atLeadingEdgeIgnoringOutOfFlow()

Closes #1869
Closes #1870

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author identified these two regressions as caused by PR #1837 and asked the AI to fix them; after the human ran a full layout-regression test and reported "several regressions" in the result, the AI iterated further.
- The human author directed the commit message once satisfied, created the PR, and asked the AI to check Copilot review comments, agreeing that a test HTML file needed correction.

</details>
