### PR TITLE
fix: Prevent float from protruding outside containing block after page break

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1478,20 +1478,25 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           top: this.getTopEdge() - this.paddingTop,
         };
       }
+      // The computed float offset from the block-start edge of its
+      // containing block may be negative when the containing block has
+      // `position: relative` and has been pushed along the block-progression
+      // direction by a margin carried over from a preceding sibling across
+      // a column/page break. Clamp the offset to be non-negative so that
+      // the float stays inside the containing block. (Issue #1885)
       if (
         containingBlockForAbsolute
           ? containingBlockForAbsolute.vertical
           : this.vertical
       ) {
-        Base.setCSSProperty(
-          element,
-          "right",
-          `${offsets.right - floatBox.x2}px`,
-        );
+        const rightValue = Math.max(0, offsets.right - floatBox.x2);
+        Base.setCSSProperty(element, "right", `${rightValue}px`);
       } else {
-        Base.setCSSProperty(element, "left", `${floatBox.x1 - offsets.left}px`);
+        const leftValue = Math.max(0, floatBox.x1 - offsets.left);
+        Base.setCSSProperty(element, "left", `${leftValue}px`);
       }
-      Base.setCSSProperty(element, "top", `${floatBox.y1 - offsets.top}px`);
+      const topValue = Math.max(0, floatBox.y1 - offsets.top);
+      Base.setCSSProperty(element, "top", `${topValue}px`);
       if (nodeContext.clearSpacer) {
         nodeContext.clearSpacer.parentNode.removeChild(nodeContext.clearSpacer);
         nodeContext.clearSpacer = null;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -97,6 +97,15 @@ module.exports = [
         file: "float-lh-rlh.html",
         title: "Float with lh/rlh height (Issue #1494, #1738)",
       },
+      {
+        file: "float-in-position-relative.html",
+        title: "Float in position:relative across page break (Issue #1885)",
+      },
+      {
+        file: "float-in-position-relative-vertical.html",
+        title:
+          "Float in position:relative across page break, vertical writing mode (Issue #1885)",
+      },
       { file: "content-attr.html", title: "Content attr()" },
       { file: "relative_floats.html", title: "Floats with position: relative" },
       { file: "target-counter.html", title: "target-counter" },

--- a/packages/core/test/files/float-in-position-relative-vertical.html
+++ b/packages/core/test/files/float-in-position-relative-vertical.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Float in position:relative across page break (vertical writing mode)</title>
+    <style>
+      @page {
+        size: 120mm 150mm;
+        margin: 15mm;
+      }
+      html {
+        writing-mode: vertical-rl;
+        font-family: sans-serif;
+        font-size: 11pt;
+        line-height: 1.6;
+      }
+      p {
+        margin-block: 0 1em;
+      }
+      .chapter {
+        margin-block-end: 2em;
+      }
+      .question {
+        position: relative;
+        padding-inline-start: 2em;
+      }
+      .float-md {
+        inline-size: 60mm;
+        block-size: 30mm;
+        margin: 0 0 0 1em;
+        float: right;
+        background: #c0d6ff;
+        border: 1px solid #66a;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="chapter">
+      <p>
+        Filler paragraph one. Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+      <p>
+        Filler paragraph two. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </p>
+      <p>
+        Filler paragraph three. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+      </p>
+      <p>
+        Filler paragraph four. Excepteur sint occaecat cupidatat non proident,
+        sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+      <p>
+        Filler paragraph five. Sed ut perspiciatis unde omnis iste natus error
+        sit voluptatem accusantium doloremque laudantium.
+      </p>
+    </section>
+    <section class="chapter">
+      <div class="question">
+        <div class="float-md"></div>
+        <p>
+          Question text after the float. This section has position:relative on
+          the container, and a float-right box as its first in-flow child.
+          When the page break occurs right before this question, the float
+          should render at the top of the content area on the next page,
+          inside the page margin box — not above it.
+        </p>
+        <p>
+          More content in the question. More content in the question. More
+          content in the question. More content in the question.
+        </p>
+      </div>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/float-in-position-relative.html
+++ b/packages/core/test/files/float-in-position-relative.html
@@ -1,0 +1,77 @@
+<!-- Test case for Issue #1885: Float at the start of a position:relative ancestor protrudes above the page top after a page break -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Float in position:relative across page break (Issue #1885)</title>
+    <style>
+      @page {
+        size: 150mm 120mm;
+        margin: 15mm;
+      }
+      html {
+        font-family: sans-serif;
+        font-size: 11pt;
+        line-height: 1.6;
+      }
+      p {
+        margin: 0 0 1em;
+      }
+      .chapter {
+        margin-bottom: 2em;
+      }
+      .question {
+        position: relative;
+        padding-left: 2em;
+      }
+      .float-md {
+        width: 60mm;
+        height: 30mm;
+        margin: 0 0 0 1em;
+        float: right;
+        background: #c0d6ff;
+        border: 1px solid #66a;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="chapter">
+      <p>
+        Filler paragraph one. Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+      <p>
+        Filler paragraph two. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </p>
+      <p>
+        Filler paragraph three. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+      </p>
+      <p>
+        Filler paragraph four. Excepteur sint occaecat cupidatat non proident,
+        sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+      <p>
+        Filler paragraph five. Sed ut perspiciatis unde omnis iste natus error
+        sit voluptatem accusantium doloremque laudantium.
+      </p>
+    </section>
+    <section class="chapter">
+      <div class="question">
+        <div class="float-md"></div>
+        <p>
+          Question text after the float. This section has position:relative on
+          the container, and a float-right box as its first in-flow child.
+          When the page break occurs right before this question, the float
+          should render at the top of the content area on the next page,
+          inside the page margin box — not above it.
+        </p>
+        <p>
+          More content in the question. More content in the question. More
+          content in the question. More content in the question.
+        </p>
+      </div>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
When a float is the first in-flow child of a `position: relative` ancestor and a page break occurs immediately before that ancestor, the float could render outside the page content area on the next page.

The float's absolute offset from its containing block was computed as `floatBox - offsets` and could become negative when the containing block's block-start edge had been pushed along the block-progression direction by a margin carried over from a preceding sibling across the column/page break. Clamp the offset to be non-negative on both axes so the float stays inside its containing block. This also covers vertical writing modes, where the block-start edge maps to the CSS `right` property.

Fixes #1885

Assisted-by: GitHub Copilot Chat:claude-opus-4.7

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for issue #1885 (a float protruding above the page top after a page break); the AI implemented the offset-clamping fix.
- The human author tested a vertical-writing-mode variant and reported the bug was still present, directing further iteration before it was fully resolved and a commit message was drafted.

</details>
