### PR TITLE
fix: preserve wrap opportunities between compact inline footnotes

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -39,6 +39,7 @@ import * as PageFloats from "./page-floats";
 import * as Plugin from "./plugin";
 import * as Matchers from "./matchers";
 import * as PseudoElement from "./pseudo-element";
+import * as SemanticFootnote from "./semantic-footnote";
 import * as Task from "./task";
 import * as Vgen from "./vgen";
 import * as VtreeImpl from "./vtree";
@@ -5290,9 +5291,25 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
 
   private hasAuthorFootnoteAfterPseudo(element: Element): boolean {
     const afterPseudo = this.getFootnoteAfterPseudo(element);
-    return (
+    if (
       !!afterPseudo &&
       !afterPseudo.hasAttribute("data-vivliostyle-default-footnote-separator")
+    ) {
+      return true;
+    }
+    const semanticFootnoteChild = Array.from(element.children).find(
+      (child) =>
+        child instanceof Element &&
+        SemanticFootnote.isSemanticFootnoteElement(child),
+    ) as Element | undefined;
+    const semanticAfterPseudo = semanticFootnoteChild
+      ? this.getFootnoteAfterPseudo(semanticFootnoteChild)
+      : null;
+    return (
+      !!semanticAfterPseudo &&
+      !semanticAfterPseudo.hasAttribute(
+        "data-vivliostyle-default-footnote-separator",
+      )
     );
   }
 
@@ -5303,6 +5320,19 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
     after.style.whiteSpace = "normal";
     after.textContent = " ";
     element.appendChild(after);
+  }
+
+  private getFootnoteBreakOpportunity(element: Element): HTMLElement | null {
+    const nextSibling = element.nextElementSibling;
+    return nextSibling?.hasAttribute("data-vivliostyle-footnote-break")
+      ? (nextSibling as HTMLElement)
+      : null;
+  }
+
+  private createFootnoteBreakOpportunity(element: HTMLElement): void {
+    const breakOpportunity = element.ownerDocument.createElement("wbr");
+    breakOpportunity.setAttribute("data-vivliostyle-footnote-break", "1");
+    element.insertAdjacentElement("afterend", breakOpportunity);
   }
 
   private updateInlineFootnoteSeparators(): void {
@@ -5323,16 +5353,28 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
       const isDefaultAfterPseudo = !!afterPseudo?.hasAttribute(
         "data-vivliostyle-default-footnote-separator",
       );
+      const breakOpportunity = this.getFootnoteBreakOpportunity(element);
       if (display === "inline" && nextDisplay === "inline") {
+        const needsDefaultSeparator = !afterPseudo && !authorAfterPseudoExists;
         // Insert the UA default only when the rendered footnote element
-        // itself does not already carry an author-defined ::after pseudo.
-        if (!afterPseudo && !authorAfterPseudoExists) {
+        // or its direct semantic footnote child does not already carry an
+        // author-defined ::after pseudo.
+        if (needsDefaultSeparator) {
           this.createDefaultFootnoteAfterPseudo(element);
+        }
+        // Author overrides can remove or replace the default separating space,
+        // which would otherwise remove the wrap opportunity between compact
+        // inline footnotes. Add an invisible break opportunity in that case.
+        if (!needsDefaultSeparator && !breakOpportunity) {
+          this.createFootnoteBreakOpportunity(element);
+        } else if (needsDefaultSeparator) {
+          breakOpportunity?.remove();
         }
       } else {
         if (isDefaultAfterPseudo) {
           afterPseudo.remove();
         }
+        breakOpportunity?.remove();
       }
     });
   }

