### PR TITLE
fix: Fix nested multi-column layout regressions on WPT

### DIFF
--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -385,6 +385,18 @@ export function fixAutoFillMultiColumnBox(
   // If it overflows, find a non-overflow block-size by binary search.
   element.style.columnFill = "auto";
   const blockSize2 = parseFloat(computedStyle.blockSize);
+  if (
+    blockSize2 <= 0 ||
+    (element.parentElement &&
+      findAncestorNonRootMultiColumn(element.parentElement))
+  ) {
+    // When the multicol has no in-flow content or is nested inside another
+    // multicol container, skip setting an explicit block-size. Setting one
+    // overrides the browser's natural height and prevents proper sizing in
+    // the parent multicol's fragmentation context. (Issue #1916)
+    element.removeAttribute("data-viv-saved-column-fill");
+    return;
+  }
   let blockSize = NaN;
   element.style.blockSize = `${blockSize2}px`;
   if (!checkRootColumnOverflow(column)) {


### PR DESCRIPTION
`fixAutoFillMultiColumnBox()` was setting an explicit `block-size` on non-root multicol elements after restoring `column-fill: auto`. This overrides the browser's natural sizing and prevents proper layout in the parent multicol's fragmentation context, causing nested multicol content (especially out-of-flow positioned elements and column rules) to collapse or render incorrectly.

Skip setting `block-size` when the element has no in-flow content (`blockSize <= 0`) or is nested inside another multi-column container, detected via the existing `findAncestorNonRootMultiColumn()`.

Fixes 8 of 11 WPT cases: all 6 `out-of-flow-in-multicolumn` tests (021, 023, 024, 028, 071, 081), `fixed-in-nested-multicol-with-viewport-container`, and `multicol-nested-column-rule-002`.

Refs #1916

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` for issue #1916's multi-column WPT failures, directing the AI to start with a specific failing test case.
- The human author found an additional related case (`multicol-nested-column-rule-002`) themselves via DevTools inspection and identified it as the same class of bug, then questioned whether a new helper the AI added was redundant with an existing one (`findAncestorNonRootMultiColumn()`) and whether it handled the `column-width`-only case correctly.
- The human author ran `/draft-commit` three times as the fix was extended to cover the additional cases.

</details>
