### PR TITLE
fix: Fix applyClearance() causing infinite page generation

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3406,9 +3406,19 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     // rendering differences with exclusion floats. Page/column float clear
     // edges from getPageFloatClearEdge() are accurate DOM measurements and
     // don't need the extra margin. (Issue #1803)
+    // Only apply rounding when actual inline floats have been laid out
+    // (leftFloatEdge or rightFloatEdge moved past beforeEdge). Without this
+    // guard, clearEdge equals beforeEdge (since leftFloatEdge/rightFloatEdge
+    // are initialized to beforeEdge in initGeom()), and Math.ceil rounding
+    // can push clearEdge past edge + tolerance, creating unnecessary
+    // clearance that causes infinite page generation. (Issue #1959)
     const floatUnit = this.getFloatLayoutUnit();
-    const inlineFloatEdgeDominates = clearEdge * dir > pageFloatClearEdge * dir;
-    if (floatUnit > 0) {
+    const hasInlineFloats =
+      this.leftFloatEdge * dir > this.beforeEdge * dir ||
+      this.rightFloatEdge * dir > this.beforeEdge * dir;
+    if (floatUnit > 0 && hasInlineFloats) {
+      const inlineFloatEdgeDominates =
+        clearEdge * dir > pageFloatClearEdge * dir;
       clearEdge =
         dir *
         (Math.ceil((clearEdge * dir) / floatUnit) +


### PR DESCRIPTION
In `applyClearance()`, the `Math.ceil` rounding and extra `floatUnit` margin (added for Issue #1803) were applied unconditionally. When no inline floats existed, `leftFloatEdge`/`rightFloatEdge` equaled `beforeEdge` (their initial value from `initGeom()`), and the rounding pushed `clearEdge` past `edge + tolerance`, creating a spurious clearance spacer. Combined with `break-inside: avoid`, this caused content to be moved to the next page where the same thing repeated, resulting in infinite blank page generation.

Guard the rounding block with a `hasInlineFloats` check that verifies `leftFloatEdge` or `rightFloatEdge` has actually moved past `beforeEdge`, ensuring the compensation is only applied when real inline floats have been laid out.

Closes #1959

Assisted-by: GitHub Copilot Chat:claude-opus-4.6

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for issue #1959, providing an external test sample URL that reproduced an infinite page-generation loop, and cited the issue's own root-cause hypothesis to guide the investigation.
- The AI located the unconditional rounding logic in `applyClearance()` (added by an earlier PR for issue #1803) as the cause and implemented the `hasInlineFloats` guard; the human author confirmed the fix and directed the commit message.

</details>
