### PR TITLE
fix: Fix list-style-image preloading for marker pseudo-element

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2928,6 +2928,10 @@ export class ViewFactory
     if (maskImage) {
       this.addImageFetchers(maskImage);
     }
+    const markerContent = computedStyle["--viv-marker-content"];
+    if (markerContent) {
+      this.addImageFetchers(markerContent);
+    }
     const isRelativePositioned =
       computedStyle["position"] === Css.ident.relative;
     const isRoot =


### PR DESCRIPTION
The `::marker` polyfill converts `list-style-image: url(...)` to the `--viv-marker-content` CSS custom property and resets `list-style-image` to `none`. This caused `addImageFetchers()` in `applyComputedStyles()` to skip the marker image URL because it only checked `list-style-image`, which was already `none` by that point.

The marker image was preloaded in the local `fetchers` array (for layout timing) but was not added to `page.fetchers` (for page capture timing), so `::marker` rendering could race against page capture.

Add `--viv-marker-content` to the set of properties checked by `addImageFetchers()` in `applyComputedStyles()` so marker image URLs are also added to `page.fetchers`.

Fixes WPT regressions: `list-style-image-applies-to-001.xht`, `-004.xht`, `-007.xht`, `-012.xht`, `-015.xht` (5 tests).

Refs PR #1946

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- Continuing the same session as PR #1946, the human author asked the AI to keep working through remaining WPT image-preloading regressions until the suite passed.
- The AI traced this remaining set of failures to the `::marker` polyfill's `--viv-marker-content` substitution bypassing the `list-style-image` check; the human author confirmed the fix against the listed WPT tests and directed the commit message to reference PR #1946.

</details>
