### PR TITLE
fix: Fix footnote marker overflow when marker has float:left

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1760,9 +1760,42 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           const floatChunkPosition = new VtreeImpl.ChunkPosition(
             c.nodePosition,
           );
+          // Save the break position count before layout. Note: doLayout()
+          // resets breakPositions to [], so after layout() returns,
+          // breakPositions contains only items from this single call.
+          // prevBreakPositionCount captures the count from the PREVIOUS
+          // iteration's result (before this call's reset), which serves as
+          // a baseline: if the new count doesn't exceed it, the current
+          // continuation placed less content than the previous one,
+          // indicating a marker-only fragment. (Issue #1956)
+          const prevBreakPositionCount = floatArea.breakPositions
+            ? floatArea.breakPositions.length
+            : 0;
           floatArea.layout(floatChunkPosition, true).then((newPosition) => {
             result.newPosition = newPosition;
             if (!newPosition || allowFragmented) {
+              // For footnotes: if fragmented, check if meaningful content was
+              // placed for this continuation. If no new BoxBreakPosition was
+              // added beyond the previous iteration's count (which acts as a
+              // baseline since doLayout() resets the array each time), fail the
+              // layout so the footnote is deferred to the next page, preventing
+              // the marker from appearing alone at the page bottom.
+              if (
+                newPosition &&
+                floatArea.isFootnote &&
+                floatArea.breakPositions
+              ) {
+                const hasNewLineContent =
+                  floatArea.breakPositions.length > prevBreakPositionCount &&
+                  floatArea.breakPositions
+                    .slice(prevBreakPositionCount)
+                    .some((bp) => bp instanceof BoxBreakPosition);
+                if (!hasNewLineContent) {
+                  failed = true;
+                  loopFrame.breakLoop();
+                  return;
+                }
+              }
               i++;
               loopFrame.continueLoop();
             } else {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -1006,6 +1006,10 @@ module.exports = [
         file: "footnotes/footnote-area-max-height-vertical.html",
         title: "Footnote area max-block-size vertical (Issue #1878)",
       },
+      {
+        file: "footnotes/footnote-marker-with-float.html",
+        title: "Footnote marker with float:left overflow (Issue #1956)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/footnotes/footnote-marker-with-float.html
+++ b/packages/core/test/files/footnotes/footnote-marker-with-float.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Footnote marker with float:left overflow (Issue #1956)</title>
+    <style>
+      @page {
+        size: 500px 300px;
+        margin: 20px;
+        outline: 1px solid cyan;
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 11px;
+        }
+      }
+
+      :root {
+        font-size: 16px;
+        font-family: Arial, sans-serif;
+        line-height: 20px;
+        widows: 1;
+        orphans: 1;
+      }
+
+      body,
+      div,
+      p {
+        margin: 0;
+        padding: 0;
+      }
+
+      .spacer {
+        height: 185px;
+        background: #f0f0f0;
+      }
+
+      .footnote {
+        float: footnote;
+        font-size: 12px;
+        line-height: 16px;
+      }
+
+      /* The float:left marker combined with display:block on the footnote
+         body span triggers the bug: the marker is placed as a CSS float
+         inside the footnote area and its height is counted even when the
+         body text doesn't fit, causing the marker to overflow at the
+         page bottom while the body moves to the next page. */
+      .footnote::footnote-marker {
+        content: counter(footnote);
+        float: left;
+        margin-inline-end: 1em;
+        font-size: 16px;
+        color: blue;
+      }
+
+      .footnote > span {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacer"></div>
+    <!-- Test: When page space is tight, the second footnote's marker
+         should NOT appear alone at the page bottom without its body text.
+         Expected: footnote 1 on page 1, footnote 2 (marker + body) on page 2. -->
+    <p>
+      Paragraph with footnote<span class="footnote"
+        ><span>First footnote body text.</span></span
+      >.
+    </p>
+    <p>
+      Another paragraph with footnote<span class="footnote"
+        ><span>Second footnote body text.</span></span
+      >.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
When `::footnote-marker` has `float: left` and the footnote body element has `display: block`, the marker is placed as a CSS float inside the footnote area. If the footnote is fragmented due to insufficient page space, the marker-only fragment was incorrectly accepted because the CSS float updated `computedBlockSize` to a positive value, bypassing the existing empty-footnote check.

In `layoutSinglePageFloatFragment`, after each footnote continuation is laid out and fragmented, check whether any `BoxBreakPosition` (text line content) was actually added. If only CSS floats were placed (no new `BoxBreakPosition`), set `failed = true` to defer the footnote to the next page, preventing the marker from appearing alone at the page bottom.

Closes #1956

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1956 (footnote marker overflow leaving the marker alone at the page bottom); the AI diagnosed the empty-footnote check being bypassed by CSS float sizing and implemented the fix.
- The human author asked for the regression test case to be improved to match the style of other footnote tests, then ran `/draft-commit` and `/address-pr-comments`.

</details>
