### PR TITLE
fix: Fix table headers not repeated on continuation pages

### DIFF
--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -601,7 +601,11 @@ export class RepetitiveElementsOwnerLayoutConstraint
       (overflownNodeContext && !nodeContext) ||
       (nodeContext && nodeContext.overflow)
     ) {
-      return false;
+      return !isOverflowInsideRepetitiveElementsOwner(
+        nodeContext,
+        overflownNodeContext,
+        repetitiveElements,
+      );
     } else {
       return true;
     }
@@ -1066,6 +1070,22 @@ export function appendFooter(
     }
   }
   return Task.newResult(true);
+}
+
+/**
+ * Check whether an overflow is within the scope of the repetitive elements
+ * owner. Returns true if the overflow should trigger header/footer skipping
+ * (i.e., the overflowing node is inside the owner), false otherwise.
+ * (Issue #1873)
+ */
+export function isOverflowInsideRepetitiveElementsOwner(
+  nodeContext: Vtree.NodeContext,
+  overflownNodeContext: Vtree.NodeContext,
+  repetitiveElements: RepetitiveElement.RepetitiveElements,
+): boolean {
+  const ownerNode = repetitiveElements.ownerSourceNode;
+  const overflowNC = nodeContext || overflownNodeContext;
+  return !overflowNC || ownerNode.contains(overflowNC.sourceNode);
 }
 
 function getRepetitiveElementsOwnerFormattingContextOrNull(

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -2377,7 +2377,11 @@ export class TableRowLayoutConstraint
       (overflownNodeContext && !nodeContext) ||
       (nodeContext && nodeContext.overflow)
     ) {
-      return false;
+      return !RepetitiveElementImpl.isOverflowInsideRepetitiveElementsOwner(
+        nodeContext,
+        overflownNodeContext,
+        repetitiveElements,
+      );
     } else {
       return true;
     }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -610,6 +610,11 @@ module.exports = [
         file: "table/nrmc-table-break-column.html",
         title: "Table column break in non-root multicol (Issue #1854)",
       },
