### PR TITLE
fix: Fix WPT flexbox-min-height-auto reftest failures with pixelRatio=0

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -516,7 +516,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   private almostEquals(
     a: number,
     b: number,
-    precision = 1.5 / (this.clientLayout.pixelRatio || 1),
+    precision = this.clientLayout.pixelRatio === 0
+      ? 0.5
+      : 1.5 / (this.clientLayout.pixelRatio || 1),
   ): boolean {
     return Math.abs(a - b) < precision;
   }


### PR DESCRIPTION
The `almostEquals()` band-edge snapping in `createFloats()` used a default precision of `1.5 / (pixelRatio || 1)`, which gave 1.5px when `pixelRatio=0`. This collapsed 1px-tall float exclusion bands to zero height, causing subsequent floats to overlap instead of stacking.

Change the fallback precision to 0.5px when `pixelRatio=0` so that `|1| < 0.5` is false and 1px bands are preserved.

Resolved WPT tests:
- css/css-flexbox/flexbox-min-height-auto-001.html
- css/css-flexbox/flexbox-min-height-auto-002a.html
- css/css-flexbox/flexbox-min-height-auto-002b.html
- css/css-flexbox/flexbox-min-height-auto-002c.html

All 24 WPT tests in issue #1917 now PASS.

Closes #1917

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` for the remaining 4 unresolved cases in issue #1917, and separately identified PR #1739 as a likely root cause and that omitting `pixelRatio=0` produced correct results, guiding the fix toward the precision-snapping logic.
- After the fix worked, the human author reflected on friction points from the session and asked the AI to document them for future sessions (documenting the WPT source/deployment relationship in a skill file, correcting an overly verbose description, and fixing a build-verification instruction that referenced an unnecessary file-watch pattern); the human author also asked to suppress a `yarn dev` deprecation warning the same way `yarn test` already did, and clarified their own preference for how build-completion should be verified.
- The human author asked for the issue #1917 fix and the unrelated tooling/doc changes to be split into separate commits, ran `/draft-commit` and `/address-pr-comments`, then asked for an amend and push.

</details>
