### PR TITLE
fix: Enable footnote fragmentation across pages

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -42,6 +42,7 @@ import * as PseudoElement from "./pseudo-element";
 import * as Task from "./task";
 import * as Vgen from "./vgen";
 import * as VtreeImpl from "./vtree";
+import { Footnote } from "./footnotes";
 import {
   FragmentLayoutConstraintType,
   Layout,
@@ -1583,7 +1584,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           floatSide,
           anchorEdge,
           true,
-          !floatLayoutContext.hasFloatFragments(),
+          area.isFootnote || !floatLayoutContext.hasFloatFragments(),
           condition,
         );
         if (fitWithinContainer) {
@@ -1717,6 +1718,17 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           });
         })
         .then(() => {
+          if (
+            !failed &&
+            floatArea.isFootnote &&
+            floatArea.computedBlockSize <= 0 &&
+            result.newPosition
+          ) {
+            // Footnote content could not be placed (e.g., widows/orphans
+            // constraints prevented fragmentation). Fail the layout so
+            // the footnote is deferred to the next page.
+            failed = true;
+          }
           if (!failed) {
             Asserts.assert(floatArea);
             if (floatArea.isFootnote) {
@@ -1812,12 +1824,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       context.restoreStashedFragments(float.floatReference);
       context.deferPageFloat(continuation);
     }
+    const isFootnote = float instanceof Footnote;
     const frame: Task.Frame<boolean> = Task.newFrame("layoutPageFloatInner");
     this.layoutSinglePageFloatFragment(
       [continuation],
       float.floatSide,
       float.clearSide,
-      !context.hasFloatFragments(),
+      isFootnote || !context.hasFloatFragments(),
       strategy,
       anchorEdge,
       pageFloatFragment,
@@ -2071,12 +2084,28 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       } else if (this.nodeContextOverflowingDueToRepetitiveElements) {
         return Task.newResult(null);
       } else {
-        const edge = LayoutHelper.calculateEdge(
+        let edge = LayoutHelper.calculateEdge(
           nodeContextAfter,
           this.clientLayout,
           0,
           this.vertical,
         );
+        // For footnotes, calculateEdge may return NaN because footnote-call
+        // has vertical-align: super. Compute edge from the element's
+        // bounding rect to enable footnote fragmentation.
+        if (isNaN(edge) && nodeContext.floatSide === "footnote") {
+          const viewNode = nodeContextAfter.viewNode as Element;
+          if (viewNode && viewNode.nodeType === 1) {
+            const rect = LayoutHelper.getElementClientRectAdjusted(
+              this.clientLayout,
+              viewNode,
+              this.vertical,
+            );
+            if (rect.right >= rect.left && rect.bottom >= rect.top) {
+              edge = this.vertical ? rect.left : rect.bottom;
+            }
+          }
+        }
         if (this.isOverflown(edge)) {
           return Task.newResult(nodeContextAfter);
         } else {
@@ -2692,8 +2721,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     }
     let widows: number;
     let orphans: number;
-    if (force) {
+    if (force && !this.isFootnote) {
       // Last resort, ignore widows/orphans
+      // (but keep enforcing them for footnotes to avoid violating
+      // widows/orphans when fragmenting footnotes across pages)
       widows = 1;
       orphans = 1;
     } else {
@@ -2924,7 +2955,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let forceRemoveSelf = false;
     if (!nodeContext) {
       // Last resort
-      if (this.forceNonfitting) {
+      if (this.forceNonfitting && !this.isFootnote) {
         Logging.logger.warn("Could not find any page breaks?!!");
         this.skipTailEdges(overflownNodeContext).then((nodeContext) => {
           if (nodeContext) {

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -612,7 +612,10 @@ export class PageFloatLayoutContext
 
   hasContinuingFloatFragmentsInFlow(flowName: string): boolean {
     return this.hasFloatFragments(
-      (fragment) => fragment.continues && fragment.getFlowName() === flowName,
+      (fragment) =>
+        fragment.continues &&
+        fragment.getFlowName() === flowName &&
+        fragment.floatSide !== "block-end",
     );
   }
 
@@ -1396,26 +1399,32 @@ export class PageFloatLayoutContext
     );
     const blockOffset = area.vertical ? area.originX : area.originY;
     const inlineOffset = area.vertical ? area.originY : area.originX;
-    blockStart = area.vertical
-      ? Math.min(
-          blockStart,
-          area.left +
-            area.getInsetLeft() +
-            area.width +
-            area.getInsetRight() +
-            blockOffset,
-        )
-      : Math.max(blockStart, area.top + blockOffset);
-    blockEnd = area.vertical
-      ? Math.max(blockEnd, area.left + blockOffset)
-      : Math.min(
-          blockEnd,
-          area.top +
-            area.getInsetTop() +
-            area.height +
-            area.getInsetBottom() +
-            blockOffset,
-        );
+    // For footnotes in the init=false pass, skip clamping blockStart/blockEnd
+    // to the area's current CSS box. The init=true pass may have constrained
+    // the area to the anchor-to-page-bottom region for footnote fragmentation,
+    // but init=false must use the full page limits for correct positioning.
+    if (!(area.isFootnote && !init)) {
+      blockStart = area.vertical
+        ? Math.min(
+            blockStart,
+            area.left +
+              area.getInsetLeft() +
+              area.width +
+              area.getInsetRight() +
+              blockOffset,
+          )
+        : Math.max(blockStart, area.top + blockOffset);
+      blockEnd = area.vertical
+        ? Math.max(blockEnd, area.left + blockOffset)
+        : Math.min(
+            blockEnd,
+            area.top +
+              area.getInsetTop() +
+              area.height +
+              area.getInsetBottom() +
+              blockOffset,
+          );
+    }
 
     function limitBlockStartEndValueWithOpenRect(getRect, rect) {
       let openRect = getRect(area.bands, rect);
@@ -1472,6 +1481,23 @@ export class PageFloatLayoutContext
           )
         ) {
           return null;
+        }
+      }
+      // For footnotes with a valid anchor edge, constrain the available
+      // block space so the footnote starts no higher than the anchor
+      // position. This enables footnote fragmentation: content that
+      // doesn't fit below the anchor overflows and is deferred to the
+      // next page.
+      if (
+        area.isFootnote &&
+        anchorEdge !== null &&
+        isFinite(anchorEdge) &&
+        logicalFloatSides[0] === "block-end"
+      ) {
+        if (area.vertical) {
+          blockStart = Math.min(blockStart, anchorEdge);
+        } else {
+          blockStart = Math.max(blockStart, anchorEdge);
         }
       }
       outerBlockSize = (blockEnd - blockStart) * area.getBoxDir();

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -917,6 +917,10 @@ module.exports = [
         title:
           "::footnote-marker list-style-position inherit/initial (Issue #1838)",
       },
+      {
+        file: "footnotes/footnote-fragmentation.html",
+        title: "Footnote fragmentation across pages (Issue #1875)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnotes/footnote-fragmentation.html
+++ b/packages/core/test/files/footnotes/footnote-fragmentation.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Footnote Fragmentation Test</title>
+    <style>
+      @page {
+        size: 105mm 148mm;
+        margin: 20mm;
+
+        @footnote {
+          border-top: 1px solid black;
+          padding-top: 1em;
+          margin-top: 1em;
+        }
+      }
+
+      :root {
+        font-size: 12pt;
+        line-height: 1.5;
+      }
+
+      .footnote {
+        float: footnote;
+        font: 0.9rem/1.5 serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Footnote Fragmentation Test</h1>
+    <p>
+      This is some sample text to fill the page. We want to simulate a case
+      where the footnote is too long to fit entirely at the bottom of the
+      page<span class="footnote">This is a very long footnote. It is
+        intentionally made long so that it cannot fit entirely within the
+        remaining space at the bottom of the page. The expected behavior (as
+        seen in Prince) is that the footnote starts on the same page as this
+        reference and continues onto the next page. However, in Vivliostyle,
+        the entire footnote may be pushed to the next page instead of being
+        split. To ensure sufficient length, we repeat content: Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Vestibulum volutpat, nunc
+        sit amet varius dignissim, lacus erat facilisis urna, vitae facilisis
+        lorem justo ut nulla. Integer non purus ut massa scelerisque
+        tincidunt. Sed ut perspiciatis unde omnis iste natus error sit
+        voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque
+        ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae
+        dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+        aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos
+        qui ratione voluptatem sequi nesciunt. (repeat as needed...)</span>
+    </p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </body>
+</html>

--- a/packages/core/test/files/footnotes/footnotes_and_page_floats.html
+++ b/packages/core/test/files/footnotes/footnotes_and_page_floats.html
@@ -28,6 +28,7 @@
       }
       .footnote {
         float: footnote;
+        break-inside: avoid;
         counter-increment: footnote;
       }
       .footnote::footnote-marker {

--- a/packages/core/test/files/footnotes/footnotes_widows_bug.html
+++ b/packages/core/test/files/footnotes/footnotes_widows_bug.html
@@ -39,6 +39,7 @@
 
       .footnote {
         float: footnote;
+        break-inside: avoid;
         counter-increment: footnote;
       }
 


### PR DESCRIPTION
Long footnotes are now split across pages starting from the page containing the footnote call, instead of being pushed entirely to the next page. Widows/orphans constraints are respected when fragmenting footnotes.
 
Changes:
- Fix calculateEdge returning NaN for footnote-call elements (due to vertical-align: super) by using getElementClientRectAdjusted as fallback
- Set allowFragmented=true for footnotes in layoutPageFloatInner and setupFloatArea so footnote content can be split
- Exclude block-end floats (footnotes) from hasContinuingFloatFragmentsInFlow to prevent body text from being blocked when a continuing footnote fragment exists
- Constrain footnote area to anchor-to-page-bottom space in setFloatAreaDimensions (init=true) so overflowing content is deferred to the next page
- Skip blockStart/blockEnd clamping for footnotes in init=false pass to ensure correct final positioning
- Respect widows/orphans when fragmenting footnotes instead of relaxing them to 1 via the force path in findBoxBreakPosition
- Prevent last-resort force-fit in doFinishBreak for footnotes so unfragmentable footnotes are deferred to the next page
- Detect zero-content footnote layout caused by widows/orphans constraints and fail gracefully to defer the footnote
- Add break-inside: avoid to existing footnote test files to preserve their pre-fragmentation baseline behavior


Closes #1875

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix issue #1875, explaining the desired behavior (footnotes should be allowed to split across pages rather than always deferring wholesale to the next page).
- The human author caught the AI dismissing a related diff as unrelated when it was actually a side effect of the fix, and repeatedly reported the fix causing infinite loops across multiple iterations before it converged.
- The human author asked for a code-review pass to catch any leftover unnecessary code from the iterative process, and asked for clarifying comments explaining the issue #1875 intent before drafting the commit message.

</details>
