### PR TITLE
fix: Fix first table row's page-break-before not propagating to the table

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1793,6 +1793,23 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     const initialNodeContext = nodeContext.copy();
     this.layoutEntireTable(nodeContext, column).then((nodeContextAfter) => {
       const tableElement = nodeContextAfter.viewNode as Element;
+
+      // CSS 2.1 §13.3.3: The first row's break-before propagates to the
+      // table.  If the first row has a forced break-before and the table is
+      // not at the leading edge of the page/column, trigger a page break
+      // before the table so it moves to the next page.
+      const firstRow = formattingContext.rows[0];
+      if (
+        firstRow &&
+        Break.isForcedBreakValue(firstRow.breakBefore) &&
+        this.hasInFlowContentBefore(tableElement, column)
+      ) {
+        tableElement.parentNode?.removeChild(tableElement);
+        column.pageBreakType = firstRow.breakBefore;
+        frame.finish(initialNodeContext);
+        return;
+      }
+
       const tableBBox = LayoutHelper.getElementClientRectAdjusted(
         column.clientLayout,
         tableElement,
@@ -1845,6 +1862,33 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
       ) {
         return true;
       }
+    }
+    return false;
+  }
+
+  /**
+   * Check if there is any in-flow content before the given view node.
+   * Walks previous siblings at each ancestor level (up to the column root)
+   * to determine whether the table is at the leading edge of the
+   * page/column.
+   */
+  private hasInFlowContentBefore(
+    viewNode: Node,
+    column: Layout.Column,
+  ): boolean {
+    let node: Node | null = viewNode;
+    while (node && node !== column.element) {
+      let sibling = node.previousSibling;
+      while (sibling) {
+        if (sibling.nodeType === 1 && !LayoutHelper.isOutOfFlow(sibling)) {
+          return true;
+        }
+        if (sibling.nodeType === 3 && !VtreeImpl.canIgnore(sibling)) {
+          return true;
+        }
+        sibling = sibling.previousSibling;
+      }
+      node = node.parentNode;
     }
     return false;
   }


### PR DESCRIPTION
CSS 2.1 §13.3.3 specifies that the first child's `break-before` value propagates to the parent. When the first `<tr>` has `page-break-before: always`, a page break should occur before the `<table>`, but this was not happening.

The first row's `breakBefore` was correctly captured into `formattingContext.rows[0].breakBefore` during initial table layout, and `hasForcedBreakInRows()` intentionally skipped it (treating it as a break before the table rather than inside), but no code performed the actual propagation to trigger a page break before the table.

In `doInitialLayout`, after `layoutEntireTable` completes, check if the first row has a forced `breakBefore` and the table is not at the leading edge of the page/column. If so, remove the table view node and set `column.pageBreakType` to move the table to the next page.

Refs #1915

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` for `css/CSS2/pagination/table-page-break-inside-avoid-5-print.html`; the AI diagnosed the missing break-before propagation from the first table row.
- The human author ran `/draft-commit` and `/address-pr-comments` to finalize the PR.

</details>
