### PR TITLE
fix: Fix WPT test failures for embedded HTML content

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -91,7 +91,7 @@ export function setResourceBaseURL(value: string): void {
 
 function getWptRawRepoRootURL(url: string): string | null {
   const matched = stripFragmentAndQuery(url).match(
-    /^(https?:\/\/raw\.githubusercontent\.com\/web-platform-tests\/wpt\/master)(?:\/|$)/,
+    /^(https?:\/\/raw\.githack\.com\/web-platform-tests\/wpt\/[^/]+)(?:\/|$)/,
   );
   return matched ? matched[1] : null;
 }
@@ -194,6 +194,14 @@ export function convertSpecialURL(url: string): string {
 
   if (
     (r =
+      /^(https?:)\/\/github\.com\/web-platform-tests\/wpt\/(blob\/|tree\/|raw\/)?(.*)$/.exec(
+        url,
+      ))
+  ) {
+    // Convert GitHub WPT URL to raw.githack.com URL (correct MIME types)
+    url = `${r[1]}//raw.githack.com/web-platform-tests/wpt/${r[2] ? "" : "master/"}${r[3]}`;
+  } else if (
+    (r =
       /^(https?:)\/\/github\.com\/([^/]+\/[^/]+)\/(blob\/|tree\/|raw\/)?(.*)$/.exec(
         url,
       ))
@@ -203,8 +211,10 @@ export function convertSpecialURL(url: string): string {
       r[4]
     }`;
   } else if ((r = /^(https?:)\/\/wpt\.live\/(.*)$/.exec(url))) {
-    // Convert WPT live URL to raw GitHub URL so it can be fetched without CORS issues.
-    url = `${r[1]}//raw.githubusercontent.com/web-platform-tests/wpt/master/${r[2]}`;
+    // Convert WPT live URL to raw.githack.com URL so it can be fetched without
+    // CORS issues and with correct MIME types for embedded resources (e.g.,
+    // <object data="..."> with type="text/html").
+    url = `${r[1]}//raw.githack.com/web-platform-tests/wpt/master/${r[2]}`;
   } else if (
     (r =
       /^(https?:)\/\/www\.aozora\.gr\.jp\/(cards\/[^/]+\/files\/[^/.]+\.html)$/.exec(

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1936,6 +1936,34 @@ export class ViewFactory
           }
         }
 
+        // Wait for object element content to load (e.g., embedded HTML via
+        // <object data="...">). This ensures proper pagination by waiting for
+        // the embedded document to fully render before proceeding.
+        // Use result.localName instead of tag because custom renderer may
+        // convert <object> to <iframe> (e.g., for bound content).
+        if (
+          result.localName === "object" &&
+          result.namespaceURI === Base.NS.XHTML &&
+          result.hasAttribute("data")
+        ) {
+          this.page.fetchers.push(Net.loadElement(result));
+        }
+
+        // Wait for iframe content to load. This ensures embedded documents
+        // (including their images and resources) are fully rendered.
+        // Handle loading="lazy" by forcing eager loading to prevent blocking.
+        if (
+          result.localName === "iframe" &&
+          result.namespaceURI === Base.NS.XHTML &&
+          result.hasAttribute("src")
+        ) {
+          const iframeElem = result as HTMLIFrameElement;
+          if (iframeElem.loading === "lazy") {
+            iframeElem.loading = "eager";
+          }
+          this.page.fetchers.push(Net.loadElement(result));
+        }
+
         this.preprocessElementStyle(computedStyle);
         this.applyComputedStyles(result, computedStyle);
 

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -42,26 +42,57 @@ describe("base", function () {
   });
 
   describe("convertSpecialURL", function () {
-    it("converts wpt.live URLs to raw GitHub URLs", function () {
+    it("converts wpt.live URLs to raw.githack.com URLs", function () {
       expect(
         module.convertSpecialURL(
           "https://wpt.live/css/css-fonts/font-face-src-list.html",
         ),
       ).toBe(
-        "https://raw.githubusercontent.com/web-platform-tests/wpt/master/css/css-fonts/font-face-src-list.html",
+        "https://raw.githack.com/web-platform-tests/wpt/master/css/css-fonts/font-face-src-list.html",
+      );
+    });
+
+    it("converts GitHub WPT URLs to raw.githack.com URLs", function () {
+      expect(
+        module.convertSpecialURL(
+          "https://github.com/web-platform-tests/wpt/blob/master/css/css-fonts/font-face-src-list.html",
+        ),
+      ).toBe(
+        "https://raw.githack.com/web-platform-tests/wpt/master/css/css-fonts/font-face-src-list.html",
+      );
+    });
+
+    it("converts GitHub WPT URLs with non-master branch to raw.githack.com URLs", function () {
+      expect(
+        module.convertSpecialURL(
+          "https://github.com/web-platform-tests/wpt/blob/merge_pr_123456/css/CSS2/fonts/font-family-008.xht",
+        ),
+      ).toBe(
+        "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/css/CSS2/fonts/font-family-008.xht",
       );
     });
   });
 
   describe("resolveURL", function () {
-    it("keeps repo-root absolute paths within the WPT raw GitHub mirror", function () {
+    it("keeps repo-root absolute paths within the WPT raw.githack.com mirror", function () {
       expect(
         module.resolveURL(
           "/fonts/Lato-Medium.ttf",
-          "https://raw.githubusercontent.com/web-platform-tests/wpt/master/css/css-fonts/font-face-src-list.html",
+          "https://raw.githack.com/web-platform-tests/wpt/master/css/css-fonts/font-face-src-list.html",
         ),
       ).toBe(
-        "https://raw.githubusercontent.com/web-platform-tests/wpt/master/fonts/Lato-Medium.ttf",
+        "https://raw.githack.com/web-platform-tests/wpt/master/fonts/Lato-Medium.ttf",
+      );
+    });
+
+    it("keeps repo-root absolute paths within the WPT mirror for non-master branches", function () {
+      expect(
+        module.resolveURL(
+          "/fonts/ahem.css",
+          "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/css/CSS2/fonts/font-family-008.xht",
+        ),
+      ).toBe(
+        "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/fonts/ahem.css",
       );
     });
   });


### PR DESCRIPTION
Fix 21 WPT vertical writing mode test cases that failed due to embedded HTML content issues in `<object>` and `<iframe>` elements.

The failures had two causes:

1. Incorrect MIME type for embedded HTML in WPT tests
   - Tests using `<object data="...">` to embed HTML failed because `raw.githubusercontent.com` serves all files as `text/plain`.
   - Change WPT URL conversion to use `raw.githack.com` which serves files with correct MIME types based on extension.
   - Keep other GitHub URL conversions using `raw.githubusercontent.com` for immediate updates.

2. Missing load completion waiting for embedded content
   - Add fetcher for `<object>` elements with `data` attribute to wait for embedded document load.
   - Add fetcher for `<iframe>` elements with `src` attribute to wait for embedded content (including images) to fully render.

Closes #1914

Assisted-by: GitHub Copilot Chat:claude-opus-4.5

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix the remaining unresolved WPT css-flexbox cases in issue #1917, and separately identified PR #1739 as a likely root cause for a different issue and that testing without `pixelRatio=0` produced correct results.
- After the fix worked, the human author reflected on session friction points and asked the AI to improve project documentation to prevent them in future sessions (documenting WPT's source/deployment relationship, correcting overly verbose descriptions, fixing a build-verification instruction, suppressing a `yarn dev` deprecation warning consistently with `yarn test`), and clarified their own preference for how the AI should verify build completion during development.
- The human author asked for the WPT-embedding fix and the documentation/tooling changes to be split into separate commits, and iterated on both through `/draft-commit` and `/address-pr-comments`.

</details>
