### PR TITLE
fix: Fix rowspan table layout in anchor-target sections

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -415,12 +415,18 @@ export class TableFormattingContext
       return firstTime;
     }
     switch (nodeContext.display) {
-      case "table-row":
+      case "table-row": {
         // Check both cellBreakPositions and fragmentIndex to determine if this
         // is the first time laying out this row (issue #1663).
+        // Previous-fragment row-spanning cells are laid out separately before
+        // the current row; they should not make the row itself a continuation.
+        const rowIndex = this.findRowIndexBySourceNode(nodeContext.sourceNode);
         return (
-          this.cellBreakPositions.length === 0 && nodeContext.fragmentIndex <= 1
+          this.cellBreakPositions.every((p) =>
+            this.isPreviousFragmentRowSpanningCellBreakPosition(p, rowIndex),
+          ) && nodeContext.fragmentIndex <= 1
         );
+      }
       case "table-cell": {
         // For cells, check if this cell's source node is in cellBreakPositions
         // or if fragmentIndex indicates this is a continuation (issue #1663).
@@ -499,6 +505,18 @@ export class TableFormattingContext
 
   findRowIndexBySourceNode(sourceNode: Node): number {
     return this.rows.findIndex((row) => sourceNode === row.sourceNode);
+  }
+
+  private isPreviousFragmentRowSpanningCellBreakPosition(
+    cellBreakPosition: BrokenTableCellPosition,
+    rowIndex: number,
+  ): boolean {
+    const cell = cellBreakPosition.cell;
+    return (
+      rowIndex >= 0 &&
+      cell.rowIndex < rowIndex &&
+      cell.rowIndex + cell.rowSpan > rowIndex
+    );
   }
 
   addCellFragment(
@@ -681,8 +699,7 @@ export class TableFormattingContext
 
   override restoreState(state: any) {
     // Create a fresh copy to prevent the saved state from being mutated
-    // when extractRowSpanningCellBreakPositions splices entries from
-    // this.cellBreakPositions during subsequent layout attempts (issue #1667).
+    // during subsequent layout attempts (issue #1667).
     this.cellBreakPositions = [].concat(state as BrokenTableCellPosition[]);
   }
 }
@@ -1024,6 +1041,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
   originalStopAtOverflow: boolean;
   inHeader: boolean;
   inFooter: boolean;
+  private didExtractRowSpanningCellBreakPositions: boolean = false;
 
   constructor(
     public readonly formattingContext: TableFormattingContext,
@@ -1120,14 +1138,15 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
   }
 
   private extractRowSpanningCellBreakPositions(): BrokenTableCellPosition[][] {
+    if (this.didExtractRowSpanningCellBreakPositions) {
+      return [];
+    }
     const cellBreakPositions = this.formattingContext.cellBreakPositions;
     if (cellBreakPositions.length === 0) {
       return [];
     }
     const rowSpanningCellBreakPositions = [];
-    let i = 0;
-    do {
-      const p = cellBreakPositions[i];
+    cellBreakPositions.forEach((p) => {
       const cell = p.cell;
       const rowIndex = cell.rowIndex;
       // Only extract cells that actually span into the current row
@@ -1142,11 +1161,10 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
           arr = rowSpanningCellBreakPositions[rowIndex] = [];
         }
         arr.push(p);
-        cellBreakPositions.splice(i, 1);
-      } else {
-        i++;
       }
-    } while (i < cellBreakPositions.length);
+    });
+    this.didExtractRowSpanningCellBreakPositions =
+      rowSpanningCellBreakPositions.length > 0;
     return rowSpanningCellBreakPositions;
   }
 

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -628,6 +628,10 @@ module.exports = [
         title: "Table column break in non-root multicol (Issue #1854)",
       },
       {
+        file: "table/table-rowspan-anchor-target.html",
+        title: "Table rowspan in anchor target (Issue #1905)",
+      },
+      {
         file: "table/overflow-into-margin-after-multipage-table.html",
         title:
           "Page content overflows into margin after multi-page table (Issue #1902)",

--- a/packages/core/test/files/table/table-rowspan-anchor-target.html
+++ b/packages/core/test/files/table/table-rowspan-anchor-target.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1905: rowspan table in an anchor-target section. -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Table rowspan in anchor target</title>
+    <style>
+      @page {
+        size: A4 portrait;
+        margin: 40mm 20mm 30mm 25mm;
+      }
+
+      :root {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 10pt;
+      }
+
+      body > section,
+      nav {
+        break-before: page;
+      }
+
+      nav ul {
+        list-style: none;
+        padding-left: 0;
+        line-height: 1.45;
+      }
+
+      nav a {
+        color: currentColor;
+        text-decoration: none;
+      }
+
+      nav a::after {
+        content: leader(dotted) target-counter(attr(href url), page);
+      }
+
+      .toc-number {
+        display: inline-block;
+        width: 5em;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      td,
+      th {
+        border: 1px solid black;
+        padding: 0.5em;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        background: rgb(203 203 203);
+      }
+
+      td {
+        font-size: 0.8rem;
+      }
+
+      th:nth-of-type(1) {
+        width: 24%;
+      }
+
+      th:nth-of-type(2) {
+        width: 37%;
+      }
+
+      th:nth-of-type(3) {
+        width: 30%;
+      }
+
+      th:nth-of-type(4) {
+        width: 9%;
+      }
+    </style>
+  </head>
+  <body>
+    <nav id="toc">
+      <h2>Table of Contents</h2>
+      <ul>
+        <li>
+          <a href="#chapter"><span class="toc-number">1</span>Chapter</a>
+        </li>
+        <li>
+          <a href="#subchapter"><span class="toc-number">1.1</span>Subchapter</a>
+        </li>
+      </ul>
+    </nav>
+    <section id="chapter">
+      <h2>1 Chapter</h2>
+      <section id="subchapter">
+        <h3>1.1 Subchapter</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Col1</th>
+              <th>Col2</th>
+              <th>Col3<br />cont.<br />cont.</th>
+              <th>Col4<br />cont.<br />cont.</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td rowspan="2">Row 1 Col 1</td>
+              <td>Row 1 Col 2</td>
+              <td>Row 1 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 2 Col 2</td>
+              <td>Row 2 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 3 Col 1</td>
+              <td>Row 3 Col 2</td>
+              <td>Row 3 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td rowspan="3">Row 4 Col 1</td>
+              <td>Row 4 Col 2</td>
+              <td>Row 4 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 5 Col 2</td>
+              <td>Row 5 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 6 Col 2</td>
+              <td>Row 6 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td rowspan="11">Row 7 Col 1</td>
+              <td>Row 7 Col 2</td>
+              <td>Row 7 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 8 Col 2</td>
+              <td>Row 8 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 9 Col 2</td>
+              <td>Row 9 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 10 Col 2</td>
+              <td>Row 10 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 11 Col 2</td>
+              <td>Row 11 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 12 Col 2</td>
+              <td>Row 12 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 13 Col 2</td>
+              <td>Row 13 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 14 Col 2</td>
+              <td>Row 14 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 15 Col 2</td>
+              <td>Row 15 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 16 Col 2</td>
+              <td>Row 16 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 17 Col 2</td>
+              <td>Row 17 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 18 Col 1</td>
+              <td>Row 18 Col 2</td>
+              <td>Row 18 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+            <tr>
+              <td>Row 19 Col 1</td>
+              <td>Row 19 Col 2</td>
+              <td>Row 19 Col 3<br />cont</td>
+              <td>1<br />2<br />3</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Preserve row-spanning cell break positions across retry layout so a multi-page table inside a section referenced by an anchor/target-counter keeps its row-spanning column on continued pages.

Add a regression test for Issue #1905 covering a rowspan table in an anchor-target section with TOC links.

Closes #1905.

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1905; directed the commit message title to reflect the specific bug fixed (per the issue) with implementation details in the body.
- The human author created the PR and ran `/address-pr-comments`, then separately asked the AI to fix a `yarn lint` error.

</details>
