### PR TITLE
feat: Add --browser option to layout regression test tool

### DIFF
--- a/docs/ja/layout-regression-test.md
+++ b/docs/ja/layout-regression-test.md
@@ -16,11 +16,13 @@
 
 ## セットアップ
 
-依存パッケージと Playwright Chromium を一度だけインストール:
+依存パッケージと Playwright ブラウザを一度だけインストール:
 
 ```bash
 yarn install
 npx playwright install chromium --with-deps
+# Firefox や WebKit も使う場合:
+npx playwright install firefox webkit --with-deps
 ```
 
 ## 基本的な実行
@@ -72,7 +74,8 @@ yarn test:layout-regression \
 ## カスタムテスト URL
 
 `--test-url` で任意の Web URL をテスト対象に追加できます（繰り返し指定可）。
-ブラウザの CORS 制限は無効化されているため、任意の Web コンテンツをテストできます:
+デフォルトブラウザの Chromium では CORS 制限が無効化されているため、任意の Web コンテンツをテストできます。
+ただし `--browser firefox` や `--browser webkit` では CORS の無効化に対応していないため、クロスオリジンのコンテンツはロードできない場合があります。
 
 ```bash
 yarn test:layout-regression \
@@ -361,6 +364,7 @@ PR 実行時は `--actual-viewer` が自動的に `git-<branch>` に設定され
 
 ```
 --mode <name>                version-diff（デフォルト）, reftest, reftest-diff
+--browser <name>             使用するブラウザ: chromium（デフォルト）, firefox, webkit
 --category <name>            カテゴリーで絞り込み（繰り返し指定可・大文字小文字を区別しない）
 --title-includes <text>      タイトルの部分文字列で絞り込み（繰り返し指定可・大文字小文字を区別しない）
 --file <path>                packages/core/test/files/ からの相対パスで絞り込み

--- a/docs/layout-regression-test.md
+++ b/docs/layout-regression-test.md
@@ -16,11 +16,13 @@ Persistent triage decisions are stored in `scripts/layout-regression-triage.yaml
 
 ## Setup
 
-Install dependencies and Playwright Chromium once:
+Install dependencies and Playwright browsers once:
 
 ```bash
 yarn install
 npx playwright install chromium --with-deps
+# To also use Firefox or WebKit:
+npx playwright install firefox webkit --with-deps
 ```
 
 ## Basic run
@@ -72,7 +74,10 @@ When different filter options are combined, they are AND conditions.
 ## Custom test URLs
 
 Any web URL can be used as a test target with `--test-url` (repeatable).
-CORS restrictions are disabled in the browser, so arbitrary web content can be tested:
+CORS restrictions are disabled in Chromium (the default browser), so arbitrary
+web content can be tested. Note that `--browser firefox` and `--browser webkit`
+do not support disabling CORS, so cross-origin content may fail to load with
+those browsers.
 
 ```bash
 yarn test:layout-regression \