--- a/packages/core/test/files/footnotes/dpub-footnote-display.html
+++ b/packages/core/test/files/footnotes/dpub-footnote-display.html
@@ -74,11 +74,11 @@
       }
 
       .inline-author-separator .footnote::after {
-        content: "\3000";
+        content: "|";
       }
 
       .compact-no-separator {
-        color: #505;
+        color: #a63a00;
       }
 
       .compact-no-separator .footnote {
@@ -90,7 +90,7 @@
       }
 
       .display-inline {
-        color: #606;
+        color: #005a8d;
       }
 
       .display-inline .footnote {
@@ -214,30 +214,30 @@
     <section class="inline-author-separator">
       <h2>footnote-display: inline with author ::after separator</h2>
       <p class="expected">
-        When author CSS sets .footnote::after content, that content should replace the default space separator between inline footnotes.
+        When author CSS sets .footnote::after content, that content should replace the default space separator between inline footnotes, and line breaks should still be allowed between adjacent footnotes even though the author separator is not whitespace.
       </p>
       <p>
-        Author CSS should be able to use an ideographic separator between inline semantic footnotes<a id="inline-author-ref-1" href="#inline-author-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
+        Author CSS should be able to use a visible non-space separator between inline semantic footnotes<a id="inline-author-ref-1" href="#inline-author-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
         and keep using that author-defined separator for the next inline footnote<a id="inline-author-ref-2" href="#inline-author-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
         instead of the default single ASCII space<a id="inline-author-ref-3" href="#inline-author-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
       </p>
-      <aside id="inline-author-note-1" class="footnote" role="doc-footnote"><a href="#inline-author-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First note.</aside>
-      <aside id="inline-author-note-2" class="footnote" role="doc-footnote"><a href="#inline-author-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second note.</aside>
-      <aside id="inline-author-note-3" class="footnote" role="doc-footnote"><a href="#inline-author-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Third note.</aside>
+      <aside id="inline-author-note-1" class="footnote" role="doc-footnote"><a href="#inline-author-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>AuthorSeparatorAlphaSegment.</aside>
+      <aside id="inline-author-note-2" class="footnote" role="doc-footnote"><a href="#inline-author-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>AuthorSeparatorBetaSegment.</aside>
+      <aside id="inline-author-note-3" class="footnote" role="doc-footnote"><a href="#inline-author-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>AuthorSeparatorGammaSegment.</aside>
     </section>
     <section class="compact-no-separator">
       <h2>footnote-display: compact with author ::after none</h2>
       <p class="expected">
-        When author CSS sets .footnote::after to none, compact inline footnotes should appear with no default separator inserted between them.
+        When author CSS sets .footnote::after to none, compact inline footnotes should appear with no default separator inserted between them, but adjacent compact notes should still be able to wrap between notes.
       </p>
       <p>
         Compact semantic footnotes should allow the author to suppress separators entirely<a id="compact-none-ref-1" href="#compact-none-note-1" class="footnote-ref" role="doc-noteref"><sup>1</sup></a>
-        so the next compact footnote follows with no generated gap<a id="compact-none-ref-2" href="#compact-none-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
+        so the next compact footnote follows with no generated gap yet can still move to the next line<a id="compact-none-ref-2" href="#compact-none-note-2" class="footnote-ref" role="doc-noteref"><sup>2</sup></a>
         and a third note also keeps that explicit no-separator behavior<a id="compact-none-ref-3" href="#compact-none-note-3" class="footnote-ref" role="doc-noteref"><sup>3</sup></a>.
       </p>
-      <aside id="compact-none-note-1" class="footnote" role="doc-footnote"><a href="#compact-none-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>First compact note.</aside>
-      <aside id="compact-none-note-2" class="footnote" role="doc-footnote"><a href="#compact-none-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>Second compact note.</aside>
-      <aside id="compact-none-note-3" class="footnote" role="doc-footnote"><a href="#compact-none-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>Third compact note.</aside>
+      <aside id="compact-none-note-1" class="footnote" role="doc-footnote"><a href="#compact-none-ref-1" class="footnote-back" role="doc-backlink"><sup>1</sup></a>CompactBreakAlphaSegment.</aside>
+      <aside id="compact-none-note-2" class="footnote" role="doc-footnote"><a href="#compact-none-ref-2" class="footnote-back" role="doc-backlink"><sup>2</sup></a>CompactBreakBetaSegment.</aside>
+      <aside id="compact-none-note-3" class="footnote" role="doc-footnote"><a href="#compact-none-ref-3" class="footnote-back" role="doc-backlink"><sup>3</sup></a>CompactBreakGammaSegment.</aside>
     </section>
     <section class="display-inline">
       <h2>display: inline</h2>


### PR DESCRIPTION
Ensure adjacent compact inline footnotes remain breakable even when author ::after overrides remove or replace the default separator.

- avoid duplicating the default separator on semantic footnote include wrappers
- add an invisible break opportunity between adjacent inline footnotes for author-override cases
- update the DPUB footnote display fixture to make the behavior visible

Follow-up to PR #1887 (Issue #1884) to cover remaining semantic footnote separator and test-fixture issues.

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- After PR #1887 merged, the human author found a remaining bug in the same test fixture (a default separator space appearing where an author override should have suppressed it) and asked the AI to investigate and fix it as a follow-up.
- The human author asked for further adjustments to test coloring and confirmed the fix before directing the commit message, framed as a follow-up to PR #1887.

</details>
