### PR TITLE
fix: Fix background-image on page container not waiting for load

### DIFF
--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -28,6 +28,7 @@ import * as Exprs from "./exprs";
 import * as Font from "./font";
 import * as LayoutHelper from "./layout-helper";
 import { StyleInstance } from "./ops";
+import { addImageFetchersToPage } from "./vgen";
 import * as Vtree from "./vtree";
 
 export let keyCount: number = 1;
@@ -1620,6 +1621,15 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
         docFaces,
       );
     }
+    // Preload images referenced by background-image, border-image-source,
+    // and filter that were propagated from :root/body to the page container,
+    // so that page.fetchers waits for them before screenshot/render.
+    for (const name of imageProperties) {
+      const val = this.getProp(context, name);
+      if (val) {
+        addImageFetchersToPage(val, page);
+      }
+    }
     for (let i = 0; i < delayedProperties.length; i++) {
       this.propagateDelayedProperty(
         context,
@@ -1758,6 +1768,11 @@ export const passPostProperties = [
   "mix-blend-mode",
   "filter",
 ];
+
+/**
+ * Image-bearing properties in passPostProperties whose URLs need preloading.
+ */
+const imageProperties = ["background-image", "border-image-source", "filter"];
 
 /**
  * Only passed when there is content assigned by the content property.

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2912,23 +2912,7 @@ export class ViewFactory
   }
 
   addImageFetchers(bg: Css.Val) {
-    if (bg instanceof Css.CommaList) {
-      const values = (bg as Css.CommaList).values;
-      for (let i = 0; i < values.length; i++) {
-        this.addImageFetchers(values[i]);
-      }
-    } else if (bg instanceof Css.URL) {
-      const url = Base.resolveWptResourceURL((bg as Css.URL).url);
-      this.page.fetchers.push(Net.loadElement(new Image(), url));
-    } else if (bg instanceof Css.Func) {
-      for (const v of (bg as Css.Func).values) {
-        this.addImageFetchers(v);
-      }
-    } else if (bg instanceof Css.SpaceList) {
-      for (const v of (bg as Css.SpaceList).values) {
-        this.addImageFetchers(v);
-      }
-    }
+    addImageFetchersToPage(bg, this.page);
   }
 
   applyComputedStyles(
@@ -4086,6 +4070,30 @@ export class Viewport {
     const root = this.root;
     while (root.lastChild) {
       root.removeChild(root.lastChild);
+    }
+  }
+}
+
+/**
+ * Recursively walk a CSS value tree and push image-load fetchers for any
+ * URL values found. Used to preload images referenced by background-image,
+ * border-image-source, filter, etc.
+ */
+export function addImageFetchersToPage(val: Css.Val, page: Vtree.Page): void {
+  if (val instanceof Css.CommaList) {
+    for (const v of val.values) {
+      addImageFetchersToPage(v, page);
+    }
+  } else if (val instanceof Css.URL) {
+    const url = Base.resolveWptResourceURL(val.url);
+    page.fetchers.push(Net.loadElement(new Image(), url));
+  } else if (val instanceof Css.Func) {
+    for (const v of val.values) {
+      addImageFetchersToPage(v, page);
+    }
+  } else if (val instanceof Css.SpaceList) {
+    for (const v of val.values) {
+      addImageFetchersToPage(v, page);
     }
   }
 }


### PR DESCRIPTION
When `background-image` from `:root`/`body` is propagated to the page area container via `passPostProperties` in `PageBoxInstance.finishContainer()`, the image URL was set on the element but no fetcher was added to `page.fetchers`. This caused a race condition where screenshots could be taken before the background image finished loading, producing intermittent blank backgrounds in WPT reftests such as
`css/CSS2/floats-clear/margin-collapse-clear-017.xht` and `css/css-display/display-contents-root-background.html`.

Add `addImageFetchersToPage()` in `page-master.ts` that recursively extracts URLs from CSS values (`Css.URL`, `Css.CommaList`, `Css.Func`, `Css.SpaceList`) and pushes `Net.loadElement()` fetchers to `page.fetchers` for `background-image`, `border-image-source`, and `filter` after they are propagated to the page container.

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` for an intermittently-failing WPT reftest, noting the pattern (background image not waited on, unlike other recently-fixed image-loading cases) and that the root-propagated background ends up on the page area container element.
- The human author found a second WPT test with the same underlying problem and had the AI extend the fix to cover it, then ran `/draft-commit` and `/address-pr-comments`.

</details>
