### PR TITLE
fix: Fix `::marker` pseudo-element property polyfill for missing CSS properties

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1648,6 +1648,27 @@ span[data-viv-leader] {
 [style*="--viv-marker-text-orientation"]::marker {
   text-orientation: var(--viv-marker-text-orientation);
 }
+[style*="--viv-marker-hyphens"]::marker {
+  hyphens: var(--viv-marker-hyphens);
+}
+[style*="--viv-marker-line-height"]::marker {
+  line-height: var(--viv-marker-line-height);
+}
+[style*="--viv-marker-tab-size"]::marker {
+  tab-size: var(--viv-marker-tab-size);
+}
+[style*="--viv-marker-text-emphasis-style"]::marker {
+  text-emphasis-style: var(--viv-marker-text-emphasis-style);
+}
+[style*="--viv-marker-text-emphasis-color"]::marker {
+  text-emphasis-color: var(--viv-marker-text-emphasis-color);
+}
+[style*="--viv-marker-text-emphasis-position"]::marker {
+  text-emphasis-position: var(--viv-marker-text-emphasis-position);
+}
+[style*="--viv-marker-text-shadow"]::marker {
+  text-shadow: var(--viv-marker-text-shadow);
+}
 
 /* initial-letter */
 [style*="--viv-initialLetter"]:has(>[data-adapt-pseudo="first-letter"])::first-letter {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3921,12 +3921,19 @@ export class CascadeInstance {
     "font-style",
     "font-weight",
     "font-variant",
+    "hyphens",
+    "line-height",
+    "tab-size",
+    "text-combine-upright",
+    "text-emphasis-color",
+    "text-emphasis-position",
+    "text-emphasis-style",
+    "text-orientation",
+    "text-shadow",
+    "text-transform",
     "unicode-bidi",
     "direction",
     "white-space",
-    "text-transform",
-    "text-combine-upright",
-    "text-orientation",
   ];
 
   /**


### PR DESCRIPTION
Add `hyphens`, `line-height`, `tab-size`, `text-emphasis-color`, `text-emphasis-position`, `text-emphasis-style`, and `text-shadow` to the `markerAllowedProps` whitelist in `css-cascade.ts` and corresponding `--viv-marker-*` polyfill CSS rules in `assets.ts`.

The native `::marker` polyfill introduced in commit 1a90b1291 only passes through CSS properties listed in `markerAllowedProps`. These missing properties caused WPT `::marker` test regressions. With this fix:

- `marker-hyphens.html`: PASS
- `marker-tab-size.html`: PASS
- `marker-text-emphasis.html`: PASS
- `marker-text-shadow.html`: PASS
- `marker-line-height.html`: 28 diffPixels (diffRatio 0.003%) remain due to subpixel font rendering differences between the native `::marker` pseudo-element and regular text elements. The test and reference renders are visually identical; this is an inherent browser rendering limitation, not a Vivliostyle bug.

Refs #1921

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to investigate the 5 unresolved `::marker` pseudo-element WPT test cases listed under issue #1921, using `/fix-wpt-reftest-failure`.
- The AI ran the reftest-diff comparison against v2.40.0 to confirm 3 were regressions and 2 were changed-fail, fetched the WPT test sources, and traced all 5 to missing entries in the `markerAllowedProps` whitelist used by the native `::marker` polyfill, then implemented the fix.

</details>
