### PR TITLE
fix: Add support for `<picture>` element and `<source media>` attribute

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -24,6 +24,8 @@ import * as Break from "./break";
 import * as Css from "./css";
 import * as CssCascade from "./css-cascade";
 import * as CssPage from "./css-page";
+import * as CssParser from "./css-parser";
+import * as CssTokenizer from "./css-tokenizer";
 import * as CssProp from "./css-prop";
 import * as CssStyler from "./css-styler";
 import * as Diff from "./diff";
@@ -1727,6 +1729,44 @@ export class ViewFactory
             if (attributeName == "style") {
               continue; // we do styling ourselves
             }
+            if (
+              attributeName === "media" &&
+              tag === "source" &&
+              ns === Base.NS.XHTML &&
+              element.parentElement?.localName === "picture"
+            ) {
+              // Evaluate the media query on <source> inside <picture>
+              // using Vivliostyle's media context (print mode by default).
+              // The browser evaluates media queries in screen mode,
+              // so we need to adjust the media attribute to match.
+              try {
+                const scope = this.context.rootScope;
+                const handler = new CssParser.ParserHandler(scope);
+                const tokenizer = new CssTokenizer.Tokenizer(
+                  attributeValue,
+                  handler,
+                );
+                const condExpr = CssParser.parseMediaQuery(
+                  tokenizer,
+                  handler,
+                  "",
+                );
+                if (condExpr) {
+                  const matches = condExpr.toExpr().evaluate(this.context);
+                  if (matches) {
+                    // Media matches: remove the media attribute so the
+                    // browser uses this source unconditionally.
+                    continue;
+                  } else {
+                    // Media doesn't match: prevent browser from using
+                    // this source.
+                    attributeValue = "not all";
+                  }
+                }
+              } catch (e) {
+                // If parsing fails, leave the attribute as-is.
+              }
+            }
             if (attributeName == "id" || attributeName == "name") {
               // Propagate transformed ids and collect them on the page
               // (only first time).
@@ -1869,8 +1909,13 @@ export class ViewFactory
             attributeName == "href" &&
             tag == "image" &&
             ns == Base.NS.SVG &&
-            attributeNS == Base.NS.XLINK
+            (attributeNS == Base.NS.XLINK || !attributeNS)
           ) {
+            // For SVG2 namespace-less href, also set the href attribute
+            // on the element since loadElement only sets xlink:href.
+            if (!attributeNS) {
+              result.setAttribute(attributeName, attributeValue);
+            }
             this.page.fetchers.push(Net.loadElement(result, attributeValue));
           } else {
             // When the document is not XML document (e.g. non-XML HTML)
@@ -1942,9 +1987,14 @@ export class ViewFactory
           !delayedSrc &&
           tag === "img" &&
           ns === Base.NS.XHTML &&
-          (result as HTMLImageElement).srcset
+          ((result as HTMLImageElement).srcset ||
+            element.parentElement?.localName === "picture")
         ) {
-          // <img srcset="..."> without src: wait for the image to load
+          // <img srcset="..."> without src, or <img> inside <picture>:
+          // wait for the image to load.
+          // Use page.fetchers (not layout-blocking fetchers) because the
+          // image source may only be resolved after DOM insertion (e.g.,
+          // <picture><source srcset="..."><img></picture>).
           this.page.fetchers.push(Net.loadElement(result));
         }
         delete computedStyle["content"];

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -192,6 +192,10 @@ module.exports = [
       { file: "compositing.html", title: "Compositing and Blending" },
       { file: "content-url-element.html", title: "Content URL" },
       {
+        file: "picture-element.html",
+        title: "picture element with source media (Issue #1089)",
+      },
+      {
         file: "content-in-page-margin-box.html",
         title: "Content in page margin box",
       },

--- a/packages/core/test/files/picture-element.html
+++ b/packages/core/test/files/picture-element.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>picture element with source media (Issue #1089)</title>
+  <style>
+    body {
+      margin: 20px;
+    }
+    figure {
+      margin: 1em 0;
+    }
+    figcaption {
+      font-size: 14px;
+      color: #333;
+    }
+  </style>
+</head>
+<body>
+  <h2>&lt;picture&gt; element with &lt;source media&gt;</h2>
+
+  <figure>
+    <figcaption>
+      <code>&lt;source media="print"&gt;</code> should be used
+      (200x200 image):
+    </figcaption>
+    <picture>
+      <source srcset="img/200x200.png" media="print">
+      <img src="img/50x50.png" alt="print media test">
+    </picture>
+  </figure>
+
+  <figure>
+    <figcaption>
+      <code>&lt;source media="screen"&gt;</code> should NOT be used
+      (50x50 fallback image):
+    </figcaption>
+    <picture>
+      <source srcset="img/200x200.png" media="screen">
+      <img src="img/50x50.png" alt="screen media test">
+    </picture>
+  </figure>
+
+  <figure>
+    <figcaption>
+      <code>&lt;source&gt;</code> without media should be used
+      (200x200 image):
+    </figcaption>
+    <picture>
+      <source srcset="img/200x200.png">
+      <img src="img/50x50.png" alt="no media test">
+    </picture>
+  </figure>
+
+  <figure>
+    <figcaption>
+      <code>&lt;source media="print"&gt;</code> with
+      <code>&lt;img&gt;</code> without src (aspect-ratio test):
+    </figcaption>
+    <picture>
+      <source srcset="img/200x200.png" media="print">
+      <img style="width: 100px; aspect-ratio: 1/1;" alt="aspect-ratio test">
+    </picture>
+  </figure>
+</body>
+</html>


### PR DESCRIPTION
Evaluate the `media` attribute on `<source>` elements inside `<picture>` using Vivliostyle's media context (print mode). Since the browser renders in screen mode, `<source media="print">` would never be selected natively. The fix parses and evaluates the media query: if it matches, the `media` attribute is removed so the browser uses the source unconditionally; if it doesn't match, it is rewritten to `"not all"` to prevent selection.

Also fix image load waiting for `<img>` inside `<picture>` without a `src` attribute. The image source is resolved by the browser only after DOM insertion (from sibling `<source>` elements), so `page.fetchers` is used to wait for the load event before page capture. This fixes the WPT test `css/css-sizing/aspect-ratio/replaced-element-012.html`.

Additionally, extend the SVG `<image>` load waiting to handle SVG2 namespace-less `href` attributes (in addition to `xlink:href`), fixing an intermittent regression in the WPT test
`css/css-transforms/transform-box/fill-box-mutation-002.html`.

Closes #1089

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- While running `/fix-wpt-reftest-failure`, the human author identified that `<picture>` element support was itself incomplete and pointed to the long-standing issue #1089 for it, asking the AI to close it out in the same pass; caught a test with a color-description/rendered-image mismatch and confirmed one candidate regression was actually already passing (small test image made timing incidental).
- The human author asked for the issue #1089 test case to be registered in `file-list.js`, ran `/draft-commit`, asked for resolved WPT test examples to be added to the commit message, and ran `/address-pr-comments`.

</details>
