### PR TITLE
fix: Replace `about:blank` handling with `data:text/html,` conversion

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -194,6 +194,14 @@ export function resolveReferenceURL(relURL: string, baseURL: string): string {
 }
 
 /**
+ * Convert `about:blank` (with optional query/fragment, case-insensitive)
+ * to `data:text/html,` so the browser can load it natively.
+ */
+export function convertAboutBlankURL(url: string): string {
+  return /^about:blank($|[?#])/i.test(url) ? "data:text/html," : url;
+}
+
+/**
  * Convert special URLs (e.g. GitHub, Gist) to their raw equivalents.
  * This is useful for fetching content from these services in a format
  * that can be easily processed by Vivliostyle.js.
@@ -204,7 +212,9 @@ export function resolveReferenceURL(relURL: string, baseURL: string): string {
 export function convertSpecialURL(url: string): string {
   let r: RegExpMatchArray;
 
-  if (
+  if ((url = convertAboutBlankURL(url)) !== url) {
+    // already converted
+  } else if (
     (r =
       /^(https?:)\/\/github\.com\/web-platform-tests\/wpt\/(blob\/|tree\/|raw\/)?(.*)$/.exec(
         url,

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -68,7 +68,7 @@ function clonePageGroupPageCounts(source: {
 function shouldSkipHeadForWebPub(url: string): boolean {
   return (
     /\.(x?html?|xht|svg)(?:[#?]|$)/i.test(url) ||
-    /^(?:about:|blob:)/i.test(Base.stripFragment(url))
+    /^(?:about:|data:|blob:)/i.test(Base.stripFragment(url))
   );
 }
 
@@ -152,7 +152,7 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     } else if (shouldSkipHeadForWebPub(url)) {
       // Web Publication primary entry (X)HTML
       // Skip HEAD request for known document URLs and special schemes.
-      // Browsers reject HEAD on blob: URLs, and about:blank is a synthetic blank document.
+      // Browsers reject non-GET methods for data: and blob: URLs.
       this.loadWebPub(url).then((opf) => {
         if (opf) {
           frame.finish(opf);

--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -39,49 +39,11 @@ export enum FetchResponseType {
 
 export type FetchResponse = Net.FetchResponse;
 
-function createSyntheticFetchResponse(
-  url: string,
-  opt_type?: FetchResponseType,
-): FetchResponse | null {
-  const strippedUrl = Base.stripFragment(url);
-  if (Base.stripFragmentAndQuery(strippedUrl).toLowerCase() !== "about:blank") {
-    return null;
-  }
-
-  const response: FetchResponse = {
-    status: 200,
-    statusText: "OK",
-    url: strippedUrl,
-    contentType: "text/html",
-    responseText: null,
-    responseXML: null,
-    responseBlob: null,
-  };
-
-  if (opt_type === FetchResponseType.BLOB) {
-    response.responseBlob = makeBlob([""], response.contentType);
-  } else if (opt_type === FetchResponseType.ARRAYBUFFER) {
-    response.responseBlob = makeBlob(
-      [new Uint8Array(0).buffer],
-      response.contentType,
-    );
-  } else {
-    response.responseText = "";
-  }
-
-  return response;
-}
-
 export function fetchFromURL(
   url: string,
   opt_type?: FetchResponseType,
   opt_method?: string,
 ): Task.Result<FetchResponse> {
-  const syntheticResponse = createSyntheticFetchResponse(url, opt_type);
-  if (syntheticResponse) {
-    return Task.newResult(syntheticResponse);
-  }
-
   const frame: Task.Frame<FetchResponse> = Task.newFrame("fetchFromURL");
   const requestInit: RequestInit = {
     method: opt_method || "GET",

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1771,6 +1771,12 @@ export class ViewFactory
                 // attributes (src, poster) so dynamic endpoints work.
                 attributeValue = Base.resolveWptResourceURL(attributeValue);
               }
+              // Convert about:blank to data:text/html, so iframes and other
+              // embedded elements load natively without stalling on a missed
+              // load event.
+              if (attributeName === "src") {
+                attributeValue = Base.convertAboutBlankURL(attributeValue);
+              }
             } else if (attributeName == "srcset") {
               attributeValue = attributeValue
                 .split(",")

--- a/packages/core/test/spec/vivliostyle/base-spec.js
+++ b/packages/core/test/spec/vivliostyle/base-spec.js
@@ -94,6 +94,40 @@ describe("base", function () {
         ),
       ).toBe("https://wpt.live/some/test.sub.any.worker.js");
     });
+
+    it("converts about:blank to data:text/html,", function () {
+      expect(module.convertSpecialURL("about:blank")).toBe("data:text/html,");
+      expect(module.convertSpecialURL("ABOUT:blank")).toBe("data:text/html,");
+      expect(module.convertSpecialURL("about:blank?Q=1")).toBe(
+        "data:text/html,",
+      );
+      expect(module.convertSpecialURL("about:blank#frag")).toBe(
+        "data:text/html,",
+      );
+    });
+  });
+
+  describe("convertAboutBlankURL", function () {
+    it("converts about:blank to data:text/html,", function () {
+      expect(module.convertAboutBlankURL("about:blank")).toBe(
+        "data:text/html,",
+      );
+      expect(module.convertAboutBlankURL("ABOUT:blank")).toBe(
+        "data:text/html,",
+      );
+      expect(module.convertAboutBlankURL("about:blank?Q=1")).toBe(
+        "data:text/html,",
+      );
+    });
+
+    it("returns non-about:blank URLs unchanged", function () {
+      expect(module.convertAboutBlankURL("https://example.com")).toBe(
+        "https://example.com",
+      );
+      expect(module.convertAboutBlankURL("data:text/html,")).toBe(
+        "data:text/html,",
+      );
+    });
   });
 
   describe("resolveURL", function () {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -23,7 +23,7 @@ import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
 describe("epub", function () {
   describe("EPUBDocStore", function () {
     describe("loadPubDoc", function () {
-      it("skips HEAD and treats about:blank as a Web Publication primary entry", function (done) {
+      it("skips HEAD and treats data: URLs as a Web Publication primary entry", function (done) {
         var store = new adapt_epub.EPUBDocStore();
         var opf = {};
         spyOn(store, "loadWebPub").and.callFake(function () {
@@ -31,8 +31,8 @@ describe("epub", function () {
         });
 
         adapt_task.start(function () {
-          store.loadPubDoc("about:blank").then(function (result) {
-            expect(store.loadWebPub).toHaveBeenCalledWith("about:blank");
+          store.loadPubDoc("data:text/html,").then(function (result) {
+            expect(store.loadWebPub).toHaveBeenCalledWith("data:text/html,");
             expect(result).toBe(opf);
             done();
           });
@@ -82,9 +82,9 @@ describe("epub", function () {
 
   describe("OPFDoc", function () {
     describe("initWithWebPubManifest", function () {
-      it("creates a primary entry for about:blank documents", function (done) {
+      it("creates a primary entry for data: URL documents", function (done) {
         var store = new adapt_epub.EPUBDocStore();
-        var opf = new adapt_epub.OPFDoc(store, "about:blank");
+        var opf = new adapt_epub.OPFDoc(store, "data:text/html,");
         var doc = new DOMParser().parseFromString(
           "<html xmlns='http://www.w3.org/1999/xhtml'><head><title>Blank</title></head><body></body></html>",
           "text/html",
@@ -94,7 +94,7 @@ describe("epub", function () {
           opf.initWithWebPubManifest({}, doc).then(function () {
             expect(opf.items.length).toBe(1);
             expect(opf.spine.length).toBe(1);
-            expect(opf.items[0].src).toBe("about:blank");
+            expect(opf.items[0].src).toBe("data:text/html,");
             done();
           });
           return adapt_task.newResult(true);

--- a/packages/core/test/spec/vivliostyle/net-spec.js
+++ b/packages/core/test/spec/vivliostyle/net-spec.js
@@ -17,73 +17,34 @@
 
 import * as adapt_base from "../../../src/vivliostyle/base";
 import * as adapt_net from "../../../src/vivliostyle/net";
+import * as adapt_task from "../../../src/vivliostyle/task";
 import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
 
 describe("net", function () {
   describe("fetchFromURL", function () {
-    it("returns a synthetic empty HTML response for about:blank", function (done) {
-      adapt_net
-        .fetchFromURL("about:blank", adapt_net.FetchResponseType.DOCUMENT)
-        .then(function (response) {
-          expect(response.status).toBe(200);
-          expect(response.statusText).toBe("OK");
-          expect(response.url).toBe("about:blank");
-          expect(response.contentType).toBe("text/html");
-          expect(response.responseText).toBe("");
-          expect(response.responseXML).toBeNull();
-          expect(response.responseBlob).toBeNull();
-          done();
-        });
-    });
-
-    it("returns a synthetic empty HTML response for about:blank with query parameters", function (done) {
-      adapt_net
-        .fetchFromURL("about:blank?Q=1", adapt_net.FetchResponseType.DOCUMENT)
-        .then(function (response) {
-          expect(response.status).toBe(200);
-          expect(response.statusText).toBe("OK");
-          expect(response.url).toBe("about:blank?Q=1");
-          expect(response.contentType).toBe("text/html");
-          expect(response.responseText).toBe("");
-          expect(response.responseXML).toBeNull();
-          expect(response.responseBlob).toBeNull();
-          done();
-        });
-    });
-
-    it("returns a synthetic empty HTML response for mixed-case about:blank URLs", function (done) {
-      adapt_net
-        .fetchFromURL("ABOUT:blank?Q=1", adapt_net.FetchResponseType.DOCUMENT)
-        .then(function (response) {
-          expect(response.status).toBe(200);
-          expect(response.statusText).toBe("OK");
-          expect(response.url).toBe("ABOUT:blank?Q=1");
-          expect(response.contentType).toBe("text/html");
-          expect(response.responseText).toBe("");
-          expect(response.responseXML).toBeNull();
-          expect(response.responseBlob).toBeNull();
-          done();
-        });
-    });
-
-    it("lets about:blank parse as an empty HTML document", function (done) {
+    it("fetches a data:text/html, URL and parses as an empty HTML document", function (done) {
       var docStore = adapt_xmldoc.newXMLDocStore();
 
-      adapt_net
-        .fetchFromURL("about:blank", adapt_net.FetchResponseType.DOCUMENT)
-        .then(function (response) {
-          adapt_xmldoc
-            .parseXMLResource(response, docStore)
-            .then(function (docHolder) {
-              expect(docHolder).not.toBeNull();
-              expect(docHolder.url).toBe("about:blank");
-              expect(docHolder.document.documentElement.namespaceURI).toBe(
-                adapt_base.NS.XHTML,
-              );
-              expect(docHolder.document.body).not.toBeNull();
-              done();
-            });
-        });
+      adapt_task.start(function () {
+        adapt_net
+          .fetchFromURL("data:text/html,", adapt_net.FetchResponseType.DOCUMENT)
+          .then(function (response) {
+            expect(response.status).toBe(200);
+            expect(response.contentType).toContain("text/html");
+
+            adapt_xmldoc
+              .parseXMLResource(response, docStore)
+              .then(function (docHolder) {
+                expect(docHolder).not.toBeNull();
+                expect(docHolder.document.documentElement.namespaceURI).toBe(
+                  adapt_base.NS.XHTML,
+                );
+                expect(docHolder.document.body).not.toBeNull();
+                done();
+              });
+          });
+        return adapt_task.newResult(true);
+      });
     });
   });
 });


### PR DESCRIPTION
Instead of synthesizing a fake fetch response for `about:blank` in `net.ts` (as done in PR #1925), convert `about:blank` to `data:text/html,` early so the browser handles it natively. This also fixes a timeout when rendering `<iframe src="about:blank">` (e.g. in the WPT reftest `css/css-transforms/transform-iframe-001.html`), where the iframe's load event was missed because the synthetic response bypassed the normal browser loading path.

- `convertSpecialURL()` in `base.ts` now maps `about:blank` (with optional query/fragment, case-insensitive) to `data:text/html,`. This covers top-level `#src=about:blank` usage via the viewer.
- `vgen.ts` converts `about:blank` to `data:text/html,` on `src` attributes during view element construction, covering iframes and other embedded elements that don't go through `convertSpecialURL()`.
- Removed `createSyntheticFetchResponse()` from `net.ts` — no longer needed since `data:` URLs are fetchable by the browser.
- Updated `shouldSkipHeadForWebPub()` in `epub.ts` to match `data:` instead of `about:`, and removed the `about:` fallback from `primaryEntryReadingOrderURL` (the `data:` path is already handled by `getPathFromURL()`; `blob:` fallback is kept).

This supersedes PR #1925.

Closes #1911

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author, investigating a WPT reftest timeout involving `<iframe src="about:blank">`, diagnosed that the earlier fix in PR #1925 was insufficient and proposed the `data:text/html,` conversion approach as a replacement, directing the AI to implement the specific set of changes.
- The human author directed the commit message to explicitly note it replaced PR #1925, and ran `/address-pr-comments`.

</details>
