### PR TITLE
fix: Avoid getComputedStyle side effect causing canvas image-orientation regression

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -78,11 +78,13 @@ function extractPseudoElementText(
       return pseudoElem.textContent || "";
     }
     // Native ::marker: read from --viv-marker-content CSS custom property.
-    // Use getComputedStyle to capture inherited values (e.g., footnote-content
-    // inheriting from the footnote wrapper).
-    const markerContent = element.ownerDocument.defaultView
-      ?.getComputedStyle(element)
-      ?.getPropertyValue("--viv-marker-content");
+    // The property is always set as an inline style on the element itself
+    // (via computedStyle in vgen.ts), so element.style is sufficient.
+    // Avoid getComputedStyle here as it can cause unwanted style computation
+    // side effects on unrelated elements (e.g., canvas image-orientation).
+    const markerContent = (element as HTMLElement).style?.getPropertyValue(
+      "--viv-marker-content",
+    );
     if (markerContent) {
       // Extract only string components from the CSS content value.
       // e.g., url(icon.png) "1. " → "1. " (url() tokens are ignored)


### PR DESCRIPTION
In `extractPseudoElementText()` in counters.ts, replace `getComputedStyle(element).getPropertyValue("--viv-marker-content")` with `element.style.getPropertyValue("--viv-marker-content")`.

The `--viv-marker-content` custom property is always set as an inline style (via vgen.ts), so `getComputedStyle` was unnecessary. Calling `getComputedStyle` on every element with an `id` triggered a Chromium-internal side effect that changed how `drawImage()` interacts with `image-orientation: none` on EXIF-oriented images, causing the WPT canvas test to regress from PASS to FAIL.

WPT: html/canvas/element/manual/drawing-images-to-the-canvas/image-orientation/drawImage-from-element-swap-width-height-orientation-none.tentative.html

Refs #1921

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to investigate why this WPT canvas test had regressed from PASS to FAIL starting at PR #1832, using `/fix-wpt-reftest-failure`.
- The AI traced the regression to an unrelated `getComputedStyle()` call triggering a Chromium-internal side effect; the human author confirmed this was one of the WPT tests listed in issue #1921 and asked for the fix and commit message to reference both the specific WPT test and that issue.

</details>
