### PR TITLE
fix: Add text-orientation support to ::marker pseudo-element

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1645,6 +1645,9 @@ span[data-viv-leader] {
 [style*="--viv-marker-text-combine-upright"]::marker {
   text-combine-upright: var(--viv-marker-text-combine-upright);
 }
+[style*="--viv-marker-text-orientation"]::marker {
+  text-orientation: var(--viv-marker-text-orientation);
+}
 
 /* initial-letter */
 [style*="--viv-initialLetter"]:has(>[data-adapt-pseudo="first-letter"])::first-letter {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3926,6 +3926,7 @@ export class CascadeInstance {
     "white-space",
     "text-transform",
     "text-combine-upright",
+    "text-orientation",
   ];
 
   /**

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1107,4 +1107,36 @@ describe("css-cascade", function () {
       });
     });
   });
+
+  describe("CascadeInstance", function () {
+    describe("markerAllowedProps", function () {
+      it("includes text-orientation for vertical writing mode support", function () {
+        expect(adapt_csscasc.CascadeInstance.markerAllowedProps).toContain(
+          "text-orientation",
+        );
+      });
+
+      it("includes all required marker properties", function () {
+        const expectedProps = [
+          "color",
+          "font-family",
+          "font-size",
+          "font-style",
+          "font-weight",
+          "font-variant",
+          "unicode-bidi",
+          "direction",
+          "white-space",
+          "text-transform",
+          "text-combine-upright",
+          "text-orientation",
+        ];
+        expectedProps.forEach((prop) => {
+          expect(adapt_csscasc.CascadeInstance.markerAllowedProps).toContain(
+            prop,
+          );
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add `text-orientation` to the allowed properties for native ::marker, fixing the WPT test `css/css-writing-modes/text-orientation-020.html` which tests `text-orientation: upright` on `li::marker`.

This regression was introduced when switching to the browser's native ::marker pseudo-element in commit 1a90b1291, which did not include `text-orientation` in the list of properties forwarded via CSS custom properties.

Ref #1914

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- While investigating issue #1914 (vertical writing mode WPT regressions), the human author asked the AI to implement a fix for the `text-orientation`-on-marker case specifically, directing the commit message to note it addressed only this one case among the larger issue.
- The human author preferred `raw.githack.com` over `raw.githubusercontent.com` for faster propagation of updated test files, but then scoped that change to WPT-specific fetches only, explaining the tradeoff (avoiding a broader dependency on an external service).
- The human author ran the full issue #1914 test suite themselves, noticed flaky failures traced to slow-loading `<object>` content and asked for a load-wait fix, excluded an already-fixed case from this commit's description, and ran `/address-pr-comments`.

</details>
