### PR TITLE
feat: Add CSS Nesting support

### DIFF
--- a/packages/core/src/vivliostyle/css-nesting.ts
+++ b/packages/core/src/vivliostyle/css-nesting.ts
@@ -1,0 +1,761 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @fileoverview CssNesting - CSS Nesting preprocessor.
+ */
+
+type StatementResult = {
+  statements: string[];
+  changed: boolean;
+};
+
+const LEGACY_PSEUDO_ELEMENTS = new Set([
+  "before",
+  "after",
+  "first-line",
+  "first-letter",
+]);
+
+const SUPPORTED_GROUP_RULES = new Set(["media", "supports", "-epubx-when"]);
+const DECLARATION_OR_BLOCK_TERMINATORS = new Set([";", "}"]);
+const RULE_HEADER_TERMINATORS = new Set(["{", ";", "}"]);
+const DECLARATION_START_TERMINATORS = new Set([";", "{", "}"]);
+
+const SCOPE_SELECTOR = ":where(:scope)";
+const NO_MATCH_SELECTOR = ":where(:not(*))";
+
+export function expandNesting(input: string): string {
+  const { statements, changed } = expandBlock(input, 0, input.length, null);
+  return changed ? statements.join("\n") : input;
+}
+
+function expandBlock(
+  input: string,
+  start: number,
+  end: number,
+  parentSelector: string | null,
+): StatementResult {
+  const statements: string[] = [];
+  const declarations: string[] = [];
+  let changed = false;
+  let index = start;
+
+  const flushDeclarations = () => {
+    if (declarations.length === 0) {
+      return;
+    }
+    if (parentSelector) {
+      statements.push(serializeRule(parentSelector, declarations));
+    } else {
+      statements.push(serializeDeclarations(declarations));
+    }
+    declarations.length = 0;
+  };
+
+  while (index < end) {
+    index = skipIgnorable(input, index, end);
+    if (index >= end || input[index] === "}") {
+      break;
+    }
+
+    if (input[index] === "@") {
+      flushDeclarations();
+      const atRule = readAtRule(input, index, end);
+      if (!atRule) {
+        break;
+      }
+      if (atRule.hasBlock && SUPPORTED_GROUP_RULES.has(atRule.name)) {
+        const inner = expandBlock(
+          input,
+          atRule.blockStart,
+          atRule.blockEnd,
+          parentSelector,
+        );
+        changed ||= inner.changed || parentSelector != null;
+        statements.push(
+          `${atRule.header} {${joinStatements(inner.statements)}}`,
+        );
+      } else {
+        statements.push(compactWhitespace(input.slice(index, atRule.end)));
+      }
+      index = atRule.end;
+      continue;
+    }
+
+    if (parentSelector && isDeclarationStart(input, index, end)) {
+      const declaration = readDeclaration(input, index, end);
+      if (!declaration) {
+        break;
+      }
+      declarations.push(compactWhitespace(declaration.text));
+      index = declaration.end;
+      continue;
+    }
+
+    flushDeclarations();
+    const rule = readStyleRule(input, index, end);
+    if (!rule) {
+      const raw = readUntilSemicolonOrBrace(input, index, end);
+      statements.push(compactWhitespace(raw.text));
+      index = raw.end;
+      continue;
+    }
+
+    const selector = parentSelector
+      ? expandNestedSelectorList(parentSelector, rule.prelude)
+      : replaceScopeAmpersands(rule.prelude);
+    if (selector) {
+      changed ||= parentSelector != null;
+      const inner = expandBlock(
+        input,
+        rule.blockStart,
+        rule.blockEnd,
+        selector,
+      );
+      changed ||= inner.changed;
+      if (inner.statements.length === 0) {
+        statements.push(`${selector} {}`);
+      } else {
+        statements.push(...inner.statements);
+      }
+    }
+    index = rule.end;
+  }
+
+  flushDeclarations();
+  return { statements, changed };
+}
+
+function serializeRule(selector: string, declarations: string[]): string {
+  return `${selector} { ${serializeDeclarations(declarations)} }`;
+}
+
+function serializeDeclarations(declarations: string[]): string {
+  return declarations
+    .map((declaration) =>
+      declaration.endsWith(";") ? declaration : `${declaration};`,
+    )
+    .join(" ");
+}
+
+function joinStatements(statements: string[]): string {
+  if (statements.length === 0) {
+    return "";
+  }
+  return ` ${statements.join(" ")} `;
+}
+
+function expandNestedSelectorList(
+  parentSelector: string,
+  prelude: string,
+): string | null {
+  const nestingSelector = makeNestingSelector(parentSelector);
+  if (!nestingSelector) {
+    return null;
+  }
+  const selectors = splitTopLevel(prelude, ",");
+  const expanded = selectors
+    .map((selector) => selector.trim())
+    .filter(Boolean)
+    .map((selector) => {
+      const replaced = replaceAmpersands(selector, nestingSelector);
+      if (replaced.found) {
+        return replaced.text;
+      }
+      return `${nestingSelector} ${selector}`;
+    })
+    .filter(Boolean);
+  if (expanded.length === 0) {
+    return null;
+  }
+  return expanded.join(", ");
+}
+
+export function replaceScopeAmpersands(selector: string): string {
+  return replaceAmpersands(selector.trim(), SCOPE_SELECTOR).text;
+}
+
+function makeNestingSelector(parentSelector: string): string | null {
+  const selectors = splitTopLevel(parentSelector, ",")
+    .map((selector) => selector.trim())
+    .filter(Boolean)
+    .filter((selector) => !containsPseudoElement(selector));
+  if (selectors.length === 0) {
+    return null;
+  }
+  return `:is(${selectors.join(", ")})`;
+}
+
+function containsPseudoElement(selector: string): boolean {
+  let index = 0;
+  while (index < selector.length) {
+    const escaped = skipEscapedCodePoint(selector, index);
+    if (escaped != null) {
+      index = escaped;
+      continue;
+    }
+    const skipped = skipQuotedStringOrComment(selector, index, selector.length);
+    if (skipped != null) {
+      index = skipped;
+      continue;
+    }
+    const char = selector[index];
+    if (char === ":") {
+      if (selector[index + 1] === ":") {
+        return true;
+      }
+      const identStart = index + 1;
+      const identEnd = readName(selector, identStart, selector.length);
+      const ident = selector.slice(identStart, identEnd).toLowerCase();
+      if (LEGACY_PSEUDO_ELEMENTS.has(ident)) {
+        return true;
+      }
+      index = identEnd;
+      continue;
+    }
+    index++;
+  }
+  return false;
+}
+
+function replaceAmpersands(
+  selector: string,
+  replacement: string,
+): { text: string; found: boolean } {
+  let index = 0;
+  let found = false;
+  let result = "";
+  const functionStack: string[] = [];
+  const replacementContainsHas = containsHasPseudoClass(replacement);
+  while (index < selector.length) {
+    const escaped = skipEscapedCodePoint(selector, index);
+    if (escaped != null) {
+      result += selector.slice(index, escaped);
+      index = escaped;
+      continue;
+    }
+    const skipped = skipQuotedStringOrComment(selector, index, selector.length);
+    if (skipped != null) {
+      result += selector.slice(index, skipped);
+      index = skipped;
+      continue;
+    }
+    const char = selector[index];
+    if (char === ":" && selector[index + 1] !== ":") {
+      const identStart = index + 1;
+      const identEnd = readName(selector, identStart, selector.length);
+      if (identEnd > identStart && selector[identEnd] === "(") {
+        functionStack.push(selector.slice(identStart, identEnd).toLowerCase());
+        result += selector.slice(index, identEnd + 1);
+        index = identEnd + 1;
+        continue;
+      }
+    }
+    if (char === "(") {
+      functionStack.push("");
+      result += char;
+      index++;
+      continue;
+    }
+    if (char === ")") {
+      functionStack.pop();
+      result += char;
+      index++;
+      continue;
+    }
+    if (char === "&") {
+      result +=
+        replacementContainsHas && functionStack.includes("has")
+          ? NO_MATCH_SELECTOR
+          : replacement;
+      found = true;
+      index++;
+      continue;
+    }
+    result += char;
+    index++;
+  }
+  return { text: result, found };
+}
+
+function containsHasPseudoClass(selector: string): boolean {
+  let index = 0;
+  while (index < selector.length) {
+    const escaped = skipEscapedCodePoint(selector, index);
+    if (escaped != null) {
+      index = escaped;
+      continue;
+    }
+    const skipped = skipQuotedStringOrComment(selector, index, selector.length);
+    if (skipped != null) {
+      index = skipped;
+      continue;
+    }
+    const char = selector[index];
+    if (char === ":" && selector[index + 1] !== ":") {
+      const identStart = index + 1;
+      const identEnd = readName(selector, identStart, selector.length);
+      if (
+        identEnd > identStart &&
+        selector.slice(identStart, identEnd).toLowerCase() === "has" &&
+        selector[identEnd] === "("
+      ) {
+        return true;
+      }
+      index = identEnd;
+      continue;
+    }
+    index++;
+  }
+  return false;
+}
+
+function splitTopLevel(input: string, separator: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let index = 0;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  while (index < input.length) {
+    const escaped = skipEscapedCodePoint(input, index);
+    if (escaped != null) {
+      index = escaped;
+      continue;
+    }
+    const skipped = skipQuotedStringOrComment(input, index, input.length);
+    if (skipped != null) {
+      index = skipped;
+      continue;
+    }
+    const char = input[index];
+    switch (char) {
+      case "(":
+        parenDepth++;
+        break;
+      case ")":
+        parenDepth = Math.max(0, parenDepth - 1);
+        break;
+      case "[":
+        bracketDepth++;
+        break;
+      case "]":
+        bracketDepth = Math.max(0, bracketDepth - 1);
+        break;
+      default:
+        if (parenDepth === 0 && bracketDepth === 0 && char === separator) {
+          parts.push(input.slice(start, index));
+          start = index + 1;
+        }
+        break;
+    }
+    index++;
+  }
+  parts.push(input.slice(start));
+  return parts;
+}
+
+function isDeclarationStart(
+  input: string,
+  start: number,
+  end: number,
+): boolean {
+  const identStart = start;
+  const identEnd = readPropertyName(input, identStart, end);
+  if (identEnd <= identStart) {
+    return false;
+  }
+  const colonIndex = skipIgnorable(input, identEnd, end);
+  if (colonIndex >= end || input[colonIndex] !== ":") {
+    return false;
+  }
+  if (input[start] === "-" && input[start + 1] === "-") {
+    return true;
+  }
+  const terminator = findTopLevelTerminator(
+    input,
+    colonIndex + 1,
+    end,
+    DECLARATION_START_TERMINATORS,
+  );
+  return !terminator || terminator.char !== "{";
+}
+
+function readPropertyName(input: string, start: number, end: number): number {
+  let index = start;
+  if (input[index] === "-") {
+    index++;
+    if (index < end && input[index] === "-") {
+      index++;
+    }
+  }
+  return readName(input, index, end);
+}
+
+function readName(input: string, start: number, end: number): number {
+  let index = start;
+  while (index < end) {
+    const char = input[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (!/[0-9A-Za-z_-]/.test(char)) {
+      break;
+    }
+    index++;
+  }
+  return index;
+}
+
+function readDeclaration(
+  input: string,
+  start: number,
+  end: number,
+): { text: string; end: number } | null {
+  const result = findTopLevelTerminator(
+    input,
+    start,
+    end,
+    DECLARATION_OR_BLOCK_TERMINATORS,
+  );
+  if (!result) {
+    const text = input.slice(start, end).trim();
+    if (!text) {
+      return null;
+    }
+    return {
+      text,
+      end,
+    };
+  }
+  const declarationEnd = result.char === ";" ? result.index + 1 : result.index;
+  return {
+    text: input.slice(start, declarationEnd).trim(),
+    end: declarationEnd,
+  };
+}
+
+function readStyleRule(
+  input: string,
+  start: number,
+  end: number,
+): {
+  prelude: string;
+  blockStart: number;
+  blockEnd: number;
+  end: number;
+} | null {
+  const header = findTopLevelTerminator(
+    input,
+    start,
+    end,
+    RULE_HEADER_TERMINATORS,
+  );
+  if (!header || header.char !== "{") {
+    return null;
+  }
+  const blockEnd = findMatchingBrace(input, header.index, end);
+  if (blockEnd < 0) {
+    return null;
+  }
+  return {
+    prelude: compactWhitespace(input.slice(start, header.index)),
+    blockStart: header.index + 1,
+    blockEnd,
+    end: blockEnd + 1,
+  };
+}
+
+function readAtRule(
+  input: string,
+  start: number,
+  end: number,
+): {
+  name: string;
+  header: string;
+  hasBlock: boolean;
+  blockStart: number;
+  blockEnd: number;
+  end: number;
+} | null {
+  const header = findTopLevelTerminator(
+    input,
+    start,
+    end,
+    RULE_HEADER_TERMINATORS,
+  );
+  if (!header) {
+    return null;
+  }
+  const nameEnd = readName(input, start + 1, end);
+  const name = input.slice(start + 1, nameEnd).toLowerCase();
+  const headerText = compactWhitespace(input.slice(start, header.index));
+  if (header.char !== "{") {
+    return {
+      name,
+      header: headerText,
+      hasBlock: false,
+      blockStart: -1,
+      blockEnd: -1,
+      end: header.index + (header.char === ";" ? 1 : 0),
+    };
+  }
+  const blockEnd = findMatchingBrace(input, header.index, end);
+  if (blockEnd < 0) {
+    return null;
+  }
+  return {
+    name,
+    header: headerText,
+    hasBlock: true,
+    blockStart: header.index + 1,
+    blockEnd,
+    end: blockEnd + 1,
+  };
+}
+
+function readUntilSemicolonOrBrace(
+  input: string,
+  start: number,
+  end: number,
+): { text: string; end: number } {
+  const result = findTopLevelTerminator(
+    input,
+    start,
+    end,
+    DECLARATION_OR_BLOCK_TERMINATORS,
+  );
+  if (!result) {
+    return { text: input.slice(start, end), end };
+  }
+  const sliceEnd = result.char === ";" ? result.index + 1 : result.index;
+  return { text: input.slice(start, sliceEnd), end: sliceEnd };
+}
+
+function findTopLevelTerminator(
+  input: string,
+  start: number,
+  end: number,
+  terminators: Set<string>,
+): { index: number; char: string } | null {
+  let index = start;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  while (index < end) {
+    const skipped = skipQuotedStringOrComment(input, index, end);
+    if (skipped != null) {
+      index = skipped;
+      continue;
+    }
+    const char = input[index];
+    switch (char) {
+      case "(":
+        parenDepth++;
+        break;
+      case ")":
+        parenDepth = Math.max(0, parenDepth - 1);
+        break;
+      case "[":
+        bracketDepth++;
+        break;
+      case "]":
+        bracketDepth = Math.max(0, bracketDepth - 1);
+        break;
+      case "{":
+        if (
+          parenDepth === 0 &&
+          bracketDepth === 0 &&
+          braceDepth === 0 &&
+          terminators.has(char)
+        ) {
+          return { index, char };
+        }
+        braceDepth++;
+        break;
+      case "}":
+        if (
+          parenDepth === 0 &&
+          bracketDepth === 0 &&
+          braceDepth === 0 &&
+          terminators.has(char)
+        ) {
+          return { index, char };
+        }
+        braceDepth = Math.max(0, braceDepth - 1);
+        break;
+      default:
+        if (
+          parenDepth === 0 &&
+          bracketDepth === 0 &&
+          braceDepth === 0 &&
+          terminators.has(char)
+        ) {
+          return { index, char };
+        }
+        break;
+    }
+    index++;
+  }
+  return null;
+}
+
+function findMatchingBrace(
+  input: string,
+  openIndex: number,
+  end: number,
+): number {
+  let index = openIndex + 1;
+  let depth = 1;
+  while (index < end) {
+    const skipped = skipQuotedStringOrComment(input, index, end);
+    if (skipped != null) {
+      index = skipped;
+      continue;
+    }
+    const char = input[index];
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth === 0) {
+        return index;
+      }
+    }
+    index++;
+  }
+  return -1;
+}
+
+function skipIgnorable(input: string, start: number, end: number): number {
+  let index = start;
+  while (index < end) {
+    const char = input[index];
+    if (isCssWhitespace(char)) {
+      index++;
+      continue;
+    }
+    if (char === "/" && input[index + 1] === "*") {
+      index = skipComment(input, index, end);
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function skipComment(input: string, start: number, end: number): number {
+  const closeIndex = input.indexOf("*/", start + 2);
+  if (closeIndex < 0 || closeIndex + 2 > end) {
+    return end;
+  }
+  return closeIndex + 2;
+}
+
+function skipQuotedStringOrComment(
+  input: string,
+  start: number,
+  end: number,
+): number | null {
+  const char = input[start];
+  if (char === '"' || char === "'") {
+    return skipString(input, start);
+  }
+  if (char === "/" && input[start + 1] === "*") {
+    return skipComment(input, start, end);
+  }
+  return null;
+}
+
+function skipEscapedCodePoint(input: string, start: number): number | null {
+  if (input[start] !== "\\") {
+    return null;
+  }
+  if (start + 1 >= input.length) {
+    return input.length;
+  }
+  return start + 2;
+}
+
+function skipString(input: string, start: number): number {
+  const quote = input[start];
+  let index = start + 1;
+  while (index < input.length) {
+    const char = input[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (char === quote) {
+      return index + 1;
+    }
+    index++;
+  }
+  return input.length;
+}
+
+function isCssWhitespace(char: string): boolean {
+  return (
+    char === " " ||
+    char === "\n" ||
+    char === "\r" ||
+    char === "\t" ||
+    char === "\f"
+  );
+}
+
+function compactWhitespace(text: string): string {
+  let result = "";
+  let index = 0;
+  let pendingSpace = false;
+
+  while (index < text.length) {
+    const skipped = skipQuotedStringOrComment(text, index, text.length);
+    if (skipped != null && text[index] !== "/") {
+      if (pendingSpace && result.length > 0) {
+        result += " ";
+        pendingSpace = false;
+      }
+      result += text.slice(index, skipped);
+      index = skipped;
+      continue;
+    }
+
+    if (skipped != null) {
+      pendingSpace = result.length > 0;
+      index = skipped;
+      continue;
+    }
+
+    const char = text[index];
+
+    if (isCssWhitespace(char)) {
+      pendingSpace = result.length > 0;
+      index++;
+      continue;
+    }
+
+    if (pendingSpace && result.length > 0) {
+      result += " ";
+      pendingSpace = false;
+    }
+
+    result += char;
+    index++;
+  }
+
+  return result;
+}

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -20,6 +20,7 @@
  */
 import * as Base from "./base";
 import * as Css from "./css";
+import { expandNesting } from "./css-nesting";
 import * as CssTokenizer from "./css-tokenizer";
 import * as Exprs from "./exprs";
 import * as Logging from "./logging";
@@ -763,6 +764,7 @@ export const OP_MEDIA_NOT: number = TokenType.LAST + 3;
   actionsErrorDecl[TokenType.C_PAR] = Action.ERROR_POP;
   actionsErrorDecl[TokenType.SEMICOL] = Action.ERROR_SEMICOL;
   actionsErrorSelector[TokenType.EOF] = Action.DONE;
+  actionsErrorSelector[TokenType.COMMA] = Action.ERROR_SEMICOL;
   actionsErrorSelector[TokenType.O_BRC] = Action.ERROR_PUSH;
   actionsErrorSelector[TokenType.C_BRC] = Action.ERROR_POP;
   actionsErrorSelector[TokenType.O_BRK] = Action.ERROR_PUSH;
@@ -1198,6 +1200,28 @@ export class Parser {
           break;
         default:
           return arr;
+      }
+      this.tokenizer.consume();
+    }
+  }
+
+  skipPseudoFunctionContents(): boolean {
+    let depth = 0;
+    while (true) {
+      const token = this.tokenizer.token();
+      switch (token.type) {
+        case TokenType.EOF:
+          return false;
+        case TokenType.C_PAR:
+          if (depth === 0) {
+            return true;
+          }
+          depth--;
+          break;
+        case TokenType.O_PAR:
+        case TokenType.FUNC:
+          depth++;
+          break;
       }
       this.tokenizer.consume();
     }
@@ -1777,8 +1801,10 @@ export class Parser {
                     break;
                   }
                 default:
-                  // TODO
-                  params = this.readPseudoParams();
+                  params = [];
+                  if (!this.skipPseudoFunctionContents()) {
+                    break pseudoclassType;
+                  }
               }
               token = tokenizer.token();
               if (token.type == TokenType.C_PAR) {
@@ -2668,6 +2694,17 @@ export class Parser {
           tokenizer.consume();
           continue;
         case Action.ERROR_SEMICOL:
+          if (
+            parsingFunctionParam &&
+            this.errorBrackets.length == 0 &&
+            token.type == TokenType.COMMA
+          ) {
+            handler.nextSelector();
+            this.actions = actionsSelectorStart;
+            selectorStartPosition = token.position + 1;
+            tokenizer.consume();
+            continue;
+          }
           if (this.errorBrackets.length == 0) {
             this.actions = actionsBase;
           }
@@ -2684,6 +2721,57 @@ export class Parser {
             return false;
           }
           if (parsingFunctionParam) {
+            if (this.actions === actionsErrorSelector) {
+              switch (token.type) {
+                case TokenType.COMMA:
+                  if (this.errorBrackets.length == 0) {
+                    handler.nextSelector();
+                    selectorStartPosition = token.position + 1;
+                    this.actions = actionsSelectorStart;
+                  }
+                  tokenizer.consume();
+                  continue;
+                case TokenType.C_PAR:
+                  if (this.errorBrackets.length == 0) {
+                    handler.endFuncWithSelector();
+                    tokenizer.consume();
+                    return true;
+                  }
+                  if (
+                    this.errorBrackets.length > 0 &&
+                    this.errorBrackets[this.errorBrackets.length - 1] ==
+                      token.type
+                  ) {
+                    this.errorBrackets.pop();
+                  }
+                  tokenizer.consume();
+                  continue;
+                case TokenType.O_BRC:
+                case TokenType.O_BRK:
+                case TokenType.O_PAR:
+                  this.errorBrackets.push(token.type + 1);
+                  tokenizer.consume();
+                  continue;
+                case TokenType.FUNC:
+                  this.errorBrackets.push(TokenType.C_PAR);
+                  tokenizer.consume();
+                  continue;
+                case TokenType.C_BRC:
+                case TokenType.C_BRK:
+                  if (
+                    this.errorBrackets.length > 0 &&
+                    this.errorBrackets[this.errorBrackets.length - 1] ==
+                      token.type
+                  ) {
+                    this.errorBrackets.pop();
+                  }
+                  tokenizer.consume();
+                  continue;
+                default:
+                  tokenizer.consume();
+                  continue;
+              }
+            }
             switch (token.type) {
               case TokenType.COMMA:
               case TokenType.C_PAR:
@@ -2800,6 +2888,33 @@ export class ErrorHandler extends ParserHandler {
 }
 
 export function parseStylesheet(
+  tokenizer: CssTokenizer.Tokenizer,
+  handler: ParserHandler,
+  baseURL: string,
+  classes: string | null,
+  media: string | null,
+): Task.Result<boolean> {
+  const parserHandler = normalizeParserHandler(handler);
+  const expandedText = expandNesting(tokenizer.input);
+  if (expandedText !== tokenizer.input) {
+    return parseStylesheetInternal(
+      new CssTokenizer.Tokenizer(expandedText, parserHandler),
+      parserHandler,
+      baseURL,
+      classes,
+      media,
+    );
+  }
+  return parseStylesheetInternal(
+    tokenizer,
+    parserHandler,
+    baseURL,
+    classes,
+    media,
+  );
+}
+
+function parseStylesheetInternal(
   tokenizer: CssTokenizer.Tokenizer,
   handler: ParserHandler,
   baseURL: string,

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -31,6 +31,7 @@ import * as Counters from "./counters";
 import * as CounterStyle from "./counter-style";
 import * as Css from "./css";
 import * as CssCascade from "./css-cascade";
+import { replaceScopeAmpersands } from "./css-nesting";
 import * as CssParser from "./css-parser";
 import * as CssProp from "./css-prop";
 import * as CssStyler from "./css-styler";
@@ -625,8 +626,18 @@ export class StyleInstance
    * @returns true if selectorText is supported selector
    */
   private evalSupportsSelector(selectorText: string): boolean {
-    const sph = new StyleParserHandler(null);
-    const tokenizer = new CssTokenizer.Tokenizer(selectorText + "{}", sph);
+    class SilentStyleParserHandler extends StyleParserHandler {
+      override errorMsg(
+        ..._args: Parameters<StyleParserHandler["errorMsg"]>
+      ): void {}
+    }
+
+    const sph = new SilentStyleParserHandler(null);
+    const normalizedSelectorText = replaceScopeAmpersands(selectorText);
+    const tokenizer = new CssTokenizer.Tokenizer(
+      normalizedSelectorText + "{}",
+      sph,
+    );
     const parser = new CssParser.Parser(
       CssParser.actionsBase,
       tokenizer,

--- a/packages/core/test/files/css-nesting-basic.html
+++ b/packages/core/test/files/css-nesting-basic.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1032: CSS Nesting basic selectors and mixed declarations -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS Nesting Basic</title>
+    <style>
+      @page {
+        size: 160mm 120mm;
+        margin: 10mm;
+      }
+
+      body {
+        font: 16px/1.4 Georgia, serif;
+      }
+
+      .note {
+        margin: 0 0 8mm;
+      }
+
+      .card {
+        color: #000;
+        margin: 0 0 6mm;
+        padding: 4mm;
+        border: 1px solid #555;
+        background: #f3f3f3;
+
+        .child {
+          color: green;
+          font-weight: 700;
+        }
+
+        &:hover {
+          color: #000;
+        }
+
+        .wrap & {
+          border-color: green;
+        }
+
+        @media print {
+          background: #dff6df;
+
+          .grandchild {
+            color: green;
+          }
+        }
+
+        background-image: linear-gradient(#dff6df, #dff6df);
+        background-repeat: no-repeat;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="note">Tests pass if the texts below are green and the card border/background are green-tinted.</p>
+    <div class="wrap">
+      <section class="card">
+        <div class="child">Nested descendant selector</div>
+        <div class="grandchild">Nested conditional selector</div>
+      </section>
+    </div>
+  </body>
+  </html>

--- a/packages/core/test/files/css-nesting-conditionals.html
+++ b/packages/core/test/files/css-nesting-conditionals.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1032: CSS Nesting nested @media and @supports adapted from WPT -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS Nesting Conditionals</title>
+    <style>
+      @page {
+        size: 160mm 120mm;
+        margin: 10mm;
+      }
+
+      body {
+        font: 16px/1.4 Georgia, serif;
+      }
+
+      .row {
+        margin: 0 0 4mm;
+      }
+
+      .test {
+        background-color: red;
+        width: 26mm;
+        height: 26mm;
+        display: inline-grid;
+        margin-right: 4mm;
+      }
+
+      .test-nested-rule > div {
+        width: 100%;
+        height: 100%;
+        background-color: red;
+      }
+
+      .test-media {
+        @media print {
+          background-color: green;
+        }
+      }
+
+      .test-supports {
+        @supports (display: grid) {
+          background-color: green;
+        }
+      }
+
+      .test-nested-rule {
+        @media print {
+          & > div {
+            background-color: green;
+          }
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <p>Tests pass if all three boxes are green.</p>
+    <div class="row">
+      <div class="test test-media"></div>
+      <div class="test test-supports"></div>
+      <div class="test test-nested-rule"><div></div></div>
+    </div>
+  </body>
+  </html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -71,6 +71,14 @@ module.exports = [
       },
       { file: "nth_selectors.html", title: "nth selectors" },
       { file: "empty_selector.html", title: "empty selector" },
+      {
+        file: "css-nesting-basic.html",
+        title: "CSS Nesting basic (Issue #1032)",
+      },
+      {
+        file: "css-nesting-conditionals.html",
+        title: "CSS Nesting conditionals (Issue #1032)",
+      },
       { file: "ui_state_selectors.html", title: "UI state selectors" },
       { file: "not-pseudo-selector.html", title: ":not pseudo selector" },
       { file: "math-sample.html", title: "MathJax" },

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -16,6 +16,7 @@
  */
 
 import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
+import * as adapt_cssnesting from "../../../src/vivliostyle/css-nesting";
 import * as adapt_csstok from "../../../src/vivliostyle/css-tokenizer";
 import * as adapt_task from "../../../src/vivliostyle/task";
 
@@ -28,6 +29,7 @@ describe("css-parser", function () {
       spyOn(handler, "pseudoclassSelector");
       spyOn(handler, "startFuncWithSelector");
       spyOn(handler, "endFuncWithSelector");
+      spyOn(handler, "pushSelectorText");
       spyOn(handler, "pseudoelementSelector");
     });
 
@@ -45,6 +47,168 @@ describe("css-parser", function () {
         return adapt_task.newResult(true);
       });
     }
+
+    describe("css nesting", function () {
+      it("expands nested selectors using :is() semantics", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            ".foo, #bar { > .baz, &.qux { color: red; } }",
+          ),
+        ).toBe(":is(.foo, #bar) > .baz, :is(.foo, #bar).qux { color: red; }");
+      });
+
+      it("keeps mixed declarations ordered around nested rules", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            ".foo, .foo::before { color: black; @media screen { color: white; } background: silver; }",
+          ),
+        ).toBe(
+          ".foo, .foo::before { color: black; }\n@media screen { .foo, .foo::before { color: white; } }\n.foo, .foo::before { background: silver; }",
+        );
+      });
+
+      it("wraps complex parent selectors with :is() when replacing &", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            "span > b { .test-4 section > & { color: red; } }",
+          ),
+        ).toBe(".test-4 section > :is(span > b) { color: red; }");
+      });
+
+      it("wraps compound-position ampersands with :is()", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            "div.test-14 { div& { color: green; } }",
+          ),
+        ).toBe("div:is(div.test-14) { color: green; }");
+      });
+
+      it("does not turn nested :has() replacements into matching selectors", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            "li:has(strong) { :has(> &) { background: red; } }",
+          ),
+        ).toBe(":has(> :where(:not(*))) { background: red; }");
+      });
+
+      it("parses nested rules without reporting syntax errors", function (done) {
+        spyOn(handler, "property");
+        parse(done, ".foo { .bar { color: red; } }", function () {
+          expect(handler.error).not.toHaveBeenCalled();
+          expect(handler.property).toHaveBeenCalled();
+          expect(handler.property.calls.mostRecent().args[0]).toBe("color");
+          expect(handler.property.calls.mostRecent().args[2]).toBe(false);
+        });
+      });
+
+      it("parses forgiving nested selectors with unknown functions", function (done) {
+        parse(
+          done,
+          ".does-not-exist { :is(.test-2, :unknown(div,&)) { color: green; } }",
+          function () {
+            expect(handler.error).not.toHaveBeenCalled();
+          },
+        );
+      });
+
+      it("captures recovered :has selector text after invalid selector items", function (done) {
+        parse(done, ".foo:has(!, > .bar) {}", function () {
+          var selectorTexts = handler.pushSelectorText.calls
+            .allArgs()
+            .map(function (args) {
+              return args[0].trim();
+            });
+          expect(selectorTexts).toContain("> .bar");
+          expect(
+            selectorTexts.some(function (text) {
+              return text.indexOf("!") >= 0;
+            }),
+          ).toBe(false);
+        });
+      });
+
+      it("preserves invalid forgiving items during expansion", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            ".does-not-exist { :is(.test-1, !&) { color: green; } }",
+          ),
+        ).toBe(":is(.test-1, !:is(.does-not-exist)) { color: green; }");
+      });
+
+      it("does not replace escaped ampersands in nested selectors", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            ".foo { .bar\\&baz { color: green; } }",
+          ),
+        ).toBe(":is(.foo) .bar\\&baz { color: green; }");
+      });
+
+      it("does not split selector lists on escaped commas", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            ".foo { .bar\\,.baz { color: green; } }",
+          ),
+        ).toBe(":is(.foo) .bar\\,.baz { color: green; }");
+      });
+
+      it("returns declaration-only stylesheets unchanged", function () {
+        expect(adapt_cssnesting.expandNesting("ul { background: green }")).toBe(
+          "ul { background: green }",
+        );
+      });
+
+      it("returns simple non-nested rules unchanged", function () {
+        expect(adapt_cssnesting.expandNesting("h1 { color: blue }")).toBe(
+          "h1 { color: blue }",
+        );
+      });
+
+      it("preserves ideographic spaces inside string literals during expansion", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            '.toc::after { content: target-text(attr(href url), before) "　" target-text(attr(href url), content); }',
+          ),
+        ).toBe(
+          '.toc::after { content: target-text(attr(href url), before) "　" target-text(attr(href url), content); }',
+        );
+      });
+
+      it("preserves ASCII whitespace inside string literals during expansion", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            '.label::after { content: "  spaced   text  "; }',
+          ),
+        ).toBe('.label::after { content: "  spaced   text  "; }');
+      });
+
+      it("still expands nested rules with semicolonless declarations", function () {
+        expect(
+          adapt_cssnesting.expandNesting(
+            ".foo { color: blue; .bar { background: green } }",
+          ),
+        ).toBe(".foo { color: blue; }\n:is(.foo) .bar { background: green; }");
+      });
+
+      it("parses semicolonless declarations after preprocessing", function (done) {
+        spyOn(handler, "property");
+        parse(done, "ul { background: green }", function () {
+          expect(handler.error).not.toHaveBeenCalled();
+          expect(handler.property).toHaveBeenCalled();
+          expect(handler.property.calls.mostRecent().args[0]).toBe(
+            "background",
+          );
+        });
+      });
+
+      it("parses simple semicolonless declarations after preprocessing", function (done) {
+        spyOn(handler, "property");
+        parse(done, "h1 { color: blue }", function () {
+          expect(handler.error).not.toHaveBeenCalled();
+          expect(handler.property).toHaveBeenCalled();
+          expect(handler.property.calls.mostRecent().args[0]).toBe("color");
+        });
+      });
+    });
 
     describe("pseudoclass", function () {
       describe(":lang", function () {

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -22,6 +22,56 @@ import * as adapt_task from "../../../src/vivliostyle/task";
 import * as vivliostyle_logging from "../../../src/vivliostyle/logging";
 
 describe("css-validator", function () {
+  function parseCascade(cssText, done, callback) {
+    var handler = new adapt_csscasc.CascadeParserHandler(
+      null,
+      null,
+      null,
+      null,
+      null,
+      adapt_cssvalid.baseValidatorSet(),
+      true,
+    );
+    handler.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
+    adapt_task.start(function () {
+      adapt_cssparse
+        .parseStylesheetFromText(cssText, handler, null, null, null)
+        .then(function (result) {
+          expect(result).toBe(true);
+          callback(handler.finish());
+          done();
+        });
+      return adapt_task.newResult(true);
+    });
+  }
+
+  describe("background shorthand regression", function () {
+    it("keeps color in cascade for a semicolonless declaration", function (done) {
+      parseCascade("h1 { color: blue }", done, function (cascade) {
+        expect(cascade.tags.h1).toBeDefined();
+        expect(cascade.tags.h1.style.color).toBeDefined();
+      });
+    });
+
+    it("keeps background-color in cascade for a semicolonless declaration", function (done) {
+      parseCascade("ul { background: green }", done, function (cascade) {
+        expect(cascade.tags.ul).toBeDefined();
+        expect(cascade.tags.ul.style["background-color"]).toBeDefined();
+      });
+    });
+
+    it("keeps background-color in cascade when semicolonless declarations precede nested rules", function (done) {
+      parseCascade(
+        "ul { background: green } li:has(strong) { display: none; :has(> &) { background: red; } }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.ul).toBeDefined();
+          expect(cascade.tags.ul.style["background-color"]).toBeDefined();
+        },
+      );
+    });
+  });
+
   describe("ValidatorSet", function () {
     it("should parse simple validator and simple rule", function (done) {
       var validatorSet = new adapt_cssvalid.ValidatorSet();


### PR DESCRIPTION
Preprocess nested rules before parsing to support CSS Nesting Module in Vivliostyle core.

Closes #1032

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to add CSS Nesting Module (`https://www.w3.org/TR/css-nesting-1/`) support to the CSS parser, specifying the implementation scope in detail: implement the full spec, but for nesting of at-rules (§3.3, "Nesting Other At-Rules") only support the at-rules Vivliostyle.js already supports, deferring nesting support for `@container`/`@layer`/`@scope` until those at-rules themselves are implemented. The human author also specified the test strategy: use WPT's `css/css-nesting` test suite, noting that only its ref-tests (files with a matching `*-ref.html`) are directly usable as Vivliostyle.js test cases (since most WPT nesting tests require JS execution), and asked for additional coverage in both the core spec tests (`packages/core/test/spec/vivliostyle/`) and the layout regression test files (`packages/core/test/files/`).
- The human author manually tested against WPT `css/css-nesting` tests in the viewer across several rounds and reported failures (including `has-nesting.html`), while also confirming that some warnings the AI flagged (e.g. for `!&` and `:unknown(div,&)` in `nest-containing-forgiving.html`) were correct per spec rather than bugs.
- The human author caught two real regressions during testing — a parse failure when a declaration was missing its trailing semicolon, and a broader regression where simple non-nested rules (`h1 { color: blue }`) stopped applying — confirming both against the pre-change canary build before asking the AI to fix them.
- The human author found one more real rendering regression (`target-text.html` page 7, a lost U+3000 ideographic space in generated `content`) while separately confirming an unrelated leader-spacing difference was not a regression, then asked the AI to add a copyright header to the new file and refactor any duplicated/redundant parsing logic before requesting a commit message and running `/address-pr-comments` twice.

</details>
