### PR TITLE
fix: Fix image preloading for `<embed>` elements and `<img srcset>` without `src`

### DIFF
--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -400,6 +400,20 @@ export function loadElement(
             (elem as any).alt = alt;
           }
         }
+      } else if (
+        elem.localName === "img" ||
+        elem.localName === "embed" ||
+        elem.localName === "object" ||
+        elem.localName === "iframe"
+      ) {
+        // No src provided: element already has its source attributes set
+        // (e.g., <img srcset="...">, <embed src="...">, <object data="...">).
+        // Check if already loaded and set a timeout as a safety net.
+        if ((elem as HTMLImageElement).complete) {
+          setTimeout(() => handler(new Event("load")), 0);
+        } else {
+          timeoutId = setTimeout(handler, 30000);
+        }
       }
       return frame.result();
     },

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1932,6 +1932,14 @@ export class ViewFactory
             }
             fetchers.push(imageFetcher);
           }
+        } else if (
+          !delayedSrc &&
+          tag === "img" &&
+          ns === Base.NS.XHTML &&
+          (result as HTMLImageElement).srcset
+        ) {
+          // <img srcset="..."> without src: wait for the image to load
+          this.page.fetchers.push(Net.loadElement(result));
         }
         delete computedStyle["content"];
 
@@ -1959,6 +1967,15 @@ export class ViewFactory
           result.localName === "object" &&
           result.namespaceURI === Base.NS.XHTML &&
           result.hasAttribute("data")
+        ) {
+          this.page.fetchers.push(Net.loadElement(result));
+        }
+
+        // Wait for embed element content to load (e.g., <embed src="image.png">).
+        if (
+          result.localName === "embed" &&
+          result.namespaceURI === Base.NS.XHTML &&
+          result.hasAttribute("src")
         ) {
           this.page.fetchers.push(Net.loadElement(result));
         }


### PR DESCRIPTION
Previously, `<embed src="...">` elements had no load-completion wait in `page.fetchers`, unlike `<object>` and `<iframe>`. This caused page captures to occur before embedded images finished loading, affecting WPT `object-fit-*-png-001e.html` tests (12 regressions).

Additionally, `<img srcset="...">` without a `src` attribute was not waited on at all, since the existing preload logic only triggered for `src`. This caused the `image-set-resolution-002.html` reference (which uses `<img srcset="... 0.5x">`) to render blank.

Changes:
- Add `<embed src="...">` load wait to `page.fetchers`
- Add `<img srcset="...">` (without `src`) load wait to `page.fetchers`

Refs PR #1946

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` to work through a CSS2/css-backgrounds image-loading regression report, correctly hypothesizing that some CSS properties lacked the load-wait handling that `<img>` already had; after that class of issue was resolved, the human author asked the AI to check the other WPT module reports in the same README for similar unresolved cases.
- The human author questioned whether `-webkit-mask-image` prefix support was still needed given modern Chrome versions, and pushed back on a proposed simplification, explaining the relevant computed-style/property-definition mechanics themselves.
- After the related PR (#1946) merged, the human author found a further regression via canary testing (`<embed>` element preloading) and asked the AI to investigate and fix it in a follow-up; ran `/draft-commit` multiple times, asked for concrete resolved-test examples in the commit message, and ran `/address-pr-comments`, questioning why the AI's fix differed from a Copilot-suggested changeset for the same code.

</details>
