### PR TITLE
fix: Fix non-overlapping EAL partitions affecting each other's layout

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1792,9 +1792,16 @@ export class StyleInstance
     layoutContext: Vtree.LayoutContext,
     forceNonFitting: boolean,
   ): Task.Result<LayoutType.Column> {
+    // Don't apply exclusions from sibling partitions when the partition's
+    // position or inline-size is unknown during layout:
+    // - auto block-size with before-edge dependency: position is unknown
+    // - auto inline-size: partition will shrink to fit content, so exclusions
+    //   from distant positions create incorrect float spacers (Issue #1171)
     const dontApplyExclusions = boxInstance.vertical
-      ? boxInstance.isAutoWidth && boxInstance.isRightDependentOnAutoWidth
-      : boxInstance.isAutoHeight && boxInstance.isTopDependentOnAutoHeight;
+      ? (boxInstance.isAutoWidth && boxInstance.isRightDependentOnAutoWidth) ||
+        boxInstance.isAutoHeight
+      : (boxInstance.isAutoHeight && boxInstance.isTopDependentOnAutoHeight) ||
+        boxInstance.isAutoWidth;
     const boxContainer = layoutContainer.element;
     const columnPageFloatLayoutContext = new PageFloats.PageFloatLayoutContext(
       regionPageFloatLayoutContext,

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -73,6 +73,11 @@ module.exports = [
         file: "incorrect_layout_with_empty_partition.html",
         title: "Incorrect layout with empty partition",
       },
+      {
+        file: "partition-overlap.html",
+        title:
+          "Partition overlap affects non-overlapping partition (Issue #1171)",
+      },
       { file: "nth_selectors.html", title: "nth selectors" },
       { file: "empty_selector.html", title: "empty selector" },
       {

--- a/packages/core/test/files/partition-overlap.html
+++ b/packages/core/test/files/partition-overlap.html
@@ -1,0 +1,74 @@
+<!-- Test case for Issue #1171: One partition affects another non-overlapping partition -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Partition overlap test (Issue #1171)</title>
+    <style>
+      @page {
+        size: 100mm;
+      }
+
+      @-epubx-page-master {
+        @-epubx-partition body {
+          -epubx-flow-from: body;
+          -epubx-required: true;
+          top: 10mm;
+          bottom: 10mm;
+          left: 10mm;
+          right: 10mm;
+        }
+        @-epubx-partition class(float) {
+          -epubx-flow-from: float-start-start;
+          inset-block-start: 10mm;
+          inset-inline-start: 10mm;
+        }
+        @-epubx-partition class(float) {
+          -epubx-flow-from: float-start-end;
+          inset-block-start: 10mm;
+          inset-inline-end: 10mm;
+        }
+        @-epubx-partition class(float) {
+          -epubx-flow-from: float-end-start;
+          inset-block-end: 10mm;
+          inset-inline-start: 10mm;
+        }
+        @-epubx-partition class(float) {
+          -epubx-flow-from: float-end-end;
+          inset-block-end: 10mm;
+          inset-inline-end: 10mm;
+        }
+      }
+
+      .eal-float-start-start {
+        -epubx-flow-into: float-start-start;
+      }
+      .eal-float-start-end {
+        -epubx-flow-into: float-start-end;
+      }
+      .eal-float-end-start {
+        -epubx-flow-into: float-end-start;
+      }
+      .eal-float-end-end {
+        -epubx-flow-into: float-end-end;
+      }
+
+      @-epubx-region .float {
+        div {
+          background-color: yellow;
+          border: 1px solid blue;
+          padding: 1rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Case 1: Two partitions at top (overlap vertically) -->
+    <div class="eal-float-start-start">start-start</div>
+    <div class="eal-float-start-end">start-end</div>
+    <p>
+      Lorem ipsum, dolor sit amet consectetur adipisicing elit. Ad fuga beatae, odit atque qui rerum molestiae vitae pariatur tempora corporis! Dolorem unde rerum labore laborum dolor ducimus esse doloremque obcaecati.
+      Odio itaque, ullam quos dolorum mollitia quae animi. Rem non nihil perferendis sunt nisi. Quos quisquam officiis magnam eius molestias, magni velit mollitia perferendis nihil vitae doloribus, deleniti, rerum voluptas!
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Auto inline-size partitions (e.g., with only `inset-block-start` and `inset-inline-start` set) incorrectly received exclusion shapes from sibling partitions during layout. The exclusions generated float spacers that pushed content out of view, even though the partitions did not actually overlap after shrinking to fit.

Extended the `dontApplyExclusions` condition in `createAndLayoutColumn()` to also skip exclusions for auto inline-size partitions (`isAutoWidth` in horizontal mode, `isAutoHeight` in vertical mode), in addition to the existing auto block-size with position dependency check.

Closes #1171

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1171 (one EAL partition affecting another non-overlapping partition); the AI diagnosed the exclusion-shape leak and implemented the fix.
- The human author ran `/draft-commit` and `/address-pr-comments`, then asked for further improvement to the regression test case.

</details>
