### PR TITLE
fix: fragment default footnotes from inline anchors

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2147,6 +2147,20 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       } else if (this.nodeContextOverflowingDueToRepetitiveElements) {
         return Task.newResult(null);
       } else {
+        const getFootnoteEdgeFromViewNode = (viewNode: Node | null): number => {
+          if (!viewNode || viewNode.nodeType !== 1) {
+            return NaN;
+          }
+          const rect = LayoutHelper.getElementClientRectAdjusted(
+            this.clientLayout,
+            viewNode as Element,
+            this.vertical,
+          );
+          if (rect.right >= rect.left && rect.bottom >= rect.top) {
+            return this.vertical ? rect.left : rect.bottom;
+          }
+          return NaN;
+        };
         let edge = LayoutHelper.calculateEdge(
           nodeContextAfter,
           this.clientLayout,
@@ -2155,23 +2169,18 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         );
         if (nodeContext.floatSide === "footnote") {
           const footnote = float as Footnote;
-          if (footnote.footnotePolicy === Css.ident.line) {
+          if (footnote.footnotePolicy === Css.ident.line || isNaN(edge)) {
             let anchorContext: Vtree.NodeContext | null = nodeContextAfter;
             while (anchorContext) {
               const sourceNode = anchorContext.shadowContext
                 ? anchorContext.shadowContext.owner
                 : anchorContext.sourceNode;
               if (sourceNode === footnote.policyAnchorNode) {
-                const viewNode = anchorContext.viewNode as Element;
-                if (viewNode && viewNode.nodeType === 1) {
-                  const rect = LayoutHelper.getElementClientRectAdjusted(
-                    this.clientLayout,
-                    viewNode,
-                    this.vertical,
-                  );
-                  if (rect.right >= rect.left && rect.bottom >= rect.top) {
-                    edge = this.vertical ? rect.left : rect.bottom;
-                  }
+                const anchorEdge = getFootnoteEdgeFromViewNode(
+                  anchorContext.viewNode,
+                );
+                if (!isNaN(anchorEdge)) {
+                  edge = anchorEdge;
                 }
                 break;
               }
@@ -2180,20 +2189,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           }
         }
         // For footnotes, calculateEdge may return NaN because footnote-call
-        // has vertical-align: super. Compute edge from the element's
-        // bounding rect to enable footnote fragmentation.
+        // has vertical-align: super. After trying the rendered anchor context,
+        // fall back to the call element's bounding rect to enable
+        // footnote fragmentation.
         if (isNaN(edge) && nodeContext.floatSide === "footnote") {
-          const viewNode = nodeContextAfter.viewNode as Element;
-          if (viewNode && viewNode.nodeType === 1) {
-            const rect = LayoutHelper.getElementClientRectAdjusted(
-              this.clientLayout,
-              viewNode,
-              this.vertical,
-            );
-            if (rect.right >= rect.left && rect.bottom >= rect.top) {
-              edge = this.vertical ? rect.left : rect.bottom;
-            }
-          }
+          edge = getFootnoteEdgeFromViewNode(nodeContextAfter.viewNode);
         }
         if (this.isOverflown(edge)) {
           return Task.newResult(nodeContextAfter);

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -973,6 +973,10 @@ module.exports = [
         title: "Footnote fragmentation across pages (Issue #1875)",
       },
       {
+        file: "footnotes/footnote-fragmentation-inline-anchor.html",
+        title: "Footnote fragmentation from inline anchor",
+      },
+      {
         file: "footnotes/footnote-fragmentation-multicol.html",
         title: "Footnote fragmentation in multi-column (Issue #1879)",
       },

--- a/packages/core/test/files/footnotes/footnote-fragmentation-inline-anchor.html
+++ b/packages/core/test/files/footnotes/footnote-fragmentation-inline-anchor.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<!-- Test case for default footnote fragmentation from an inline anchor -->
+<!--
+  Page content area: 400px wide x 300px tall, margin 20px -> content 360x260px.
+  Spacer fills 180px -> 80px remain.
+    - anchor line:              20px
+    - footnote overhead:        ~7px
+    - footnote first line:      16px
+    - minimum needed to start:  ~43px
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>footnote fragmentation from inline anchor</title>
+    <style>
+      @page {
+        size: 400px 300px;
+        margin: 20px;
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 11px;
+        }
+
+        @footnote {
+          border-top: 1px solid black;
+          margin-top: 4px;
+          padding-top: 2px;
+        }
+      }
+
+      :root {
+        font-size: 16px;
+        font-family: Arial, sans-serif;
+        line-height: 20px;
+        widows: 1;
+        orphans: 1;
+      }
+
+      body,
+      div,
+      p {
+        margin: 0;
+        padding: 0;
+      }
+
+      .spacer {
+        height: 180px;
+        background: #f0f0f0;
+      }
+
+      .footnote {
+        float: footnote;
+        font-size: 12px;
+        line-height: 16px;
+      }
+
+      .footnote::footnote-call,
+      .footnote::footnote-marker {
+        content: counter(footnote);
+        vertical-align: super;
+        font-size: 10px;
+        color: blue;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacer"></div>
+    <p>
+      This is the anchor paragraph. It contains a footnote<span class="footnote"
+        >This footnote body spans three lines of text to make the constraint
+        meaningful. It should appear at the bottom of page 1 together with its
+        anchor, because there is enough vertical space for both.</span
+      > that should stay on the same page.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
When calculateEdge() returns NaN for a default footnote call, resolve the anchor edge from the rendered anchor context before falling back to the call element rect. This keeps the first footnote fragment on the anchor page instead of deferring the whole footnote to the next page.

Add a regression testcase for inline-anchor footnote fragmentation and register it in the core test file list.

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- After PR #1903 merged, the human author found a related but distinct case: without `footnote-policy: line`, a footnote's first line should still stay on its anchor page, but instead the whole footnote moved to the next page (reproducible on both canary and stable) — suspecting PR #1877's fragmentation fix was incomplete, and asked the AI to investigate.
- The human author asked for a commit message for this follow-up PR and ran `/address-pr-comments`.

</details>
