### PR TITLE
feat: support CSS footnote properties and pseudos for semantic footnotes

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -861,6 +861,7 @@ export const UserAgentXml = `
 
 .-vivliostyle-footnote-content {
   float: footnote;
+  --viv-semantic-footnote-content: 1;
 }
 
 .-vivliostyle-table-cell-container {
@@ -1353,10 +1354,13 @@ m|math[display="block"] {
 
 /* CSS GCPM footnotes */
 ::footnote-marker {
-  content: counter(footnote) ". ";
   list-style-position: inside;
 }
-::footnote-call {
+/* Semantic DPUB/EPUB footnotes provide their own default call/marker path. */
+:not(aside[epub|type~="footnote"], aside[epub\:type~="footnote"], aside[role~="doc-footnote"])::footnote-marker {
+  content: counter(footnote) ". ";
+}
+:not(a[epub|type~="noteref"], a[epub\:type~="noteref"], a[role~="doc-noteref"])::footnote-call {
   content: counter(footnote);
   font-size: 0.75em;
   vertical-align: super;
@@ -1365,23 +1369,18 @@ m|math[display="block"] {
 
 /* EPUB/DPUB footnotes */
 
-a[epub|type="noteref"],
-a[epub\:type="noteref"],
-a[role="doc-noteref"] {
+a[epub|type="noteref"]:not(sup > *, :has(> sup)),
+a[epub\:type="noteref"]:not(sup > *, :has(> sup)),
+a[role="doc-noteref"]:not(sup > *, :has(> sup)) {
   font-size: 0.75em;
   vertical-align: super;
   line-height: 0;
 }
 
-sup > a[epub|type="noteref"],
-a[epub|type="noteref"] > sup,
-sup > a[epub\:type="noteref"],
-a[epub\:type="noteref"] > sup,
-sup > a[role="doc-noteref"],
-a[role="doc-noteref"] > sup {
-  font-size: unset;
-  vertical-align: unset;
-  line-height: unset;
+a[epub|type="noteref"][data-vivliostyle-footnote-first-ref],
+a[epub\:type="noteref"][data-vivliostyle-footnote-first-ref],
+a[role="doc-noteref"][data-vivliostyle-footnote-first-ref] {
+  counter-increment: footnote;
 }
 
 a[epub|type="noteref"]:href-epub-type(footnote, aside),
@@ -1609,10 +1608,6 @@ span[data-viv-leader] {
   font-variant-numeric: tabular-nums;
   white-space: pre;
   text-transform: none;
-}
-[style*="--viv-footnote-inline-separator"]::after {
-  content: var(--viv-footnote-inline-separator);
-  white-space: normal;
 }
 [style*="--viv-footnote-white-space"] {
   white-space: var(--viv-footnote-white-space);

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -33,6 +33,7 @@ import * as LayoutHelper from "./layout-helper";
 import * as Logging from "./logging";
 import * as Matchers from "./matchers";
 import * as Plugin from "./plugin";
+import * as SemanticFootnote from "./semantic-footnote";
 import * as Vtree from "./vtree";
 import { CssStyler, Layout } from "./types";
 import { TokenType } from "./css-tokenizer";
@@ -419,7 +420,7 @@ export const SPECIALS = {
 // Persist footnote-call counter values on the call element so footnote-marker
 // can render the same value even if page-based counters reset on the footnote
 // page or during re-layout.
-const FOOTNOTE_COUNTER_ATTR = "data-viv-footnote-counter";
+export const FOOTNOTE_COUNTER_ATTR = "data-viv-footnote-counter";
 function getFootnoteCounterMap(element: Element): Record<string, number[]> {
   const stored = element.getAttribute(FOOTNOTE_COUNTER_ATTR);
   if (!stored) {
@@ -456,6 +457,59 @@ function setFootnoteCounterValues(
   const map = getFootnoteCounterMap(element);
   map[counterName] = values;
   element.setAttribute(FOOTNOTE_COUNTER_ATTR, JSON.stringify(map));
+}
+
+function getDuplicateSemanticFootnoteCounterValues(
+  element: Element,
+  counterName: string,
+): number[] | null {
+  if (
+    !SemanticFootnote.isSemanticFootnoteNoterefElement(element) ||
+    element.hasAttribute(SemanticFootnote.SEMANTIC_FOOTNOTE_FIRST_REF_ATTR)
+  ) {
+    return null;
+  }
+  const storedOnElement = getFootnoteCounterMap(element)[counterName];
+  if (storedOnElement) {
+    return storedOnElement;
+  }
+  const href =
+    element.getAttribute("href") ||
+    element.getAttributeNS(Base.NS.XLINK, "href");
+  if (!href) {
+    return null;
+  }
+  const baseURL = element.baseURI || element.ownerDocument?.baseURI || "";
+  const resolvedHref = Base.resolveReferenceURL(href, baseURL);
+  if (resolvedHref === "#") {
+    return null;
+  }
+  if (resolvedHref.replace(/#.*$/, "") !== baseURL.replace(/#.*$/, "")) {
+    return null;
+  }
+  const hashIndex = resolvedHref.indexOf("#");
+  if (hashIndex < 0 || hashIndex === resolvedHref.length - 1) {
+    return null;
+  }
+  const target = element.ownerDocument?.getElementById(
+    resolvedHref.substring(hashIndex + 1),
+  );
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  const storedOnTarget = getFootnoteCounterMap(target)[counterName];
+  if (storedOnTarget) {
+    setFootnoteCounterValues(element, counterName, storedOnTarget);
+    return storedOnTarget;
+  }
+  return null;
+}
+
+function hasNonTrivialFootnotePseudoContent(
+  pseudoProps: ElementStyle,
+): boolean {
+  const content = getProp(pseudoProps, "content");
+  return !!content && Vtree.nonTrivialContent(content.value);
 }
 
 export function isSpecialName(name: string): boolean {
@@ -2252,6 +2306,13 @@ export class ContentPropVisitor extends Css.FilterVisitor {
         setFootnoteCounterValues(this.element, counterName, values);
       }
     };
+    if (this.pseudoName === "footnote-call" && this.element) {
+      const storedDuplicateSemanticFootnoteCounter =
+        getDuplicateSemanticFootnoteCounterValues(this.element, counterName);
+      if (storedDuplicateSemanticFootnoteCounter) {
+        return formatCounterValues(storedDuplicateSemanticFootnoteCounter);
+      }
+    }
     if (this.pseudoName === "footnote-marker" && this.element) {
       const map = getFootnoteCounterMap(this.element);
       const stored = map[counterName];
@@ -3364,7 +3425,10 @@ export class CascadeInstance {
         resetMap["footnote"] = 0;
       }
     }
-    if (floatVal === Css.ident.footnote) {
+    if (
+      floatVal === Css.ident.footnote &&
+      !this.currentStyle["--viv-semantic-footnote-content"]
+    ) {
       if (!incrementMap) {
         incrementMap = Object.create(null);
       }
@@ -3675,12 +3739,44 @@ export class CascadeInstance {
         }
         const pseudoProps = pseudos[pseudoName];
         if (pseudoProps) {
+          const floatValue = getProp(this.currentStyle, "float")?.value;
+          const isSemanticNoteref =
+            element instanceof Element &&
+            SemanticFootnote.isSemanticFootnoteNoterefElement(element);
+          const isSemanticFootnote =
+            element instanceof Element &&
+            SemanticFootnote.isSemanticFootnoteElement(element);
+          const isSemanticFootnoteContent = !!getProp(
+            this.currentStyle,
+            "--viv-semantic-footnote-content",
+          );
+          const isFootnoteFloat = floatValue === Css.ident.footnote;
+          // Keep explicit empty before/after pseudos on rendered footnotes so
+          // author content:none can suppress the layout-level default separator.
+          const allowFootnoteBeforeAfter =
+            (pseudoName === "before" || pseudoName === "after") &&
+            (isFootnoteFloat ||
+              isSemanticFootnote ||
+              isSemanticFootnoteContent) &&
+            !!pseudoProps["content"];
+          const hasSemanticFootnotePseudoContent =
+            hasNonTrivialFootnotePseudoContent(pseudoProps);
+          const allowSemanticFootnoteCall =
+            pseudoName === "footnote-call" &&
+            isSemanticNoteref &&
+            hasSemanticFootnotePseudoContent;
+          const allowSemanticFootnoteMarker =
+            pseudoName === "footnote-marker" &&
+            (isSemanticFootnote || isSemanticFootnoteContent) &&
+            hasSemanticFootnotePseudoContent;
           if (
             ((pseudoName === "before" || pseudoName === "after") &&
               !(
+                allowFootnoteBeforeAfter ||
                 Vtree.nonTrivialContent(
                   (pseudoProps["content"] as CascadeValue)?.value,
-                ) || this.hasNonTrivialViewConditionalPseudoContent(pseudoProps)
+                ) ||
+                this.hasNonTrivialViewConditionalPseudoContent(pseudoProps)
               )) ||
             (pseudoName === "marker" &&
               !Display.isListItem(
@@ -3688,7 +3784,13 @@ export class CascadeInstance {
               )) ||
             ((pseudoName === "footnote-call" ||
               pseudoName === "footnote-marker") &&
-              getProp(this.currentStyle, "float")?.value !== Css.ident.footnote)
+              floatValue !== Css.ident.footnote &&
+              !allowSemanticFootnoteCall &&
+              !allowSemanticFootnoteMarker) ||
+            ((pseudoName === "footnote-call" ||
+              pseudoName === "footnote-marker") &&
+              isSemanticFootnoteContent &&
+              !hasSemanticFootnotePseudoContent)
           ) {
             delete pseudos[pseudoName];
           } else if (before) {
@@ -3724,6 +3826,15 @@ export class CascadeInstance {
                   element,
                   styler,
                 );
+                // Preserve the original footnote-marker content for semantic
+                // footnotes so vgen can re-evaluate it with the final counter.
+                const footnoteMarkerContent = pseudoProps[
+                  "content"
+                ] as CascadeValue;
+                if (footnoteMarkerContent) {
+                  this.currentStyle["_footnote-marker-content"] =
+                    footnoteMarkerContent;
+                }
                 // Set display: list-item for native ::marker to work
                 this.currentStyle["display"] = new CascadeValue(
                   Css.getName("list-item"),

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -2870,17 +2870,40 @@ export function parseStylesheetFromText(
   classes: string | null,
   media: string | null,
 ): Task.Result<boolean> {
+  const parserHandler = normalizeParserHandler(handler);
   return Task.handle(
     "parseStylesheetFromText",
     (frame) => {
-      const tok = new CssTokenizer.Tokenizer(text, handler);
-      parseStylesheet(tok, handler, baseURL, classes, media).thenFinish(frame);
+      const tok = new CssTokenizer.Tokenizer(text, parserHandler);
+      parseStylesheet(tok, parserHandler, baseURL, classes, media).thenFinish(
+        frame,
+      );
     },
     (frame, err) => {
       Logging.logger.warn(err, `Failed to parse stylesheet text: ${text}`);
       frame.finish(false);
     },
   );
+}
+
+function normalizeParserHandler(handler: ParserHandler): ParserHandler {
+  if (handler instanceof DispatchParserHandler) {
+    return handler;
+  }
+  if (handler instanceof SlaveParserHandler) {
+    if (handler.owner) {
+      return handler.owner;
+    }
+    // Some parser entry points are passed a top-level slave handler. Wrap it in
+    // a dispatch handler once so selector functions parse through the normal
+    // dispatch path and the slave retains a stable owner reference.
+    const dispatchHandler = new DispatchParserHandler();
+    dispatchHandler.flavor = handler.flavor;
+    dispatchHandler.slave = handler;
+    handler.owner = dispatchHandler;
+    return dispatchHandler;
+  }
+  return handler;
 }
 
 export function parseStylesheetFromURL(

--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -21,6 +21,7 @@ import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as Css from "./css";
 import * as PageFloats from "./page-floats";
+import * as SemanticFootnote from "./semantic-footnote";
 import * as Task from "./task";
 import * as Vtree from "./vtree";
 import { Layout } from "./types";
@@ -34,6 +35,7 @@ export class Footnote extends PageFloats.PageFloat {
     flowName: string,
     public readonly footnotePolicy: Css.Ident | null,
     floatMinWrapBlock: Css.Numeric | null,
+    public readonly policyAnchorNode: Node,
   ) {
     super(
       nodePosition,
@@ -48,6 +50,23 @@ export class Footnote extends PageFloats.PageFloat {
   override isAllowedToPrecede(other: PageFloats.PageFloat): boolean {
     return !(other instanceof Footnote);
   }
+}
+
+function getLinePolicyConstraintNode(anchorNode: Node): Node {
+  let element =
+    anchorNode.nodeType === Node.ELEMENT_NODE
+      ? (anchorNode as Element)
+      : anchorNode.parentElement;
+  while (element) {
+    if (
+      /^(p|li|dd|dt|td|th|blockquote)$/i.test(element.localName) &&
+      !element.querySelector("br")
+    ) {
+      return element;
+    }
+    element = element.parentElement;
+  }
+  return anchorNode;
 }
 
 /**
@@ -82,8 +101,16 @@ export class LineFootnotePolicyLayoutConstraint
   constructor(public readonly footnote: Footnote) {}
 
   allowLayout(nodeContext: Vtree.NodeContext): boolean {
-    const nodePosition = nodeContext.toNodePosition();
-    return !Vtree.isSameNodePosition(nodePosition, this.footnote.nodePosition);
+    let sourceNode: Node | null = nodeContext.shadowContext
+      ? nodeContext.shadowContext.owner
+      : nodeContext.sourceNode;
+    while (sourceNode) {
+      if (sourceNode === this.footnote.policyAnchorNode) {
+        return false;
+      }
+      sourceNode = sourceNode.parentNode;
+    }
+    return true;
   }
 }
 
@@ -129,12 +156,22 @@ export class FootnoteLayoutStrategy
 
     const nodePosition = nodeContext.toNodePosition();
     Asserts.assert(pageFloatLayoutContext.flowName);
+    let policyAnchorNode: Node = nodeContext.sourceNode;
+    const shadowOwner = nodeContext.shadowContext?.owner;
+    if (
+      shadowOwner instanceof Element &&
+      SemanticFootnote.isSemanticFootnoteNoterefElement(shadowOwner)
+    ) {
+      policyAnchorNode = shadowOwner;
+    }
+    policyAnchorNode = getLinePolicyConstraintNode(policyAnchorNode);
     const float: PageFloats.PageFloat = new Footnote(
       nodePosition,
       floatReference,
       pageFloatLayoutContext.flowName,
       nodeContext.footnotePolicy,
       nodeContext.floatMinWrapBlock,
+      policyAnchorNode,
     );
     float.insidePageFloatArea = insidePageFloat;
     if (insidePageFloat) {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -5187,6 +5187,17 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
     const styler = viewFactory?.styler;
     const xmldoc = viewFactory?.xmldoc;
     const compactFootnotes = this.rootViewNodes.filter((node) => {
+      const computedStyle =
+        node.ownerDocument.defaultView?.getComputedStyle(node);
+      const renderedFootnoteDisplay =
+        computedStyle?.getPropertyValue("--viv-footnote-display").trim() || "";
+      if (renderedFootnoteDisplay === "compact") {
+        return !(
+          computedStyle?.display === "list-item" &&
+          computedStyle.getPropertyValue("list-style-position").trim() ===
+            "outside"
+        );
+      }
       const offset = node.getAttribute(Base.ELEMENT_OFFSET_ATTR);
       if (!offset || !styler || !xmldoc) {
         return false;
@@ -5222,7 +5233,6 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
     const tolerance = 1.5 / (this.clientLayout.pixelRatio || 1);
     const measureCompactInlineSize = (element: HTMLElement): number => {
       const clone = element.cloneNode(true) as HTMLElement;
-      clone.style.removeProperty("--viv-footnote-inline-separator");
       Base.setCSSProperty(clone, "display", "inline-block");
       Base.setCSSProperty(clone, "position", "absolute");
       Base.setCSSProperty(clone, "visibility", "hidden");
@@ -5272,6 +5282,29 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
     );
   }
 
+  private getFootnoteAfterPseudo(element: Element): HTMLElement | null {
+    return Array.from(element.children).find(
+      (child) => PseudoElement.getPseudoName(child) === "after",
+    ) as HTMLElement | null;
+  }
+
+  private hasAuthorFootnoteAfterPseudo(element: Element): boolean {
+    const afterPseudo = this.getFootnoteAfterPseudo(element);
+    return (
+      !!afterPseudo &&
+      !afterPseudo.hasAttribute("data-vivliostyle-default-footnote-separator")
+    );
+  }
+
+  private createDefaultFootnoteAfterPseudo(element: HTMLElement): void {
+    const after = element.ownerDocument.createElement("span");
+    PseudoElement.setPseudoName(after, "after");
+    after.setAttribute("data-vivliostyle-default-footnote-separator", "1");
+    after.style.whiteSpace = "normal";
+    after.textContent = " ";
+    element.appendChild(after);
+  }
+
   private updateInlineFootnoteSeparators(): void {
     this.rootViewNodes.forEach((node, index) => {
       const element = node as HTMLElement;
@@ -5284,10 +5317,22 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
         nextElement?.ownerDocument.defaultView?.getComputedStyle(
           nextElement,
         ).display;
+      const afterPseudo = this.getFootnoteAfterPseudo(element);
+      const authorAfterPseudoExists =
+        this.hasAuthorFootnoteAfterPseudo(element);
+      const isDefaultAfterPseudo = !!afterPseudo?.hasAttribute(
+        "data-vivliostyle-default-footnote-separator",
+      );
       if (display === "inline" && nextDisplay === "inline") {
-        element.style.setProperty("--viv-footnote-inline-separator", '" "');
+        // Insert the UA default only when the rendered footnote element
+        // itself does not already carry an author-defined ::after pseudo.
+        if (!afterPseudo && !authorAfterPseudoExists) {
+          this.createDefaultFootnoteAfterPseudo(element);
+        }
       } else {
-        element.style.removeProperty("--viv-footnote-inline-separator");
+        if (isDefaultAfterPseudo) {
+          afterPseudo.remove();
+        }
       }
     });
   }

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -912,6 +912,27 @@ export class PageFloatLayoutContext
     }
     for (let i = this.floatsDeferredToNext.length - 1; i >= 0; i--) {
       const continuation = this.floatsDeferredToNext[i];
+      const float = continuation.float;
+      if (
+        this.floatReference === FloatReference.PAGE &&
+        "footnotePolicy" in float &&
+        float.footnotePolicy === Css.ident.line &&
+        this.footnoteAnchorsSeen.has(float.getId())
+      ) {
+        // Once the anchor line has already appeared on the page, a deferred
+        // footnote-policy: line footnote can no longer move independently.
+        if (this.locked) {
+          this.invalidate();
+          return;
+        }
+        this.removeFloatDeferredToNext(float);
+        this.forbid(float);
+        this.invalidate();
+        return;
+      }
+    }
+    for (let i = this.floatsDeferredToNext.length - 1; i >= 0; i--) {
+      const continuation = this.floatsDeferredToNext[i];
       if (!continuation.float.isAllowedOnContext(this)) {
         if (this.locked) {
           this.invalidate();

--- a/packages/core/src/vivliostyle/pseudo-element.ts
+++ b/packages/core/src/vivliostyle/pseudo-element.ts
@@ -44,6 +44,7 @@ export const pseudoNames = [
   "first-line",
   "first-letter",
   "before",
+  "footnote-call",
   "",
   /* content */
   "after",

--- a/packages/core/src/vivliostyle/semantic-footnote.ts
+++ b/packages/core/src/vivliostyle/semantic-footnote.ts
@@ -15,10 +15,67 @@
  * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @fileoverview Semantic footnote helper utilities.
+ *
+ * This module owns semantic-footnote-specific rules that are independent from
+ * the main view-generation flow: element/reference detection, shared marker
+ * attributes, first-reference bookkeeping, and style-merging helpers that can
+ * be driven by injected style accessors.
+ *
+ * Keep view-tree sequencing and DOM construction in vgen.ts. Extend this
+ * module when new DPUB/EPUB semantic footnote behavior can be expressed as
+ * pure reference/style helpers that do not need direct access to ViewFactory
+ * state.
  */
 
 import * as Base from "./base";
+import * as Css from "./css";
+import * as Exprs from "./exprs";
 import * as Plugin from "./plugin";
+import * as Vtree from "./vtree";
+import { CssCascade } from "./types";
+
+export const SEMANTIC_FOOTNOTE_FIRST_REF_ATTR =
+  "data-vivliostyle-footnote-first-ref";
+export const SEMANTIC_FOOTNOTE_REFERENCED_ATTR =
+  "data-vivliostyle-footnote-referenced";
+
+type CascadeValueLike = {
+  value: Css.Val;
+  priority: number;
+  evaluate?: (context: Exprs.Context, propName: string) => Css.Val;
+  filterValue?: (visitor: unknown) => CascadeValueLike;
+};
+
+type ElementStyleMap = {
+  [key: string]: CssCascade.ElementStyle;
+};
+
+export type SemanticFootnoteStyleAccess = {
+  getStyle: (element: Element) => CssCascade.ElementStyle | null;
+  getProp: (
+    style: CssCascade.ElementStyle | null | undefined,
+    propName: string,
+  ) => CascadeValueLike | null | undefined;
+  getStyleMap: (
+    style: CssCascade.ElementStyle,
+    mapName: string,
+  ) => ElementStyleMap | null | undefined;
+  getMutableStyleMap: (
+    style: CssCascade.ElementStyle,
+    mapName: string,
+  ) => ElementStyleMap;
+  createCascadeValue: (value: Css.Val, priority: number) => CascadeValueLike;
+  filterFootnoteMarkerContent: (
+    content: CascadeValueLike,
+    element: Element,
+  ) => Css.Val;
+};
+
+export type SemanticFootnoteStyleState = {
+  sourceStyle: CssCascade.ElementStyle | null;
+  footnoteDisplay: Css.Val | null;
+  footnotePolicy: Css.Ident | null;
+};
 
 function hasToken(value: string | null, token: string): boolean {
   return !!(value && value.match(new RegExp(`(^|\\s)${token}($|\\s)`)));
@@ -50,15 +107,304 @@ export function isSemanticFootnoteNoterefElement(element: Element): boolean {
   return hasToken(epubType, "noteref");
 }
 
+export function resolveSemanticFootnoteReference(
+  element: Element,
+  baseURL: string,
+): string | null {
+  if (!isSemanticFootnoteNoterefElement(element)) {
+    return null;
+  }
+  const href =
+    element.getAttribute("href") ||
+    element.getAttributeNS(Base.NS.XLINK, "href");
+  if (!href) {
+    return null;
+  }
+  const resolvedHref = Base.resolveReferenceURL(href, baseURL);
+  return resolvedHref === "#" ? null : resolvedHref;
+}
+
+export function resolveSemanticFootnoteTarget(
+  element: Element,
+  baseURL: string,
+  resolveElement: (reference: string) => Element | null,
+): Element | null {
+  const resolvedHref = resolveSemanticFootnoteReference(element, baseURL);
+  if (!resolvedHref) {
+    return null;
+  }
+  const target = resolveElement(resolvedHref);
+  return target && isSemanticFootnoteElement(target) ? target : null;
+}
+
+export function initializeFirstSemanticFootnoteReferenceOffsets(
+  ownerDocument: Document,
+  baseURL: string,
+  getElementOffset: (element: Element) => number,
+  firstRefOffsets: Map<string, number>,
+  initialized: { value: boolean },
+): void {
+  if (initialized.value) {
+    return;
+  }
+  const anchorElements = ownerDocument.getElementsByTagName("a");
+  for (let i = 0; i < anchorElements.length; i++) {
+    const anchor = anchorElements.item(i);
+    const resolvedHref = resolveSemanticFootnoteReference(anchor, baseURL);
+    if (!resolvedHref || firstRefOffsets.has(resolvedHref)) {
+      continue;
+    }
+    firstRefOffsets.set(resolvedHref, getElementOffset(anchor));
+  }
+  initialized.value = true;
+}
+
+export function shouldGenerateSemanticFootnote(
+  element: Element,
+  baseURL: string,
+  getElementOffset: (element: Element) => number,
+  firstRefOffsets: Map<string, number>,
+  initialized: { value: boolean },
+): boolean {
+  if (element.localName !== "a" || !isSemanticFootnoteNoterefElement(element)) {
+    return true;
+  }
+  const resolvedHref = resolveSemanticFootnoteReference(element, baseURL);
+  if (!resolvedHref) {
+    return true;
+  }
+  initializeFirstSemanticFootnoteReferenceOffsets(
+    element.ownerDocument,
+    baseURL,
+    getElementOffset,
+    firstRefOffsets,
+    initialized,
+  );
+  const firstOffset = firstRefOffsets.get(resolvedHref);
+  return firstOffset == null || getElementOffset(element) === firstOffset;
+}
+
+function getFootnoteDisplayOverride(
+  style: CssCascade.ElementStyle | null,
+  styleAccess: SemanticFootnoteStyleAccess,
+): CascadeValueLike | null {
+  const footnoteDisplay = styleAccess.getProp(style, "footnote-display");
+  if (footnoteDisplay) {
+    return footnoteDisplay;
+  }
+  const display = styleAccess.getProp(style, "display");
+  if (display?.value === Css.ident.inline) {
+    return styleAccess.createCascadeValue(Css.ident.inline, display.priority);
+  }
+  return null;
+}
+
+export function mergeSemanticFootnoteIncludeStyle(
+  element: Element,
+  elementStyle: CssCascade.ElementStyle,
+  shadowContext: Vtree.ShadowContext | null,
+  baseURL: string,
+  resolveElement: (reference: string) => Element | null,
+  footnoteCounterAttr: string,
+  styleAccess: SemanticFootnoteStyleAccess,
+): CssCascade.ElementStyle {
+  if (
+    element.namespaceURI !== Base.NS.SHADOW ||
+    element.localName !== "include" ||
+    !element.classList.contains("-vivliostyle-footnote-content")
+  ) {
+    return elementStyle;
+  }
+
+  const owner = shadowContext?.owner;
+  if (!(owner instanceof Element) || !isSemanticFootnoteNoterefElement(owner)) {
+    return elementStyle;
+  }
+
+  const target = resolveSemanticFootnoteTarget(owner, baseURL, resolveElement);
+  if (!target) {
+    return elementStyle;
+  }
+
+  const footnoteCounter = owner.getAttribute(footnoteCounterAttr);
+  if (footnoteCounter) {
+    element.setAttribute(footnoteCounterAttr, footnoteCounter);
+    target.setAttribute(footnoteCounterAttr, footnoteCounter);
+  } else {
+    element.removeAttribute(footnoteCounterAttr);
+    target.removeAttribute(footnoteCounterAttr);
+  }
+
+  const targetStyle = styleAccess.getStyle(target);
+  if (!targetStyle) {
+    return elementStyle;
+  }
+
+  const mergedStyle = { ...elementStyle } as CssCascade.ElementStyle;
+  const footnoteDisplay = getFootnoteDisplayOverride(targetStyle, styleAccess);
+  const footnotePolicy = styleAccess.getProp(targetStyle, "footnote-policy");
+  const targetPseudos = styleAccess.getStyleMap(targetStyle, "_pseudos");
+  const targetAfterPseudo = targetPseudos?.["after"];
+
+  if (footnoteDisplay) {
+    mergedStyle["footnote-display"] = footnoteDisplay;
+  }
+  if (footnotePolicy) {
+    mergedStyle["footnote-policy"] = footnotePolicy;
+  }
+  if (targetAfterPseudo) {
+    const pseudos = styleAccess.getMutableStyleMap(mergedStyle, "_pseudos");
+    pseudos["after"] = { ...targetAfterPseudo };
+  }
+
+  return mergedStyle;
+}
+
+export function mergeSemanticFootnoteRootStyle(
+  element: Element,
+  elementStyle: CssCascade.ElementStyle,
+  shadowContext: Vtree.ShadowContext | null,
+  context: Exprs.Context,
+  styleAccess: SemanticFootnoteStyleAccess,
+): CssCascade.ElementStyle {
+  if (
+    !(
+      shadowContext?.type === Vtree.ShadowType.ROOTED &&
+      isSemanticFootnoteElement(element)
+    )
+  ) {
+    return elementStyle;
+  }
+
+  const sourceStyle = styleAccess.getStyle(element);
+  if (!sourceStyle) {
+    return elementStyle;
+  }
+
+  const mergedStyle = { ...elementStyle } as CssCascade.ElementStyle;
+  const footnoteDisplay = getFootnoteDisplayOverride(sourceStyle, styleAccess);
+  const footnotePolicy = styleAccess.getProp(sourceStyle, "footnote-policy");
+  const pseudos = styleAccess.getStyleMap(sourceStyle, "_pseudos");
+  const footnoteMarkerProps = pseudos?.["footnote-marker"];
+  const footnoteMarkerContent = styleAccess.getProp(
+    footnoteMarkerProps,
+    "content",
+  );
+  const footnoteMarkerListStylePosition = styleAccess.getProp(
+    footnoteMarkerProps,
+    "list-style-position",
+  );
+
+  if (footnoteDisplay) {
+    mergedStyle["footnote-display"] = footnoteDisplay;
+  }
+  if (footnotePolicy) {
+    mergedStyle["footnote-policy"] = footnotePolicy;
+  }
+  if (
+    footnoteMarkerContent &&
+    footnoteMarkerListStylePosition?.evaluate?.(
+      context,
+      "list-style-position",
+    ) === Css.ident.outside
+  ) {
+    const filteredMarkerContent = styleAccess.filterFootnoteMarkerContent(
+      footnoteMarkerContent,
+      element,
+    );
+    mergedStyle["--viv-marker-content"] = styleAccess.createCascadeValue(
+      filteredMarkerContent,
+      0,
+    );
+    mergedStyle["display"] = styleAccess.createCascadeValue(
+      Css.getName("list-item"),
+      0,
+    );
+    mergedStyle["list-style-position"] = styleAccess.createCascadeValue(
+      Css.ident.outside,
+      0,
+    );
+    mergedStyle["list-style-type"] = styleAccess.createCascadeValue(
+      Css.ident.none,
+      0,
+    );
+    mergedStyle["list-style-image"] = styleAccess.createCascadeValue(
+      Css.ident.none,
+      0,
+    );
+  }
+
+  return mergedStyle;
+}
+
+export function getSemanticFootnoteStyleState(
+  element: Element,
+  shadowContext: Vtree.ShadowContext | null,
+  styleAccess: SemanticFootnoteStyleAccess,
+): SemanticFootnoteStyleState {
+  const sourceStyle =
+    shadowContext?.type === Vtree.ShadowType.ROOTED &&
+    isSemanticFootnoteElement(element)
+      ? styleAccess.getStyle(element)
+      : null;
+  return {
+    sourceStyle,
+    footnoteDisplay:
+      getFootnoteDisplayOverride(sourceStyle, styleAccess)?.value || null,
+    footnotePolicy:
+      (styleAccess.getProp(sourceStyle, "footnote-policy")
+        ?.value as Css.Ident) || null,
+  };
+}
+
+export function resolveMarkerContentValue(
+  val: Css.Val,
+  context: Exprs.Context,
+): Css.Val {
+  if (val instanceof Css.Expr) {
+    const result = val.expr.evaluate(context);
+    if (typeof result === "string") {
+      return new Css.Str(result);
+    }
+    if (typeof result === "number") {
+      return new Css.Str(String(result));
+    }
+    return val;
+  }
+  if (val instanceof Css.SpaceList) {
+    return new Css.SpaceList(
+      val.values.map((item) => resolveMarkerContentValue(item, context)),
+    );
+  }
+  return val;
+}
+
+export function refreshSemanticFootnoteMarkerContent(
+  sourceStyle: CssCascade.ElementStyle | null,
+  computedStyle: { [key: string]: Css.Val },
+  context: Exprs.Context,
+): void {
+  const rawMarkerContent = sourceStyle?.[
+    "_footnote-marker-content"
+  ] as CascadeValueLike;
+  if (rawMarkerContent) {
+    computedStyle["--viv-marker-content"] = resolveMarkerContentValue(
+      rawMarkerContent.value,
+      context,
+    );
+  }
+}
+
 /**
  * Mark aside elements that are referenced by semantic footnote noteref anchors
- * with the `data-vivliostyle-footnote-referenced` attribute.
+ * with the semantic footnote referenced attribute.
  * This is used by the UA stylesheet to apply `display: none` only to asides
  * that are actually referenced (so unreferenced asides with `float: footnote`
  * set by the author stylesheet are not hidden). (Issue #1823)
  */
 function markReferencedFootnoteElements(document: Document): void {
   const anchorElements = document.getElementsByTagName("a");
+  const firstReferenceTargets = new Set<string>();
   for (let i = 0; i < anchorElements.length; i++) {
     const anchor = anchorElements.item(i);
     if (!isSemanticFootnoteNoterefElement(anchor)) {
@@ -75,7 +421,12 @@ function markReferencedFootnoteElements(document: Document): void {
     const id = anchor.hash.substring(1);
     const target = document.getElementById(id);
     if (target && isSemanticFootnoteElement(target)) {
-      target.setAttribute("data-vivliostyle-footnote-referenced", "true");
+      const resolvedHref = anchor.baseURI.replace(/#.*$/, "") + anchor.hash;
+      if (!firstReferenceTargets.has(resolvedHref)) {
+        firstReferenceTargets.add(resolvedHref);
+        anchor.setAttribute(SEMANTIC_FOOTNOTE_FIRST_REF_ATTR, "true");
+      }
+      target.setAttribute(SEMANTIC_FOOTNOTE_REFERENCED_ATTR, "true");
     }
   }
 }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -108,6 +108,8 @@ export class ViewFactory
   private static FOOTNOTE_CALL_OWNER_ATTR = "data-viv-footnote-call-owner";
   document: Document;
   exprContentListener: Vtree.ExprContentListener;
+  private computedStyleParentFontSizeOverride: number | null = null;
+  private computedStyleParentLineHeightOverride: number | null = null;
 
   // provided by layout
   nodeContext: Vtree.NodeContext | null = null;
@@ -172,66 +174,34 @@ export class ViewFactory
     );
   }
 
-  private initializeSemanticFootnoteFirstRefOffsets(ownerDocument: Document) {
-    if (this.semanticFootnoteFirstRefOffsetsInitialized.value) {
-      return;
-    }
-    const anchorElements = ownerDocument.getElementsByTagName("a");
-    for (let i = 0; i < anchorElements.length; i++) {
-      const anchor = anchorElements.item(i);
-      if (!SemanticFootnote.isSemanticFootnoteNoterefElement(anchor)) {
-        continue;
-      }
-      const anchorHref =
-        anchor.getAttribute("href") ||
-        anchor.getAttributeNS(Base.NS.XLINK, "href");
-      if (!anchorHref) {
-        continue;
-      }
-      const resolvedHref = Base.resolveReferenceURL(
-        anchorHref,
-        this.xmldoc.url,
-      );
-      if (resolvedHref === "#") {
-        continue;
-      }
-      if (this.semanticFootnoteFirstRefOffsets.has(resolvedHref)) {
-        continue;
-      }
-      this.semanticFootnoteFirstRefOffsets.set(
-        resolvedHref,
-        this.xmldoc.getElementOffset(anchor),
-      );
-    }
-    this.semanticFootnoteFirstRefOffsetsInitialized.value = true;
-  }
-
-  /**
-   * True only for the first semantic footnote reference to the same target.
-   */
-  private shouldGenerateSemanticFootnote(element: Element): boolean {
+  private syncSemanticFootnoteCounterToTarget(element: Element): void {
     if (
       element.localName !== "a" ||
-      !SemanticFootnote.isSemanticFootnoteNoterefElement(element)
+      !SemanticFootnote.isSemanticFootnoteNoterefElement(element) ||
+      !SemanticFootnote.shouldGenerateSemanticFootnote(
+        element,
+        this.xmldoc.url,
+        (noteref) => this.xmldoc.getElementOffset(noteref),
+        this.semanticFootnoteFirstRefOffsets,
+        this.semanticFootnoteFirstRefOffsetsInitialized,
+      )
     ) {
-      return true;
+      return;
     }
-    const href =
-      element.getAttribute("href") ||
-      element.getAttributeNS(Base.NS.XLINK, "href");
-    if (!href) {
-      return true;
+    const footnoteCounter = element.getAttribute(
+      CssCascade.FOOTNOTE_COUNTER_ATTR,
+    );
+    if (!footnoteCounter) {
+      return;
     }
-    const resolvedHref = Base.resolveReferenceURL(href, this.xmldoc.url);
-    if (resolvedHref === "#") {
-      return true;
+    const target = SemanticFootnote.resolveSemanticFootnoteTarget(
+      element,
+      this.xmldoc.url,
+      (reference) => this.xmldoc.getElement(reference),
+    );
+    if (target) {
+      target.setAttribute(CssCascade.FOOTNOTE_COUNTER_ATTR, footnoteCounter);
     }
-    this.initializeSemanticFootnoteFirstRefOffsets(element.ownerDocument);
-    const firstOffset = this.semanticFootnoteFirstRefOffsets.get(resolvedHref);
-    if (firstOffset == null) {
-      return true;
-    }
-    return this.xmldoc.getElementOffset(element) === firstOffset;
   }
 
   createPseudoelementShadow(
@@ -257,15 +227,38 @@ export class ViewFactory
     const addedNames: string[] = [];
     const root = PseudoElement.document.createElementNS(Base.NS.SHADOW, "root");
     let att = root;
+    const suppressSemanticNoterefContent =
+      SemanticFootnote.isSemanticFootnoteNoterefElement(element) &&
+      !!pseudoMap["footnote-call"] &&
+      Vtree.nonTrivialContent(
+        (pseudoMap["footnote-call"]["content"] as CssCascade.CascadeValue)
+          ?.value,
+      );
     for (const name of PseudoElement.pseudoNames) {
       let elem: Element;
       if (name) {
         if (!pseudoMap[name]) {
           continue;
         }
+        const isSemanticFootnote =
+          SemanticFootnote.isSemanticFootnoteElement(element);
+        const isSemanticFootnoteContentInclude =
+          element.namespaceURI === Base.NS.SHADOW &&
+          element.localName === "include" &&
+          element.classList.contains("-vivliostyle-footnote-content");
+        if (
+          name == "footnote-call" &&
+          !SemanticFootnote.isSemanticFootnoteNoterefElement(element)
+        ) {
+          continue;
+        }
         if (
           name == "footnote-marker" &&
-          !(isRoot && this.isFootnote) &&
+          !(
+            isSemanticFootnote ||
+            isSemanticFootnoteContentInclude ||
+            (isRoot && this.isFootnote)
+          ) &&
           !this.nodeContext?.pluginProps["nestedFootnoteDetached"] // (Issue #1352)
         ) {
           continue;
@@ -292,10 +285,21 @@ export class ViewFactory
         if (
           name === "before" ||
           name === "after" ||
+          name === "footnote-call" ||
           name === "footnote-marker"
         ) {
           const content = pseudoMap[name]["content"] as CssCascade.CascadeValue;
-          if (!content || !Vtree.nonTrivialContent(content.value)) {
+          const allowFootnoteEmptyPseudo =
+            (name === "before" || name === "after") &&
+            ((computedStyle["float"] as Css.Val) === Css.ident.footnote ||
+              isSemanticFootnote ||
+              isSemanticFootnoteContentInclude) &&
+            !!content;
+          if (
+            !content ||
+            (!Vtree.nonTrivialContent(content.value) &&
+              !allowFootnoteEmptyPseudo)
+          ) {
             continue;
           }
         }
@@ -303,6 +307,9 @@ export class ViewFactory
         elem = PseudoElement.document.createElementNS(Base.NS.XHTML, "span");
         PseudoElement.setPseudoName(elem, name);
       } else {
+        if (suppressSemanticNoterefContent) {
+          continue;
+        }
         elem = PseudoElement.document.createElementNS(
           Base.NS.SHADOW,
           "content",
@@ -429,7 +436,13 @@ export class ViewFactory
     ) {
       if (
         templateURLVal !== Css.ident.footnote ||
-        this.shouldGenerateSemanticFootnote(element)
+        SemanticFootnote.shouldGenerateSemanticFootnote(
+          element,
+          this.xmldoc.url,
+          (noteref) => this.xmldoc.getElementOffset(noteref),
+          this.semanticFootnoteFirstRefOffsets,
+          this.semanticFootnoteFirstRefOffsetsInitialized,
+        )
       ) {
         const url =
           templateURLVal instanceof Css.URL
@@ -969,6 +982,7 @@ export class ViewFactory
       ? this.nodeContext.shadowContext.styler
       : this.styler;
     let elementStyle = styler.getStyle(element, false);
+    this.syncSemanticFootnoteCounterToTarget(element);
     if (!this.nodeContext.shadowContext) {
       const offset = this.xmldoc.getElementOffset(element);
       Matchers.NthFragmentMatcher.registerFragmentIndex(
@@ -978,6 +992,26 @@ export class ViewFactory
       );
     }
     const computedStyle: { [key: string]: Css.Val } = {};
+    const semanticFootnoteStyleAccess: SemanticFootnote.SemanticFootnoteStyleAccess =
+      {
+        getStyle: (target) => this.styler.getStyle(target, false),
+        getProp: (style, propName) =>
+          style ? CssCascade.getProp(style, propName) : null,
+        getStyleMap: (style, mapName) => CssCascade.getStyleMap(style, mapName),
+        getMutableStyleMap: (style, mapName) =>
+          CssCascade.getMutableStyleMap(style, mapName),
+        createCascadeValue: (value, priority) =>
+          new CssCascade.CascadeValue(value, priority),
+        filterFootnoteMarkerContent: (content, target) =>
+          content.filterValue(
+            new CssCascade.ContentPropVisitor(
+              this.styler.cascade,
+              target,
+              this.styler.cascade.counterResolver,
+              "footnote-marker",
+            ),
+          ).value,
+      };
     if (!this.nodeContext.parent) {
       const inheritedValues = this.inheritFromSourceParent(elementStyle);
       elementStyle = inheritedValues.elementStyle;
@@ -1011,6 +1045,22 @@ export class ViewFactory
       elementStyle = inheritedValues.elementStyle;
       this.nodeContext.lang = inheritedValues.lang;
     }
+    elementStyle = SemanticFootnote.mergeSemanticFootnoteIncludeStyle(
+      element,
+      elementStyle,
+      this.nodeContext.shadowContext as Vtree.ShadowContext,
+      this.xmldoc.url,
+      (reference) => this.xmldoc.getElement(reference),
+      CssCascade.FOOTNOTE_COUNTER_ATTR,
+      semanticFootnoteStyleAccess,
+    );
+    elementStyle = SemanticFootnote.mergeSemanticFootnoteRootStyle(
+      element,
+      elementStyle,
+      this.nodeContext.shadowContext as Vtree.ShadowContext,
+      this.context,
+      semanticFootnoteStyleAccess,
+    );
     this.nodeContext.vertical = this.computeStyle(
       this.nodeContext.vertical,
       this.nodeContext.direction === "rtl",
@@ -1052,6 +1102,14 @@ export class ViewFactory
     }
 
     let display = computedStyle["display"];
+
+    if (
+      SemanticFootnote.isSemanticFootnoteElement(element) &&
+      !isSemanticFootnoteInRootedShadow &&
+      element.hasAttribute(SemanticFootnote.SEMANTIC_FOOTNOTE_REFERENCED_ATTR)
+    ) {
+      display = computedStyle["display"] = Css.ident.none;
+    }
 
     if (Css.isDefaultingValue(display)) {
       if (display === Css.ident.initial || display === Css.ident.unset) {
@@ -1129,7 +1187,20 @@ export class ViewFactory
       const isFootnoteBodyInFootnoteArea =
         this.isFootnote &&
         (!this.nodeContext?.parent ||
-          this.nodeContext.pluginProps["nestedFootnoteDetached"]);
+          this.nodeContext.pluginProps["nestedFootnoteDetached"] ||
+          isSemanticFootnoteInRootedShadow);
+      const semanticFootnoteStyle =
+        SemanticFootnote.getSemanticFootnoteStyleState(
+          element,
+          this.nodeContext.shadowContext as Vtree.ShadowContext,
+          semanticFootnoteStyleAccess,
+        );
+      SemanticFootnote.refreshSemanticFootnoteMarkerContent(
+        semanticFootnoteStyle.sourceStyle,
+        computedStyle,
+        this.context,
+      );
+      footnoteDisplay = semanticFootnoteStyle.footnoteDisplay;
 
       let floating =
         floatSide instanceof Css.SpaceList ||
@@ -1150,7 +1221,8 @@ export class ViewFactory
         // Don't want to set it in view DOM CSS.
         delete computedStyle["float"];
         if (floatSide === Css.ident.footnote) {
-          footnoteDisplay = computedStyle["footnote-display"];
+          footnoteDisplay =
+            computedStyle["footnote-display"] || footnoteDisplay;
           usesOutsideFootnoteMarker = !!computedStyle["--viv-marker-content"];
           if (isFootnoteBodyInFootnoteArea) {
             // Root of the footnote body being rendered in footnote area.
@@ -1158,9 +1230,14 @@ export class ViewFactory
             // entry, with call marker handled separately. (Issue #1352)
             floating = false;
             const footnoteDisplayName = footnoteDisplay?.toString();
+            if (footnoteDisplayName) {
+              computedStyle["--viv-footnote-display"] =
+                Css.getName(footnoteDisplayName);
+            }
             display = usesOutsideFootnoteMarker
               ? Css.getName("list-item")
-              : footnoteDisplayName === "inline"
+              : footnoteDisplayName === "inline" ||
+                  footnoteDisplayName === "compact"
                 ? Css.ident.inline
                 : Css.ident.block;
             computedStyle["display"] = display;
@@ -1171,6 +1248,28 @@ export class ViewFactory
             // false — layout needs this to collect the float properly.
             computedStyle["display"] = Css.ident.inline;
           }
+        }
+      }
+      if (
+        isFootnoteBodyInFootnoteArea &&
+        SemanticFootnote.isSemanticFootnoteElement(element)
+      ) {
+        usesOutsideFootnoteMarker =
+          usesOutsideFootnoteMarker || !!computedStyle["--viv-marker-content"];
+        const footnoteDisplayName = footnoteDisplay?.toString();
+        if (footnoteDisplayName) {
+          computedStyle["--viv-footnote-display"] =
+            Css.getName(footnoteDisplayName);
+        }
+        if (usesOutsideFootnoteMarker) {
+          display = computedStyle["display"] = Css.getName("list-item");
+        }
+        if (
+          !usesOutsideFootnoteMarker &&
+          (footnoteDisplayName === "inline" ||
+            footnoteDisplayName === "compact")
+        ) {
+          display = computedStyle["display"] = Css.ident.inline;
         }
       }
       if (clearSide) {
@@ -1357,7 +1456,12 @@ export class ViewFactory
           }
         }
       }
-      const footnotePolicy = computedStyle["footnote-policy"] as Css.Ident;
+      const footnotePolicy =
+        (computedStyle["footnote-policy"] as Css.Ident) ||
+        semanticFootnoteStyle.footnotePolicy;
+      if (footnotePolicy && !Css.isDefaultingValue(footnotePolicy)) {
+        computedStyle["--viv-footnote-policy"] = footnotePolicy;
+      }
       this.nodeContext.footnotePolicy =
         footnotePolicy && !Css.isDefaultingValue(footnotePolicy)
           ? footnotePolicy
@@ -2896,6 +3000,68 @@ export class ViewFactory
     return null;
   }
 
+  private getFootnoteAreaInheritedMetrics(): {
+    fontSize: number | null;
+    lineHeight: number | null;
+  } {
+    const pageContextElement = this.page.pageAreaElement?.parentElement
+      ?.parentElement as HTMLElement | null;
+    const pageContextStyle = pageContextElement
+      ? this.viewport.window.getComputedStyle(pageContextElement)
+      : null;
+    const fontSize =
+      (pageContextStyle &&
+        this.parsePlusLayoutUnitAdj(pageContextStyle.fontSize)) ||
+      this.context.rootFontSize ||
+      this.context.initialFontSize;
+    const lineHeight =
+      (pageContextStyle &&
+        this.parsePlusLayoutUnitAdj(pageContextStyle.lineHeight)) ||
+      this.context.rootLineHeight ||
+      fontSize * this.context.pref.lineHeight;
+    return { fontSize, lineHeight };
+  }
+
+  private getComputedFontMetrics(
+    element: Element,
+    fallback: { fontSize: number | null; lineHeight: number | null },
+  ): { fontSize: number | null; lineHeight: number | null } {
+    const style = this.viewport.window.getComputedStyle(element);
+    const fontSize =
+      this.parsePlusLayoutUnitAdj(style.fontSize) ?? fallback.fontSize;
+    const lineHeight =
+      this.parsePlusLayoutUnitAdj(style.lineHeight) ??
+      fallback.lineHeight ??
+      (fontSize != null ? fontSize * this.context.pref.lineHeight : null);
+    return { fontSize, lineHeight };
+  }
+
+  private getParentViewStyle(): CSSStyleDeclaration | null {
+    return this.nodeContext?.parent?.viewNode?.nodeType === 1
+      ? this.viewport.window.getComputedStyle(
+          this.nodeContext.parent.viewNode as Element,
+        )
+      : null;
+  }
+
+  private getParentComputedMetrics(parentStyle: CSSStyleDeclaration | null): {
+    fontSize: number | null;
+    lineHeight: number | null;
+  } {
+    return {
+      fontSize:
+        this.computedStyleParentFontSizeOverride ??
+        (parentStyle
+          ? this.parsePlusLayoutUnitAdj(parentStyle.fontSize)
+          : this.context.rootFontSize),
+      lineHeight:
+        this.computedStyleParentLineHeightOverride ??
+        (parentStyle
+          ? this.parsePlusLayoutUnitAdj(parentStyle.lineHeight)
+          : this.context.rootLineHeight),
+    };
+  }
+
   /**
    * Get "lh" unit size in px
    * @return line-height in px, or null if cannot be determined
@@ -2905,16 +3071,9 @@ export class ViewFactory
     fontSize: Css.Val,
     lineHeight: Css.Val,
   ): number | null {
-    const parentStyle =
-      this.nodeContext?.parent?.viewNode?.nodeType === 1
-        ? this.viewport.window.getComputedStyle(
-            this.nodeContext.parent.viewNode as Element,
-          )
-        : null;
-
-    const parentLineHeight = parentStyle
-      ? this.parsePlusLayoutUnitAdj(parentStyle.lineHeight)
-      : this.context.rootLineHeight;
+    const parentStyle = this.getParentViewStyle();
+    const parentMetrics = this.getParentComputedMetrics(parentStyle);
+    const parentLineHeight = parentMetrics.lineHeight;
 
     if (propName === "line-height" || propName === "font-size") {
       // For line-height property or for font-size property, return parent line-height.
@@ -2972,9 +3131,7 @@ export class ViewFactory
       if (fontSize && !(fontSize instanceof Css.Numeric)) {
         return null; // cannot determine
       }
-      const parentFontSize = parentStyle
-        ? this.parsePlusLayoutUnitAdj(parentStyle.fontSize)
-        : this.context.rootFontSize;
+      const parentFontSize = parentMetrics.fontSize;
       if (fontSize instanceof Css.Numeric) {
         const fontSizePx = CssCascade.convertFontSizeToPx(
           fontSize,
@@ -3002,16 +3159,8 @@ export class ViewFactory
    * @return font-size in px, or null if cannot be determined
    */
   private getEmUnitSize(propName: string, fontSize: Css.Val): number | null {
-    const parentStyle =
-      this.nodeContext?.parent?.viewNode?.nodeType === 1
-        ? this.viewport.window.getComputedStyle(
-            this.nodeContext.parent.viewNode as Element,
-          )
-        : null;
-
-    const parentFontSize = parentStyle
-      ? this.parsePlusLayoutUnitAdj(parentStyle.fontSize)
-      : this.context.rootFontSize;
+    const parentStyle = this.getParentViewStyle();
+    const parentFontSize = this.getParentComputedMetrics(parentStyle).fontSize;
 
     if (propName === "font-size" || fontSize == null) {
       // For font-size property or when font-size is not specified, return parent font-size.
@@ -3166,77 +3315,104 @@ export class ViewFactory
 
     const pseudoMap = CssCascade.getStyleMap(footnoteStyle, "_pseudos");
     vertical = this.computeStyle(vertical, rtl, footnoteStyle, computedStyle);
-    if (pseudoMap && pseudoMap["before"]) {
-      const pseudoStyle = pseudoMap["before"];
-      const hasSpecifiedDisplay = !!CssCascade.getProp(pseudoStyle, "display");
-      const childComputedStyle: { [key: string]: Css.Val } = {};
-      const span = this.createElement(Base.NS.XHTML, "span");
-      PseudoElement.setPseudoName(span, "before");
-      target.appendChild(span);
-      this.computeStyle(vertical, rtl, pseudoStyle, childComputedStyle);
-      if (!hasSpecifiedDisplay) {
-        childComputedStyle["display"] = Css.ident.block;
-      }
-
-      const contentCascadeValue = CssCascade.getProp(pseudoStyle, "content");
-      if (contentCascadeValue) {
-        const contentElement =
-          this.sourceNode?.nodeType === 1
-            ? (this.sourceNode as Element)
-            : this.xmldoc.root;
-        childComputedStyle["content"] = contentCascadeValue
-          .filterValue(
-            new CssCascade.ContentPropVisitor(
-              this.styler.cascade,
-              contentElement,
-              this.styler.cascade.counterResolver,
-              "before",
-            ),
-          )
-          .evaluate(this.context, "content");
-      }
-
-      const content = childComputedStyle["content"];
-      if (Vtree.nonTrivialContent(content)) {
-        content.visit(
-          new Vtree.ContentPropertyHandler(
-            span,
-            this.context,
-            content,
-            this.exprContentListener,
-          ),
-        );
-
-        const images = span.querySelectorAll("img[src]");
-        for (let i = 0; i < images.length; i++) {
-          const image = images[i] as HTMLImageElement;
-          const src = image.getAttribute("src");
-          if (!src) {
-            continue;
-          }
-          const fetcher = Net.loadElement(image, src);
-          fetchers.push(fetcher);
-          this.page.fetchers.push(fetcher);
-        }
-
-        const rootSrc = span.getAttribute("src");
-        if (rootSrc) {
-          let image = span.querySelector("img") as HTMLImageElement | null;
-          if (!image) {
-            image = this.document.createElement("img");
-            image.setAttribute("src", rootSrc);
-            span.appendChild(image);
-          }
-          const fetcher = Net.loadElement(image, rootSrc);
-          fetchers.push(fetcher);
-          this.page.fetchers.push(fetcher);
-        }
-      }
-      delete childComputedStyle["content"];
-      this.applyComputedStyles(span, childComputedStyle);
+    const inheritedMetrics = this.getFootnoteAreaInheritedMetrics();
+    if (!computedStyle["font-size"] && inheritedMetrics.fontSize != null) {
+      computedStyle["font-size"] = new Css.Numeric(
+        inheritedMetrics.fontSize,
+        "px",
+      );
     }
     delete computedStyle["content"];
-    this.applyComputedStyles(target, computedStyle);
+    const prevFontSizeOverride = this.computedStyleParentFontSizeOverride;
+    const prevLineHeightOverride = this.computedStyleParentLineHeightOverride;
+    // @footnote and @footnote::before resolve em/lh units from the page context,
+    // not from the noteref that triggered semantic footnote generation.
+    this.computedStyleParentFontSizeOverride = inheritedMetrics.fontSize;
+    this.computedStyleParentLineHeightOverride = inheritedMetrics.lineHeight;
+    try {
+      this.applyComputedStyles(target, computedStyle);
+      const targetMetrics = this.getComputedFontMetrics(
+        target,
+        inheritedMetrics,
+      );
+      this.computedStyleParentFontSizeOverride = targetMetrics.fontSize;
+      this.computedStyleParentLineHeightOverride = targetMetrics.lineHeight;
+      if (pseudoMap && pseudoMap["before"]) {
+        const pseudoStyle = pseudoMap["before"];
+        const hasSpecifiedDisplay = !!CssCascade.getProp(
+          pseudoStyle,
+          "display",
+        );
+        const childComputedStyle: { [key: string]: Css.Val } = {};
+        const span = this.createElement(Base.NS.XHTML, "span");
+        PseudoElement.setPseudoName(span, "before");
+        target.appendChild(span);
+        this.computeStyle(vertical, rtl, pseudoStyle, childComputedStyle);
+        if (!hasSpecifiedDisplay) {
+          childComputedStyle["display"] = Css.ident.block;
+        }
+
+        const contentCascadeValue = CssCascade.getProp(pseudoStyle, "content");
+        if (contentCascadeValue) {
+          const contentElement =
+            this.sourceNode?.nodeType === 1
+              ? (this.sourceNode as Element)
+              : this.xmldoc.root;
+          childComputedStyle["content"] = contentCascadeValue
+            .filterValue(
+              new CssCascade.ContentPropVisitor(
+                this.styler.cascade,
+                contentElement,
+                this.styler.cascade.counterResolver,
+                "before",
+              ),
+            )
+            .evaluate(this.context, "content");
+        }
+
+        const content = childComputedStyle["content"];
+        if (Vtree.nonTrivialContent(content)) {
+          content.visit(
+            new Vtree.ContentPropertyHandler(
+              span,
+              this.context,
+              content,
+              this.exprContentListener,
+            ),
+          );
+
+          const images = span.querySelectorAll("img[src]");
+          for (let i = 0; i < images.length; i++) {
+            const image = images[i] as HTMLImageElement;
+            const src = image.getAttribute("src");
+            if (!src) {
+              continue;
+            }
+            const fetcher = Net.loadElement(image, src);
+            fetchers.push(fetcher);
+            this.page.fetchers.push(fetcher);
+          }
+
+          const rootSrc = span.getAttribute("src");
+          if (rootSrc) {
+            let image = span.querySelector("img") as HTMLImageElement | null;
+            if (!image) {
+              image = this.document.createElement("img");
+              image.setAttribute("src", rootSrc);
+              span.appendChild(image);
+            }
+            const fetcher = Net.loadElement(image, rootSrc);
+            fetchers.push(fetcher);
+            this.page.fetchers.push(fetcher);
+          }
+        }
+        delete childComputedStyle["content"];
+        this.applyComputedStyles(span, childComputedStyle);
+      }
+    } finally {
+      this.computedStyleParentFontSizeOverride = prevFontSizeOverride;
+      this.computedStyleParentLineHeightOverride = prevLineHeightOverride;
+    }
     if (fetchers.length) {
       return TaskUtil.waitForFetchers(fetchers).thenReturn(vertical);
     }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -894,9 +894,39 @@ module.exports = [
           "DPUB noteref duplicate reference should not duplicate footnote body (Issue #1767)",
       },
       {
+        file: "footnotes/dpub-footnote-duplicate-reference-call-marker.html",
+        title:
+          "DPUB duplicate reference with ::footnote-call/::footnote-marker",
+      },
+      {
         file: "footnotes/dpub-footnote-inherit.html",
         title:
           "DPUB footnote should inherit from source parent, not noteref (Issue #1770)",
+      },
+      {
+        file: "footnotes/dpub-footnote-display.html",
+        title: "DPUB footnote-display (Issue #1884)",
+      },
+      {
+        file: "footnotes/dpub-footnote-policy.html",
+        title: "DPUB footnote-policy comparison (Issue #1884)",
+      },
+      {
+        file: "footnotes/dpub-footnote-call-marker.html",
+        title: "DPUB ::footnote-call/::footnote-marker (Issue #1884)",
+      },
+      {
+        file: "footnotes/dpub-footnote-call-replaces-content.html",
+        title: "DPUB ::footnote-call replaces noteref content",
+      },
+      {
+        file: "footnotes/dpub-footnote-area-before-inherits-font-size.html",
+        title: "DPUB @footnote ::before inherits @footnote font-size",
+      },
+      {
+        file: "footnotes/dpub-footnote-call-marker-outside.html",
+        title:
+          "DPUB ::footnote-marker outside list-style-position (Issue #1884)",
       },
       {
         file: "footnotes/epub-footnotes-static-number.html",

--- a/packages/core/test/files/footnotes/default-footnote-pseudo-styles.html
+++ b/packages/core/test/files/footnotes/default-footnote-pseudo-styles.html
@@ -20,12 +20,12 @@
   </head>
   <body>
     <p>
-      Footnote call should be rendered by default as a superscript counter<span class="footnote"
+      Footnote call should be rendered by default as a superscript counter<span class="footnote" role="doc-footnote"
         >Footnote marker should be rendered by default with the footnote counter and a trailing period.</span
       >.
     </p>
     <p>
-      Another footnote should increment the counter automatically<span class="footnote"
+      Another footnote should increment the counter automatically<span class="footnote" epub:type="footnote"
         >This is the second footnote for default marker/call style verification.</span
       >.
     </p>

--- a/packages/core/test/files/footnotes/dpub-footnote-area-before-inherits-font-size.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-area-before-inherits-font-size.html
@@ -1,0 +1,49 @@
+<!-- Test case for semantic footnote area pseudo inheriting @footnote font-size -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB @footnote ::before inherits @footnote font-size</title>
+  <style>
+    @page {
+      size: 160mm 120mm;
+      margin: 12mm;
+    }
+
+    @footnote {
+      font-size: 100px;
+      margin-block-start: 0.5em;
+    }
+
+    :root {
+      counter-reset: footnote;
+      font-size: 16px;
+    }
+
+    body {
+      font-family: serif;
+      line-height: 1.45;
+    }
+
+    a[role="doc-noteref"]::footnote-call {
+      content: counter(footnote);
+    }
+
+    aside[role="doc-footnote"]::footnote-marker {
+      content: counter(footnote) ". ";
+    }
+  </style>
+</head>
+<body>
+  <h1>DPUB @footnote ::before inherits @footnote font-size</h1>
+  <p>
+    Expected: footnote area margin-block-start is 50px and the @footnote ::before
+    margin-block-end is 40px when @footnote sets font-size: 100px.
+  </p>
+  <p>
+    The quick brown fox<a href="#fn-fox" role="doc-noteref">*</a>
+    jumps over the lazy dog.
+  </p>
+  <aside id="fn-fox" role="doc-footnote">The fox is an animal.</aside>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/dpub-footnote-call-marker-outside.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-call-marker-outside.html
@@ -1,0 +1,55 @@
+<!-- Test case for Issue #1884: semantic ::footnote-marker outside -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB ::footnote-marker outside</title>
+  <style>
+    @page {
+      size: 160mm 120mm;
+      margin: 12mm;
+    }
+
+    :root {
+      counter-reset: footnote;
+    }
+
+    body {
+      font-family: serif;
+      line-height: 1.45;
+    }
+
+    a.footnote-ref > sup {
+      display: none;
+    }
+
+    a.footnote-ref::footnote-call {
+      content: "[" counter(footnote) "]";
+    }
+
+    aside.footnote {
+      margin-inline-start: 1.5em;
+    }
+
+    aside.footnote > a.footnote-back {
+      display: none;
+    }
+
+    aside.footnote::footnote-marker {
+      content: "[" counter(footnote) "] ";
+      list-style-position: outside;
+    }
+  </style>
+</head>
+<body>
+  <h1>DPUB ::footnote-marker outside</h1>
+  <p>Expected: generated semantic footnote markers render outside multi-line footnote bodies.</p>
+  <p>
+    Outside markers should work too<a id="fnref1" href="#fn1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+    with another note<a id="fnref2" href="#fn2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>.
+  </p>
+
+  <aside id="fn1" class="footnote" role="doc-footnote"><a href="#fnref1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First outside marker note with enough additional text to wrap onto a second line, making the hanging marker position easy to see.</aside>
+  <aside id="fn2" class="footnote" role="doc-footnote"><a href="#fnref2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second outside marker note with another longer sentence so the outside alignment is visually obvious here as well.</aside>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/dpub-footnote-call-marker.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-call-marker.html
@@ -1,0 +1,52 @@
+<!-- Test case for Issue #1884: semantic ::footnote-call and ::footnote-marker -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB ::footnote-call and ::footnote-marker</title>
+  <style>
+    @page {
+      size: 160mm 120mm;
+      margin: 12mm;
+    }
+
+    :root {
+      counter-reset: footnote;
+    }
+
+    body {
+      font-family: serif;
+      line-height: 1.45;
+    }
+
+    a.footnote-ref > sup {
+      display: none;
+    }
+
+    a.footnote-ref::footnote-call {
+      content: "[" counter(footnote) "]";
+    }
+
+    aside.footnote > a.footnote-back {
+      display: none;
+    }
+
+    aside.footnote::footnote-marker {
+      content: "[" counter(footnote) "] ";
+    }
+  </style>
+</head>
+<body>
+  <h1>DPUB ::footnote-call and ::footnote-marker</h1>
+  <p>Expected: the source HTML sup markers are hidden and replaced with generated [1], [2].</p>
+  <p>
+    VFM is developed in the GitHub repository<a id="fnref1" href="#fn1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>.
+  </p>
+  <p>
+    Footnotes can also be written inline<a id="fnref2" href="#fn2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>.
+  </p>
+
+  <aside id="fn1" class="footnote" role="doc-footnote"><a href="#fnref1" class="footnote-back" role="doc-backlink"><sup>1</sup></a><a href="https://github.com/vivliostyle/vfm">VFM</a></aside>
+  <aside id="fn2" class="footnote" role="doc-footnote"><a href="#fnref2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>This part is a footnote.</aside>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/dpub-footnote-call-replaces-content.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-call-replaces-content.html
@@ -1,0 +1,44 @@
+<!-- Test case for semantic ::footnote-call replacing source noteref content -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB ::footnote-call replaces source content</title>
+  <style>
+    @page {
+      size: 160mm 120mm;
+      margin: 12mm;
+    }
+
+    :root {
+      counter-reset: footnote;
+    }
+
+    body {
+      font-family: serif;
+      line-height: 1.45;
+    }
+
+    a[role="doc-noteref"]::footnote-call {
+      content: counter(footnote);
+    }
+
+    aside[role="doc-footnote"]::footnote-marker {
+      content: counter(footnote) ". ";
+    }
+  </style>
+</head>
+<body>
+  <h1>DPUB ::footnote-call replaces source content</h1>
+  <p>
+    Expected: the visible noteref calls are 1 and 2 only, not 1* and 2*.
+    The call styling should match the semantic noteref styling only once.
+  </p>
+  <p>
+    The quick brown fox<a href="#fn-fox" role="doc-noteref">*</a>
+    jumps over the lazy dog<a href="#fn-dog" role="doc-noteref">*</a>.
+  </p>
+  <aside id="fn-fox" role="doc-footnote">The fox is an animal.</aside>
+  <aside id="fn-dog" role="doc-footnote">The dog is also an animal.</aside>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/dpub-footnote-display.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-display.html
@@ -1,0 +1,256 @@
+<!-- Test case for Issue #1884: semantic display:inline and footnote-display -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>DPUB footnote display</title>
+    <style>
+      @page {
+        size: 148mm 210mm;
+        margin: 16mm;
+
+        @bottom-center {
+          font-size: 0.85rem;
+          content: "Page " counter(page);
+        }
+      }
+
+      body {
+        font-family: serif;
+        line-height: 1.4;
+      }
+
+      section {
+        margin-block: 0 1.4rem;
+      }
+
+      h1 {
+        margin-bottom: 0.5rem;
+      }
+
+      h2 {
+        margin-bottom: 0.3rem;
+      }
+
+      p {
+        margin: 0.35rem 0;
+      }
+
+      .keep-together {
+        break-inside: avoid;
+      }
+
+      .expected {
+        font-size: 0.9rem;
+        font-style: italic;
+      }
+
+      .footnote-display-block {
+        color: #800;
+      }
+
+      .footnote-display-inline {
+        color: #080;
+      }
+
+      .footnote-display-inline .footnote {
+        footnote-display: inline;
+      }
+
+      .footnote-display-compact {
+        color: #008;
+      }
+
+      .footnote-display-compact .footnote {
+        footnote-display: compact;
+      }
+
+      .inline-author-separator {
+        color: #055;
+      }
+
+      .inline-author-separator .footnote {
+        footnote-display: inline;
+      }
+
+      .inline-author-separator .footnote::after {
+        content: "\3000";
+      }
+
+      .compact-no-separator {
+        color: #505;
+      }
+
+      .compact-no-separator .footnote {
+        footnote-display: compact;
+      }
+
+      .compact-no-separator .footnote::after {
+        content: none;
+      }
+
+      .display-inline {
+        color: #606;
+      }
+
+      .display-inline .footnote {
+        display: inline;
+      }
+
+      .outside-marker-inline,
+      .outside-marker-compact {
+        color: #244;
+      }
+
+      .outside-marker-inline .footnote {
+        footnote-display: inline;
+      }
+
+      .outside-marker-compact .footnote {
+        footnote-display: compact;
+      }
+
+      .outside-marker-inline .footnote-ref::footnote-call,
+      .outside-marker-compact .footnote-ref::footnote-call {
+        content: "[" counter(footnote) "]";
+      }
+
+      .outside-marker-inline .footnote::footnote-marker,
+      .outside-marker-compact .footnote::footnote-marker {
+        content: "[" counter(footnote) "] ";
+        list-style-position: outside;
+      }
+
+      .outside-marker-inline .footnote-back,
+      .outside-marker-compact .footnote-back {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>DPUB footnote display test</h1>
+    <section class="footnote-display-block">
+      <h2>footnote-display: block (default)</h2>
+      <p class="expected">
+        Each semantic footnote body should start on its own line in the footnote area by default.
+      </p>
+      <p>
+        Block footnotes remain separated<a id="block-ref-1" href="#block-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        even when the note text is short<a id="block-ref-2" href="#block-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        and could otherwise fit beside another note<a id="block-ref-3" href="#block-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
+      </p>
+      <aside id="block-note-1" class="footnote" role="doc-footnote"><a href="#block-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First block note.</aside>
+      <aside id="block-note-2" class="footnote" role="doc-footnote"><a href="#block-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second block note.</aside>
+      <aside id="block-note-3" class="footnote" role="doc-footnote"><a href="#block-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Third block note with a little more text.</aside>
+    </section>
+    <section class="footnote-display-inline">
+      <h2>footnote-display: inline</h2>
+      <p class="expected">
+        Inline footnotes should stay in one inline run even when a longer note wraps, with a normal space between note bodies.
+      </p>
+      <p>
+        Inline footnotes should begin as a loose run of notes<a id="inline-ref-1" href="#inline-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        and then continue through a longer inline note that wraps to the next line in the footnote area<a id="inline-ref-2" href="#inline-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        before a trailing short note carries on inline rather than becoming a separate block<a id="inline-ref-3" href="#inline-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
+      </p>
+      <aside id="inline-note-1" class="footnote" role="doc-footnote"><a href="#inline-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>Short inline note.</aside>
+      <aside id="inline-note-2" class="footnote" role="doc-footnote"><a href="#inline-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>A longer inline note that should wrap to another line so the example shows that inline footnotes still remain part of one inline sequence after wrapping.</aside>
+      <aside id="inline-note-3" class="footnote" role="doc-footnote"><a href="#inline-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Trailing inline note.</aside>
+    </section>
+    <section class="footnote-display-compact">
+      <h2>footnote-display: compact</h2>
+      <p class="expected">
+        Compact footnotes should behave like unbreakable inline notes by default, and only fall back to block when a single note cannot fit on one rendered line.
+      </p>
+      <p class="keep-together">
+        Four short compact notes should wrap as inline nowrap units<a id="compact-ref-1" href="#compact-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        with the next short compact note still on that first line<a id="compact-ref-2" href="#compact-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        and then continue on the next line with another short compact note<a id="compact-ref-3" href="#compact-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>
+        plus one more short compact note on that same following line<a id="compact-ref-4" href="#compact-note-4" class="footnote-ref" role="doc-noteref"><sup>4</sup></a>.
+      </p>
+      <p>
+        A compact note that is too long to fit as a single unbroken inline note should fall back to block<a id="compact-ref-5" href="#compact-note-5" class="footnote-ref" role="doc-noteref"><sup>5</sup></a>
+        while the following short compact notes can still share a later line inline<a id="compact-ref-6" href="#compact-note-6" class="footnote-ref" role="doc-noteref"><sup>6</sup></a>
+        and continue with another short compact note on that same line<a id="compact-ref-7" href="#compact-note-7" class="footnote-ref" role="doc-noteref"><sup>7</sup></a>
+        before a final longer compact note falls back to block again<a id="compact-ref-8" href="#compact-note-8" class="footnote-ref" role="doc-noteref"><sup>8</sup></a>.
+      </p>
+      <aside id="compact-note-1" class="footnote" role="doc-footnote"><a href="#compact-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>Short compact note.</aside>
+      <aside id="compact-note-2" class="footnote" role="doc-footnote"><a href="#compact-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Another short compact note.</aside>
+      <aside id="compact-note-3" class="footnote" role="doc-footnote"><a href="#compact-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Another short compact note.</aside>
+      <aside id="compact-note-4" class="footnote" role="doc-footnote"><a href="#compact-ref-4" class="footnote-back" role="doc-backlink"><sup>4</sup></a>Short compact note.</aside>
+      <aside id="compact-note-5" class="footnote" role="doc-footnote"><a href="#compact-ref-5" class="footnote-back" role="doc-backlink"><sup>5</sup></a>A medium-length compact note that is long enough that keeping it as a single unbroken inline note would overflow the footnote measure, so it should become a block footnote.</aside>
+      <aside id="compact-note-6" class="footnote" role="doc-footnote"><a href="#compact-ref-6" class="footnote-back" role="doc-backlink"><sup>6</sup></a>Short compact note.</aside>
+      <aside id="compact-note-7" class="footnote" role="doc-footnote"><a href="#compact-ref-7" class="footnote-back" role="doc-backlink"><sup>7</sup></a>Another short note.</aside>
+      <aside id="compact-note-8" class="footnote" role="doc-footnote"><a href="#compact-ref-8" class="footnote-back" role="doc-backlink"><sup>8</sup></a>A longer trailing compact note that no longer fits as a single unbroken inline note.</aside>
+    </section>
+    <section class="outside-marker-inline">
+      <h2>footnote-display: inline with outside markers</h2>
+      <p class="expected">
+        Outside footnote markers should keep each semantic footnote as a list item, even when footnote-display:inline is specified.
+      </p>
+      <p>
+        Outside-marker inline footnotes should not collapse into one inline run<a id="outside-inline-ref-1" href="#outside-inline-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        when the marker is rendered outside the footnote body<a id="outside-inline-ref-2" href="#outside-inline-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        and a third footnote should still remain a separate list item<a id="outside-inline-ref-3" href="#outside-inline-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
+      </p>
+      <aside id="outside-inline-note-1" class="footnote" role="doc-footnote"><a href="#outside-inline-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>Short inline note.</aside>
+      <aside id="outside-inline-note-2" class="footnote" role="doc-footnote"><a href="#outside-inline-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>A longer inline note that should wrap to another line so the example shows that outside markers do not allow one inline sequence.</aside>
+      <aside id="outside-inline-note-3" class="footnote" role="doc-footnote"><a href="#outside-inline-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Trailing inline note.</aside>
+    </section>
+    <section class="outside-marker-compact">
+      <h2>footnote-display: compact with outside markers</h2>
+      <p class="expected">
+        Outside markers should also prevent compact semantic footnotes from being forced into inline nowrap rendering.
+      </p>
+      <p>
+        Compact outside-marker footnotes should stay as separate list items<a id="outside-compact-ref-1" href="#outside-compact-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        rather than sharing a single inline row<a id="outside-compact-ref-2" href="#outside-compact-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        even when another short footnote follows<a id="outside-compact-ref-3" href="#outside-compact-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
+      </p>
+      <aside id="outside-compact-note-1" class="footnote" role="doc-footnote"><a href="#outside-compact-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First compact note.</aside>
+      <aside id="outside-compact-note-2" class="footnote" role="doc-footnote"><a href="#outside-compact-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second compact note.</aside>
+      <aside id="outside-compact-note-3" class="footnote" role="doc-footnote"><a href="#outside-compact-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Third compact note.</aside>
+    </section>
+    <section class="inline-author-separator">
+      <h2>footnote-display: inline with author ::after separator</h2>
+      <p class="expected">
+        When author CSS sets .footnote::after content, that content should replace the default space separator between inline footnotes.
+      </p>
+      <p>
+        Author CSS should be able to use an ideographic separator between inline semantic footnotes<a id="inline-author-ref-1" href="#inline-author-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        and keep using that author-defined separator for the next inline footnote<a id="inline-author-ref-2" href="#inline-author-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        instead of the default single ASCII space<a id="inline-author-ref-3" href="#inline-author-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
+      </p>
+      <aside id="inline-author-note-1" class="footnote" role="doc-footnote"><a href="#inline-author-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First note.</aside>
+      <aside id="inline-author-note-2" class="footnote" role="doc-footnote"><a href="#inline-author-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second note.</aside>
+      <aside id="inline-author-note-3" class="footnote" role="doc-footnote"><a href="#inline-author-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Third note.</aside>
+    </section>
+    <section class="compact-no-separator">
+      <h2>footnote-display: compact with author ::after none</h2>
+      <p class="expected">
+        When author CSS sets .footnote::after to none, compact inline footnotes should appear with no default separator inserted between them.
+      </p>
+      <p>
+        Compact semantic footnotes should allow the author to suppress separators entirely<a id="compact-none-ref-1" href="#compact-none-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        so the next compact footnote follows with no generated gap<a id="compact-none-ref-2" href="#compact-none-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        and a third note also keeps that explicit no-separator behavior<a id="compact-none-ref-3" href="#compact-none-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
+      </p>
+      <aside id="compact-none-note-1" class="footnote" role="doc-footnote"><a href="#compact-none-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First compact note.</aside>
+      <aside id="compact-none-note-2" class="footnote" role="doc-footnote"><a href="#compact-none-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second compact note.</aside>
+      <aside id="compact-none-note-3" class="footnote" role="doc-footnote"><a href="#compact-none-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Third compact note.</aside>
+    </section>
+    <section class="display-inline">
+      <h2>display: inline</h2>
+      <p class="expected">
+        Semantic footnotes with display:inline should behave like footnote-display:inline and stay in one inline run in the footnote area.
+      </p>
+      <p>
+        Inline footnotes should begin as a loose run of notes<a id="display-inline-ref-1" href="#display-inline-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        and continue through another short note<a id="display-inline-ref-2" href="#display-inline-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        without forcing a new block for each footnote body.
+      </p>
+      <aside id="display-inline-note-1" class="footnote" role="doc-footnote"><a href="#display-inline-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First inline note.</aside>
+      <aside id="display-inline-note-2" class="footnote" role="doc-footnote"><a href="#display-inline-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second inline note.</aside>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/footnotes/dpub-footnote-duplicate-reference-call-marker.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-duplicate-reference-call-marker.html
@@ -1,0 +1,63 @@
+<!-- Test case for duplicate semantic footnote references with ::footnote-call/::footnote-marker -->
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="UTF-8" />
+  <title>DPUB footnote duplicate reference with ::footnote-call and ::footnote-marker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    @page {
+      size: 500px 300px;
+      @bottom-center {
+        content: "Page " counter(page);
+      }
+    }
+    body {
+      font-family: serif;
+      line-height: 1.4;
+    }
+
+    a[role=doc-noteref]::footnote-call,
+    aside[role=doc-footnote]::footnote-marker {
+      content: counter(footnote);
+      font-size: 0.75em;
+      vertical-align: super;
+    }
+
+    a[role=doc-noteref] > sup,
+    aside[role=doc-footnote] > a[role=doc-backlink] {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <p>
+    Expected result: the footnote bodies "1 Aaaaaa" and "2 Bbbbbb" should appear once.
+    The final-page duplicate reference to fn1 must still render as "1".
+  </p>
+
+  <p>
+    Aaa<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a>
+    bbb<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.
+  </p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>Dummy text.</p>
+  <p>
+    Ccc aaa<a id="fnref1-1" href="#fn1" role="doc-noteref"><sup>1</sup></a>.
+    This second reference must be "1" and must not create another footnote body.
+  </p>
+
+  <aside id="fn1" role="doc-footnote">
+    <a href="#fnref1" role="doc-backlink"><sup>1</sup></a>Aaaaaa
+  </aside>
+  <aside id="fn2" role="doc-footnote">
+    <a href="#fnref2" role="doc-backlink"><sup>2</sup></a>Bbbbbb
+  </aside>
+</body>
+</html>

--- a/packages/core/test/files/footnotes/dpub-footnote-policy.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-policy.html
@@ -1,0 +1,88 @@
+<!-- Test case for Issue #1884: semantic footnote-policy comparison -->
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>DPUB footnotes with and without footnote-policy: line</title>
+    <style>
+      @page {
+        size: 500px 260px;
+        margin: 40px;
+
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+      }
+      :root {
+        font-size: 16px;
+        font-family: Arial, sans-serif;
+        line-height: 20px;
+        widows: 2;
+        orphans: 2;
+      }
+      body,
+      p,
+      section,
+      h1,
+      h2,
+      div {
+        margin: 0;
+      }
+      section + section {
+        break-before: page;
+      }
+      h1 {
+        font-size: 16px;
+        line-height: 20px;
+        margin-bottom: 10px;
+      }
+      h2 {
+        font-size: 16px;
+        line-height: 20px;
+        margin-bottom: 10px;
+      }
+      .expected {
+        font-style: italic;
+        min-block-size: 40px;
+      }
+      .spacer-no-policy {
+        block-size: 30px;
+      }
+      .spacer-policy {
+        block-size: 50px;
+      }
+      .policy-line {
+        footnote-policy: line;
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h1>DPUB footnote-policy test</h1>
+      <h2>Without footnote-policy: line</h2>
+      <p class="expected">
+        The anchor paragraph should stay on page 1 while only the footnote body moves to page 2.
+      </p>
+      <div class="spacer-no-policy"></div>
+      <p>Filler paragraph near the bottom of page 1.</p>
+      <p>
+        Anchor paragraph for footnote 1<a id="fnref1" href="#fn1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+      </p>
+      <p>Paragraph after the anchor should appear on the next page.</p>
+      <aside id="fn1" class="footnote" role="doc-footnote"><a href="#fnref1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>Footnote 1 should appear on page 2 while its anchor paragraph remains on page 1.</aside>
+    </section>
+    <section>
+      <h2>With footnote-policy: line</h2>
+      <p class="expected">
+        The anchor paragraph and the footnote body should both move to the next page together.
+      </p>
+      <div class="spacer-policy"></div>
+      <p>Filler paragraph near the bottom of the policy-line page.</p>
+      <p>
+        Anchor paragraph for footnote 2<a id="fnref2" href="#fn2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+      </p>
+      <p>Paragraph after the policy-line anchor should remain on the following page.</p>
+      <aside id="fn2" class="footnote policy-line" role="doc-footnote"><a href="#fnref2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Footnote 2 and its anchor paragraph should both move to the next page.</aside>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/footnotes/footnote-display.html
+++ b/packages/core/test/files/footnotes/footnote-display.html
@@ -72,6 +72,30 @@
       .footnote-display-compact .footnote {
         footnote-display: compact;
       }
+
+      .inline-author-separator {
+        color: #055;
+      }
+
+      .inline-author-separator .footnote {
+        footnote-display: inline;
+      }
+
+      .inline-author-separator .footnote::after {
+        content: "\3000";
+      }
+
+      .compact-no-separator {
+        color: #505;
+      }
+
+      .compact-no-separator .footnote {
+        footnote-display: compact;
+      }
+
+      .compact-no-separator .footnote::after {
+        content: none;
+      }
     </style>
   </head>
   <body>
@@ -114,6 +138,28 @@
         while the following short compact notes can still share a later line inline<span class="footnote">Short compact note.</span>
         and continue with another short compact note on that same line<span class="footnote">Another short note.</span>
         before a final longer compact note falls back to block again<span class="footnote">A longer trailing compact note that no longer fits as a single unbroken inline note.</span>.
+      </p>
+    </section>
+    <section class="inline-author-separator">
+      <h2>footnote-display: inline with author ::after separator</h2>
+      <p class="expected">
+        Author CSS for .footnote::after should replace the default space separator between inline footnotes.
+      </p>
+      <p>
+        Author CSS should be able to use an ideographic separator between inline footnotes<span class="footnote">First note.</span>
+        and keep using that author-defined separator for the next inline footnote<span class="footnote">Second note.</span>
+        instead of the default single ASCII space<span class="footnote">Third note.</span>.
+      </p>
+    </section>
+    <section class="compact-no-separator">
+      <h2>footnote-display: compact with author ::after none</h2>
+      <p class="expected">
+        Author CSS for .footnote::after should also be able to suppress the default separator entirely for compact inline footnotes.
+      </p>
+      <p>
+        Compact footnotes should allow the author to suppress separators entirely<span class="footnote">First compact note.</span>
+        so the next compact footnote follows with no generated gap<span class="footnote">Second compact note.</span>
+        and a third note also keeps that explicit no-separator behavior<span class="footnote">Third compact note.</span>.
       </p>
     </section>
   </body>

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -100,6 +100,75 @@ describe("css-validator", function () {
         return adapt_task.newResult(true);
       });
     });
+
+    it("should parse selector functions with a top-level cascade handler", function (done) {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      var handler = new adapt_csscasc.CascadeParserHandler(
+        null,
+        null,
+        null,
+        null,
+        null,
+        validatorSet,
+        true,
+      );
+      handler.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
+      var warnListener = jasmine.createSpy("warn listener");
+      vivliostyle_logging.logger.addListener(
+        vivliostyle_logging.LogLevel.WARN,
+        warnListener,
+      );
+      adapt_task.start(function () {
+        adapt_cssparse
+          .parseStylesheetFromText(
+            '@namespace epub "http://www.idpf.org/2007/ops";\n:not(a[epub|type~="noteref"], a[epub\\:type~="noteref"], a[role~="doc-noteref"])::footnote-call { content: counter(footnote); }',
+            handler,
+            null,
+            null,
+            null,
+          )
+          .then(function (result) {
+            expect(result).toBe(true);
+            expect(warnListener).not.toHaveBeenCalled();
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+    it("should parse semantic footnote noteref default selectors", function (done) {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      var handler = new adapt_csscasc.CascadeParserHandler(
+        null,
+        null,
+        null,
+        null,
+        null,
+        validatorSet,
+        true,
+      );
+      handler.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
+      var warnListener = jasmine.createSpy("warn listener");
+      vivliostyle_logging.logger.addListener(
+        vivliostyle_logging.LogLevel.WARN,
+        warnListener,
+      );
+      adapt_task.start(function () {
+        adapt_cssparse
+          .parseStylesheetFromText(
+            '@namespace epub "http://www.idpf.org/2007/ops";\na[epub|type="noteref"]:not(sup > *, :has(> sup)),\na[epub\\:type="noteref"]:not(sup > *, :has(> sup)),\na[role="doc-noteref"]:not(sup > *, :has(> sup)) { font-size: 0.75em; vertical-align: super; line-height: 0; }',
+            handler,
+            null,
+            null,
+            null,
+          )
+          .then(function (result) {
+            expect(result).toBe(true);
+            expect(warnListener).not.toHaveBeenCalled();
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
     it("should parse validator and space rule", function (done) {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();

--- a/packages/core/test/spec/vivliostyle/page-floats-spec.js
+++ b/packages/core/test/spec/vivliostyle/page-floats-spec.js
@@ -1496,6 +1496,67 @@ describe("page-floats", function () {
         expect(context.removePageFloatFragment).not.toHaveBeenCalled();
         expect(context.floatsDeferredToNext).toEqual([cont3, cont4]);
       });
+
+      it("forbids deferred line-policy footnotes on page contexts after the anchor appeared", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        spyOn(pageContext, "invalidate").and.callThrough();
+        var float = new PageFloat(
+          dummyNodePosition(),
+          FloatReference.PAGE,
+          "block-end",
+          null,
+          "body",
+        );
+        float.footnotePolicy = adapt_css.ident.line;
+        pageContext.addPageFloat(float);
+        var continuation = new PageFloatContinuation(float, {});
+        pageContext.floatsDeferredToNext = [continuation];
+        pageContext.footnoteAnchorsSeen.add(float.getId());
+
+        pageContext.finish();
+
+        expect(pageContext.isForbidden(float)).toBe(true);
+        expect(pageContext.floatsDeferredToNext).toEqual([]);
+        expect(pageContext.invalidate).toHaveBeenCalled();
+      });
+
+      it("does not forbid deferred line-policy footnotes on region contexts", function () {
+        var regionContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.REGION,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        spyOn(regionContext, "invalidate").and.callThrough();
+        var float = new PageFloat(
+          dummyNodePosition(),
+          FloatReference.REGION,
+          "block-end",
+          null,
+          "body",
+        );
+        float.footnotePolicy = adapt_css.ident.line;
+        regionContext.addPageFloat(float);
+        var continuation = new PageFloatContinuation(float, {});
+        regionContext.floatsDeferredToNext = [continuation];
+        regionContext.footnoteAnchorsSeen.add(float.getId());
+
+        regionContext.finish();
+
+        expect(regionContext.isForbidden(float)).toBe(false);
+        expect(regionContext.invalidate).not.toHaveBeenCalled();
+      });
     });
 
     describe("#invalidate", function () {


### PR DESCRIPTION
Support CSS GCPM footnote behavior on DPUB/EPUB semantic footnotes.

- apply footnote-display and footnote-policy to semantic footnotes
- support ::footnote-call and ::footnote-marker on semantic noteref/footnote pairs
- support display:inline and compact/inline separator behavior for semantic footnotes
- preserve author ::after overrides for inline and compact footnotes
- support list-style-position: outside for semantic ::footnote-marker
- keep duplicate semantic noteref references in sync with stored footnote counters
- add and consolidate regression tests for semantic footnote display, policy, marker rendering, duplicate references, and footnote area inheritance
- refactor semantic footnote helper logic into dedicated utilities

Closes #1884

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1884 (CSS footnote properties/pseudos for semantic footnotes); over an extended session, reported that `footnote-display`/`footnote-policy` weren't working yet, then, after a partial fix, asked why the AI's semantic outside-marker implementation didn't reuse the existing browser-`::marker`-based approach used elsewhere, redirecting it to match that pattern.
- The human author caught and directed fixes for numerous follow-on regressions found through careful manual testing: markers disappearing, UA-vs-author stylesheet handling of `::footnote-call/marker` needing a different mechanism (specified in detail), a missing element-name restriction that broke non-DPUB semantic footnotes with GCPM styling, a console error, CSS parser failures on complex UA selectors, incorrect noteref numbering on the final page, `em`-unit values not inheriting font-size correctly from the right ancestor in several distinct cases (traced with precise pixel-value reasoning), and inline/compact footnote separator spacing bugs.
- The human author asked for a broad refactoring/cleanup pass given the amount of iterative trial-and-error, requested targeted code comments and a module-level doc comment, and made several architecture decisions on where logic should live (e.g., keeping one helper in `css-cascade.ts` rather than moving it to `semantic-footnote.ts`).
- The human author ran a full layout-regression suite themselves confirming all diffs were expected improvements, directed the final commit type (`feat:`) and title, and ran `/address-pr-comments` across two rounds, including verifying via direct testing whether a Copilot-flagged concern was actually still reproducible.

</details>
