### PR TITLE
fix: Fix deferred footnotes skipped on blank spread-break pages

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1514,6 +1514,14 @@ export class StyleInstance
   ): Task.Result<boolean> {
     const flowPosition = this.currentLayoutPosition.flowPositions[flowName];
     if (!flowPosition || !this.matchPageSide(flowPosition.startBreakType)) {
+      // On blank pages created by spread breaks (e.g., break-after: left),
+      // still try to place deferred page floats such as footnotes that were
+      // deferred from the previous page. (Issue #1880)
+      if (flowPosition) {
+        this.setFormattingContextToColumn(column, flowName);
+        column.init();
+        return this.layoutDeferredPageFloats(column);
+      }
       return Task.newResult(true);
     }
 
@@ -1611,6 +1619,21 @@ export class StyleInstance
                       column,
                       newPosition,
                     );
+                  // CSS Fragmentation: forced break-after on the last child
+                  // of a fragmentainer has no effect when there is no more
+                  // content after it. When all content in the flow is consumed
+                  // (newPosition is null and no remaining flow chunks) and the
+                  // column has a pageBreakType from the last element's
+                  // break-after, clear it to avoid generating unnecessary
+                  // blank pages. (Issue #1880)
+                  if (!newPosition && column.pageBreakType) {
+                    // Count remaining positions (excluding current and removed)
+                    const remainingPositions =
+                      flowPosition.positions.length - removedIndices.length - 1; // -1 for current position being removed
+                    if (remainingPositions <= 0) {
+                      column.pageBreakType = null;
+                    }
+                  }
                   if (column.pageBreakType && lastAfterPosition) {
                     selected.chunkPosition = lastAfterPosition;
 


### PR DESCRIPTION
On blank pages created by spread breaks (e.g., break-after: left), deferred page floats such as footnotes were not placed because layoutColumn() returned early without calling layoutDeferredPageFloats().

Also, per CSS Fragmentation Level 3, forced break-after on the last child of a fragmentainer should not generate a break at the end of the box. Clear column.pageBreakType when all content is consumed and no remaining flow chunks exist, to avoid generating unnecessary trailing blank pages.

Closes #1880

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1880; questioned why a test case produced an unexpected extra blank final page, and pointed out that a `break-after` on the last element in `<body>` should not affect layout since there's nothing after it to break from — prompting further investigation.
- The human author caught that the AI's own regression test case didn't actually test the deferred-footnote/spread-break scenario it was supposed to (page-content and page-number references in the test didn't match the actual rendered layout) and had it corrected before accepting the fix.
- The human author directed the commit message and ran `/address-pr-comments`.

</details>
