### PR TITLE
fix: prevent WPT SVG test errors

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -67,7 +67,7 @@ function clonePageGroupPageCounts(source: {
 
 function shouldSkipHeadForWebPub(url: string): boolean {
   return (
-    /\.(x?html?|xht)(?:[#?]|$)/i.test(url) ||
+    /\.(x?html?|xht|svg)(?:[#?]|$)/i.test(url) ||
     /^(?:about:|blob:)/i.test(Base.stripFragment(url))
   );
 }

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -40,6 +40,25 @@ describe("epub", function () {
         });
       });
 
+      it("skips HEAD and treats .svg URLs as a Web Publication primary entry", function (done) {
+        var store = new adapt_epub.EPUBDocStore();
+        var url =
+          "https://raw.githack.com/web-platform-tests/wpt/master/svg/styling/css-var-on-length-attributes-02.svg";
+        var opf = {};
+        spyOn(store, "loadWebPub").and.callFake(function () {
+          return adapt_task.newResult(opf);
+        });
+
+        adapt_task.start(function () {
+          store.loadPubDoc(url).then(function (result) {
+            expect(store.loadWebPub).toHaveBeenCalledWith(url);
+            expect(result).toBe(opf);
+            done();
+          });
+          return adapt_task.newResult(true);
+        });
+      });
+
       it("skips HEAD and treats blob: URLs as a Web Publication primary entry", function (done) {
         var store = new adapt_epub.EPUBDocStore();
         var url =


### PR DESCRIPTION
PR #1929 changed the URL used to fetch WPT test files, which caused SVG references served from raw.githack.com to fail with a 403 on HEAD requests and report errors such as "Failed to fetch a source document".

Fix this by treating .svg URLs as Web Publication primary entries in EPUBDocStore.loadPubDoc(), so they skip the HEAD probe and go directly through the existing loadWebPub() path.

Ref #1911

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author reported this regression from PR #1929 affecting a previously-fixed issue (#1911) and asked the AI to fix it.
- The human author asked for the commit message, then asked for it to be revised to include specific additional details.

</details>
