### PR TITLE
fix: Improve Local dev server and WPT test URLs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ yarn test           # Test
 
 ### Interactive Development Workflow
 
-- **Core+Viewer dev**: `yarn dev` at root → auto-opens http://localhost:3000/core/test/files/ (Test cases)
+- **Core+Viewer dev**: `yarn dev` at root → auto-opens http://localhost:3300/core/test/files/ (Test cases)
 - **Test files**: Add HTML to `packages/core/test/files/` + entry in `file-list.js` (appears in Test cases)
 
 ### Visual Testing with VS Code Integrated Browser
@@ -69,10 +69,10 @@ Use the VS Code integrated browser for routine rendering checks and bug reproduc
 
 **Test URLs**:
 
-- Test cases: http://localhost:3000/core/test/files/
+- Test cases: http://localhost:3300/core/test/files/
 - Local test:
-  - With test file: `http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/<test>.html`
-  - With any URL: `http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=<URL>`
+  - With test file: `http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/<test>.html`
+  - With any URL: `http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=<URL>`
 - Note: Omit `&debug=true` for visual testing to avoid flickering during render process
 
 ## Naming Conventions

--- a/.github/skills/resolve-issue/SKILL.md
+++ b/.github/skills/resolve-issue/SKILL.md
@@ -49,7 +49,7 @@ Fetch a GitHub issue, create a minimal test case, visually confirm the bug, fix 
 Use the VS Code integrated browser to confirm the issue:
 
 1. **Navigate to the test file**:
-   - URL: `http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/<filename>.html`
+   - URL: `http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/<filename>.html`
    - Do NOT add `&debug=true` (causes flickering during rendering).
 
 2. **Wait for rendering to complete**:
@@ -115,7 +115,7 @@ Summarize:
 ### 10. Check for Regressions
 
 - Look at related test files in `packages/core/test/files/` to ensure similar features still work.
-- If the fix touches layout/pagination logic, navigate through a few other test cases via the Test Cases page (`http://localhost:3000/core/test/files/`).
+- If the fix touches layout/pagination logic, navigate through a few other test cases via the Test Cases page (`http://localhost:3300/core/test/files/`).
 
 ### 11. Run Tests
 
@@ -150,6 +150,6 @@ yarn test:layout-regression --actual-viewer dev --baseline-viewer canary
 ## Notes
 
 - The dev server (`yarn dev`) auto-rebuilds on source changes and auto-reloads the viewer. Once it's running, any code fix will be reflected by reloading the page.
-- Test files in `packages/core/test/files/` appear in the test case list at `http://localhost:3000/core/test/files/`.
-- If the issue references an EPUB or external URL, you can also test directly via `http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=<URL>` without creating a local file.
+- Test files in `packages/core/test/files/` appear in the test case list at `http://localhost:3300/core/test/files/`.
+- If the issue references an EPUB or external URL, you can also test directly via `http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=<URL>` without creating a local file.
 - Prefer the integrated browser for normal reproduction and verification loops. Use Chrome DevTools MCP when you need capabilities closer to DevTools itself, such as console, network, performance, Lighthouse, memory, or advanced emulation.

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -38,11 +38,11 @@ yarn build-dev  # build a development version of both Core and Viewer.
 yarn dev        # start watching source files and open browser.
 ```
 
-With `yarn dev`, a web server starts ([Browsersync](https://browsersync.io/) with live-reload enabled), and Google Chrome should automatically open. If no browser opens, open <http://localhost:3000/core/test/files/>. On saving any source file, the browser automatically reloads.
+With `yarn dev`, a web server starts ([Browsersync](https://browsersync.io/) with live-reload enabled), and Google Chrome should automatically open. If no browser opens, open <http://localhost:3300/core/test/files/>. On saving any source file, the browser automatically reloads.
 
 ### Viewer and test files
 
-Viewer HTML file (in development mode) is located at `packages/viewer/lib/vivliostyle-viewer-dev.html`. You can open an (X)HTML file with a URL (relative to the viewer HTML file) specified to `#src=` hash parameter. For example, <http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/print_media/index.html> opens a test file for print media located at `packages/core/test/files/print_media/index.html`.
+Viewer HTML file (in development mode) is located at `packages/viewer/lib/vivliostyle-viewer-dev.html`. You can open an (X)HTML file with a URL (relative to the viewer HTML file) specified to `#src=` hash parameter. For example, <http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/print_media/index.html> opens a test file for print media located at `packages/core/test/files/print_media/index.html`.
 
 Test HTML files, intended to be used during development, are located at `packages/core/test/files/`. You are encouraged to add test files useful for implementing and verifying features.
 

