### PR TITLE
Security: Unescaped transformed URL can break out of CSS url() context

### DIFF
--- a/packages/core/src/vivliostyle/urls.ts
+++ b/packages/core/src/vivliostyle/urls.ts
@@ -24,6 +24,11 @@
  * @returns transformed attributeValue
  */
 
+const escapeURLForCSS = (url) =>
+  String(url).replace(/[\u0000-\u001F\u007F"'()\\\s]/g, (m) =>
+    `%${m.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`,
+  );
+
 export const transformURIs = (
   attributeValue,
   baseUrl,
@@ -33,14 +38,15 @@ export const transformURIs = (
     .replace(
       /[uU][rR][lL]\(\s*"((\\([^0-9a-fA-F]+|[0-9a-fA-F]+\s*)|[^"\r\n])+)"/gm,
       (match, m1) =>
-        `url("${documentURLTransformer.transformURL(m1, baseUrl)}"`,
+        `url("${escapeURLForCSS(documentURLTransformer.transformURL(m1, baseUrl))}"`,
     )
     .replace(
       /[uU][rR][lL]\(\s*'((\\([^0-9a-fA-F]+|[0-9a-fA-F]+\s*)|[^'\r\n])+)'/gm,
       (match, m1) =>
-        `url('${documentURLTransformer.transformURL(m1, baseUrl)}'`,
+        `url('${escapeURLForCSS(documentURLTransformer.transformURL(m1, baseUrl))}'`,
     )
     .replace(
       /[uU][rR][lL]\(\s*((\\([^0-9a-fA-F]+|[0-9a-fA-F]+\s*)|[^"'\r\n\)\s])+)/gm,
-      (match, m1) => `url(${documentURLTransformer.transformURL(m1, baseUrl)}`,
+      (match, m1) =>
+        `url(${escapeURLForCSS(documentURLTransformer.transformURL(m1, baseUrl))}`,
     );

--- a/packages/core/src/vivliostyle/urls.ts
+++ b/packages/core/src/vivliostyle/urls.ts
@@ -18,15 +18,23 @@
  * @fileoverview Urls - URL Utilities
  */
 
+import * as Base from "./base";
+import { escapeParse } from "./css-tokenizer";
+
 /**
  * transform all urls in attributeValue using documentURLTransformer.
  *
  * @returns transformed attributeValue
  */
 
-const escapeURLForCSS = (url) =>
-  String(url).replace(/[\u0000-\u001F\u007F"'()\\\s]/g, (m) =>
-    `%${m.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`,
+const escapeUrlForCssString = (url) =>
+  String(url).replace(/[\u0000-\u001F"\\\u2028\u2029]/g, Base.escapeChar);
+
+const serializeUrlForCssString = (url) => `"${escapeUrlForCssString(url)}"`;
+
+const transformUrlForCss = (url, baseUrl, documentURLTransformer) =>
+  serializeUrlForCssString(
+    documentURLTransformer.transformURL(escapeParse(String(url)), baseUrl),
   );
 
 export const transformURIs = (
@@ -38,15 +46,15 @@ export const transformURIs = (
     .replace(
       /[uU][rR][lL]\(\s*"((\\([^0-9a-fA-F]+|[0-9a-fA-F]+\s*)|[^"\r\n])+)"/gm,
       (match, m1) =>
-        `url("${escapeURLForCSS(documentURLTransformer.transformURL(m1, baseUrl))}"`,
+        `url(${transformUrlForCss(m1, baseUrl, documentURLTransformer)}`,
     )
     .replace(
       /[uU][rR][lL]\(\s*'((\\([^0-9a-fA-F]+|[0-9a-fA-F]+\s*)|[^'\r\n])+)'/gm,
       (match, m1) =>
-        `url('${escapeURLForCSS(documentURLTransformer.transformURL(m1, baseUrl))}'`,
+        `url(${transformUrlForCss(m1, baseUrl, documentURLTransformer)}`,
     )
     .replace(
       /[uU][rR][lL]\(\s*((\\([^0-9a-fA-F]+|[0-9a-fA-F]+\s*)|[^"'\r\n\)\s])+)/gm,
       (match, m1) =>
-        `url(${escapeURLForCSS(documentURLTransformer.transformURL(m1, baseUrl))}`,
+        `url(${transformUrlForCss(m1, baseUrl, documentURLTransformer)}`,
     );

--- a/packages/core/test/spec/vivliostyle/urls-spec.js
+++ b/packages/core/test/spec/vivliostyle/urls-spec.js
@@ -36,7 +36,7 @@ describe("urls", function () {
           transformer,
         ),
       ).toEqual(
-        'url("aaa|http://foo.com/test/?x=#bar|" ),url(aaa|#test| ), url(\'aaa|#test?x="|\') url other text',
+        'url("aaa|http://foo.com/test/?x=#bar|" ),url("aaa|#test|" ), url("aaa|#test?x=\\22 |") url other text',
       );
     });
     it("transform all urls with url-modifier.", function () {
@@ -49,21 +49,50 @@ describe("urls", function () {
           transformer,
         ),
       ).toEqual(
-        'url("aaa|http://foo.com/test/?x=#bar|" test modifiers ),url(aaa|#test| rgb(100, 200, 50 ) test ), url(\'aaa|#test?x="|\' calc(50% - 2em)) url other text',
+        'url("aaa|http://foo.com/test/?x=#bar|" test modifiers ),url("aaa|#test|" rgb(100, 200, 50 ) test ), url("aaa|#test?x=\\22 |" calc(50% - 2em)) url other text',
       );
     });
     it("transform all urls with escape.", function () {
-      expect(
-        module.transformURIs(
-          'URL( "aa\\"\\\'\\2F\\27 \\22  \\\r\\\nbb" \\"\\\'\\2F\\27 \\22  \\\r\\\n),' +
-            "url( aa\\\"\\'\\2F\\27 \\22  \\\r\\\nbb ), " +
-            "uRL('aa\\\"\\'\\2F\\27 \\22  \\\r\\\nbb' calc(50% - 2em)) url other text",
-          "aaa",
-          transformer,
-        ),
-      ).toEqual(
-        "url(\"aaa|aa\\\"\\'\\2F\\27 \\22  \\\r\\\nbb|\" \\\"\\'\\2F\\27 \\22  \\\r\\\n),url(aaa|aa\\\"\\'\\2F\\27 \\22  \\\r\\\nbb| ), url('aaa|aa\\\"\\'\\2F\\27 \\22  \\\r\\\nbb|' calc(50% - 2em)) url other text",
+      var captured = [];
+      var decodeAwareTransformer = {
+        transformURL: function (m1, baaseUrl) {
+          captured.push(m1);
+          return baaseUrl + "|" + m1 + "|";
+        },
+      };
+      var transformed = module.transformURIs(
+        'URL( "aa\\"\\\'\\2F\\27 \\22  \\\r\\\nbb" \\"\\\'\\2F\\27 \\22  \\\r\\\n),' +
+          "url( aa\\\"\\'\\2F\\27 \\22  \\\r\\\nbb ), " +
+          "uRL('aa\\\"\\'\\2F\\27 \\22  \\\r\\\nbb' calc(50% - 2em)) url other text",
+        "aaa",
+        decodeAwareTransformer,
       );
+
+      expect(captured.length).toBe(3);
+      expect(captured[0]).toBe(captured[1]);
+      expect(captured[1]).toBe(captured[2]);
+      expect(captured[0]).toContain('"');
+      expect(captured[0]).toContain("'");
+      expect(captured[0]).toContain("/");
+      expect(captured[0]).not.toContain("\\2F");
+      expect(captured[0]).not.toContain("\\22");
+      expect(transformed).toContain('url("aaa|');
+      expect(transformed).not.toContain("url(aaa|");
+    });
+
+    it("serializes transformed URLs as safe CSS strings", function () {
+      var transformed = module.transformURIs('url("#orig")', "aaa", {
+        transformURL: function () {
+          return '#safe") red/*\\\u2028\u2029';
+        },
+      });
+
+      expect(transformed).toContain('url("');
+      expect(transformed).toContain("\\22 ");
+      expect(transformed).toContain("\\5c ");
+      expect(transformed).toContain("\\2028 ");
+      expect(transformed).toContain("\\2029 ");
+      expect(transformed).not.toContain('") red/*');
     });
   });
 });


### PR DESCRIPTION
## Summary

Security: Unescaped transformed URL can break out of CSS url() context

## Problem

**Severity**: `High` | **File**: `packages/core/src/vivliostyle/urls.ts:L34`

In `transformURIs`, the return value of `documentURLTransformer.transformURL(...)` is directly interpolated into CSS `url(...)` strings without escaping. If a transformer returns a value containing quotes, closing parentheses, or control characters, it can terminate the URL token and inject additional CSS content. This is especially risky when processing untrusted documents/CSS or when custom transformers are used.

## Solution

Strictly escape/encode transformed URL output before interpolation (e.g., percent-encode unsafe characters for URL tokens), or construct URL tokens via a safe serializer instead of string concatenation. Reject transformed values containing `"`, `'`, `)`, newlines, or CSS-breaking characters.

## Changes

- `packages/core/src/vivliostyle/urls.ts` (modified)