### PR TITLE
fix: support about:blank in publication loading

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -65,6 +65,13 @@ function clonePageGroupPageCounts(source: {
   return cloned;
 }
 
+function shouldSkipHeadForWebPub(url: string): boolean {
+  return (
+    /\.(x?html?|xht)(?:[#?]|$)/i.test(url) ||
+    /^(?:about:|blob:)/i.test(Base.stripFragment(url))
+  );
+}
+
 export type Position = {
   spineIndex: number;
   pageIndex: number;
@@ -142,15 +149,16 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     } else if (/\.json(?:ld)?(?:[#?]|$)/i.test(url)) {
       // Web Publication Manifest
       this.loadWebPubManifest(url, frame);
-    } else if (/\.(x?html?|xht)(?:[#?]|$)/i.test(url)) {
+    } else if (shouldSkipHeadForWebPub(url)) {
       // Web Publication primary entry (X)HTML
-      // Skip HEAD request to avoid potential CORS errors on cross-origin servers
+      // Skip HEAD request for known document URLs and special schemes.
+      // Browsers reject HEAD on blob: URLs, and about:blank is a synthetic blank document.
       this.loadWebPub(url).then((opf) => {
         if (opf) {
           frame.finish(opf);
           return;
         }
-        // A URL with a known HTML extension cannot be the root of an unzipped EPUB.
+        // These URLs cannot be the root of an unzipped EPUB container.
         this.reportLoadError(url);
         frame.finish(null);
       });
@@ -1199,9 +1207,20 @@ export class OPFDoc {
     }
     // TODO: other metadata...
 
-    const primaryEntryPath = this.getPathFromURL(this.pubURL);
-    if (!manifestObj["readingOrder"] && doc && primaryEntryPath !== null) {
-      manifestObj["readingOrder"] = [encodeURI(primaryEntryPath)];
+    const primaryEntryURL = Base.stripFragment(this.pubURL);
+    const primaryEntryPath = this.getPathFromURL(primaryEntryURL);
+    const primaryEntryReadingOrderURL =
+      primaryEntryPath !== null
+        ? encodeURI(primaryEntryPath)
+        : /^(?:about:|blob:)/i.test(primaryEntryURL)
+          ? primaryEntryURL
+          : null;
+    if (
+      !manifestObj["readingOrder"] &&
+      doc &&
+      primaryEntryReadingOrderURL !== null
+    ) {
+      manifestObj["readingOrder"] = [primaryEntryReadingOrderURL];
 
       // Find TOC in the primary entry (X)HTML
       for (const anchorElem of Toc.findTocAnchorElements(doc)) {

--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -39,11 +39,49 @@ export enum FetchResponseType {
 
 export type FetchResponse = Net.FetchResponse;
 
+function createSyntheticFetchResponse(
+  url: string,
+  opt_type?: FetchResponseType,
+): FetchResponse | null {
+  const strippedUrl = Base.stripFragment(url);
+  if (Base.stripFragmentAndQuery(strippedUrl).toLowerCase() !== "about:blank") {
+    return null;
+  }
+
+  const response: FetchResponse = {
+    status: 200,
+    statusText: "OK",
+    url: strippedUrl,
+    contentType: "text/html",
+    responseText: null,
+    responseXML: null,
+    responseBlob: null,
+  };
+
+  if (opt_type === FetchResponseType.BLOB) {
+    response.responseBlob = makeBlob([""], response.contentType);
+  } else if (opt_type === FetchResponseType.ARRAYBUFFER) {
+    response.responseBlob = makeBlob(
+      [new Uint8Array(0).buffer],
+      response.contentType,
+    );
+  } else {
+    response.responseText = "";
+  }
+
+  return response;
+}
+
 export function fetchFromURL(
   url: string,
   opt_type?: FetchResponseType,
   opt_method?: string,
 ): Task.Result<FetchResponse> {
+  const syntheticResponse = createSyntheticFetchResponse(url, opt_type);
+  if (syntheticResponse) {
+    return Task.newResult(syntheticResponse);
+  }
+
   const frame: Task.Frame<FetchResponse> = Task.newFrame("fetchFromURL");
   const requestInit: RequestInit = {
     method: opt_method || "GET",

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -1,5 +1,6 @@
 /**
  * Copyright 2017 Daishinsha Inc.
+ * Copyright 2026 Vivliostyle Foundation
  *
  * Vivliostyle.js is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,10 +17,91 @@
  */
 
 import * as adapt_epub from "../../../src/vivliostyle/epub";
+import * as adapt_task from "../../../src/vivliostyle/task";
 import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
 
 describe("epub", function () {
+  describe("EPUBDocStore", function () {
+    describe("loadPubDoc", function () {
+      it("skips HEAD and treats about:blank as a Web Publication primary entry", function (done) {
+        var store = new adapt_epub.EPUBDocStore();
+        var opf = {};
+        spyOn(store, "loadWebPub").and.callFake(function () {
+          return adapt_task.newResult(opf);
+        });
+
+        adapt_task.start(function () {
+          store.loadPubDoc("about:blank").then(function (result) {
+            expect(store.loadWebPub).toHaveBeenCalledWith("about:blank");
+            expect(result).toBe(opf);
+            done();
+          });
+          return adapt_task.newResult(true);
+        });
+      });
+
+      it("skips HEAD and treats blob: URLs as a Web Publication primary entry", function (done) {
+        var store = new adapt_epub.EPUBDocStore();
+        var url =
+          "blob:http://localhost:3000/12345678-1234-1234-1234-123456789abc";
+        var opf = {};
+        spyOn(store, "loadWebPub").and.callFake(function () {
+          return adapt_task.newResult(opf);
+        });
+
+        adapt_task.start(function () {
+          store.loadPubDoc(url).then(function (result) {
+            expect(store.loadWebPub).toHaveBeenCalledWith(url);
+            expect(result).toBe(opf);
+            done();
+          });
+          return adapt_task.newResult(true);
+        });
+      });
+    });
+  });
+
   describe("OPFDoc", function () {
+    describe("initWithWebPubManifest", function () {
+      it("creates a primary entry for about:blank documents", function (done) {
+        var store = new adapt_epub.EPUBDocStore();
+        var opf = new adapt_epub.OPFDoc(store, "about:blank");
+        var doc = new DOMParser().parseFromString(
+          "<html xmlns='http://www.w3.org/1999/xhtml'><head><title>Blank</title></head><body></body></html>",
+          "text/html",
+        );
+
+        adapt_task.start(function () {
+          opf.initWithWebPubManifest({}, doc).then(function () {
+            expect(opf.items.length).toBe(1);
+            expect(opf.spine.length).toBe(1);
+            expect(opf.items[0].src).toBe("about:blank");
+            done();
+          });
+          return adapt_task.newResult(true);
+        });
+      });
+
+      it("creates a primary entry when the publication URL is the root document", function (done) {
+        var store = new adapt_epub.EPUBDocStore();
+        var opf = new adapt_epub.OPFDoc(store, "https://example.com/webpub/");
+        var doc = new DOMParser().parseFromString(
+          "<html xmlns='http://www.w3.org/1999/xhtml'><head><title>Root</title></head><body></body></html>",
+          "text/html",
+        );
+
+        adapt_task.start(function () {
+          opf.initWithWebPubManifest({}, doc).then(function () {
+            expect(opf.items.length).toBe(1);
+            expect(opf.spine.length).toBe(1);
+            expect(opf.items[0].src).toBe("https://example.com/webpub/");
+            done();
+          });
+          return adapt_task.newResult(true);
+        });
+      });
+    });
+
     describe("OPFDocumentURLTransformer", function () {
       var opfDoc = new adapt_epub.OPFDoc(null, null);
       opfDoc.spine = opfDoc.items = [

--- a/packages/core/test/spec/vivliostyle/net-spec.js
+++ b/packages/core/test/spec/vivliostyle/net-spec.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 Daishinsha Inc.
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as adapt_base from "../../../src/vivliostyle/base";
+import * as adapt_net from "../../../src/vivliostyle/net";
+import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
+
+describe("net", function () {
+  describe("fetchFromURL", function () {
+    it("returns a synthetic empty HTML response for about:blank", function (done) {
+      adapt_net
+        .fetchFromURL("about:blank", adapt_net.FetchResponseType.DOCUMENT)
+        .then(function (response) {
+          expect(response.status).toBe(200);
+          expect(response.statusText).toBe("OK");
+          expect(response.url).toBe("about:blank");
+          expect(response.contentType).toBe("text/html");
+          expect(response.responseText).toBe("");
+          expect(response.responseXML).toBeNull();
+          expect(response.responseBlob).toBeNull();
+          done();
+        });
+    });
+
+    it("returns a synthetic empty HTML response for about:blank with query parameters", function (done) {
+      adapt_net
+        .fetchFromURL("about:blank?Q=1", adapt_net.FetchResponseType.DOCUMENT)
+        .then(function (response) {
+          expect(response.status).toBe(200);
+          expect(response.statusText).toBe("OK");
+          expect(response.url).toBe("about:blank?Q=1");
+          expect(response.contentType).toBe("text/html");
+          expect(response.responseText).toBe("");
+          expect(response.responseXML).toBeNull();
+          expect(response.responseBlob).toBeNull();
+          done();
+        });
+    });
+
+    it("returns a synthetic empty HTML response for mixed-case about:blank URLs", function (done) {
+      adapt_net
+        .fetchFromURL("ABOUT:blank?Q=1", adapt_net.FetchResponseType.DOCUMENT)
+        .then(function (response) {
+          expect(response.status).toBe(200);
+          expect(response.statusText).toBe("OK");
+          expect(response.url).toBe("ABOUT:blank?Q=1");
+          expect(response.contentType).toBe("text/html");
+          expect(response.responseText).toBe("");
+          expect(response.responseXML).toBeNull();
+          expect(response.responseBlob).toBeNull();
+          done();
+        });
+    });
+
+    it("lets about:blank parse as an empty HTML document", function (done) {
+      var docStore = adapt_xmldoc.newXMLDocStore();
+
+      adapt_net
+        .fetchFromURL("about:blank", adapt_net.FetchResponseType.DOCUMENT)
+        .then(function (response) {
+          adapt_xmldoc
+            .parseXMLResource(response, docStore)
+            .then(function (docHolder) {
+              expect(docHolder).not.toBeNull();
+              expect(docHolder.url).toBe("about:blank");
+              expect(docHolder.document.documentElement.namespaceURI).toBe(
+                adapt_base.NS.XHTML,
+              );
+              expect(docHolder.document.body).not.toBeNull();
+              done();
+            });
+        });
+    });
+  });
+});


### PR DESCRIPTION
fixes #1911

- synthesize empty HTML responses for about:blank fetches
- skip HEAD probing for about: and blob: URLs
- keep query-bearing about:blank URLs loadable

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.5

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1911 (error loading `about:blank` on WPT reftests); redirected the AI's initial approach, asking to revert a `viewer.ts` change and instead extend the existing HEAD-request-skip condition in `epub.ts` to cover `about:` and `blob:` URLs.
- The human author asked the AI to explain the existing `createSyntheticFetchResponse()` helper's behavior in detail, questioned an edge case with query-parameter URLs (`about:blank?Q=1` still failing), and pushed back on adding a dedicated test file, judging existing WPT coverage sufficient for catching future regressions.
- The human author directed the commit message and ran `/address-pr-comments`.

</details>
