### PR TITLE
fix: Fix rem and rlh units incorrect when using font shorthand with var() and calc()

### DIFF
--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1265,8 +1265,22 @@ export class FontShorthandValidator extends SimpleShorthandValidator {
     this.error = false;
     const validators = this.validatorSet.validators;
     if (!list[index].visit(validators["font-size"])) {
-      this.error = true;
-      return index;
+      // If font-size validation fails and a calc() was incorrectly consumed
+      // as font-weight by super.validateList (calc() is ambiguous between
+      // font-weight <number> and font-size <length>), backtrack to the
+      // calc() token's position and re-validate as font-size. (Issue #1955)
+      const fontWeight = this.values["font-weight"];
+      const calcIndex =
+        fontWeight instanceof Css.Func && fontWeight.name === "calc"
+          ? list.indexOf(fontWeight)
+          : -1;
+      if (calcIndex >= 0 && list[calcIndex].visit(validators["font-size"])) {
+        delete this.values["font-weight"];
+        index = calcIndex;
+      } else {
+        this.error = true;
+        return index;
+      }
     }
     this.values["font-size"] = list[index++];
     if (list[index] === Css.slash) {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -25,6 +25,10 @@ module.exports = [
       },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
+        file: "root-font-var-calc.html",
+        title: "rem/rlh with font shorthand var() calc() (Issue #1955)",
+      },
+      {
         file: "web_font_in_page_margin.html",
         title: "Web font in page margin",
       },

--- a/packages/core/test/files/root-font-var-calc.html
+++ b/packages/core/test/files/root-font-var-calc.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1955: rem and rlh units are incorrect when using font shorthand with var() and calc() -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>rem/rlh with font shorthand var() calc() (Issue #1955)</title>
+  <style>
+    @page { size: 200mm 150mm; }
+    :root {
+      --fs: calc(10 * 10px);
+      --lh: calc(200px / 2);
+      font: var(--fs) / var(--lh) sans-serif;
+    }
+    #test {
+      font-size: 1rem;
+      line-height: 1rlh;
+      border: solid;
+      margin: 10px;
+    }
+    #ref {
+      border: solid;
+      margin: 10px;
+    }
+    p {
+      font: 16px/1.5 sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <p>The two boxes below should be identical.</p>
+  <div id="test">TEST</div>
+  <div id="ref">TEST</div>
+</body>
+</html>


### PR DESCRIPTION
When `:root` sets the font via shorthand with `var()` containing `calc()` values (e.g., `font: var(--fs) / var(--lh) sans-serif`), the `FontShorthandValidator` incorrectly consumed the `calc()` function as `font-weight` (since `font-weight` accepts `<number>` which includes `calc()`), causing font-size/line-height expansion to fail. As a result, `rootFontSize` and `rootLineHeight` were never set, making `rem` and `rlh` units resolve to wrong values.

Add backtracking logic in `FontShorthandValidator.validateList()`: when font-size validation fails and `font-weight` was set to a `calc()` function, undo that assignment and retry from the `calc()` position as font-size.

Closes #1955

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1955 (rem/rlh units incorrect with font shorthand + var()/calc()); the AI diagnosed the shorthand validator's parsing ambiguity and implemented the backtracking fix.
- The human author asked for a `title` element to be added to the regression test case, then ran `/draft-commit` and `/address-pr-comments`.

</details>
