### PR TITLE
fix: Fix footnote fragmentation in multi-column layout

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -231,6 +231,36 @@ export function clearForcedColumnBreaks(prevNode: Node, currNode: Node): void {
 }
 
 /**
+ * Check if an element has non-root multi-column styles (column-count or
+ * column-width) set on its inline style.
+ *
+ * NOTE: Do not use `instanceof HTMLElement` for the check because it does
+ * not work when the node is inside an iframe. (Issue #1000)
+ */
+export function hasNonRootMultiColumnStyle(element: Element): boolean {
+  const style = (element as HTMLElement).style;
+  if (!style) return false;
+  return (
+    !isNaN(parseFloat(style.columnCount)) ||
+    !isNaN(parseFloat(style.columnWidth))
+  );
+}
+
+/**
+ * Check if the given element or any of its descendants establishes a
+ * non-root multi-column layout (via inline style).
+ */
+export function containsNonRootMultiColumn(element: Element): boolean {
+  if (hasNonRootMultiColumnStyle(element)) return true;
+  for (const descendant of element.querySelectorAll("*")) {
+    if (hasNonRootMultiColumnStyle(descendant)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Find the nearest ancestor element that establishes a multi-column
  * layout but is not the root column element.
  */
@@ -248,10 +278,7 @@ export function findAncestorNonRootMultiColumn(node: Node): Element | null {
       // This is the root column element.
       break;
     }
-    if (
-      !isNaN(parseFloat(style.columnCount)) ||
-      !isNaN(parseFloat(style.columnWidth))
-    ) {
+    if (hasNonRootMultiColumnStyle(elem as HTMLElement)) {
       return elem;
     }
     if (style.position === "absolute") {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1727,7 +1727,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             // Footnote content could not be placed (e.g., widows/orphans
             // constraints prevented fragmentation). Fail the layout so
             // the footnote is deferred to the next page.
-            failed = true;
+            // Exception: during iterative footnote sizing (Issue #1879),
+            // allow empty fragments so the retry cycle can continue.
+            const floatContext = context.getPageFloatLayoutContext(
+              firstFloat.floatReference,
+            );
+            if (floatContext.footnoteMaxBlockSize == null) {
+              failed = true;
+            }
           }
           if (!failed) {
             Asserts.assert(floatArea);

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -21,6 +21,7 @@ import * as Asserts from "./asserts";
 import * as Css from "./css";
 import * as Constants from "./constants";
 import * as GeometryUtil from "./geometry-util";
+import * as LayoutHelper from "./layout-helper";
 import * as Logging from "./logging";
 import * as CssLogicalUtil from "./css-logical-util";
 import * as Sizing from "./sizing";
@@ -32,6 +33,14 @@ export const FloatReference = PageFloats.FloatReference;
 export type FloatReference = PageFloats.FloatReference; // eslint-disable-line no-redeclare
 
 type PageFloatID = PageFloats.PageFloatID;
+
+/**
+ * Minimum outer block size (in px) for a footnote during iterative sizing.
+ * When the halved size falls below this threshold, the retry loop stops and
+ * the footnote is forbidden instead. Chosen to be roughly one line-height so
+ * that the fragment is still visually meaningful. (Issue #1879)
+ */
+const MIN_FOOTNOTE_BLOCK_SIZE = 20;
 
 export function floatReferenceOf(str: string): FloatReference {
   switch (str) {
@@ -357,6 +366,21 @@ export class PageFloatLayoutContext
   private floatsDeferredFromPrevious: PageFloatContinuation[];
   private layoutConstraints: LayoutType.LayoutConstraint[] = [];
   private locked: boolean = false;
+  /**
+   * Maximum outer block size for footnotes on this page.
+   * Set when a footnote is placed but then found to be not-allowed (anchor
+   * not reachable in multi-column). Each retry halves this value until
+   * the footnote fits or is too small to display. (Issue #1879)
+   */
+  footnoteMaxBlockSize: number | null = null;
+
+  /**
+   * Tracks footnote IDs whose anchors have been registered at least once
+   * during this page's layout cycle. Unlike floatAnchors, this set
+   * survives invalidate() calls, so we can detect feedback loops where
+   * a footnote's own size pushes its anchor off the page. (Issue #1879)
+   */
+  private footnoteAnchorsSeen: Set<PageFloatID> = new Set();
 
   /**
    * Reference to the outer column's context for page float area contexts.
@@ -621,6 +645,16 @@ export class PageFloatLayoutContext
 
   registerPageFloatAnchor(float: PageFloat, anchorViewNode: Node) {
     this.floatAnchors[float.getId()] = anchorViewNode;
+    // Record that this float's anchor has been seen at least once on this
+    // page, propagating up the context hierarchy so the page-level context
+    // can detect feedback loops. (Issue #1879)
+    if ("footnotePolicy" in float) {
+      let ctx: PageFloatLayoutContext | null = this;
+      while (ctx) {
+        ctx.footnoteAnchorsSeen.add(float.getId());
+        ctx = ctx.parent ?? ctx.outerContext;
+      }
+    }
   }
 
   collectPageFloatAnchors() {
@@ -766,9 +800,53 @@ export class PageFloatLayoutContext
       const fragment = this.floatFragments[i];
       const notAllowedFloat = fragment.findNotAllowedFloat(this);
       if (notAllowedFloat) {
+        const isFootnote =
+          fragment.area &&
+          "isFootnote" in fragment.area &&
+          (fragment.area as any).isFootnote;
         if (this.locked) {
           this.invalidate();
         } else {
+          // Issue #1879: For footnotes in multi-column, try reducing the
+          // footnote size instead of forbidding. When a page-level footnote
+          // is too large, it reduces column/page heights so much that the
+          // anchor can't be reached (feedback loop). Halving the size and
+          // retrying lets the footnote fragment at a size that still allows
+          // the anchor to be reached during re-layout.
+          // Detect multi-column: either root multicol (multiple column
+          // contexts) or non-root multicol (browser-native columns inside
+          // a single column context).
+          const hasMultiColumn =
+            isFootnote &&
+            this.footnoteAnchorsSeen.has(notAllowedFloat.getId()) &&
+            (this.children.some((child) => child.children.length > 1) ||
+              this.children.some((child) =>
+                child.children.some((grandchild) => {
+                  const elem = grandchild.getContainer()?.element;
+                  return (
+                    elem != null &&
+                    LayoutHelper.containsNonRootMultiColumn(elem)
+                  );
+                }),
+              ));
+          if (hasMultiColumn) {
+            const currentOuter =
+              fragment.area.computedBlockSize +
+              fragment.area.getInsetBefore() +
+              fragment.area.getInsetAfter();
+            const newMax =
+              this.footnoteMaxBlockSize != null
+                ? this.footnoteMaxBlockSize / 2
+                : currentOuter / 2;
+            if (newMax >= MIN_FOOTNOTE_BLOCK_SIZE) {
+              // Retry with reduced size
+              this.footnoteMaxBlockSize = newMax;
+              this.removePageFloatFragment(fragment);
+              this.removeEndFloatFragments(fragment.floatSide);
+              return true;
+            }
+            // Too small to display — fall through to forbid
+          }
           this.removePageFloatFragment(fragment);
           this.forbid(notAllowedFloat);
 
@@ -1501,7 +1579,22 @@ export class PageFloatLayoutContext
         }
       }
       outerBlockSize = (blockEnd - blockStart) * area.getBoxDir();
-      blockSize = outerBlockSize - area.getInsetBefore() - area.getInsetAfter();
+      // Issue #1879: Apply footnoteMaxBlockSize constraint from iterative
+      // retry. When a footnote was found too large (anchor not reachable
+      // in multi-column re-layout), this limits the footnote area.
+      if (area.isFootnote && this.footnoteMaxBlockSize != null) {
+        outerBlockSize = Math.min(outerBlockSize, this.footnoteMaxBlockSize);
+        // Adjust blockStart accordingly for correct positioning
+        if (area.vertical) {
+          blockStart = blockEnd + outerBlockSize;
+        } else {
+          blockStart = blockEnd - outerBlockSize;
+        }
+      }
+      blockSize = Math.max(
+        0,
+        outerBlockSize - area.getInsetBefore() - area.getInsetAfter(),
+      );
       outerInlineSize = (inlineEnd - inlineStart) * area.getInlineDir();
       inlineSize = outerInlineSize - area.getInsetStart() - area.getInsetEnd();
       if (!force && (blockSize <= 0 || inlineSize <= 0)) {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -921,6 +921,10 @@ module.exports = [
         file: "footnotes/footnote-fragmentation.html",
         title: "Footnote fragmentation across pages (Issue #1875)",
       },
+      {
+        file: "footnotes/footnote-fragmentation-multicol.html",
+        title: "Footnote fragmentation in multi-column (Issue #1879)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnotes/footnote-fragmentation-multicol.html
+++ b/packages/core/test/files/footnotes/footnote-fragmentation-multicol.html
@@ -1,0 +1,62 @@
+<!-- Test case for Issue #1879: Footnote fragmentation in multi-column layout -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Footnote Fragmentation in Multi-Column</title>
+    <style>
+      @page {
+        size: 148mm 210mm;
+        margin: 20mm;
+        @footnote {
+          border-top: 1px solid black;
+          padding-top: 0.5em;
+          margin-top: 0.5em;
+        }
+      }
+      :root { font: 12pt/1.5 serif; }
+      body {
+        column-count: 2;
+        column-gap: 8mm;
+        column-rule: 1px solid #ccc;
+      }
+      h1 { font-size: 1.2em; }
+      .footnote { float: footnote; font: 0.9rem/1.4 serif; }
+    </style>
+  </head>
+  <body>
+    <h1>Footnote Fragmentation in Multi-Column</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum
+      volutpat, nunc sit amet varius dignissim, lacus erat facilisis urna,
+      vitae facilisis lorem justo ut nulla. Integer non purus ut massa
+      scelerisque tincidunt.</p>
+    <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+      accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae
+      ab illo inventore veritatis et quasi architecto beatae vitae dicta
+      sunt explicabo.</p>
+    <p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
+      fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem
+      sequi nesciunt.<span class="footnote">
+        This is a deliberately very long footnote that cannot fit entirely
+        in the remaining footnote area on the current page. Expected: it
+        should start on this page and continue on the next page, as it
+        does in single-column layout after PR #1877. Lorem ipsum dolor sit
+        amet, consectetur adipiscing elit. Vestibulum volutpat, nunc sit
+        amet varius dignissim, lacus erat facilisis urna, vitae facilisis
+        lorem justo ut nulla. Integer non purus ut massa scelerisque
+        tincidunt. Sed ut perspiciatis unde omnis iste natus error sit
+        voluptatem accusantium doloremque laudantium, totam rem aperiam,
+        eaque ipsa quae ab illo inventore veritatis et quasi architecto
+        beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia
+        voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur
+        magni dolores eos qui ratione voluptatem sequi nesciunt.
+        eaque ipsa quae ab illo inventore veritatis et quasi architecto
+        beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia
+        voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur
+        magni dolores eos qui ratione voluptatem sequi nesciunt.
+      </span></p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </body>
+</html>


### PR DESCRIPTION
PR #1877 enabled footnote fragmentation across pages for single-column, but in multi-column layout, a long footnote was pushed entirely to the next page instead of fragmenting.

Root cause: When a page-level footnote is too large, it reduces all columns' heights so much that the footnote anchor becomes unreachable during re-layout, causing the footnote to be forbidden and deferred.

Fix: Introduce iterative footnote sizing in checkAndForbidNotAllowedFloat(). When a not-allowed footnote is detected in a multi-column context (root or non-root), halve its maximum block size and retry instead of immediately forbidding it. This breaks the feedback loop by producing a smaller footnote fragment that still allows the anchor to be reached.

Changes:
- page-floats.ts: Add footnoteMaxBlockSize for iterative sizing, footnoteAnchorsSeen to detect feedback loops, multi-column detection for both root and non-root (browser-native) multi-column, and Math.max(0, blockSize) clamp in setFloatAreaDimensions
- layout.ts: Allow empty footnote fragments during iterative sizing so the retry cycle can continue

Closes #1879

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1879 (footnote fragmentation in multi-column layout); the AI implemented iterative footnote sizing to break the anchor-unreachable feedback loop.
- The human author ran a full layout-regression test and reported additional Footnotes-category failures (empty footnote areas); the AI fixed those, and the human author further tested a non-root multi-column variant and asked for the same fix to cover it.
- After creating the PR, the human author ran `/address-pr-comments #1881` to have Copilot's automated review suggestions addressed, including consolidating duplicated non-root-multicolumn detection logic into a shared helper and reconsidering an `instanceof HTMLElement` check that could misbehave inside iframes.

</details>
