### PR TITLE
fix: Preserve named page styles during target-counter relayout

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1822,19 +1822,29 @@ export class OPFView implements Vgen.CustomRendererFactory {
       // This is necessary for named page with target-counter() to work.
       // (fix for issue #1136)
       const shouldKeepOldPageTypeInCounterResolveScope =
-        // In target-counter resolution rerender, preserve an existing boundary
+        // In target-counter resolution rerender, preserve the existing
         // pageType only when the old page is still layout-consistent.
         inCounterResolveScopeAtStart &&
         !isOldPageOffsetStale &&
-        pageIndexToRender > 0 &&
-        hasBoundaryBetweenPrevAndOld &&
-        nextPageContinuesOldPageType;
+        pageIndexToRender > 0;
       shouldKeepOldPageType =
         oldPage.pageType != null &&
         (shouldKeepOldPageTypeInCounterResolveScope ||
           pageIndexToRender === 0 ||
           oldPage.pageType === prevPage?.pageType);
       page.pageType = shouldKeepOldPageType ? oldPage.pageType : null;
+
+      if (inCounterResolveScopeAtStart) {
+        // Re-resolve the page-start type during target-counter rerender so a
+        // stale named page is not reused when the new start is actually default.
+        const pageStartPageType =
+          viewItem.instance.getPageStartPageTypeOverride(page.position);
+        if (pageStartPageType === "") {
+          page.pageType = "";
+        } else if (pageStartPageType) {
+          page.pageType = pageStartPageType;
+        }
+      }
 
       if (!inCounterResolveScopeAtStart && !shouldKeepOldPageType) {
         const shouldUsePrevPageTypeToFixEarlyBoundary =

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -810,7 +810,9 @@ export class StyleInstance
 
   private getExplicitPageType(style: CssCascade.ElementStyle): string | null {
     const pageValue = CssCascade.getProp(style, "page");
-    if (!pageValue) {
+    // `page` is non-inherited; defaulting values and `auto` do not establish a
+    // named page group and must not keep a stale named page alive.
+    if (!pageValue || Css.isDefaultingValue(pageValue.value)) {
       return null;
     }
     const pageType = pageValue.evaluate(this, "page").toString();
@@ -826,6 +828,61 @@ export class StyleInstance
       return null;
     }
     return this.getExplicitPageType(style);
+  }
+
+  getPageStartPageType(
+    layoutPosition: Vtree.LayoutPosition,
+  ): string | null | undefined {
+    const pageStartOffset = this.getPageStartOffset(layoutPosition, true);
+    const startElement = this.getPageStartElement(
+      layoutPosition,
+      pageStartOffset,
+    );
+    let currentElement = startElement;
+    while (currentElement) {
+      const style = this.styler.getStyle(currentElement, false);
+      const pageValue = style && CssCascade.getProp(style, "page");
+      // Resolve the page-start named page before page master selection, where
+      // `styler.cascade.currentPageType` may still describe the previous page.
+      if (pageValue && !Css.isDefaultingValue(pageValue.value)) {
+        const pageType = pageValue.evaluate(this, "page").toString();
+        if (pageType && pageType.toLowerCase() !== "auto") {
+          return pageType;
+        }
+      }
+      if (currentElement === this.xmldoc.root) {
+        break;
+      }
+      currentElement = currentElement.parentElement;
+    }
+    return "";
+  }
+
+  getPageStartPageTypeOverride(
+    layoutPosition: Vtree.LayoutPosition,
+  ): string | null | undefined {
+    const pageStartPageType = this.getPageStartPageType(layoutPosition);
+    if (pageStartPageType !== "") {
+      return undefined;
+    }
+    // A page can start at a wrapper element while the actual named page is on
+    // its first in-flow child, e.g. `section > div.B { page: B; }`.
+    const pageStartOffset = this.getPageStartOffset(layoutPosition, true);
+    let currentElement = this.getPageStartElement(
+      layoutPosition,
+      pageStartOffset,
+    );
+    while (currentElement) {
+      currentElement = this.getFirstInFlowChildElement(currentElement);
+      if (!currentElement) {
+        break;
+      }
+      const pageType = this.getPageGroupPageType(currentElement);
+      if (pageType) {
+        return pageType;
+      }
+    }
+    return "";
   }
 
   private getPreviousInFlowSibling(element: Element): Element | null {
@@ -2546,6 +2603,14 @@ export class StyleInstance
     page.isBlankPage = cp.isBlankPage;
     cp.page++;
 
+    // Choose the effective page type before selecting `@page` styles so page
+    // backgrounds and margin boxes use the same named-page context as content.
+    const pageStartPageType = this.getPageStartPageTypeOverride(cp);
+    if (pageStartPageType === "") {
+      page.pageType = "";
+    } else if (pageStartPageType) {
+      page.pageType = pageStartPageType;
+    }
     if (page.pageType == null) {
       page.pageType =
         (page.isBlankPage

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -227,6 +227,14 @@ module.exports = [
         title: "target-counter and margin bug",
       },
       {
+        file: "target-counter-default-page-type.html",
+        title: "target-counter() with default page type",
+      },
+      {
+        file: "target-counter-named-page-style.html",
+        title: "target-counter() named page style (Issue #1966)",
+      },
+      {
         file: "target-counter-named-pages-left-right.html",
         title: "target-counter() named pages with :left/:right (Issue #1497)",
       },
@@ -471,6 +479,10 @@ module.exports = [
       {
         file: "named-pages/page-child-element.html",
         title: "Named Page on Child Element with Running Element (Issue #1833)",
+      },
+      {
+        file: "named-pages/page-child-first-page.html",
+        title: "Named Page on Child Element at Page Start",
       },
     ],
   },

--- a/packages/core/test/files/named-pages/page-child-first-page.html
+++ b/packages/core/test/files/named-pages/page-child-first-page.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Named Page on Child Element at Page Start</title>
+    <style>
+      @page {
+        size: 300px;
+        margin: 36px;
+      }
+
+      @page A {
+        background: yellow;
+      }
+
+      .A {
+        page: A;
+      }
+
+      @page B {
+        background: pink;
+      }
+
+      .B {
+        page: B;
+      }
+
+      section + section {
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <div class="A">
+        <p>This page should have yellow background.</p>
+      </div>
+    </section>
+    <section>
+      <div class="B">
+        <p>This page should have pink background.</p>
+      </div>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-counter-default-page-type.html
+++ b/packages/core/test/files/target-counter-default-page-type.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<!-- Test case for target-counter() with omitted page property between named page runs -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-counter default page type</title>
+    <style>
+      :root {
+        font-family: "Times New Roman", Times, serif;
+        line-height: 1.8;
+        widows: 1;
+        orphans: 1;
+      }
+
+      * {
+        margin: 0;
+      }
+
+      @page {
+        size: 300px;
+        margin: 36px;
+        outline: 1px dotted;
+        @bottom-center {
+          content: counter(page);
+          font-size: 0.8em;
+        }
+      }
+
+      @page :first {
+        counter-reset: page 10000;
+      }
+
+      @page Cover {
+        background-color: lightgray;
+      }
+
+      @page TOC {
+        background-color: yellow;
+      }
+
+      @page A:left {
+        background-color: orange;
+      }
+
+      @page A:right {
+        background-color: cyan;
+      }
+
+      @page C:left {
+        background-color: pink;
+      }
+
+      @page C:right {
+        background-color: lime;
+      }
+
+      .cover {
+        page: Cover;
+        text-align: center;
+      }
+
+      nav {
+        page: TOC;
+      }
+
+      nav a::after {
+        content: " " target-counter(attr(href), page);
+      }
+
+      hr,
+      section {
+        break-before: page;
+      }
+
+      section.a {
+        page: A;
+      }
+
+      section.c {
+        page: C;
+      }
+
+      ul {
+        padding-left: 1.2em;
+      }
+
+      p,
+      li {
+        font-size: 14px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="cover">
+      <h1>Named pages + target-counter() test</h1>
+      <p>This page should be Cover (lightgray).</p>
+    </div>
+
+    <nav>
+      <ul>
+        <li>
+          <a href="#target"
+            >Target WWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW WWWWWWWWWWWWWW</a
+          >
+        </li>
+      </ul>
+      <hr />
+      <p>
+        TOC pages should remain yellow. target-counter() resolution may increase
+        TOC page count and flip left/right for following named pages.
+      </p>
+    </nav>
+
+    <section class="a">
+      <h2>A-1</h2>
+      <p>Expected page type and side: A:right (cyan).</p>
+    </section>
+
+    <section class="a">
+      <h2>A-2</h2>
+      <p>Expected page type and side: A:left (orange).</p>
+    </section>
+
+    <section class="a">
+      <h2>A-3</h2>
+      <p>Expected page type and side: A:right (cyan).</p>
+    </section>
+
+    <section class="b" id="target">
+      <h2>Default page target</h2>
+      <p>Expected page type and side: default:left (white).</p>
+      <p>This page is referenced from TOC by target-counter().</p>
+    </section>
+
+    <section class="c">
+      <h2>C-1</h2>
+      <p>Expected page type and side: C:right (lime).</p>
+    </section>
+
+    <section class="c">
+      <h2>C-2</h2>
+      <p>Expected page type and side: C:left (pink).</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-counter-named-page-style.html
+++ b/packages/core/test/files/target-counter-named-page-style.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1966: target-counter() must not drop named page styles -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-counter named page style</title>
+    <style>
+      @page {
+        size: 148mm 210mm;
+        margin: 16mm;
+
+        @bottom-center {
+          content: counter(page);
+          font-size: 10pt;
+        }
+      }
+
+      @page toc {
+        background-color: #ccc;
+      }
+
+      body {
+        font-family: serif;
+        font-size: 14pt;
+        line-height: 1.4;
+      }
+
+      section {
+        min-height: 40mm;
+      }
+
+      .toc {
+        page: toc;
+      }
+
+      .toc a::after {
+        content: leader(" ") target-counter(attr(href), page);
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <p>Issue only exists with this page before the named TOC page.</p>
+    </section>
+
+    <section class="toc">
+      <h1>Contents</h1>
+      <ul>
+        <li><a href="#section1">Section 1</a></li>
+      </ul>
+      <p>The background of this TOC page should be gray.</p>
+    </section>
+
+    <section>
+      <h1 id="section1">Section 1</h1>
+      <p>This heading is referenced from the TOC by target-counter().</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Resolve named page type before selecting `@page` styles during layout and `target-counter()` rerendering, so pages with named `page` values keep their intended page styles instead of falling back to stale or default page types.

The page-start resolution now distinguishes omitted/default `page` values from actual named pages, resets to the default page type when appropriate, and still honors named pages on the first in-flow child chain of a page-start wrapper. This prevents default pages from leaking a previous named page style while preserving cases such as `section > div.B { page: B; }`.

Add regression coverage for the `target-counter()` named page case, default page type handling, and named pages applied on child elements at page start.

Closes #1966

Assisted-by: GitHub Copilot Chat:gpt-5.5

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for issue #1966, explaining that it was likely a regression caused by PR #1714's own fix for a related named-page/`target-counter()` interaction, and asked the AI to review both the page-type-application logic and the `target-counter()` relayout logic together.
- Across an extended session, the AI investigated `epub.ts`/`counters.ts`/`css-cascade.ts`, built a minimal reproduction from a linked gist, and iterated on the fix; the human author verified the fix did not regress the original scenario PR #1714 was meant to solve, and directed the commit message and regression test coverage.

</details>