--- a/docs/ja/contribution-guide.md
+++ b/docs/ja/contribution-guide.md
@@ -38,11 +38,11 @@ yarn build-dev  # build a development version of both Core and Viewer.
 yarn dev        # start watching source files and open browser.
 ```
 
-`yarn dev` を使用すると、（[Browsersync](https://browsersync.io/) によりライブリロードが有効な）Webサーバーが起動し、Google Chromeが自動的に開きます。 ブラウザーが開かない場合は、<http://localhost:3000/core/test/files/>を開きます。 ソースファイルを保存すると、ブラウザは自動的にリロードされます。
+`yarn dev` を使用すると、（[Browsersync](https://browsersync.io/) によりライブリロードが有効な）Webサーバーが起動し、Google Chromeが自動的に開きます。 ブラウザーが開かない場合は、<http://localhost:3300/core/test/files/>を開きます。 ソースファイルを保存すると、ブラウザは自動的にリロードされます。
 
 ### ビューワーとテストファイル
 
-開発モード中のビューワーHTMLファイルは `packages/viewer/lib/vivliostyle-viewer-dev.html` にあります。`#src=` ハッシュパラメータを指定して、ビューワーHTMLファイルから相対の(X)HTMLファイルをURLで指定できます。例えば、<http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/print_media/index.html> は `packages/core/test/files/print_media/index.html` にあるprint mediaのテストファイルを開きます。
+開発モード中のビューワーHTMLファイルは `packages/viewer/lib/vivliostyle-viewer-dev.html` にあります。`#src=` ハッシュパラメータを指定して、ビューワーHTMLファイルから相対の(X)HTMLファイルをURLで指定できます。例えば、<http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=../../core/test/files/print_media/index.html> は `packages/core/test/files/print_media/index.html` にあるprint mediaのテストファイルを開きます。
 
 開発中に使用することを目的としたテストHTMLファイルは、 `packages/core/test/files/` にあります。 機能の実装と検証に役立つテストファイルを追加することをお勧めします。
 

--- a/docs/ja/layout-regression-test.md
+++ b/docs/ja/layout-regression-test.md
@@ -202,8 +202,8 @@ yarn test:reftest-diff \
 |------|-----|------|
 | キーワード | `canary` | https://vivliostyle.vercel.app/ |
 | キーワード | `stable` | https://vivliostyle.org/viewer/ |
-| キーワード | `dev` | http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html |
-| キーワード | `prod` | http://localhost:3000/viewer/lib/ |
+| キーワード | `dev` | http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html |
+| キーワード | `prod` | http://localhost:3300/viewer/lib/ |
 | `git-<branch>` | `git-fix-issue1775` | Vercel PR プレビュー（ブランチ: `fix-issue1775`） |
 | `git:<branch>` | `git:fix/issue-1775` | 同形式; `/` は `-` にサニタイズ（ブランチ: `fix-issue-1775`） |
 | バージョン | `v2.35.0` | https://vivliostyle.github.io/viewer/v2.35.0/ |
@@ -251,7 +251,7 @@ yarn test:layout-regression \
 `--actual-viewer` をもとに決定され、actual/baseline の両方で同じ参照URLを使います。
 
 - `--actual-viewer` がローカル（`localhost`/`127.0.0.1`）の場合:
-  - `http://localhost:3000/core/test/files/`
+  - `http://localhost:3300/core/test/files/`
 - `--actual-viewer` がレガシーURL（`vivliostyle-viewer.html`）の場合:
   - `https://raw.githack.com/vivliostyle/vivliostyle.js/<ref>/packages/core/test/files/`
 - それ以外の場合:

