### PR TITLE
fix: Fix CSS image preloading for `filter` and `shape-outside`

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2949,6 +2949,14 @@ export class ViewFactory
     if (clipPath) {
       this.addImageFetchers(clipPath);
     }
+    const filter = computedStyle["filter"];
+    if (filter) {
+      this.addImageFetchers(filter);
+    }
+    const shapeOutside = computedStyle["shape-outside"];
+    if (shapeOutside) {
+      this.addImageFetchers(shapeOutside);
+    }
     const markerContent = computedStyle["--viv-marker-content"];
     if (markerContent) {
       this.addImageFetchers(markerContent);


### PR DESCRIPTION
Add `filter` and `shape-outside` to the set of CSS properties whose `url()` references are preloaded via `addImageFetchers()` in `applyComputedStyles()`. Without this, external SVG resources referenced by these properties were not fetched before page capture:

- `filter: url()`: the external SVG filter is not applied, so the element renders without the filter effect (e.g. hue-rotate).
- `shape-outside: url()`: the image shape data is unavailable, so float wrapping falls back to the element's margin box.

WPT reftests fixed (FAIL → PASS):
- `css/filter-effects/filter-external-002-test.html`
- `css/css-shapes/shape-outside/shape-image/shape-image-009.html`
- `css/css-shapes/shape-outside/shape-image/shape-image-011.html`

Note: Some `shape-outside` reftests (e.g. `shape-image-006.html`, `shape-image-012.html`, `shape-image-025.html` through `027.html`) remain failing because `resolveWptResourceURL()` converts `url()` values from `raw.githack.com` to `wpt.live`, which lacks CORS headers. `shape-outside` requires CORS-same-origin image data to extract the shape, so the cross-origin fetch is blocked. This CORS issue needs to be addressed separately.

Refs PR #1946, PR #1950

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- Continuing the same session as PR #1950, the human author asked the AI to keep working through the remaining css-masking/filter/shapes WPT regressions.
- The AI extended the image-preloading fix to `filter` and `shape-outside`, and identified that some remaining `shape-outside` failures are a separate CORS limitation from `resolveWptResourceURL()`'s `raw.githack.com` → `wpt.live` conversion rather than a preloading gap, documenting this distinction in the PR description.

</details>
