### PR TITLE
fix: Fix CORS and cross-origin resource regressions in WPT tests

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -89,11 +89,12 @@ export function setResourceBaseURL(value: string): void {
   resourceBaseURL = value;
 }
 
-function getWptRawRepoRootURL(url: string): string | null {
-  const matched = stripFragmentAndQuery(url).match(
-    /^(https?:\/\/raw\.githack\.com\/web-platform-tests\/wpt\/[^/]+)(?:\/|$)/,
+function getWptLiveURL(url: string): string | null {
+  const result = url.replace(
+    /^(https?:)\/\/raw\.githack\.com\/web-platform-tests\/wpt\/[^/]+\//,
+    "$1//wpt.live/",
   );
-  return matched ? matched[1] : null;
+  return result !== url ? result : null;
 }
 
 /**
@@ -117,6 +118,9 @@ export function resolveURL(relURL: string, baseURL: string): string {
   if (baseURL.match(/^\w{2,}:\/\/[^\/]+$/)) {
     baseURL = `${baseURL}/`;
   }
+  // If baseURL is a WPT raw.githack.com URL, resolve sub-resources against
+  // wpt.live instead so that dynamic resources (.py scripts) work correctly.
+  baseURL = getWptLiveURL(baseURL) ?? baseURL;
   let r: string[];
   if (relURL.match(/^\/\//)) {
     r = baseURL.match(/^(\w{2,}:)\/\//);
@@ -126,10 +130,6 @@ export function resolveURL(relURL: string, baseURL: string): string {
     return relURL;
   }
   if (relURL.match(/^\//)) {
-    const wptRawRepoRootURL = getWptRawRepoRootURL(baseURL);
-    if (wptRawRepoRootURL) {
-      return wptRawRepoRootURL + relURL;
-    }
     r = baseURL.match(/^(\w{2,}:\/\/[^\/]+)\//);
     if (r) {
       return r[1] + relURL;
@@ -214,7 +214,11 @@ export function convertSpecialURL(url: string): string {
     // Convert WPT live URL to raw.githack.com URL so it can be fetched without
     // CORS issues and with correct MIME types for embedded resources (e.g.,
     // <object data="..."> with type="text/html").
-    url = `${r[1]}//raw.githack.com/web-platform-tests/wpt/master/${r[2]}`;
+    // Exception: .sub.* files require WPT server-side template substitution
+    // (e.g. {{hosts[alt][]}}) and must remain on wpt.live to be served correctly.
+    if (!/\.sub\.[^/]+(?:[?#].*)?$/.test(r[2])) {
+      url = `${r[1]}//raw.githack.com/web-platform-tests/wpt/master/${r[2]}`;
+    }
   } else if (
     (r =
       /^(https?:)\/\/www\.aozora\.gr\.jp\/(cards\/[^/]+\/files\/[^/.]+\.html)$/.exec(

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -71,28 +71,58 @@ describe("base", function () {
         "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/css/CSS2/fonts/font-family-008.xht",
       );
     });
+
+    it("does not convert wpt.live .sub.* URLs to raw.githack.com (server-side substitution required)", function () {
+      expect(
+        module.convertSpecialURL(
+          "https://wpt.live/fetch/corb/img-png-mislabeled-as-html.sub.html",
+        ),
+      ).toBe("https://wpt.live/fetch/corb/img-png-mislabeled-as-html.sub.html");
+      expect(
+        module.convertSpecialURL(
+          "https://wpt.live/density-size-correction/density-corrected-size-img-cross-origin.sub.html",
+        ),
+      ).toBe(
+        "https://wpt.live/density-size-correction/density-corrected-size-img-cross-origin.sub.html",
+      );
+      expect(
+        module.convertSpecialURL("https://wpt.live/some/test.sub.any.js"),
+      ).toBe("https://wpt.live/some/test.sub.any.js");
+      expect(
+        module.convertSpecialURL(
+          "https://wpt.live/some/test.sub.any.worker.js",
+        ),
+      ).toBe("https://wpt.live/some/test.sub.any.worker.js");
+    });
   });
 
   describe("resolveURL", function () {
-    it("keeps repo-root absolute paths within the WPT raw.githack.com mirror", function () {
+    it("resolves repo-root absolute paths to wpt.live when base is a WPT raw.githack.com URL", function () {
       expect(
         module.resolveURL(
           "/fonts/Lato-Medium.ttf",
           "https://raw.githack.com/web-platform-tests/wpt/master/css/css-fonts/font-face-src-list.html",
         ),
-      ).toBe(
-        "https://raw.githack.com/web-platform-tests/wpt/master/fonts/Lato-Medium.ttf",
-      );
+      ).toBe("https://wpt.live/fonts/Lato-Medium.ttf");
     });
 
-    it("keeps repo-root absolute paths within the WPT mirror for non-master branches", function () {
+    it("resolves repo-root absolute paths to wpt.live for non-master branch WPT raw.githack.com URLs", function () {
       expect(
         module.resolveURL(
           "/fonts/ahem.css",
           "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/css/CSS2/fonts/font-family-008.xht",
         ),
+      ).toBe("https://wpt.live/fonts/ahem.css");
+    });
+
+    it("resolves relative sub-resources to wpt.live when base is a WPT raw.githack.com URL", function () {
+      expect(
+        module.resolveURL(
+          "resources/dpr.py?name=square.png&dpr=2",
+          "https://raw.githack.com/web-platform-tests/wpt/master/content-dpr/image.html",
+        ),
       ).toBe(
-        "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/fonts/ahem.css",
+        "https://wpt.live/content-dpr/resources/dpr.py?name=square.png&dpr=2",
       );
     });
   });


### PR DESCRIPTION
PR #1890 introduced a conversion of `wpt.live` URLs to `raw.githack.com/web-platform-tests/wpt/master/` in `convertSpecialURL()` so that WPT tests could be opened in a regular browser without CORS issues. This caused regressions in two ways:

1. Sub-resources referenced via relative or absolute paths (e.g. `resources/dpr.py?name=square.png`) were resolved against the `raw.githack.com` origin, where dynamic `.py` scripts do not work. Fixed by replacing `getWptRawRepoRootURL()` with `getWptLiveURL()` in `resolveURL()`: when the `baseURL` is a `raw.githack.com` WPT URL, all relative sub-resource URLs are now resolved back to `wpt.live`.
2. WPT `.sub.*` files contain server-side template substitution markers (e.g. `{{hosts[alt][]}}`), which only the `wpt.live` server can expand. Converting these to `raw.githack.com` served the unexpanded template as HTML, breaking cross-origin image tests in `fetch/corb`, `fetch/orb`, `density-size-correction`, and `content-dpr`. Fixed by skipping the `raw.githack.com` conversion for `.sub.*` files in `convertSpecialURL()`.

Closes #1919

Assisted-by: GitHub Copilot Chat:claude-sonnet-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` for a set of CORS/cross-origin regressions traced to an earlier PR (#1890) and let the AI investigate the two distinct root causes.
- The human author ran `yarn dev` and tested locally, ran `/address-pr-comments`, and asked the AI to check a specific test result during verification.

</details>