--- a/docs/layout-regression-test.md
+++ b/docs/layout-regression-test.md
@@ -204,8 +204,8 @@ yarn test:reftest-diff \
 |--------|---------|-------------|
 | keyword | `canary` | https://vivliostyle.vercel.app/ |
 | keyword | `stable` | https://vivliostyle.org/viewer/ |
-| keyword | `dev` | http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html |
-| keyword | `prod` | http://localhost:3000/viewer/lib/ |
+| keyword | `dev` | http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html |
+| keyword | `prod` | http://localhost:3300/viewer/lib/ |
 | `git-<branch>` | `git-fix-issue1775` | Vercel PR preview (branch: `fix-issue1775`) |
 | `git:<branch>` | `git:fix/issue-1775` | Same format; `/` is sanitized to `-` (branch: `fix-issue-1775`) |
 | version | `v2.35.0` | https://vivliostyle.github.io/viewer/v2.35.0/ |
@@ -254,7 +254,7 @@ is chosen from `--actual-viewer`, and the same source URL is used for both
 actual and baseline.
 
 - If `--actual-viewer` is local (`localhost`/`127.0.0.1`):
-  - `http://localhost:3000/core/test/files/`
+  - `http://localhost:3300/core/test/files/`
 - If `--actual-viewer` is a legacy viewer URL (`vivliostyle-viewer.html`):
   - `https://raw.githack.com/vivliostyle/vivliostyle.js/<ref>/packages/core/test/files/`
 - Otherwise:

--- a/packages/core/test/files/index.html
+++ b/packages/core/test/files/index.html
@@ -50,6 +50,9 @@
       var dirLocal = "../../core/test/files/";
       var urlOnline =
         "https://raw.githack.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/";
