### PR TITLE
fix: Fix CSS nesting recovery for malformed declarations

### DIFF
--- a/packages/core/src/vivliostyle/css-nesting.ts
+++ b/packages/core/src/vivliostyle/css-nesting.ts
@@ -72,11 +72,16 @@ function expandBlock(
     }
 
     if (input[index] === "@") {
-      flushDeclarations();
       const atRule = readAtRule(input, index, end);
       if (!atRule) {
         break;
       }
+      if (parentSelector && !SUPPORTED_GROUP_RULES.has(atRule.name)) {
+        declarations.push(compactWhitespace(input.slice(index, atRule.end)));
+        index = atRule.end;
+        continue;
+      }
+      flushDeclarations();
       if (atRule.hasBlock && SUPPORTED_GROUP_RULES.has(atRule.name)) {
         const inner = expandBlock(
           input,
@@ -110,6 +115,15 @@ function expandBlock(
     if (!rule) {
       const raw = readUntilSemicolonOrBrace(input, index, end);
       statements.push(compactWhitespace(raw.text));
+      index = raw.end;
+      continue;
+    }
+    if (
+      parentSelector &&
+      shouldKeepRuleLikeChunkInDeclarations(input, index, rule)
+    ) {
+      const raw = readRuleLikeDeclaration(input, index, rule.end, end);
+      declarations.push(compactWhitespace(raw.text));
       index = raw.end;
       continue;
     }
@@ -381,16 +395,40 @@ function isDeclarationStart(
   if (colonIndex >= end || input[colonIndex] !== ":") {
     return false;
   }
-  if (input[start] === "-" && input[start + 1] === "-") {
-    return true;
-  }
   const terminator = findTopLevelTerminator(
     input,
     colonIndex + 1,
     end,
     DECLARATION_START_TERMINATORS,
   );
-  return !terminator || terminator.char !== "{";
+  if (terminator?.char === "{") {
+    return !isLikelyNestedTypeOrUniversalSelector(
+      input,
+      start,
+      identEnd,
+      colonIndex,
+      terminator.index,
+    );
+  }
+  return true;
+}
+
+function isLikelyNestedTypeOrUniversalSelector(
+  input: string,
+  start: number,
+  identEnd: number,
+  colonIndex: number,
+  blockIndex: number,
+): boolean {
+  if (skipIgnorable(input, identEnd, blockIndex) !== colonIndex) {
+    return false;
+  }
+  const afterColon = skipIgnorable(input, colonIndex + 1, blockIndex);
+  if (afterColon !== colonIndex + 1 || afterColon >= blockIndex) {
+    return false;
+  }
+  const char = input[afterColon];
+  return char === ":" || char === "\\" || /[A-Za-z_-]/.test(char);
 }
 
 function readPropertyName(input: string, start: number, end: number): number {
@@ -476,6 +514,64 @@ function readStyleRule(
     blockStart: header.index + 1,
     blockEnd,
     end: blockEnd + 1,
+  };
+}
+
+function shouldKeepRuleLikeChunkInDeclarations(
+  input: string,
+  start: number,
+  rule: {
+    prelude: string;
+    blockStart: number;
+    blockEnd: number;
+    end: number;
+  },
+): boolean {
+  if (!isPlausibleNestedSelectorPrelude(input, start, rule.blockStart - 1)) {
+    return true;
+  }
+  const bodyStart = skipIgnorable(input, rule.blockStart, rule.blockEnd);
+  return bodyStart < rule.blockEnd && input[bodyStart] === ";";
+}
+
+function isPlausibleNestedSelectorPrelude(
+  input: string,
+  start: number,
+  end: number,
+): boolean {
+  const index = skipIgnorable(input, start, end);
+  if (index >= end) {
+    return false;
+  }
+  const char = input[index];
+  return (
+    char === "&" ||
+    char === "." ||
+    char === "#" ||
+    char === ":" ||
+    char === "[" ||
+    char === "|" ||
+    char === "*" ||
+    char === ">" ||
+    char === "+" ||
+    char === "~" ||
+    char === "\\" ||
+    /[A-Za-z_-]/.test(char)
+  );
+}
+
+function readRuleLikeDeclaration(
+  input: string,
+  start: number,
+  ruleEnd: number,
+  end: number,
+): { text: string; end: number } {
+  const suffixStart = skipIgnorable(input, ruleEnd, end);
+  const declarationEnd =
+    suffixStart < end && input[suffixStart] === ";" ? suffixStart + 1 : ruleEnd;
+  return {
+    text: input.slice(start, declarationEnd),
+    end: declarationEnd,
   };
 }
 

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -208,6 +208,18 @@ describe("css-parser", function () {
         ).toBe(".foo { color: blue; }\n:is(.foo) .bar { background: green; }");
       });
 
+      it("still expands type selectors followed by pseudo-classes", function () {
+        expect(
+          adapt_cssnesting.expandNesting(".foo { a:hover { color: red; } }"),
+        ).toBe(":is(.foo) a:hover { color: red; }");
+      });
+
+      it("still expands namespace-prefixed type selectors", function () {
+        expect(
+          adapt_cssnesting.expandNesting(".foo { |a { color: red; } }"),
+        ).toBe(":is(.foo) |a { color: red; }");
+      });
+
       it("parses semicolonless declarations after preprocessing", function (done) {
         spyOn(handler, "property");
         parse(done, "ul { background: green }", function () {


### PR DESCRIPTION
Keep `css-nesting` preprocessing from rewriting malformed declaration syntax into nested rules or nested at-rules.

Treat property-like `ident:` prefixes as declarations, keep unsupported nested `@rule`s inside the parent declaration block, and preserve ambiguous rule-like chunks such as `color{...}` or `12 @page {...}` for normal CSS error recovery.

This restores PASS for these WPT cases:
- `css/CSS2/css1/c71-fwd-parsing-000.xht`
- `css/CSS2/syntax/malformed-decl-006.xht`
- `css/CSS2/syntax/malformed-decl-block-001.xht`
- `css/css-variables/variable-reference-18.html`

Refs #1921

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` for the CSS Nesting malformed-declaration WPT regressions (issue #1921), and the AI investigated and implemented the preprocessing fix.
- The human author ran `/draft-commit` and `/address-pr-comments`.

</details>
