### PR TITLE
fix: resolve CSS WPT hang cases

### DIFF
--- a/packages/core/src/vivliostyle/css-tokenizer.ts
+++ b/packages/core/src/vivliostyle/css-tokenizer.ts
@@ -1532,11 +1532,17 @@ export class Tokenizer {
       const charCode = input.charCodeAt(position);
       switch (actions[charCode] || actions[65] /*A*/) {
         case Action.INVALID:
-          tokenText = input.substring(tokenPosition, position);
           if (isNaN(charCode)) {
+            tokenText = input.substring(tokenPosition, position);
             // unclosed comment `/***[EOF]`, unclosed string `"**[EOF]`
             tokenType = TokenType.EOF;
+          } else if (actions === actionsNormal && tokenType === TokenType.EOF) {
+            tokenType = TokenType.INVALID;
+            tokenPosition = position;
+            tokenText = input.substring(position, position + 1);
+            position++;
           } else {
+            tokenText = input.substring(tokenPosition, position);
             // invalid, e.g, `.` in `:nth-child([.])` (Issue #597)
             tokenType = TokenType.INVALID;
           }
@@ -2002,6 +2008,10 @@ export class Tokenizer {
       }
       actions = actionsNormal;
       seenSpace = false;
+      tokenType = TokenType.EOF;
+      tokenPosition = position;
+      tokenText = "";
+      tokenNum = 0;
       token = buffer[tail & indexMask];
     }
     this.position = position;

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -689,33 +689,8 @@ export class ListValidator extends PropertyValidator {
   }
 
   validateSingle(inval: Css.Val): Css.Val {
-    // no need to worry about "specials"
-    let outval: Css.Val = null;
-    let current = this.first;
-    while (
-      current !== this.successTerminal &&
-      current !== this.failureTerminal
-    ) {
-      if (!inval) {
-        current = current.failure;
-        continue;
-      }
-      if (current.isSpecial()) {
-        current = current.success;
-        continue;
-      }
-      outval = inval.visit(current.validator);
-      if (!outval) {
-        current = current.failure;
-        continue;
-      }
-      inval = null;
-      current = current.success;
-    }
-    if (current === this.successTerminal) {
-      return outval;
-    }
-    return null;
+    const out = this.validateList([inval], false, 0);
+    return out ? out[0] : null;
   }
 
   override visitEmpty(empty: Css.Val): Css.Val {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -48,6 +48,17 @@ import * as Layout from "./layout";
 import { XmlDoc } from "./types";
 
 const namespacePrefixMap: { [key: string]: string } = {};
+const xhtmlElementsRenderedAsDiv = new Set([
+  "base",
+  "body",
+  "head",
+  "html",
+  "link",
+  "meta",
+  "script",
+  "style",
+  "title",
+]);
 
 export type CustomRenderer = (
   p1: Element,
@@ -1542,13 +1553,7 @@ export class ViewFactory
       let tag = element.localName;
       let originalTag = tag;
       if (ns == Base.NS.XHTML) {
-        if (
-          tag == "html" ||
-          tag == "body" ||
-          tag == "script" ||
-          tag == "link" ||
-          tag == "meta"
-        ) {
+        if (xhtmlElementsRenderedAsDiv.has(tag)) {
           tag = "div";
         } else if (tag == "vide_") {
           tag = "video";

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -26,6 +26,7 @@ describe("css-parser", function () {
 
     beforeEach(function () {
       spyOn(handler, "error");
+      spyOn(handler, "idSelector");
       spyOn(handler, "pseudoclassSelector");
       spyOn(handler, "startFuncWithSelector");
       spyOn(handler, "endFuncWithSelector");
@@ -46,6 +47,23 @@ describe("css-parser", function () {
           });
         return adapt_task.newResult(true);
       });
+    }
+
+    function tokenize(text) {
+      var tokenizer = new adapt_csstok.Tokenizer(text, handler);
+      var tokens = [];
+      while (true) {
+        var token = tokenizer.token();
+        tokens.push({
+          type: token.type,
+          text: token.text,
+          position: token.position,
+        });
+        if (token.type === adapt_csstok.TokenType.EOF) {
+          return tokens;
+        }
+        tokenizer.consume();
+      }
     }
 
     describe("css nesting", function () {
@@ -206,6 +224,67 @@ describe("css-parser", function () {
           expect(handler.error).not.toHaveBeenCalled();
           expect(handler.property).toHaveBeenCalled();
           expect(handler.property.calls.mostRecent().args[0]).toBe("color");
+        });
+      });
+    });
+
+    describe("tokenizer recovery", function () {
+      it("advances past standalone invalid delimiter characters after previous tokens", function () {
+        var tokens = tokenize("a `");
+
+        expect(
+          tokens.map(function (token) {
+            return token.type;
+          }),
+        ).toEqual([
+          adapt_csstok.TokenType.IDENT,
+          adapt_csstok.TokenType.INVALID,
+          adapt_csstok.TokenType.EOF,
+        ]);
+        expect(tokens[0].text).toBe("a");
+        expect(tokens[1].text).toBe("`");
+        expect(tokens[2].position).toBe(3);
+      });
+
+      it("advances past repeated NUL bytes in misdecoded stylesheets", function () {
+        var tokens = tokenize("@\u0000c\u0000h");
+
+        expect(
+          tokens
+            .filter(function (token) {
+              return token.type === adapt_csstok.TokenType.INVALID;
+            })
+            .map(function (token) {
+              return token.text;
+            }),
+        ).toEqual(["\u0000", "\u0000"]);
+        expect(
+          tokens
+            .filter(function (token) {
+              return token.type === adapt_csstok.TokenType.IDENT;
+            })
+            .map(function (token) {
+              return token.text;
+            }),
+        ).toEqual(["c", "h"]);
+        expect(
+          tokens.map(function (token) {
+            return token.type;
+          }),
+        ).toEqual([
+          adapt_csstok.TokenType.AT,
+          adapt_csstok.TokenType.INVALID,
+          adapt_csstok.TokenType.IDENT,
+          adapt_csstok.TokenType.INVALID,
+          adapt_csstok.TokenType.IDENT,
+          adapt_csstok.TokenType.EOF,
+        ]);
+        expect(tokens[tokens.length - 1].position).toBe(5);
+      });
+
+      it("lets parser recovery reach the next selector after an invalid at-rule delimiter", function (done) {
+        parse(done, "@foo `; #pass { color: green; }", function () {
+          expect(handler.idSelector).toHaveBeenCalledWith("pass");
         });
       });
     });

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -16,6 +16,7 @@
  */
 
 import * as adapt_csscasc from "../../../src/vivliostyle/css-cascade";
+import * as adapt_css from "../../../src/vivliostyle/css";
 import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
 import * as adapt_cssvalid from "../../../src/vivliostyle/css-validator";
 import * as adapt_task from "../../../src/vivliostyle/task";
@@ -160,6 +161,31 @@ describe("css-validator", function () {
         return adapt_task.newResult(true);
       });
     });
+
+    it("rejects invalid single values for text-autospace-like nested alternates", function () {
+      var validatorSet = new adapt_cssvalid.ValidatorSet();
+      validatorSet.initBuiltInValidators();
+      validatorSet.parse(
+        "foo = normal | auto | no-autospace | [[ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]];",
+      );
+
+      expect(adapt_css.getName("x").visit(validatorSet.validators.foo)).toBe(
+        null,
+      );
+    });
+
+    it("accepts valid single values for text-autospace-like nested alternates", function () {
+      var validatorSet = new adapt_cssvalid.ValidatorSet();
+      validatorSet.initBuiltInValidators();
+      validatorSet.parse(
+        "foo = normal | auto | no-autospace | [[ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]];",
+      );
+
+      expect(
+        adapt_css.getName("punctuation").visit(validatorSet.validators.foo),
+      ).not.toBe(null);
+    });
+
     it("should parse simple validator that compare values case-insensitively.", function (done) {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();


### PR DESCRIPTION
Fix issue #1901 by making CSS tokenizer recovery advance on malformed delimiters, routing validator single-value checks through validateList(), and rendering display:contents-exposed head/style content without leaking real style elements into the viewer UI.

Exclude css/printing/zero-size-003-print.tentative.html from this fix scope because it matches the endless-loop class tracked in #941.

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for the WPT hang cases in #1901; across an extensive investigation, reported that `yarn test` was failing, that the viewer still hung with invalid `text-autospace` values, and precisely diagnosed via DevTools that the hang traced to `value.visit(validator)` in `css-validator.ts`.
- The human author asked whether an earlier `text-polyfill.ts` change was actually meaningless and should be reverted (correct), explained why a reference-file discrepancy was itself a bug in the WPT reference (unrelated to Vivliostyle) and proposed filing an upstream WPT fix separately while prioritizing the Vivliostyle-side fix first.
- The human author asked to revert an unrelated one-line change to `layout-regression.mjs` that had crept in, caught an incorrect `display: contents` rendering expectation by comparing against real browser behavior, and explicitly deferred one specific infinite-loop case to a separate, already-tracked issue (#941) rather than fixing it here; the human author also refined the drafted commit title for accuracy before finalizing.

</details>
