### PR TITLE
fix: fix footnote area max-height/max-block-size and box-sizing support

### DIFF
--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -18,6 +18,7 @@
  * @fileoverview Footnotes
  */
 import * as Asserts from "./asserts";
+import * as Base from "./base";
 import * as Css from "./css";
 import * as PageFloats from "./page-floats";
 import * as Task from "./task";
@@ -201,6 +202,63 @@ export class FootnoteLayoutStrategy
         floatArea.convertPercentageSizesToPx(element);
         column.setComputedInsets(element, floatArea);
         column.setComputedWidthAndHeight(element, floatArea);
+        // Handle box-sizing: border-box for footnote areas (Issue #1878).
+        // The layout engine always works in content-box mode. When the user
+        // specifies box-sizing: border-box, convert max-height/min-height
+        // to content-box equivalents and reset box-sizing on the element.
+        const computedBoxSizing =
+          column.clientLayout.getElementComputedStyle(element)?.boxSizing;
+        if (computedBoxSizing === "border-box") {
+          const blockInsets = floatArea.vertical
+            ? floatArea.paddingLeft +
+              floatArea.paddingRight +
+              floatArea.borderLeft +
+              floatArea.borderRight
+            : floatArea.paddingTop +
+              floatArea.paddingBottom +
+              floatArea.borderTop +
+              floatArea.borderBottom;
+          // In vertical writing mode, block-direction properties are
+          // width/max-width/min-width instead of height/max-height/min-height.
+          const blockProps = floatArea.vertical
+            ? ["max-width", "min-width", "width"]
+            : ["max-height", "min-height", "height"];
+          const cs = getComputedStyle(element);
+          for (const prop of blockProps) {
+            const val = cs.getPropertyValue(prop);
+            if (val && val !== "none") {
+              const px = parseFloat(val);
+              if (!isNaN(px)) {
+                Base.setCSSProperty(
+                  element,
+                  prop,
+                  `${Math.max(0, px - blockInsets)}px`,
+                );
+              }
+            }
+          }
+          Base.setCSSProperty(element, "box-sizing", "content-box");
+        }
+        // CSS GCPM §2.4.2: "The max-height property on the footnote area
+        // limits the size of this area, unless the page contains only
+        // footnotes." When the page-level context has
+        // ignoreFootnoteAreaMaxHeight set (detected after a prior layout
+        // pass found no body content), remove max-height. (Issue #1878)
+        let pageCtx: PageFloats.PageFloatLayoutContext | null =
+          column.pageFloatLayoutContext as PageFloats.PageFloatLayoutContext;
+        while (pageCtx) {
+          if (pageCtx.ignoreFootnoteAreaMaxHeight) {
+            // Clear both logical and physical max-block-size properties
+            Base.setCSSProperty(element, "max-block-size", "");
+            Base.setCSSProperty(
+              element,
+              floatArea.vertical ? "max-width" : "max-height",
+              "",
+            );
+            break;
+          }
+          pageCtx = pageCtx.parent ?? null;
+        }
         return Task.newResult(undefined);
       });
   }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1588,6 +1588,28 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           condition,
         );
         if (fitWithinContainer) {
+          // For footnotes with max-block-size, setFloatAreaDimensions may
+          // have set the block dimension larger than the CSS max-block-size
+          // (because positioning uses page-level limits, not area bounds).
+          // Clamp to max-block-size so the JS dimension matches the browser-
+          // rendered dimension, preventing coordinate mismatches in
+          // initGeom()/computedBlockSize calculations. (Issue #1878)
+          if (area.isFootnote) {
+            const cs = getComputedStyle(area.element);
+            if (area.vertical) {
+              const maxW = parseFloat(cs.maxWidth);
+              if (!isNaN(maxW) && area.width > maxW) {
+                area.width = maxW;
+                Base.setCSSProperty(area.element, "width", `${maxW}px`);
+              }
+            } else {
+              const maxH = parseFloat(cs.maxHeight);
+              if (!isNaN(maxH) && area.height > maxH) {
+                area.height = maxH;
+                Base.setCSSProperty(area.element, "height", `${maxH}px`);
+              }
+            }
+          }
           // New dimensions have been set, remove exclusion floats and re-init
           area.killFloats();
           area.init();

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1671,6 +1671,59 @@ export class StyleInstance
             column.saveDistanceToBlockEndFloats();
             const edge = column.pageFloatLayoutContext.getMaxReachedAfterEdge();
             column.updateMaxReachedAfterEdge(edge);
+
+            // CSS GCPM §2.4.2: "The max-height property on the footnote area
+            // limits the size of this area, unless the page contains only
+            // footnotes." (Issue #1878)
+            // Detect pages with only footnote continuation(s) and no body
+            // content. If the column placed no body content (computedBlockSize
+            // is 0) and there are footnote fragments with max-height, remove
+            // those fragments and retry without max-height.
+            if (column.computedBlockSize === 0) {
+              const colCtx =
+                column.pageFloatLayoutContext as PageFloats.PageFloatLayoutContext;
+              // Traverse up the context hierarchy to find footnote fragments
+              // (footnotes are stored at the PAGE-level context)
+              let ctx: PageFloats.PageFloatLayoutContext | null = colCtx;
+              while (ctx) {
+                const footnoteFragments = ctx.floatFragments.filter(
+                  (f) => "isFootnote" in f.area && (f.area as any).isFootnote,
+                );
+                if (
+                  footnoteFragments.length > 0 &&
+                  !ctx.ignoreFootnoteAreaMaxHeight
+                ) {
+                  const hasMaxHeight = footnoteFragments.some((f) => {
+                    const cs = getComputedStyle(f.area.element);
+                    const isSet = (v: string) => v !== "" && v !== "none";
+                    // Check the logical property first, then the
+                    // corresponding physical property for block direction
+                    return (
+                      isSet(cs.getPropertyValue("max-block-size")) ||
+                      isSet(
+                        (f.area as any).vertical ? cs.maxWidth : cs.maxHeight,
+                      )
+                    );
+                  });
+                  if (hasMaxHeight) {
+                    ctx.ignoreFootnoteAreaMaxHeight = true;
+                    for (const frag of footnoteFragments) {
+                      // Remove fragment so it can be re-laid out
+                      colCtx.removePageFloatFragment(frag, true);
+                      // Remove deferred continuation from first pass
+                      const float = frag.continuations[0]?.float;
+                      if (float) {
+                        ctx.removeFloatDeferredToNext(float);
+                      }
+                    }
+                    // Invalidate column to trigger retry
+                    colCtx.invalidate();
+                    break;
+                  }
+                }
+                ctx = ctx.parent;
+              }
+            }
           }
           frame.finish(true);
         });

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -375,6 +375,14 @@ export class PageFloatLayoutContext
   footnoteMaxBlockSize: number | null = null;
 
   /**
+   * When true, max-height on @footnote areas should be ignored.
+   * Set when a page contains only footnote continuation(s) and no body
+   * content. Per CSS GCPM §2.4.2, max-height should not apply in this
+   * case. (Issue #1878)
+   */
+  ignoreFootnoteAreaMaxHeight: boolean = false;
+
+  /**
    * Tracks footnote IDs whose anchors have been registered at least once
    * during this page's layout cycle. Unlike floatAnchors, this set
    * survives invalidate() calls, so we can detect feedback loops where
@@ -695,6 +703,13 @@ export class PageFloatLayoutContext
     } else {
       const parent = this.getParent(float.floatReference);
       parent.deferPageFloat(continuation);
+    }
+  }
+
+  removeFloatDeferredToNext(float: PageFloat) {
+    const index = this.floatsDeferredToNext.findIndex((c) => c.float === float);
+    if (index >= 0) {
+      this.floatsDeferredToNext.splice(index, 1);
     }
   }
 
@@ -1477,11 +1492,13 @@ export class PageFloatLayoutContext
     );
     const blockOffset = area.vertical ? area.originX : area.originY;
     const inlineOffset = area.vertical ? area.originY : area.originX;
-    // For footnotes in the init=false pass, skip clamping blockStart/blockEnd
-    // to the area's current CSS box. The init=true pass may have constrained
-    // the area to the anchor-to-page-bottom region for footnote fragmentation,
-    // but init=false must use the full page limits for correct positioning.
-    if (!(area.isFootnote && !init)) {
+    // For footnotes, skip clamping blockStart/blockEnd to the area's own
+    // dimensions. The area dimensions may be constrained by max-block-size
+    // (max-height in horizontal, max-width in vertical), but the footnote
+    // needs the full page limits for correct block-end positioning.
+    // After positioning, the block dimension is clamped to max-block-size
+    // in setupFloatArea. (Issue #1878)
+    if (!area.isFootnote) {
       blockStart = area.vertical
         ? Math.min(
             blockStart,

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -690,6 +690,7 @@ export namespace PageFloats {
     writingMode: Css.Val;
     direction: Css.Val;
     floatFragments: PageFloatFragment[];
+    ignoreFootnoteAreaMaxHeight: boolean;
     readonly parent: PageFloatLayoutContext;
     readonly effectiveParent: PageFloatLayoutContext | null;
     readonly flowName: string | null;
@@ -721,6 +722,7 @@ export namespace PageFloats {
     collectPageFloatAnchors(): any;
     isAnchorAlreadyAppeared(floatId: PageFloatID): boolean;
     deferPageFloat(continuation: PageFloatContinuation): void;
+    removeFloatDeferredToNext(float: PageFloat): void;
     hasPrecedingFloatsDeferredToNext(
       float: PageFloat,
       ignoreReference?: boolean,

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -925,6 +925,18 @@ module.exports = [
         file: "footnotes/footnote-fragmentation-multicol.html",
         title: "Footnote fragmentation in multi-column (Issue #1879)",
       },
+      {
+        file: "footnotes/footnote-area-max-height.html",
+        title: "Footnote area max-height (Issue #1878)",
+      },
+      {
+        file: "footnotes/footnote-area-max-height-box-sizing.html",
+        title: "Footnote area max-height with box-sizing (Issue #1878)",
+      },
+      {
+        file: "footnotes/footnote-area-max-height-vertical.html",
+        title: "Footnote area max-block-size vertical (Issue #1878)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnotes/footnote-area-max-height-box-sizing.html
+++ b/packages/core/test/files/footnotes/footnote-area-max-height-box-sizing.html
@@ -1,0 +1,47 @@
+<!-- Test case for Issue #1878: Footnote area max-height with box-sizing: border-box -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Footnote Fragmentation Test</title>
+    <style>
+      @page {
+        size: 105mm 148mm;
+        margin: 20mm;
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 0.8rem;
+        }
+
+        @footnote {
+          border-top: 1px solid black;
+          padding-top: 1em;
+          margin-top: 1em;
+          max-height: 50vh;
+          box-sizing: border-box;
+          background: pink;
+        }
+      }
+
+      :root {
+        font-size: 12pt;
+        line-height: 1.5;
+      }
+
+      .footnote {
+        float: footnote;
+        font: 0.9rem/1.5 serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Footnote Fragmentation Test</h1>
+    <p>This is some sample text to fill the page. We want to simulate a case where the footnote is too long to fit entirely at the bottom of the page<span class="footnote">This is a very long footnote. It is intentionally made long so that it cannot fit entirely within the remaining space at the bottom of the page. The expected behavior (as seen in Prince) is that the footnote starts on the same page as this reference and continues onto the next page. However, in Vivliostyle, the entire footnote may be pushed to the next page instead of being split. To ensure sufficient length, we repeat content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum volutpat, nunc sit amet varius dignissim, lacus erat facilisis urna, vitae facilisis lorem justo ut nulla. Integer non purus ut massa scelerisque tincidunt. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident.</span></p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </body>
+</html>

--- a/packages/core/test/files/footnotes/footnote-area-max-height-vertical.html
+++ b/packages/core/test/files/footnotes/footnote-area-max-height-vertical.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Footnote Fragmentation Test</title>
+    <style>
+      @page {
+        size: 148mm 105mm;
+        margin: 20mm;
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 0.8rem;
+        }
+
+        @footnote {
+          border-block-start: 1px solid black;
+          padding-block-start: 1em;
+          margin-block-start: 1em;
+          max-block-size: 50vb;
+          box-sizing: border-box;
+          background: pink;
+        }
+      }
+
+      :root {
+        writing-mode: vertical-rl;
+        font-size: 12pt;
+        line-height: 1.5;
+      }
+
+      .footnote {
+        float: footnote;
+        font: 0.9rem/1.5 serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Footnote Fragmentation Test</h1>
+    <p>This is some sample text to fill the page. We want to simulate a case where the footnote is too long to fit entirely at the bottom of the page<span class="footnote">This is a very long footnote. It is intentionally made long so that it cannot fit entirely within the remaining space at the bottom of the page. The expected behavior (as seen in Prince) is that the footnote starts on the same page as this reference and continues onto the next page. However, in Vivliostyle, the entire footnote may be pushed to the next page instead of being split. To ensure sufficient length, we repeat content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum volutpat, nunc sit amet varius dignissim, lacus erat facilisis urna, vitae facilisis lorem justo ut nulla. Integer non purus ut massa scelerisque tincidunt. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. (repeat as needed...)</span></p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </body>
+</html>

--- a/packages/core/test/files/footnotes/footnote-area-max-height.html
+++ b/packages/core/test/files/footnotes/footnote-area-max-height.html
@@ -1,0 +1,46 @@
+<!-- Test case for Issue #1878: Footnote area max-height and positioning -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Footnote Fragmentation Test</title>
+    <style>
+      @page {
+        size: 105mm 148mm;
+        margin: 20mm;
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 0.8rem;
+        }
+
+        @footnote {
+          border-top: 1px solid black;
+          padding-top: 1em;
+          margin-top: 1em;
+          max-block-size: 50vh;
+          background: pink;
+        }
+      }
+
+      :root {
+        font-size: 12pt;
+        line-height: 1.5;
+      }
+
+      .footnote {
+        float: footnote;
+        font: 0.9rem/1.5 serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Footnote Fragmentation Test</h1>
+    <p>This is some sample text to fill the page. We want to simulate a case where the footnote is too long to fit entirely at the bottom of the page<span class="footnote">This is a very long footnote. It is intentionally made long so that it cannot fit entirely within the remaining space at the bottom of the page. The expected behavior (as seen in Prince) is that the footnote starts on the same page as this reference and continues onto the next page. However, in Vivliostyle, the entire footnote may be pushed to the next page instead of being split. To ensure sufficient length, we repeat content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum volutpat, nunc sit amet varius dignissim, lacus erat facilisis urna, vitae facilisis lorem justo ut nulla. Integer non purus ut massa scelerisque tincidunt. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident.</span></p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </body>
+</html>


### PR DESCRIPTION
- Fix max-height on `@footnote` area causing footnote to be deferred to the next page due to area.height being clamped by getComputedStyle() used value
- Fix box-sizing: border-box not working properly for footnote areas by converting to content-box equivalents
- Implement CSS GCPM §2.4.2: ignore max-height on footnote-only pages
- Fix vertical writing mode (max-block-size/max-width) causing infinite loop due to coordinate space mismatch between JS area dimensions and browser-rendered dimensions

closes #1878

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1878; when an initial fix looked incomplete, the human author quoted the relevant CSS GCPM spec section (§2.4.2, footnote-area size) directly to guide the correction.
- The human author reminded the AI that the default `@footnote` styling still applies when no `@page { @footnote {} }` override exists, then, after the AI reported vertical-writing-mode footnote fragmentation as a separate pre-existing bug unrelated to this issue, pushed back — pointing out the vertical-writing-mode case worked fine without `max-width`/`max-block-size`, so it had to be related — and had the AI fix it within this same PR.
- The human author directed the commit message, created the PR, and ran `/address-pr-comments`.

</details>