@@ -377,6 +382,7 @@ All three modes write `report.html` alongside `report.json` and `report.md`.
 
 ```
 --mode <name>                version-diff (default), reftest, or reftest-diff
+--browser <name>             Browser to use: chromium (default), firefox, or webkit
 --category <name>            Run only this category (repeatable, case-insensitive)
 --title-includes <text>      Run entries whose title includes text (repeatable, case-insensitive)
 --file <path>                Run entries by file path relative to packages/core/test/files/

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { chromium } from "playwright";
+import { chromium, firefox, webkit } from "playwright";
 import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
 import yaml from "js-yaml";
@@ -42,6 +42,7 @@ const wptReftestViewerParams = "&pixelRatio=0";
 
 const defaults = {
   mode: "version-diff",
+  browser: "chromium",
   outDir: "",
   timeoutSec: 30,
   maxDiffRatio: 0.00002,
@@ -320,6 +321,10 @@ function parseArgs(argv) {
       opts.viewportWidth = Number(argv[++i]);
     } else if (a === "--viewport-height") {
       opts.viewportHeight = Number(argv[++i]);
+    } else if (a === "--browser") {
+      opts.browser = String(argv[++i] || "")
+        .trim()
+        .toLowerCase();
     } else if (a === "--skip-screenshots") {
       opts.skipScreenshots = true;
     } else if (a === "--concurrency") {
@@ -378,6 +383,11 @@ function parseArgs(argv) {
     if (!actualLabelSet) {
       opts.actualLabel = resolved.label ?? "actual";
     }
+  }
+
+  const validBrowsers = ["chromium", "firefox", "webkit"];
+  if (!validBrowsers.includes(opts.browser)) {
+    throw new Error(`--browser must be one of: ${validBrowsers.join(", ")}`);
   }
 
   if (!Number.isFinite(opts.timeoutSec) || opts.timeoutSec <= 0) {
@@ -512,6 +522,7 @@ Options:
   --pixel-threshold <0..1>   Pixel diff sensitivity (default 0.1)
   --viewport-width <number>  Browser viewport width
   --viewport-height <number> Browser viewport height
+  --browser <name>           Browser to use: chromium (default), firefox, or webkit
   --skip-screenshots         Skip image capture/compare, check page counts only
   --concurrency <number>     Number of entries to capture in parallel (default: os.availableParallelism())
   --export-html              Export rendered HTML snapshot for each entry
@@ -1516,6 +1527,12 @@ async function capturePages({
   await page.goto(url, { waitUntil: "domcontentloaded", timeout: timeoutMs });
   await waitForViewerReady(page, timeoutMs);
 
+  // Hide Vercel's live-feedback widget that gets injected into Vercel preview
+  // deployments — it would appear in screenshots and cause spurious diffs.
+  await page.addStyleTag({
+    content: "vercel-live-feedback { display: none !important; }",
+  });
+
   const errorMsg = await checkViewerError(page);
   if (errorMsg) {
     throw new Error(`Viewer error: ${errorMsg}`);
@@ -1580,14 +1597,14 @@ async function captureOneSide({
   viewportWidth,
   viewportHeight,
 }) {
-  const context = await browser.newContext({
-    viewport: { width: viewportWidth, height: viewportHeight },
-    // Use device scale factor 2 to get more accurate pixel diffs.
-    deviceScaleFactor: 2,
-  });
-  const page = await context.newPage();
-
+  let context;
   try {
+    context = await browser.newContext({
+      viewport: { width: viewportWidth, height: viewportHeight },
+      // Use device scale factor 2 to get more accurate pixel diffs.
+      deviceScaleFactor: 2,
+    });
+    const page = await context.newPage();
     const captured = await capturePages({
       page,
       url,
@@ -1601,7 +1618,13 @@ async function captureOneSide({
   } catch (err) {
     return { ok: false, error: toComparableError(err) };
   } finally {
-    await page.close();
+    if (context) {
+      try {
+        await context.close();
+      } catch (closeErr) {
+        console.warn("Failed to close browser context:", closeErr);
+      }
+    }
   }
 }
 
@@ -2441,15 +2464,18 @@ function writeReports(outDir, result, triageStatusMap) {
 </tr>`,
         )
         .concat(
-          resultWithTriage.errors.map(
-            (item) => `<tr>
+          resultWithTriage.errors.map((item) => {
+            const isBaselineSide =
+              item.side === result.labels.baseline ||
+              item.side.startsWith(result.labels.baseline + "-");
+            return `<tr>
   <td class="test-path">${renderAnchor(item.sourceUrl, escapeHtml(item.title), "test-link")}</td>
-  <td>${renderFallbackViewerBadge(item.baselineUrl)}</td>
-  <td>${renderBadge("ERROR", "error", item.actualUrl)}</td>
+  <td>${isBaselineSide ? renderBadge("ERROR", "error", item.baselineUrl) : renderFallbackViewerBadge(item.baselineUrl)}</td>
+  <td>${isBaselineSide ? renderFallbackViewerBadge(item.actualUrl) : renderBadge("ERROR", "error", item.actualUrl)}</td>
   <td data-change-type="error">${renderChangeCell("error")}</td>
   <td>${escapeHtml(`${item.side}: ${item.error.message}`)}</td>
-</tr>`,
-          ),
+</tr>`;
+          }),
         )
         .join("\n");
   const html = `<!doctype html>
@@ -2904,9 +2930,13 @@ async function main() {
     ensureDir(dir);
   }
 
-  const browser = await chromium.launch({
+  const browserEngines = { chromium, firefox, webkit };
+  const browserEngine = browserEngines[opts.browser] ?? chromium;
+  const launchArgs =
+    opts.browser === "chromium" ? { args: ["--disable-web-security"] } : {};
+  const browser = await browserEngine.launch({
     headless: true,
-    args: ["--disable-web-security"],
+    ...launchArgs,
   });
 
   const differences = [];
@@ -2919,6 +2949,14 @@ async function main() {
   // Dispatch all captures into a bounded concurrency pool.
   // Each entry produces a Promise that resolves with [baseline, actual].
   const limit = pLimit(opts.concurrency);
+
+  // Handle Ctrl+C: exit immediately so pending async tasks can't keep logging.
+  // The browser subprocess will be cleaned up by the OS when this process exits.
+  process.once("SIGINT", () => {
+    process.stdout.write("\nInterrupted.\n");
+    process.exit(130);
+  });
+
   const entryPromises = targets.map((target, i) => {
     const id = String(i + 1).padStart(4, "0");
     const slug = `${id}-${sanitizeName(target.category)}-${sanitizeName(target.title)}`;


### PR DESCRIPTION
- Add --browser option (chromium/firefox/webkit) to allow running layout regression tests with different browsers via Playwright
- Fix WebKit memory exhaustion: close browser context instead of just the page in captureOneSide(), preventing context accumulation
- Fix ERROR badge shown in wrong column in report.html when the error occurred on the baseline side
- Hide Vercel live-feedback widget (`<vercel-live-feedback>`) via injected CSS to prevent it from appearing in screenshots and causing spurious diffs when approvedViewer is a Vercel preview deployment
- Handle Ctrl+C (SIGINT) gracefully: call process.exit(130) immediately so pending async tasks don't keep logging after interruption; also wrap browser.newContext() in try/catch to avoid unhandled rejections when the browser is closed mid-run
- Update docs/layout-regression-test.md and docs/ja/layout-regression-test.md to document the new --browser option and multi-browser install instructions

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to add a `--browser` option to the layout-regression tool so tests could run against Firefox/WebKit via Playwright, then tested it and reported a WebKit memory exhaustion issue and a Vercel widget appearing in screenshots as a spurious diff.
- The human author asked for the docs to be updated, directed the commit message, created the PR, and ran `/address-pr-comments`; separately reported that Ctrl+C didn't interrupt promptly, tested an initial fix ("no improvement"), and confirmed a later attempt worked before asking for an amended commit message covering the interrupt-handling fix too.

</details>
