### PR TITLE
fix: Fix static position of absolutely positioned elements in baseline-aligned table cells

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -963,6 +963,7 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
               new TableCell(this.rowIndex, this.columnIndex, elem),
             );
             this.columnIndex++;
+            fixTableCellWrapperForBaseline(elem);
             // Propagate cell break values to the row for forced break detection
             const cellRow = formattingContext.rows[this.rowIndex];
             if (cellRow) {
@@ -1112,7 +1113,10 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     }
     return cellFragment.pseudoColumn
       .layout(startChunkPosition, true)
-      .thenReturn(true);
+      .thenAsync(() => {
+        fixTableCellWrapperForBaseline(cellViewNode);
+        return Task.newResult(true);
+      });
   }
 
   /**
@@ -2183,6 +2187,47 @@ function adjustCellHeight(
       padding.top;
     Base.setCSSProperty(cellContentElement, "max-height", `${height}px`);
   }
+}
+
+/**
+ * When a table cell has vertical-align: baseline and its content wrapper
+ * contains only out-of-flow children (position: absolute/fixed), the wrapper
+ * generates a spurious baseline from whitespace text nodes. This causes the
+ * browser's baseline alignment to incorrectly shift the absolutely positioned
+ * elements' static positions. Fix by setting the wrapper to display: contents
+ * so it becomes transparent to the box model and the browser can apply its
+ * table-cell baseline static-position fix correctly.
+ */
+function fixTableCellWrapperForBaseline(cellViewNode: Element): void {
+  // Find the table cell element (cellViewNode may be the wrapper div itself
+  // due to the shadow/template model, not the <td>)
+  const cellElement = cellViewNode.matches("td, th")
+    ? cellViewNode
+    : cellViewNode.closest("td, th");
+  if (!cellElement) {
+    return;
+  }
+  const cellStyle = (cellElement as HTMLElement).style;
+  if (cellStyle.verticalAlign !== "baseline") {
+    return;
+  }
+  const wrapper = cellElement.querySelector(
+    ".-vivliostyle-table-cell-container",
+  );
+  if (!wrapper) {
+    return;
+  }
+  const children = wrapper.children;
+  if (children.length === 0) {
+    return;
+  }
+  for (let i = 0; i < children.length; i++) {
+    const pos = (children[i] as HTMLElement).style.position;
+    if (pos !== "absolute" && pos !== "fixed") {
+      return;
+    }
+  }
+  Base.setCSSProperty(wrapper, "display", "contents");
 }
 
 /**


### PR DESCRIPTION
The `-vivliostyle-table-cell-container` wrapper div inside table cells generated a spurious baseline from whitespace text nodes. When a cell had `vertical-align: baseline` and contained only out-of-flow children (`position: absolute`), the browser's baseline alignment incorrectly shifted the wrapper down, displacing the absolutely positioned elements' static positions.

Add `fixTableCellWrapperForBaseline()` in `table.ts` that sets the wrapper to `display: contents` when all its child elements are out-of-flow. This makes the wrapper transparent to the box model so the browser can correctly determine the static position. The fix is applied in both the unfragmented table path (`EntireTableLayoutStrategy`) and the fragmented table path (`TableLayoutStrategy.layoutCell`).

WPT: `css/css-tables/table-cell-baseline-static-position.html`

Refs #1921

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to investigate a WPT reftest failure using `/fix-wpt-reftest-failure`; the AI compared the test/reference/diff screenshots to identify that an absolutely positioned child was rendered shifted down within a baseline-aligned table cell.
- The AI traced the root cause to the internal `-vivliostyle-table-cell-container` wrapper acquiring a spurious baseline from whitespace, and implemented the `display: contents` fix for the out-of-flow-only case, applying it to both the fragmented and unfragmented table layout paths; the human author confirmed the fix and directed the commit message, referencing issue #1921.

</details>
