### PR TITLE
fix: Fix null pointer errors with MathML pseudo-elements and SVG

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3416,7 +3416,7 @@ export class CascadeInstance {
         setMap["list-item"] = (this.currentElement as any).value;
       }
     }
-    if (this.currentElement?.parentNode.nodeType === Node.DOCUMENT_NODE) {
+    if (this.currentElement?.parentNode?.nodeType === Node.DOCUMENT_NODE) {
       if (!resetMap) {
         resetMap = Object.create(null);
       }

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -1000,10 +1000,10 @@ export class Styler implements AbstractStyler {
       return Number.POSITIVE_INFINITY;
     }
     const context = this.context;
-    while (true) {
+    while (this.last) {
       let next: Node = this.last.firstChild;
       if (next == null) {
-        while (true) {
+        while (this.last) {
           if (this.last.nodeType == 1) {
             this.cascade.popElement(this.last as Element);
             this.primary = this.primaryStack.pop();
@@ -1036,7 +1036,7 @@ export class Styler implements AbstractStyler {
             break;
           }
           this.last = this.last.parentNode;
-          if (this.last === this.root) {
+          if (!this.last || this.last === this.root) {
             this.last = null;
             if (startOffset < this.lastOffset) {
               if (targetSlippedOffset < 0) {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2244,7 +2244,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     checkPoints.splice(0, checkPoints.length); // make empty
     let totalLineCount = 0;
     let firstPseudo = nodeContext.firstPseudo; // :first-letter is not processed here
-    if (firstPseudo.count == 0) {
+    if (firstPseudo?.count === 0) {
       firstPseudo = firstPseudo.outer; // move to line pseudoelement (if any)
     }
     frame

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -3251,7 +3251,7 @@ export class ViewFactory
     }
     const boxOffset = nodeContext.boxOffset + nodeOffset;
     const arr = [];
-    while (nodeContext.firstPseudo === firstPseudo) {
+    while (nodeContext && nodeContext.firstPseudo === firstPseudo) {
       arr.push(nodeContext);
       nodeContext = nodeContext.parent;
     }


### PR DESCRIPTION
Add null checks in layout, vgen, css-cascade, and css-styler to prevent "Cannot read properties of null" errors when rendering WPT test cases with MathML ::first-letter/::first-line pseudo-elements and SVG files.

The WPT test case `mathml/relations/css-styling/first-line-first-letter-pseudo-elements-002.html` no longer throws TypeError, but still has a visual difference with the reference. This rendering issue should be addressed in a separate issue.

- Fixes #1910

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for the null-pointer TypeError on WPT test cases (#1910); ran the reftest suite themselves to verify.
- The human author removed two test additions that didn't actually reproduce the issue (confirmed by checking they didn't throw on the pre-fix canary viewer either), ran `/address-pr-comments`, and separately asked the AI to fix a `yarn lint` error.

</details>
