### PR TITLE
fix: keep footnote-policy: line anchors with fragmented footnotes

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2153,6 +2153,32 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           0,
           this.vertical,
         );
+        if (nodeContext.floatSide === "footnote") {
+          const footnote = float as Footnote;
+          if (footnote.footnotePolicy === Css.ident.line) {
+            let anchorContext: Vtree.NodeContext | null = nodeContextAfter;
+            while (anchorContext) {
+              const sourceNode = anchorContext.shadowContext
+                ? anchorContext.shadowContext.owner
+                : anchorContext.sourceNode;
+              if (sourceNode === footnote.policyAnchorNode) {
+                const viewNode = anchorContext.viewNode as Element;
+                if (viewNode && viewNode.nodeType === 1) {
+                  const rect = LayoutHelper.getElementClientRectAdjusted(
+                    this.clientLayout,
+                    viewNode,
+                    this.vertical,
+                  );
+                  if (rect.right >= rect.left && rect.bottom >= rect.top) {
+                    edge = this.vertical ? rect.left : rect.bottom;
+                  }
+                }
+                break;
+              }
+              anchorContext = anchorContext.parent;
+            }
+          }
+        }
         // For footnotes, calculateEdge may return NaN because footnote-call
         // has vertical-align: super. Compute edge from the element's
         // bounding rect to enable footnote fragmentation.

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -970,14 +970,18 @@ export class PageFloatLayoutContext
     for (let i = this.floatsDeferredToNext.length - 1; i >= 0; i--) {
       const continuation = this.floatsDeferredToNext[i];
       const float = continuation.float;
+      const existingFragment = this.findPageFloatFragment(float);
       if (
         this.floatReference === FloatReference.PAGE &&
         "footnotePolicy" in float &&
         float.footnotePolicy === Css.ident.line &&
-        this.footnoteAnchorsSeen.has(float.getId())
+        this.footnoteAnchorsSeen.has(float.getId()) &&
+        !existingFragment
       ) {
         // Once the anchor line has already appeared on the page, a deferred
         // footnote-policy: line footnote can no longer move independently.
+        // If a fragment already started on this page, the deferred part is
+        // just the continuation and should remain allowed to split.
         if (this.locked) {
           this.invalidate();
           return;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -836,6 +836,10 @@ module.exports = [
       },
       { file: "footnotes/footnote-policy.html", title: "footnote-policy" },
       {
+        file: "footnotes/footnote-policy-line-fragmentation.html",
+        title: "footnote-policy: line fragmentation (Issue #1899)",
+      },
+      {
         file: "footnotes/footnote-area-at-footnote.html",
         title: "Footnote area with @footnote",
       },

--- a/packages/core/test/files/footnotes/footnote-policy-line-fragmentation.html
+++ b/packages/core/test/files/footnotes/footnote-policy-line-fragmentation.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1899: footnote-policy: line should allow footnote fragmentation before moving the anchor -->
+<!--
+  Page content area: 400px wide x 300px tall, margin 20px -> content 360x260px.
+  Spacer fills 180px -> 80px remain.
+    - anchor line:              20px
+    - footnote overhead:        ~7px
+    - footnote first line:      16px
+    - minimum needed to start:  ~43px
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>footnote-policy: line fragmentation</title>
+    <style>
+      @page {
+        size: 400px 300px;
+        margin: 20px;
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 11px;
+        }
+
+        @footnote {
+          border-top: 1px solid black;
+          margin-top: 4px;
+          padding-top: 2px;
+        }
+      }
+
+      :root {
+        font-size: 16px;
+        font-family: Arial, sans-serif;
+        line-height: 20px;
+        widows: 1;
+        orphans: 1;
+      }
+
+      body,
+      div,
+      p {
+        margin: 0;
+        padding: 0;
+      }
+
+      .spacer {
+        height: 180px;
+        background: #f0f0f0;
+      }
+
+      .footnote {
+        float: footnote;
+        font-size: 12px;
+        line-height: 16px;
+      }
+
+      .footnote::footnote-call,
+      .footnote::footnote-marker {
+        content: counter(footnote);
+        vertical-align: super;
+        font-size: 10px;
+        color: blue;
+      }
+
+      .policy-line {
+        footnote-policy: line;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacer"></div>
+    <p>
+      This is the anchor paragraph. It contains a footnote<span
+        class="footnote policy-line"
+        >This footnote body spans three lines of text to make the constraint
+        meaningful. It should appear at the bottom of page 1 together with its
+        anchor, because there is enough vertical space for both.</span
+      > that should stay on the same page.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Use the line-policy anchor block edge when placing fragmented footnotes. Do not forbid deferred line-policy continuations after a fragment has already started on the current page.
Add a regression test for Issue #1899.

closes #1899

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1899; when the fix initially seemed to work in one test case but not fully, they continued testing and directed further iteration, including clarifying that default `@footnote` styling still applies when no `@page { @footnote {} }` override exists.
- The human author ran a full layout-regression test themselves and confirmed it passed before merging.

</details>
