### PR TITLE
fix: Fix CSS image preloading for border-image, list-style-image, mask-image, and video poster

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1796,18 +1796,20 @@ export class ViewFactory
             if (
               attributeName === "poster" &&
               tag === "video" &&
-              ns === Base.NS.XHTML &&
-              hasAutoWidth &&
-              hasAutoHeight
+              ns === Base.NS.XHTML
             ) {
               const image = new Image();
               const fetcher = Net.loadElement(image, attributeValue);
-              fetchers.push(fetcher);
-              images.push({
-                image,
-                element: result as HTMLElement,
-                fetcher,
-              });
+              if (hasAutoWidth && hasAutoHeight) {
+                fetchers.push(fetcher);
+                images.push({
+                  image,
+                  element: result as HTMLElement,
+                  fetcher,
+                });
+              } else {
+                this.page.fetchers.push(fetcher);
+              }
             }
           } else if (attributeNS == "http://www.w3.org/2000/xmlns/") {
             continue; // namespace declaration (in Firefox)
@@ -2895,6 +2897,14 @@ export class ViewFactory
     } else if (bg instanceof Css.URL) {
       const url = Base.resolveWptResourceURL((bg as Css.URL).url);
       this.page.fetchers.push(Net.loadElement(new Image(), url));
+    } else if (bg instanceof Css.Func) {
+      for (const v of (bg as Css.Func).values) {
+        this.addImageFetchers(v);
+      }
+    } else if (bg instanceof Css.SpaceList) {
+      for (const v of (bg as Css.SpaceList).values) {
+        this.addImageFetchers(v);
+      }
     }
   }
 
@@ -2905,6 +2915,18 @@ export class ViewFactory
     const bg = computedStyle["background-image"];
     if (bg) {
       this.addImageFetchers(bg);
+    }
+    const borderImageSource = computedStyle["border-image-source"];
+    if (borderImageSource) {
+      this.addImageFetchers(borderImageSource);
+    }
+    const listStyleImage = computedStyle["list-style-image"];
+    if (listStyleImage) {
+      this.addImageFetchers(listStyleImage);
+    }
+    const maskImage = computedStyle["mask-image"];
+    if (maskImage) {
+      this.addImageFetchers(maskImage);
     }
     const isRelativePositioned =
       computedStyle["position"] === Css.ident.relative;


### PR DESCRIPTION
Previously, `applyComputedStyles()` only called `addImageFetchers()` for `background-image`. Images specified via other CSS properties were applied to the DOM but not waited on before page capture, causing WPT reftest failures where screenshots were taken before images finished loading.

Changes:
- Add `border-image-source`, `list-style-image`, and `mask-image` to the set of CSS properties whose image URLs are preloaded via `addImageFetchers()` in `applyComputedStyles()`
- Extend `addImageFetchers()` to recurse into `Css.Func` and `Css.SpaceList` values so that URLs inside CSS functions like `image-set()` are also preloaded
- Fix `<video poster>` handling: when the video has explicit dimensions (not `hasAutoWidth && hasAutoHeight`), add the poster fetcher to `this.page.fetchers` so it is still waited on before page capture

Examples of WPT reftests fixed (FAIL → PASS):
- `border-image-source`: `css/css-backgrounds/border-image-002.html`, `border-image-repeat-space-*.html`, etc. (25 tests)
- `image-set()`: `css/css-images/image-set/image-set-rendering.html`, `image-set-dpi-rendering.html`, etc. (12 tests)
- `mask-image`: `css/css-masking/mask-image/mask-image-1a.html`, `mask-composite-1a.html`, etc. (43 tests)
- `list-style-image`: `css/CSS2/lists/list-style-image-005.xht` (1 test)
- `<video poster>`: `css/css-sizing/aspect-ratio-replaced-element-012.html`, etc. (5 tests)

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to investigate WPT canary-vs-stable regressions in CSS2 and css-backgrounds, hypothesizing that images loaded via certain CSS properties (unlike `img` elements) weren't being waited on before page capture, using `/fix-wpt-reftest-failure`.
- Across an extended investigation, the AI traced how `background-image` was preloaded via `addImageFetchers()` but `border-image-source`/`list-style-image`/`mask-image`/`image-set()` were not; the human author corrected the AI when it initially judged the `mask-image` fetcher addition unnecessary, pointing out that computed style values reflect whatever the browser supports regardless of whether Vivliostyle explicitly defines the property.
- The human author confirmed the fix against the listed WPT reftests and directed the commit message.

</details>
