### PR TITLE
fix: fix invalid selector recovery for css nesting

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4466,6 +4466,7 @@ export class CascadeParserHandler
   elementStyle: ElementStyle = null;
   conditionCount: number = 0;
   pseudoelement: string | null = null;
+  selectorFunctionContainsPseudoelement: boolean = false;
   footnoteContent: boolean = false;
   cascade: Cascade;
   state: ParseState;
@@ -4506,6 +4507,22 @@ export class CascadeParserHandler
     this.insertNonPrimary(chained);
   }
 
+  private invalidContinuationAfterPseudoelement(continuation: string): boolean {
+    if (this.pseudoelement) {
+      this.invalidSelector(
+        `::${this.pseudoelement} followed by ${continuation}`,
+      );
+      return true;
+    }
+    if (this.selectorFunctionContainsPseudoelement) {
+      this.invalidSelector(
+        `Selector containing pseudo-element followed by ${continuation}`,
+      );
+      return true;
+    }
+    return false;
+  }
+
   isInsideSelectorRule(mnemonics: string): boolean {
     if (this.state != ParseState.TOP) {
       this.reportAndSkip(mnemonics);
@@ -4516,6 +4533,9 @@ export class CascadeParserHandler
 
   override tagSelector(ns: string | null, name: string | null): void {
     if (!name && !ns) {
+      return;
+    }
+    if (this.invalidContinuationAfterPseudoelement(name ? name : "*")) {
       return;
     }
     if (name) {
@@ -4548,8 +4568,7 @@ export class CascadeParserHandler
   }
 
   override classSelector(name: string): void {
-    if (this.pseudoelement) {
-      this.invalidSelector(`::${this.pseudoelement} followed by .${name}`);
+    if (this.invalidContinuationAfterPseudoelement(`.${name}`)) {
       return;
     }
     this.specificity += 256;
@@ -4560,8 +4579,7 @@ export class CascadeParserHandler
     name: string,
     params: (number | string)[],
   ): void {
-    if (this.pseudoelement) {
-      this.invalidSelector(`::${this.pseudoelement} followed by :${name}`);
+    if (this.invalidContinuationAfterPseudoelement(`:${name}`)) {
       return;
     }
     switch (name.toLowerCase()) {
@@ -4677,6 +4695,9 @@ export class CascadeParserHandler
     name: string,
     params: (number | string)[],
   ): void {
+    if (this.invalidContinuationAfterPseudoelement(`::${name}`)) {
+      return;
+    }
     switch (name) {
       case "before":
       case "after":
@@ -4728,6 +4749,9 @@ export class CascadeParserHandler
   }
 
   override idSelector(id: string): void {
+    if (this.invalidContinuationAfterPseudoelement(`#${id}`)) {
+      return;
+    }
     this.specificity += 65536;
     this.chain.push(new CheckIdAction(id));
   }
@@ -4738,6 +4762,9 @@ export class CascadeParserHandler
     op: TokenType,
     value: string | null,
   ): void {
+    if (this.invalidContinuationAfterPseudoelement(`[${name}]`)) {
+      return;
+    }
     this.specificity += 256;
     name = name.toLowerCase();
     value = value || "";
@@ -4816,6 +4843,9 @@ export class CascadeParserHandler
   }
 
   override descendantSelector(): void {
+    if (this.invalidContinuationAfterPseudoelement("descendant selector")) {
+      return;
+    }
     const condition = `d${conditionCount++}`;
     this.processChain(
       new ConditionItemAction(
@@ -4827,6 +4857,9 @@ export class CascadeParserHandler
   }
 
   override childSelector(): void {
+    if (this.invalidContinuationAfterPseudoelement("child selector")) {
+      return;
+    }
     const condition = `c${conditionCount++}`;
     this.processChain(
       new ConditionItemAction(
@@ -4838,6 +4871,11 @@ export class CascadeParserHandler
   }
 
   override adjacentSiblingSelector(): void {
+    if (
+      this.invalidContinuationAfterPseudoelement("adjacent sibling selector")
+    ) {
+      return;
+    }
     const condition = `a${conditionCount++}`;
     this.processChain(
       new ConditionItemAction(
@@ -4849,6 +4887,11 @@ export class CascadeParserHandler
   }
 
   override followingSiblingSelector(): void {
+    if (
+      this.invalidContinuationAfterPseudoelement("following sibling selector")
+    ) {
+      return;
+    }
     const condition = `f${conditionCount++}`;
     this.processChain(
       new ConditionItemAction(
@@ -4866,6 +4909,7 @@ export class CascadeParserHandler
   override nextSelector(): void {
     this.finishChain();
     this.pseudoelement = null;
+    this.selectorFunctionContainsPseudoelement = false;
     this.footnoteContent = false;
     this.specificity = 0;
     this.chain = [];
@@ -4878,6 +4922,7 @@ export class CascadeParserHandler
     this.state = ParseState.SELECTOR;
     this.elementStyle = {} as ElementStyle;
     this.pseudoelement = null;
+    this.selectorFunctionContainsPseudoelement = false;
     this.specificity = 0;
     this.footnoteContent = false;
     this.chain = [];
@@ -4915,6 +4960,7 @@ export class CascadeParserHandler
       this.processChain(this.makeApplyRuleAction(this.specificity));
       this.chain = null;
       this.pseudoelement = null;
+      this.selectorFunctionContainsPseudoelement = false;
       this.viewConditionId = null;
       this.footnoteContent = false;
       this.specificity = 0;
@@ -5067,6 +5113,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   chains: ChainedAction[][] = [];
   maxSpecificity: number = 0;
   selectorTexts: string[] = [];
+  containsPseudoelementSelector: boolean = false;
 
   constructor(public readonly parent: CascadeParserHandler) {
     super(
@@ -5082,6 +5129,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   }
 
   override nextSelector(): void {
+    this.containsPseudoelementSelector ||= !!this.pseudoelement;
     if (this.chain) {
       this.chains.push(this.chain);
     }
@@ -5094,6 +5142,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   }
 
   override endFuncWithSelector(): void {
+    this.containsPseudoelementSelector ||= !!this.pseudoelement;
     if (this.chain) {
       this.chains.push(this.chain);
     }
@@ -5109,6 +5158,8 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
       if (this.increasingSpecificity()) {
         this.parent.specificity += this.maxSpecificity;
       }
+      this.parent.selectorFunctionContainsPseudoelement ||=
+        this.containsPseudoelementSelector;
     } else {
       // func argument is empty or all invalid
       this.parentChain.push(new CheckConditionAction("")); // always fails

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -764,7 +764,6 @@ export const OP_MEDIA_NOT: number = TokenType.LAST + 3;
   actionsErrorDecl[TokenType.C_PAR] = Action.ERROR_POP;
   actionsErrorDecl[TokenType.SEMICOL] = Action.ERROR_SEMICOL;
   actionsErrorSelector[TokenType.EOF] = Action.DONE;
-  actionsErrorSelector[TokenType.COMMA] = Action.ERROR_SEMICOL;
   actionsErrorSelector[TokenType.O_BRC] = Action.ERROR_PUSH;
   actionsErrorSelector[TokenType.C_BRC] = Action.ERROR_POP;
   actionsErrorSelector[TokenType.O_BRK] = Action.ERROR_PUSH;

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -38,7 +38,7 @@ describe("css-validator", function () {
         .parseStylesheetFromText(cssText, handler, null, null, null)
         .then(function (result) {
           expect(result).toBe(true);
-          callback(handler.finish());
+          callback(handler.finish(), handler);
           done();
         });
       return adapt_task.newResult(true);
@@ -67,6 +67,58 @@ describe("css-validator", function () {
         function (cascade) {
           expect(cascade.tags.ul).toBeDefined();
           expect(cascade.tags.ul.style["background-color"]).toBeDefined();
+        },
+      );
+    });
+  });
+
+  describe("invalid selector list recovery", function () {
+    it("drops an invalid selector list instead of salvaging later selectors", function (done) {
+      parseCascade(
+        "p { background: lime; } foo % address, p { background: red; }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.p).toBeDefined();
+          expect(cascade.tags.p.style["background-color"]).toBeDefined();
+          expect(
+            cascade.tags.p.style["background-color"].value.toString(),
+          ).toBe("lime");
+        },
+      );
+    });
+
+    it("drops an invalid selector list even when it uses !important", function (done) {
+      parseCascade(
+        "foo % address, p { background: red ! important; } p { background: lime; }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.p).toBeDefined();
+          expect(cascade.tags.p.style["background-color"]).toBeDefined();
+          expect(
+            cascade.tags.p.style["background-color"].value.toString(),
+          ).toBe("lime");
+        },
+      );
+    });
+  });
+
+  describe("contextually invalid selectors", function () {
+    it("invalidates selectors continued after pseudo-elements inside :is()", function (done) {
+      parseCascade(
+        ":is(*, ::before) * { color: purple; }",
+        done,
+        function (_cascade, handler) {
+          expect(handler.invalid).toBe(true);
+        },
+      );
+    });
+
+    it("invalidates pseudo-elements continued after pseudo-elements inside :is()", function (done) {
+      parseCascade(
+        ":is(*, ::before)::after { color: purple; }",
+        done,
+        function (_cascade, handler) {
+          expect(handler.invalid).toBe(true);
         },
       );
     });


### PR DESCRIPTION
This fixes the bug found in the following WPT test cases:
- https://wpt.live/css/css-nesting/contextually-invalid-selectors-002.html
- https://wpt.live/css/selectors/old-tests/css3-modsel-156.xml
- https://wpt.live/css/selectors/old-tests/css3-modsel-156c.xml

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- While working on unrelated layout-regression tool improvements, the human author noticed CSS Nesting (PR #1889) failed a specific WPT test case for contextually-invalid selector recovery, and asked the AI to investigate and fix it.
- The human author directed the commit message, created the PR, and ran `/address-pr-comments`.

</details>
