### PR TITLE
fix: Fix `clip-path: url()` external SVG references not waited on before page capture

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2945,6 +2945,10 @@ export class ViewFactory
     if (maskImage) {
       this.addImageFetchers(maskImage);
     }
+    const clipPath = computedStyle["clip-path"];
+    if (clipPath) {
+      this.addImageFetchers(clipPath);
+    }
     const markerContent = computedStyle["--viv-marker-content"];
     if (markerContent) {
       this.addImageFetchers(markerContent);


### PR DESCRIPTION
Add `clip-path` to the set of CSS properties whose `url()` image references are preloaded via `addImageFetchers()` in `applyComputedStyles()`. Without this, external SVG `<clipPath>` elements referenced by `clip-path: url(...)` were not fetched before the page screenshot was taken. The browser treats an in-flight `clip-path` URL reference as an empty clip path, hiding the element entirely until the SVG finishes loading.

WPT reftests fixed (FAIL → PASS):
- `css/css-masking/clip-path/clip-path-url-reference-external.html`
- `css/css-masking/clip-path/reference-nonexisting-existing-local.html`

Refs PR #1946

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to investigate css-masking WPT regressions (4 cases reported by canary-vs-stable comparison) using `/fix-wpt-reftest-failure`.
- The AI fetched the WPT test sources for all 4 regressions, identified 3 as related to `clip-path` URL references and traced them to PR #1946's image-preloading fetcher list not including `clip-path`, then implemented the fix for those 3 (the 4th, `mask-position-4d.html`, was addressed separately).

</details>
