### PR TITLE
fix: Fix CORS errors and hangs when opening WPT files in Vivliostyle Viewer

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -89,12 +89,23 @@ export function setResourceBaseURL(value: string): void {
   resourceBaseURL = value;
 }
 
-function getWptLiveURL(url: string): string | null {
-  const result = url.replace(
+function getWptRawRepoRootURL(url: string): string | null {
+  const matched = stripFragmentAndQuery(url).match(
+    /^(https?:\/\/raw\.githack\.com\/web-platform-tests\/wpt\/[^/]+)(?:\/|$)/,
+  );
+  return matched ? matched[1] : null;
+}
+
+/**
+ * Convert a WPT raw.githack.com URL to the equivalent wpt.live URL.
+ * Applied at DOM/CSS output points for resource URLs (images, fonts, etc.)
+ * so that dynamic WPT endpoints (e.g. `.py` scripts) work correctly.
+ */
+export function resolveWptResourceURL(url: string): string {
+  return url.replace(
     /^(https?:)\/\/raw\.githack\.com\/web-platform-tests\/wpt\/[^/]+\//,
     "$1//wpt.live/",
   );
-  return result !== url ? result : null;
 }
 
 /**
@@ -118,9 +129,6 @@ export function resolveURL(relURL: string, baseURL: string): string {
   if (baseURL.match(/^\w{2,}:\/\/[^\/]+$/)) {
     baseURL = `${baseURL}/`;
   }
-  // If baseURL is a WPT raw.githack.com URL, resolve sub-resources against
-  // wpt.live instead so that dynamic resources (.py scripts) work correctly.
-  baseURL = getWptLiveURL(baseURL) ?? baseURL;
   let r: string[];
   if (relURL.match(/^\/\//)) {
     r = baseURL.match(/^(\w{2,}:)\/\//);
@@ -130,6 +138,10 @@ export function resolveURL(relURL: string, baseURL: string): string {
     return relURL;
   }
   if (relURL.match(/^\//)) {
+    const wptRawRepoRootURL = getWptRawRepoRootURL(baseURL);
+    if (wptRawRepoRootURL) {
+      return wptRawRepoRootURL + relURL;
+    }
     r = baseURL.match(/^(\w{2,}:\/\/[^\/]+)\//);
     if (r) {
       return r[1] + relURL;

--- a/packages/core/src/vivliostyle/css-prop.ts
+++ b/packages/core/src/vivliostyle/css-prop.ts
@@ -267,6 +267,10 @@ export class UrlTransformVisitor extends Css.FilterVisitor {
   }
 
   override visitURL(url: Css.URL): Css.Val {
-    return new Css.URL(this.transformer.transformURL(url.url, this.baseUrl));
+    return new Css.URL(
+      Base.resolveWptResourceURL(
+        this.transformer.transformURL(url.url, this.baseUrl),
+      ),
+    );
   }
 }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -3065,7 +3065,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     if (!result) {
       result = this.viewport.document.createElement("object");
       if (data) {
-        result.setAttribute("data", data);
+        result.setAttribute("data", Base.resolveWptResourceURL(data));
       }
       result.setAttribute("data-adapt-process-children", "true");
     }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1774,9 +1774,15 @@ export class ViewFactory
             } else if (attributeName == "srcset") {
               attributeValue = attributeValue
                 .split(",")
-                .map((value) =>
-                  Base.resolveWptResourceURL(this.resolveURL(value.trim())),
-                )
+                .map((entry) => {
+                  const parts = entry.trim().split(/\s+/);
+                  const url = Base.resolveWptResourceURL(
+                    this.resolveURL(parts[0]),
+                  );
+                  return parts.length > 1
+                    ? `${url} ${parts.slice(1).join(" ")}`
+                    : url;
+                })
                 .join(",");
             } else if (
               attributeName === "data" &&
@@ -2887,7 +2893,7 @@ export class ViewFactory
         this.addImageFetchers(values[i]);
       }
     } else if (bg instanceof Css.URL) {
-      const url = (bg as Css.URL).url;
+      const url = Base.resolveWptResourceURL((bg as Css.URL).url);
       this.page.fetchers.push(Net.loadElement(new Image(), url));
     }
   }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1766,11 +1766,17 @@ export class ViewFactory
                   attributeValue,
                   this.xmldoc.url,
                 );
+              } else {
+                // Convert WPT raw.githack.com URLs to wpt.live for resource
+                // attributes (src, poster) so dynamic endpoints work.
+                attributeValue = Base.resolveWptResourceURL(attributeValue);
               }
             } else if (attributeName == "srcset") {
               attributeValue = attributeValue
                 .split(",")
-                .map((value) => this.resolveURL(value.trim()))
+                .map((value) =>
+                  Base.resolveWptResourceURL(this.resolveURL(value.trim())),
+                )
                 .join(",");
             } else if (
               attributeName === "data" &&

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -97,33 +97,55 @@ describe("base", function () {
   });
 
   describe("resolveURL", function () {
-    it("resolves repo-root absolute paths to wpt.live when base is a WPT raw.githack.com URL", function () {
+    it("keeps repo-root absolute paths within the WPT raw.githack.com mirror", function () {
       expect(
         module.resolveURL(
           "/fonts/Lato-Medium.ttf",
           "https://raw.githack.com/web-platform-tests/wpt/master/css/css-fonts/font-face-src-list.html",
         ),
-      ).toBe("https://wpt.live/fonts/Lato-Medium.ttf");
+      ).toBe(
+        "https://raw.githack.com/web-platform-tests/wpt/master/fonts/Lato-Medium.ttf",
+      );
     });
 
-    it("resolves repo-root absolute paths to wpt.live for non-master branch WPT raw.githack.com URLs", function () {
+    it("keeps repo-root absolute paths within the WPT mirror for non-master branches", function () {
       expect(
         module.resolveURL(
           "/fonts/ahem.css",
           "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/css/CSS2/fonts/font-family-008.xht",
         ),
-      ).toBe("https://wpt.live/fonts/ahem.css");
+      ).toBe(
+        "https://raw.githack.com/web-platform-tests/wpt/merge_pr_123456/fonts/ahem.css",
+      );
     });
 
-    it("resolves relative sub-resources to wpt.live when base is a WPT raw.githack.com URL", function () {
+    it("resolves relative sub-resources within raw.githack.com (not converted to wpt.live)", function () {
       expect(
         module.resolveURL(
           "resources/dpr.py?name=square.png&dpr=2",
           "https://raw.githack.com/web-platform-tests/wpt/master/content-dpr/image.html",
         ),
       ).toBe(
+        "https://raw.githack.com/web-platform-tests/wpt/master/content-dpr/resources/dpr.py?name=square.png&dpr=2",
+      );
+    });
+  });
+
+  describe("resolveWptResourceURL", function () {
+    it("converts raw.githack.com WPT URLs to wpt.live for browser-loaded resources", function () {
+      expect(
+        module.resolveWptResourceURL(
+          "https://raw.githack.com/web-platform-tests/wpt/master/content-dpr/resources/dpr.py?name=square.png&dpr=2",
+        ),
+      ).toBe(
         "https://wpt.live/content-dpr/resources/dpr.py?name=square.png&dpr=2",
       );
+    });
+
+    it("passes through non-WPT URLs unchanged", function () {
+      expect(
+        module.resolveWptResourceURL("https://example.com/image.png"),
+      ).toBe("https://example.com/image.png");
     });
   });
 


### PR DESCRIPTION
PR #1941 converted all sub-resource base URLs from `raw.githack.com` to `wpt.live` inside `resolveURL()`. This broke `loadPublication()` because internal path calculations (e.g. `getPathFromURL` calling `resolveURL("", pubURL)`) received a different origin, causing empty readingOrder and a hang. Additionally, resolving stylesheets to `wpt.live` triggered CORS errors since Vivliostyle fetches them via `fetch()`.

Fix by separating the two concerns:

- `resolveURL()` now keeps all URLs on `raw.githack.com` (CORS-safe for `fetch()`). Absolute paths (`/fonts/ahem.css`) are resolved within the repo root via `getWptRawRepoRootURL()` (restoring the pre-#1941 behavior).

- A new `resolveWptResourceURL()` converts `raw.githack.com` URLs to `wpt.live` and is applied only at DOM output points (`UrlTransformVisitor.visitURL()` for CSS `url()` values, and `ViewFactory.resolveURL()` for HTML `src`/`href`/`poster` attributes). Since browsers load images and fonts without CORS restrictions, these resources are fetched from `wpt.live` where `.py` scripts work correctly.

Refs #1919

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author reported a regression from PR #1941 causing CORS errors and hangs when opening WPT files directly in the viewer (outside the layout-regression tool), and precisely explained that the root cause was `resolveURL()`'s new `getWptLiveURL()` call affecting every caller, not something specific to any one test.
- The human author confirmed the fix resolved the hang, then reported a follow-up CORS problem for HTML file loading, guiding the AI toward the two-function separation (internal path resolution vs. DOM-output URL rewriting) as the fix; ran `/draft-commit` and `/address-pr-comments`, and reported and had fixed two further SVG-related regressions found during verification.

</details>