+      {
+        file: "table/table-header-repeat.html",
+        title:
+          "Table header repeat with complex multipage tables (Issue #1873)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/table/table-header-repeat.html
+++ b/packages/core/test/files/table/table-header-repeat.html
@@ -1,0 +1,616 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="utf-8"/>
+<title>Test: Table header repeat</title>
+<style>
+:root {
+    --color-1: rgb(203 203 203);
+    --color-grey: grey;
+    --color-2: rgb(240, 245, 231);
+}
+
+@page {
+    size: A4 portrait;
+    margin-left: 25mm;
+    margin-right: 20mm;
+    margin-top: 40mm;
+    margin-bottom: 30mm;
+
+}
+
+
+
+@media print {
+    :root {
+        font-size: 10pt;
+    }
+
+}
+
+html {
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.align-right {
+    margin-inline-start: auto;
+}
+
+.align-bottom {
+    margin-block-start: auto;
+}
+
+
+h4,
+h5,
+h6 {
+    font-size: 1rem;
+}
+
+
+table {
+    border-collapse: collapse;
+}
+
+td > p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+td,
+th {
+    vertical-align: top;
+    padding: 0.5em;
+}
+
+caption,
+figcaption {
+    padding: 1em;
+}
+
+caption {
+    font-weight: bold;
+}
+
+
+.table-cell-grey {
+    background-color: var(--color-grey);
+}
+
+
+.small-font {
+    font-size: 0.6rem;
+}
+
+.simple-list {
+    margin-top: 0;
+    margin-bottom: 0;
+    list-style: none;
+    padding: 0;
+}
+
+
+
+.table-2 {
+    width: 100%;
+}
+
+.table-2 > thead > tr > th {
+    text-align: left;
+    background-color: var(--color-1);
+}
+
+.table-2 > tbody > tr > td:first-of-type {
+    width: 33%;
+}
+
+
+
+table.table-3 {
+    width: 100%;
+}
+
+table.table-3 > tbody > tr > td {
+    font-size: 0.8rem;
+}
+
+.table-3 > thead > tr > th {
+    text-align: left;
+    background-color: var(--color-1);
+}
+
+.table-3 > thead > tr > th,
+.table-3 > tbody > tr > td {
+    border: 1px solid black;
+}
+
+.table-3 > thead > tr:nth-of-type(2) > th:nth-of-type(1) {
+    width: 4%;
+}
+
+.table-3 > thead > tr:nth-of-type(2) > th:nth-of-type(2) {
+    width: 16%;
+}
+
+.table-inner {
+    border: 0 none;
+    text-align: left;
+}
+
+table.table-inner {
+    width: 100%;
+}
+
+
+table.table-1 {
+    width: 100%;
+}
+
+.table-1 > thead > tr > th {
+    text-align: left;
+    background-color: var(--color-1);
+}
+
+.table-1 > thead > tr > th,
+.table-1 > tbody > tr > td {
+    border: 1px solid black;
+}
+
+.table-1 > tbody > tr > td:nth-of-type(1),
+.table-1 > tbody > tr > td:nth-of-type(4) {
+    width: 10%;
+    text-align: center;
+    background-color: var(--color-2);
+}
+
+.table-1 > tbody > tr > td:nth-of-type(2),
+.table-1 > tbody > tr > td:nth-of-type(5) {
+    width: 25%;
+}
+
+.table-1 > tbody > tr > td:nth-of-type(3),
+.table-1 > tbody > tr > td:nth-of-type(6) {
+    width: 15%;
+    text-align: center;
+}
+</style>
+</head>
+<body>
+<section>
+    <table class="table-1">
+        <thead>
+        <tr>
+            <th>xxxxx</th>
+            <th>xxxxx</th>
+            <th>xxxxx</th>
+            <th>xxxxx</th>
+            <th>xxxxx</th>
+            <th>xxxxx</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+        </tr>
+        <tr>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+            <td>xxxxx</td>
+        </tr>
+        </tbody>
+    </table>
+    <section>
+        <h4>Section 1</h4>
+        <table class="table-2">
+            <thead>
+            <tr>
+                <th>xxxxxxxx</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            </tbody>
+        </table>
+        <table class="table-3">
+            <thead>
+            <tr>
+                <th colspan="3">Header row 1 (colspan 3)</th>
+            </tr>
+            <tr>
+                <th rowspan="2">1</th>
+                <th rowspan="2">
+                    <ul class="simple-list">
+                        <li>Col2</li>
+                        <li>(rowspan 2)</li>
+                    </ul>
+                </th>
+                <th>
+                    <ul class="simple-list">
+                        <li>Header row 2 col 3</li>
+                        <li>cont.</li>
+                    </ul>
+                </th>
+            </tr>
+            <tr>
+                <th>Header row 3 col 3</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 1 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 2 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 3 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 4 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 5 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 6 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 7 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 8 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 9 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 10 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 11 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 12 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 13 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 14 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 15 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 16 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 17 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 18 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 19 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 20 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 21 col 3</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 22 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <table class="table-1">
+            <caption>xxxxxxxxxx</caption>
+        </table>
+        <em>xxx xxxxxxxxxx.</em>
+    </section>
+    <section>
+        <h4>Section 2</h4>
+        <table class="table-2">
+            <thead>
+            <tr>
+                <th>xxxxxxxx</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            <tr>
+                <td>xxxx:</td>
+                <td>xxxx</td>
+            </tr>
+            </tbody>
+        </table>
+        <table class="table-3">
+            <thead>
+            <tr>
+                <th colspan="3">Header row 1 (colspan 3)</th>
+            </tr>
+            <tr>
+                <th rowspan="2">1</th>
+                <th rowspan="2">
+                    <ul class="simple-list">
+                        <li>Col2</li>
+                        <li>(rowspan 2)</li>
+                    </ul>
+                </th>
+                <th>
+                    <ul class="simple-list">
+                        <li>Header row 2 col 3</li>
+                        <li>cont.</li>
+                    </ul>
+                </th>
+            </tr>
+            <tr>
+                <th>Header row 3 col 3</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="table-cell-grey"></td>
+                <td>
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 1 col 3<br/>cont.</td>
+            </tr>
+            <tr>
+                <td class="table-cell-grey" rowspan="2"></td>
+                <td rowspan="2">
+                    <ul class="simple-list">
+                        <li>Item 1</li>
+                        <li>Item 2</li>
+                        <li>Item 3</li>
+                        <li>Item 4</li>
+                    </ul>
+                </td>
+                <td>Content row 2 col 3<br/>cont.</td>
+            </tr>
+            <tr>
+                <td>
+                    <table class="table-inner">
+                        <tbody>
+                        <tr>
+                            <td>Content row 3 col 3<br/>cont.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </section>
+</section>
+</body>
+</html>


### PR DESCRIPTION
Table headers of complex multipage tables were sometimes not repeated on subsequent pages. This happened when content after the table (e.g., another section) caused overflow — the overflow was incorrectly attributed to the table's layout constraint, triggering header skipping.

Fix: In `allowLayout()` of `RepetitiveElementsOwnerLayoutConstraint` and `TableRowLayoutConstraint`, check whether the overflowing node is actually inside the table. Overflow from content outside the table no longer triggers header/footer skipping for that table.

Also add a test case for the issue.

- closes #1873

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author reproduced issue #1873 with a combined test file, confirmed it was not a regression (present in past Vivliostyle.js versions too), and asked the AI to investigate and fix it.
- After a layout-regression test run showed 2 existing tests changing, the human author confirmed the new results were correct (both tests assumed footnotes wouldn't split mid-fragment, which the fix legitimately changed) by adding `break-inside: avoid` to reproduce the old behavior.
- The human author asked the AI to deduplicate a helper function shared between two files, and later suggested simplifying it further to use `ownerNode.contains(node)` directly; directed test registration details (category, directory, title with the issue number) and the commit message, created the PR, and asked the AI to check and address Copilot review comments, then requested an amend commit for a follow-up correction.

</details>
