### PR TITLE
fix: Improve error messages for load failures and enable CORS on dev server

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -403,14 +403,19 @@ export class EPUBDocStore extends OPS.OPSDocStore {
       Logging.logger.error(`Failed to load ${docURL}. Invalid data.`);
     } else if (
       docURL.startsWith("http:") &&
-      Base.baseURL.startsWith("https:")
+      Base.baseURL.startsWith("https:") &&
+      // Browsers allow http://localhost from https:// (no mixed content block);
+      // the real error there is CORS, handled by likelyCorsProblem() below.
+      !/^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(?:[/?#]|$)/.test(
+        docURL,
+      )
     ) {
       Logging.logger.error(
         `Failed to load ${docURL}. Mixed Content ("http:" content on "https:" context) is not allowed.`,
       );
     } else if (likelyCorsProblem()) {
       Logging.logger.error(
-        `Failed to load ${docURL}. This may be caused by the server not allowing cross-origin resource sharing (CORS).`,
+        `Failed to load ${docURL}. This may be caused by network error, incorrect URL, or the server not allowing cross-origin resource sharing (CORS).`,
       );
     } else {
       Logging.logger.error(

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -358,7 +358,7 @@ export function parseXMLResource(
   if (!doc) {
     const parser = new DOMParser();
     const text = response.responseText;
-    if (text) {
+    if (text != null) {
       const contentType = resolveContentType(response);
       doc = parseAndReturnNullIfError(
         text,

--- a/packages/core/test/spec/vivliostyle/xmldoc-spec.js
+++ b/packages/core/test/spec/vivliostyle/xmldoc-spec.js
@@ -270,5 +270,35 @@ describe("xml-doc", function () {
         complete();
       });
     });
+
+    it("returns a non-null XMLDocHolder for an empty response body", function (done) {
+      var docStore = adapt_xmldoc.newXMLDocStore();
+      var result = adapt_xmldoc.parseXMLResource(
+        { responseText: "", contentType: "text/html", url: "blank.html" },
+        docStore,
+      );
+      result.then(function (docHolder) {
+        expect(docHolder).not.toBeNull();
+        expect(docHolder.document).not.toBeNull();
+        done();
+      });
+    });
+
+    it("returns null for a null response body (fetch failure)", function (done) {
+      var docStore = adapt_xmldoc.newXMLDocStore();
+      var result = adapt_xmldoc.parseXMLResource(
+        {
+          responseText: null,
+          responseXML: null,
+          contentType: null,
+          url: "blank.html",
+        },
+        docStore,
+      );
+      result.then(function (docHolder) {
+        expect(docHolder).toBeNull();
+        done();
+      });
+    });
   });
 });

--- a/packages/viewer/gulpfile.js
+++ b/packages/viewer/gulpfile.js
@@ -327,6 +327,7 @@ function serve(isDevelopment) {
       ghostMode: false, // do not mirror clicks, scrolls etc. between multiple browsers
       notify: false, // do not show any notifications in the browser
       port: 3000,
+      cors: true, // allow cross-origin requests so online viewers can load local test files
     },
     (_, bs) => {
       const localOrigin = getLocalServerOrigin(bs);


### PR DESCRIPTION
- Fix false CORS error on empty response: change `if (text)` to `if (text != null)` in parseXMLResource so that an empty-body response (e.g. blank.html) renders a blank page instead of triggering a load error
- Broaden the "likely CORS" error message to mention network error and incorrect URL as other possible causes, since the browser hides the real failure reason (DNS, timeout, cert, CORS all look the same from JS)
- Exclude localhost/127.0.0.1/::1 from the Mixed Content check: browsers do not block http://localhost from https:// pages, so the real error in that case is CORS, not Mixed Content
- Enable CORS on the dev server (browserSync `cors: true`) so that online viewers such as https://vivliostyle.vercel.app can load test files from the local dev server

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to improve inaccurate CORS/load-failure error messages; iterated on distinguishing "likely invalid URL" from "likely CORS" cases (e.g. a non-existent domain still showed a CORS-specific message) and questioned whether a URL-validation regex detail (`[/?#]`) was actually necessary.
- The human author asked about local-viewer-vs-online-viewer CORS handling, directed the commit message, created the PR, ran `/address-pr-comments`, and asked for a reviewer reply to be drafted.

</details>
