### PR TITLE
fix: Fix named-page breaks after out-of-flow siblings

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3584,7 +3584,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         // prevent unnecessary breaks at the beginning of the column/page
         // after out-of-flow elements, e.g. position:absolute or running().
         // (Issue #1176)
-        !atLeadingEdgeIgnoringOutOfFlow()
+        !atLeadingEdgeIgnoringOutOfFlow() &&
+        !atLeadingEdgeAfterOnlyOutOfFlowSiblings()
       );
     }
 
@@ -3620,6 +3621,44 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         }
       }
       return true;
+    }
+
+    // Issue #1915: if a normal-flow element is preceded only by out-of-flow
+    // siblings, treat it like the leading edge and suppress an extra forced
+    // break. Keep pseudo/shadow-generated content out of this special case.
+    function atLeadingEdgeAfterOnlyOutOfFlowSiblings(): boolean {
+      if (
+        lastAfterNodeContext ||
+        !nodeContext?.viewNode ||
+        nodeContext.shadowContext ||
+        nodeContext.after ||
+        nodeContext.floatSide ||
+        !nodeContext.parent?.viewNode ||
+        LayoutHelper.isOutOfFlow(nodeContext.parent.viewNode)
+      ) {
+        return false;
+      }
+      let sawOutOfFlowSibling = false;
+      for (let nc = nodeContext; nc?.parent && !nc.after; nc = nc.parent) {
+        if (nc !== nodeContext && LayoutHelper.isOutOfFlow(nc.viewNode)) {
+          return false;
+        }
+        let node = nc.viewNode?.previousSibling;
+        while (
+          node &&
+          (VtreeImpl.canIgnore(node, nc.parent.whitespace) ||
+            LayoutHelper.isOutOfFlow(node))
+        ) {
+          if (LayoutHelper.isOutOfFlow(node)) {
+            sawOutOfFlowSibling = true;
+          }
+          node = node.previousSibling;
+        }
+        if (node) {
+          return false;
+        }
+      }
+      return sawOutOfFlowSibling;
     }
 
     const processForcedBreak = () => {


### PR DESCRIPTION
Suppress forced page breaks only for the narrow case where a normal-flow element is preceded solely by out-of-flow siblings under a normal-flow parent.

Keep the existing leading-edge handling for general out-of-flow ancestry, and exclude `shadowContext` so pseudo/shadow-generated content does not lose valid forced breaks.

This change turns the following WPT tests from FAIL to PASS:
- `css/css-page/page-name-fixed-pos-001-print.html`
- `css/css-page/page-name-float-001-print.html`
- `css/css-page/page-name-propagated-004-print.html`

It preserves the intended unsupported status of
`css/css-page/page-name-003-print.html` and avoids regressions in `break_on_pseudo_of_flow_elements.html`.

Refs #1915

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to fix a set of named-page WPT test failures related to out-of-flow siblings preceding forced breaks, part of the larger issue #1915 grouping.
- The human author directed the fix's scope and verification against the specific WPT test files listed.

</details>
