### PR TITLE
fix: fix footnote fragmentation after moving multicol call

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -251,9 +251,17 @@ export function hasNonRootMultiColumnStyle(element: Element): boolean {
  * non-root multi-column layout (via inline style).
  */
 export function containsNonRootMultiColumn(element: Element): boolean {
-  if (hasNonRootMultiColumnStyle(element)) return true;
+  if (
+    !element.hasAttribute("data-vivliostyle-column") &&
+    hasNonRootMultiColumnStyle(element)
+  ) {
+    return true;
+  }
   for (const descendant of element.querySelectorAll("*")) {
-    if (hasNonRootMultiColumnStyle(descendant)) {
+    if (
+      !descendant.hasAttribute("data-vivliostyle-column") &&
+      hasNonRootMultiColumnStyle(descendant)
+    ) {
       return true;
     }
   }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1755,12 +1755,36 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             // Footnote content could not be placed (e.g., widows/orphans
             // constraints prevented fragmentation). Fail the layout so
             // the footnote is deferred to the next page.
-            // Exception: during iterative footnote sizing (Issue #1879),
-            // allow empty fragments so the retry cycle can continue.
+            // Exception: during iterative footnote sizing, an empty first
+            // fragment can mean we need to start or continue the retry cycle
+            // instead of deferring the whole footnote. This is what lets the
+            // moved-call multicol case retry on the current page (#1891).
             const floatContext = context.getPageFloatLayoutContext(
               firstFloat.floatReference,
             );
             if (floatContext.footnoteMaxBlockSize == null) {
+              if (
+                floatContext.initFootnoteRetryFromEmptyFragment(
+                  firstFloat,
+                  floatArea,
+                )
+              ) {
+                if (floatArea.element.parentNode) {
+                  floatArea.element.parentNode.removeChild(floatArea.element);
+                }
+                this.layoutSinglePageFloatFragment(
+                  continuations,
+                  floatSide,
+                  clearSide,
+                  allowFragmented,
+                  strategy,
+                  anchorEdge,
+                  pageFloatFragment,
+                ).then((retryResult) => {
+                  frame.finish(retryResult);
+                });
+                return;
+              }
               failed = true;
             }
           }
@@ -2101,6 +2125,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         0,
       );
       const nodeContextAfter = this.setFloatAnchorViewNode(nodeContext);
+      // Record the anchor before fragment lookup so empty-fragment retries can
+      // still tell that this footnote call has already been encountered on the
+      // current page (Issue #1891).
+      context.markPageFloatAnchorSeen(float);
       const pageFloatFragment = strategy.findPageFloatFragment(float, context);
       const continuation = new PageFloats.PageFloatContinuation(
         float,

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -651,18 +651,23 @@ export class PageFloatLayoutContext
     );
   }
 
+  markPageFloatAnchorSeen(float: PageFloat) {
+    if (!("footnotePolicy" in float)) {
+      return;
+    }
+    let ctx: PageFloatLayoutContext | null = this;
+    while (ctx) {
+      ctx.footnoteAnchorsSeen.add(float.getId());
+      ctx = ctx.parent ?? ctx.outerContext;
+    }
+  }
+
   registerPageFloatAnchor(float: PageFloat, anchorViewNode: Node) {
     this.floatAnchors[float.getId()] = anchorViewNode;
     // Record that this float's anchor has been seen at least once on this
     // page, propagating up the context hierarchy so the page-level context
     // can detect feedback loops. (Issue #1879)
-    if ("footnotePolicy" in float) {
-      let ctx: PageFloatLayoutContext | null = this;
-      while (ctx) {
-        ctx.footnoteAnchorsSeen.add(float.getId());
-        ctx = ctx.parent ?? ctx.outerContext;
-      }
-    }
+    this.markPageFloatAnchorSeen(float);
   }
 
   collectPageFloatAnchors() {
@@ -807,6 +812,75 @@ export class PageFloatLayoutContext
     return result;
   }
 