+      var urlTestFiles = isLocal
+        ? new URL("./", location.href).href
+        : urlOnline;
 
       var fileList = module.exports;
       fileList.forEach(function (group) {
@@ -77,10 +80,7 @@
           var parameterProd = path && "#src=" + path + (entry.options || "");
           var parameterDev =
             (parameterProd ? parameterProd + "&" : "#") + "debug=true";
-          var parameterOnline = parameterProd.replace(
-            new RegExp(dirLocal, "g"),
-            urlOnline,
-          );
+          var parameterOnline = parameterProd.replaceAll(dirLocal, urlTestFiles);
           var parameterOld = parameterOnline.replace(
             /\bsrc=/g,
             /\bbookMode=true\b/.test(entry.options) ? "b=" : "x=",

--- a/packages/viewer/gulpfile.js
+++ b/packages/viewer/gulpfile.js
@@ -34,8 +34,10 @@ const VIEWER_JS_FILES = {
   production: path.relative(DEST_DIR, pkg.main),
   development: "js/vivliostyle-viewer-dev.js",
 };
+const DEV_SERVER_PORT = 3300;
+const DEV_SERVER_ORIGIN = `http://localhost:${DEV_SERVER_PORT}`;
 const DEV_SERVER_LOCK_FILE = path.resolve(".cache", "dev-server.json");
-const DEV_SERVER_DEFAULT_URL = "http://localhost:3000/core/test/files/";
+const DEV_SERVER_DEFAULT_URL = `${DEV_SERVER_ORIGIN}/core/test/files/`;
 
 const VIVLIOSTYLE_VERSION = process.env["VIVLIOSTYLE_VERSION"];
 const VERSION =
@@ -141,7 +143,7 @@ function findRunningDevServer() {
 
 function getLocalServerOrigin(bs) {
   if (!bs || typeof bs.getOption !== "function") {
-    return "http://localhost:3000";
+    return DEV_SERVER_ORIGIN;
   }
   const urls = bs.getOption("urls");
   if (urls && typeof urls.get === "function") {
@@ -150,7 +152,7 @@ function getLocalServerOrigin(bs) {
       return local;
     }
   }
-  return "http://localhost:3000";
+  return DEV_SERVER_ORIGIN;
 }
 
 function getDevServerUrl(localUrl) {
@@ -326,7 +328,7 @@ function serve(isDevelopment) {
       startPath: "/core/test/files/",
       ghostMode: false, // do not mirror clicks, scrolls etc. between multiple browsers
       notify: false, // do not show any notifications in the browser
-      port: 3000,
+      port: DEV_SERVER_PORT,
       cors: true, // allow cross-origin requests so online viewers can load local test files
     },
     (_, bs) => {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -2,6 +2,9 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 
+const DEV_SERVER_PORT = 3300;
+const DEV_SERVER_DEFAULT_URL = `http://localhost:${DEV_SERVER_PORT}/core/test/files/`;
+
 const DEV_SERVER_LOCK_FILE = resolve(
   process.cwd(),
   "packages/viewer/.cache/dev-server.json",
@@ -27,7 +30,7 @@ function getExistingDevServerUrl() {
   try {
     const lock = JSON.parse(readFileSync(DEV_SERVER_LOCK_FILE, "utf8"));
     if (isProcessAlive(lock.pid)) {
-      return lock.url || "http://localhost:3000/core/test/files/";
+      return lock.url || DEV_SERVER_DEFAULT_URL;
     }
   } catch {
     // Ignore parse/read errors and remove broken lock file below.

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -32,13 +32,15 @@ const fileListPath = path.join(
   "packages/core/test/files/file-list.js",
 );
 const testFilesRootPrefix = "packages/core/test/files/";
+const localDevServerOrigin = "http://localhost:3300";
+const localDevServerTestFilesUrl = `${localDevServerOrigin}/core/test/files/`;
 
 // These params are appended last so that values explicitly specified earlier
 // via --extra-viewer-params take precedence: the viewer always uses the first
 // occurrence of a repeated parameter, so a user-supplied zoom or spread value
 // will win and these fallbacks will be ignored for that parameter.
 const fallbackViewerParams = "&zoom=1&spread=false";
-const wptReftestViewerParams = "&pixelRatio=0";
+const wptReftestViewerParams = "&pixelRatio=0&bookMode=false";
 
 const defaults = {
   mode: "version-diff",
@@ -268,7 +270,7 @@ function testFilesBaseUrlForViewer(viewerUrl, gitRef) {
       return `${origin}/core/test/files/`;
     } catch {
       // Fallback for malformed local viewer URL values.
-      return "http://localhost:3000/core/test/files/";
+      return localDevServerTestFilesUrl;
     }
   }
 
@@ -619,11 +621,11 @@ function resolveViewerSpec(spec) {
     return { url: "https://vivliostyle.org/viewer/", label: "stable" };
   if (s === "dev")
     return {
-      url: "http://localhost:3000/viewer/lib/vivliostyle-viewer-dev.html",
+      url: `${localDevServerOrigin}/viewer/lib/vivliostyle-viewer-dev.html`,
       label: "dev",
     };
   if (s === "prod")
-    return { url: "http://localhost:3000/viewer/lib/", label: "prod" };
+    return { url: `${localDevServerOrigin}/viewer/lib/`, label: "prod" };
 
   // git-<branch> or git:<branch> → Vercel PR preview URL (e.g. git-fix-issue1775)
   if (/^git[-:]/.test(s)) {


### PR DESCRIPTION
Change the local development server defaults from `localhost:3000` to `localhost:3300` across `yarn dev`, layout-regression helpers, and the developer documentation.

When the test case index is opened locally, make online viewers use the local test file URLs as `#src=` targets so newly added test files can be opened before they exist on GitHub.

Also append `bookMode=false` to WPT reftest viewer params so WPT runs disable EPUB/WebPub-specific behavior.

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author asked to change the dev server's default port from 3000 (which conflicts with other common tools such as the VS Code Live Preview extension) to 3300, and verified the resulting `yarn dev` behavior themselves.
- The human author separately added a `bookMode=false` fix themselves for WPT viewer parameters, ran `/address-pr-comments`, and suggested simplifying a `split().join()` call to the equivalent `replaceAll()` for clarity.

</details>