+  private hasRootMultiColumnFootnoteContext(): boolean {
+    return this.children.some((child) => {
+      let rootColumnCount = 0;
+      for (const grandchild of child.children) {
+        if (grandchild.generatingNodePosition) {
+          continue;
+        }
+        rootColumnCount += 1;
+        if (rootColumnCount > 1) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+
+  private hasNonRootMultiColumnFootnoteContext(): boolean {
+    return this.children.some((child) =>
+      child.children.some((grandchild) => {
+        const elem = grandchild.getContainer()?.element;
+        return elem != null && LayoutHelper.containsNonRootMultiColumn(elem);
+      }),
+    );
+  }
+
+  private hasMultiColumnFootnoteContext(): boolean {
+    return (
+      this.hasRootMultiColumnFootnoteContext() ||
+      this.hasNonRootMultiColumnFootnoteContext()
+    );
+  }
+
+  private trySetFootnoteRetryMaxBlockSize(currentOuter: number): boolean {
+    const newMax =
+      this.footnoteMaxBlockSize != null
+        ? this.footnoteMaxBlockSize / 2
+        : currentOuter / 2;
+    if (newMax < MIN_FOOTNOTE_BLOCK_SIZE) {
+      return false;
+    }
+    this.footnoteMaxBlockSize = newMax;
+    return true;
+  }
+
+  initFootnoteRetryFromEmptyFragment(
+    float: PageFloat,
+    area: LayoutType.PageFloatArea,
+  ): boolean {
+    // Issue #1891: when the footnote call moves later in a multicol flow, the
+    // first attempt may produce an empty fragment before footnoteMaxBlockSize
+    // has been initialized. Seed the usual size-reduction loop from the space
+    // currently available on the page instead of deferring the whole footnote.
+    if (
+      !(
+        "footnotePolicy" in float &&
+        this.footnoteMaxBlockSize == null &&
+        this.footnoteAnchorsSeen.has(float.getId()) &&
+        this.hasMultiColumnFootnoteContext()
+      )
+    ) {
+      return false;
+    }
+    const availableOuterBlockSize =
+      (area.vertical ? area.width : area.height) +
+      area.getInsetBefore() +
+      area.getInsetAfter();
+    return this.trySetFootnoteRetryMaxBlockSize(availableOuterBlockSize);
+  }
+
   checkAndForbidNotAllowedFloat(): boolean {
     if (this.checkAndForbidFloatFollowingDeferredFloat()) {
       return true;
@@ -828,34 +902,17 @@ export class PageFloatLayoutContext
           // anchor can't be reached (feedback loop). Halving the size and
           // retrying lets the footnote fragment at a size that still allows
           // the anchor to be reached during re-layout.
-          // Detect multi-column: either root multicol (multiple column
-          // contexts) or non-root multicol (browser-native columns inside
-          // a single column context).
           const hasMultiColumn =
             isFootnote &&
             this.footnoteAnchorsSeen.has(notAllowedFloat.getId()) &&
-            (this.children.some((child) => child.children.length > 1) ||
-              this.children.some((child) =>
-                child.children.some((grandchild) => {
-                  const elem = grandchild.getContainer()?.element;
-                  return (
-                    elem != null &&
-                    LayoutHelper.containsNonRootMultiColumn(elem)
-                  );
-                }),
-              ));
+            this.hasMultiColumnFootnoteContext();
           if (hasMultiColumn) {
             const currentOuter =
               fragment.area.computedBlockSize +
               fragment.area.getInsetBefore() +
               fragment.area.getInsetAfter();
-            const newMax =
-              this.footnoteMaxBlockSize != null
-                ? this.footnoteMaxBlockSize / 2
-                : currentOuter / 2;
-            if (newMax >= MIN_FOOTNOTE_BLOCK_SIZE) {
+            if (this.trySetFootnoteRetryMaxBlockSize(currentOuter)) {
               // Retry with reduced size
-              this.footnoteMaxBlockSize = newMax;
               this.removePageFloatFragment(fragment);
               this.removeEndFloatFragments(fragment.floatSide);
               return true;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -718,6 +718,7 @@ export namespace PageFloats {
     findPageFloatFragment(float: PageFloat): PageFloatFragment | null;
     hasFloatFragments(condition?: (p1: PageFloatFragment) => boolean): boolean;
     hasContinuingFloatFragmentsInFlow(flowName: string): boolean;
+    markPageFloatAnchorSeen(float: PageFloat): void;
     registerPageFloatAnchor(float: PageFloat, anchorViewNode: Node): void;
     collectPageFloatAnchors(): any;
     isAnchorAlreadyAppeared(floatId: PageFloatID): boolean;
@@ -735,6 +736,10 @@ export namespace PageFloats {
       flowName?: string | null,
     ): PageFloatContinuation[];
     getFloatsDeferredToNextInChildContexts(): PageFloat[];
+    initFootnoteRetryFromEmptyFragment(
+      float: PageFloat,
+      area: Layout.PageFloatArea,
+    ): boolean;
     checkAndForbidNotAllowedFloat(): boolean;
     checkAndForbidFloatFollowingDeferredFloat(): boolean;
     finish(): void;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -973,6 +973,11 @@ module.exports = [
         title: "Footnote fragmentation in multi-column (Issue #1879)",
       },
       {
+        file: "footnotes/footnote-fragmentation-multicol-moved-call.html",
+        title:
+          "Footnote fragmentation in multi-column after moving call (Issue #1891)",
+      },
+      {
         file: "footnotes/footnote-area-max-height.html",
         title: "Footnote area max-height (Issue #1878)",
       },

--- a/packages/core/test/files/footnotes/footnote-fragmentation-multicol-moved-call.html
+++ b/packages/core/test/files/footnotes/footnote-fragmentation-multicol-moved-call.html
@@ -1,0 +1,63 @@
+<!-- Test case for Issue #1891: Footnote fragmentation in multicol after moving footnote call position -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Footnote Fragmentation in Multi-Column After Moving Call</title>
+    <style>
+      @page {
+        size: 148mm 210mm;
+        margin: 20mm;
+        @footnote {
+          border-top: 1px solid black;
+          padding-top: 0.5em;
+          margin-top: 0.5em;
+        }
+      }
+      :root { font: 12pt/1.5 serif; }
+      body {
+        column-count: 2;
+        column-gap: 8mm;
+        column-rule: 1px solid #ccc;
+      }
+      h1 { font-size: 1.2em; }
+      .footnote { float: footnote; font: 0.9rem/1.4 serif; }
+    </style>
+  </head>
+  <body>
+    <h1>Footnote Fragmentation in Multi-Column After Moving Call</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum
+      volutpat, nunc sit amet varius dignissim, lacus erat facilisis urna,
+      vitae facilisis lorem justo ut nulla. Integer non purus ut massa
+      scelerisque tincidunt.</p>
+    <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+      accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae
+      ab illo inventore veritatis et quasi architecto beatae vitae dicta
+      sunt explicabo.</p>
+    <p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
+      fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem
+      sequi nesciunt.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.<span class="footnote">
+        This is a deliberately very long footnote that cannot fit entirely
+        in the remaining footnote area on the current page. Expected: it
+        should start on this page and continue on the next page, even after
+        moving the footnote call later in the same multi-column flow. Lorem
+        ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum
+        volutpat, nunc sit amet varius dignissim, lacus erat facilisis urna,
+        vitae facilisis lorem justo ut nulla. Integer non purus ut massa
+        scelerisque tincidunt. Sed ut perspiciatis unde omnis iste natus
+        error sit voluptatem accusantium doloremque laudantium, totam rem
+        aperiam, eaque ipsa quae ab illo inventore veritatis et quasi
+        architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
+        voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
+        consequuntur magni dolores eos qui ratione voluptatem sequi
+        nesciunt. Eaque ipsa quae ab illo inventore veritatis et quasi
+        architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
+        voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
+        consequuntur magni dolores eos qui ratione voluptatem sequi
+        nesciunt.
+      </span></p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </body>
+</html>


### PR DESCRIPTION
- enable empty-fragment retry for multicol footnotes
- record footnote anchors earlier in layout
- avoid false multicol detection on root column wrappers
- fixes #1891

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for issue #1891 (footnote fragmentation failing after a multicol footnote call moved position); when the AI attributed an additional widows-related diff to being unrelated, the human author pushed back, correctly identifying it as a side effect of the fix.
- The human author asked for a code-review/refactoring pass afterward given the iterative nature of the fix, then asked for clarifying code comments describing the issue's intent before drafting the commit message.

</details>
