### PR TITLE
fix: Improve browser shorthand expansion and generated content `text-box` support

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -642,12 +642,14 @@ export function mergeIn(
       const av = cascval.increaseSpecificity(specificity);
       setPropCascadeValue(target, prop, av, context);
 
-      // Expand shorthand property (its value contains variables).
-      const propListLH = (
+      // Reserve longhand slots for shorthand declarations, including
+      // browser-supported shorthands discovered lazily by ValidatorSet.
+      const validatorSet = (
         context as Exprs.Context & {
           style: { validatorSet: CssValidator.ValidatorSet };
         }
-      ).style?.validatorSet.shorthands[prop]?.propList;
+      ).style?.validatorSet;
+      const propListLH = validatorSet?.getShorthand(prop, av.value)?.propList;
       if (propListLH) {
         for (const propLH of propListLH) {
           const avLH = new CascadeValue(Css.empty, av.priority);
@@ -4224,7 +4226,7 @@ export class CascadeInstance {
           // all variables substituted
           const validatorSet = (styler as any)
             .validatorSet as CssValidator.ValidatorSet;
-          const shorthand = validatorSet?.shorthands[name]?.clone();
+          const shorthand = validatorSet?.getShorthand(name, value)?.clone();
           if (shorthand) {
             if (Css.isDefaultingValue(value)) {
               for (const nameLH of shorthand.propList) {
@@ -4240,7 +4242,8 @@ export class CascadeInstance {
             } else {
               // The var()-substituted value may have complex structure
               // (e.g. SpaceList in SpaceList) that ShorthandValidator
-              // cannot handle, so use toString and parseValue.
+              // cannot handle directly, so normalize it through parseValue
+              // before expanding the shorthand to longhands.
               const valueSH = CssParser.parseValue(
                 (styler as any).scope,
                 new CssTokenizer.Tokenizer(value.toString(), null),

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -21,8 +21,10 @@
  */
 import * as CounterStyle from "./counter-style";
 import * as Css from "./css";
+import * as CssParser from "./css-parser";
 import * as CssTokenizer from "./css-tokenizer";
 import * as CmykStore from "./cmyk-store";
+import * as Exprs from "./exprs";
 import * as Base from "./base";
 import { ValidationTxt } from "./assets";
 import { TokenType } from "./css-tokenizer";
@@ -1362,6 +1364,74 @@ export class TextSpacingShorthandValidator extends SimpleShorthandValidator {
   }
 }
 
+export class BrowserShorthandValidator extends ShorthandValidator {
+  // Browser-supported shorthands that Vivliostyle does not model explicitly
+  // still need to participate in shorthand/longhand cascade resolution.
+  // This validator reuses the browser's own shorthand expansion instead of
+  // requiring one dedicated validator class per shorthand.
+  constructor(
+    public readonly name: string,
+    propList: string[] = [],
+  ) {
+    super();
+    this.propList = propList;
+  }
+
+  override clone(): this {
+    const other = new (this.constructor as any)(this.name, [...this.propList]);
+    other.validatorSet = this.validatorSet;
+    return other;
+  }
+
+  private validateValueText(valueText: string): boolean {
+    const expanded = this.validatorSet.expandBrowserShorthand(
+      this.name,
+      valueText,
+    );
+    if (!expanded) {
+      this.error = true;
+      return false;
+    }
+
+    this.propList = expanded.propList;
+    this.values = {};
+    for (const name of expanded.propList) {
+      const valueText = expanded.values[name];
+      if (!valueText) {
+        continue;
+      }
+      const parsed = CssParser.parseValue(
+        this.validatorSet.scope,
+        new CssTokenizer.Tokenizer(valueText, null),
+        "",
+      );
+      if (!parsed) {
+        this.error = true;
+        return false;
+      }
+      this.values[name] = parsed;
+    }
+    this.error = false;
+    return true;
+  }
+
+  override validateList(list: Css.Val[]): number {
+    const value =
+      list.length === 1
+        ? list[0].toString()
+        : new Css.SpaceList(list).toString();
+    if (!this.validateValueText(value)) {
+      return 0;
+    }
+    return list.length;
+  }
+
+  override visitCommaList(list: Css.CommaList): Css.Val {
+    this.validateValueText(list.toString());
+    return null;
+  }
+}
+
 const propsExcludedFromAll = [
   "unicode-bidi",
   "direction",
@@ -1486,6 +1556,85 @@ export class ValidatorSet {
   shorthands: { [key: string]: ShorthandValidator } = {};
   layoutProps: ValueMap = {};
   backgroundProps: ValueMap = {};
+  readonly scope = new Exprs.LexicalScope(null);
+  private browserShorthandStyle: CSSStyleDeclaration | null = null;
+  private browserShorthandMisses: { [key: string]: true } = {};
+
+  private getBrowserShorthandStyle(): CSSStyleDeclaration | null {
+    if (this.browserShorthandStyle !== null) {
+      return this.browserShorthandStyle;
+    }
+    if (typeof document === "undefined") {
+      return null;
+    }
+    this.browserShorthandStyle = document.createElement("div").style;
+    return this.browserShorthandStyle;
+  }
+
+  expandBrowserShorthand(
+    name: string,
+    valueText: string,
+  ): { propList: string[]; values: { [key: string]: string } } | null {
+    const style = this.getBrowserShorthandStyle();
+    if (!style) {
+      return null;
+    }
+    style.cssText = "";
+    style.setProperty(name, valueText);
+    const propList = Array.from({ length: style.length }, (_, i) =>
+      style.item(i),
+    ).filter((prop): prop is string => !!prop);
+    if (
+      !propList.length ||
+      (propList.length === 1 && propList[0] === name.toLowerCase())
+    ) {
+      return null;
+    }
+    // Use a detached CSSStyleDeclaration as a browser-native shorthand parser,
+    // then feed the resulting longhand values back into Vivliostyle's cascade.
+    const values: { [key: string]: string } = {};
+    for (const prop of propList) {
+      values[prop] = style.getPropertyValue(prop);
+    }
+    return { propList, values };
+  }
+
+  getShorthand(
+    name: string,
+    value?: Css.Val | string,
+  ): ShorthandValidator | null {
+    const shorthand = this.shorthands[name];
+    if (shorthand) {
+      return shorthand;
+    }
+    if (this.browserShorthandMisses[name]) {
+      return null;
+    }
+    if (value == null) {
+      return null;
+    }
+    const expanded = this.expandBrowserShorthand(
+      name,
+      typeof value === "string" ? value : value.toString(),
+    );
+    if (!expanded) {
+      if (
+        typeof value === "string"
+          ? !/\bvar\(/i.test(value)
+          : !containsVar(value)
+      ) {
+        this.browserShorthandMisses[name] = true;
+      }
+      return null;
+    }
+    const browserShorthand = new BrowserShorthandValidator(
+      name,
+      expanded.propList,
+    );
+    browserShorthand.setOwner(this);
+    this.shorthands[name] = browserShorthand;
+    return browserShorthand;
+  }
 
   private addReplacement(
     val: ValidatingGroup,
@@ -2087,9 +2236,7 @@ export class ValidatorSet {
     if (
       Css.isCustomPropName(name) ||
       // Check if it is a `@font-face` descriptor (Issue #1307)
-      ruleType === "font-face" ||
-      // Check if the property value containing `var(…)`
-      containsVar(value)
+      ruleType === "font-face"
     ) {
       receiver.simpleProperty(name, value, important);
       return;
@@ -2110,11 +2257,31 @@ export class ValidatorSet {
       prefix = r[1];
       name = r[2];
     }
+    const shorthandName = prefix ? origName : name;
+    if (containsVar(value)) {
+      // Register browser-supported shorthands before var() resolution so the
+      // later cascade pass can still expand mixed shorthand/longhand usage.
+      this.getShorthand(shorthandName, value);
+      receiver.simpleProperty(origName, value, important);
+      return;
+    }
     const px = this.prefixes[name];
     if (!px || !px[prefix]) {
       if (CSS.supports(origName, value.toString())) {
-        // Browser supports this property
-        receiver.simpleProperty(origName, value, important);
+        const shorthand = this.getShorthand(shorthandName, value)?.clone();
+        if (shorthand) {
+          if (Css.isDefaultingValue(value)) {
+            shorthand.propagateDefaultingValue(value, important, receiver);
+          } else {
+            value.visit(shorthand);
+            if (!shorthand.finish(important, receiver)) {
+              receiver.invalidPropertyValue(origName, value);
+            }
+          }
+        } else {
+          // Browser supports this property
+          receiver.simpleProperty(origName, value, important);
+        }
       } else if (prefix && !Base.knownPrefixes.includes(`-${prefix}-`)) {
         // Ignore properties with unknown prefix to avoid unnecessary warnings
       } else {
@@ -2147,7 +2314,11 @@ export class ValidatorSet {
         receiver.invalidPropertyValue(origName, value);
       }
     } else {
-      const shorthand = this.shorthands[name].clone();
+      const shorthand = this.getShorthand(name, value)?.clone();
+      if (!shorthand) {
+        receiver.unknownProperty(origName, value);
+        return;
+      }
       if (Css.isDefaultingValue(value)) {
         shorthand.propagateDefaultingValue(value, important, receiver);
       } else {

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1776,6 +1776,17 @@ const imageProperties = ["background-image", "border-image-source", "filter"];
 
 /**
  * Only passed when there is content assigned by the content property.
+ *
+ * This list is for properties that need to be propagated to the generated DOM
+ * element as browser CSS properties. Keep browser-expanded longhands here
+ * rather than their shorthand forms (for example, text-box-trim/text-box-edge
+ * instead of text-box).
+ *
+ * text-autospace and text-spacing-trim are intentionally omitted for now:
+ * generated content handles them via TextPolyfill.processGeneratedContent()
+ * with explicit values from boxInstance.getProp(), not by inheriting browser
+ * CSS properties. If generated content switches to browser-native handling for
+ * those properties in the future, add them back here.
  */
 export const passContentProperties = [
   "color",
@@ -1791,7 +1802,6 @@ export const passContentProperties = [
   "text-indent",
   "text-transform",
   "white-space",
-  "text-wrap",
   "text-wrap-mode",
   "text-wrap-style",
   "word-spacing",
@@ -1810,7 +1820,6 @@ export const passContentProperties = [
   "text-decoration-skip-ink",
   "text-decoration-style",
   "text-decoration-thickness",
-  "text-emphasis",
   "text-emphasis-color",
   "text-emphasis-position",
   "text-emphasis-style",
@@ -1822,6 +1831,9 @@ export const passContentProperties = [
   "text-underline-offset",
   "text-underline-position",
   "text-overflow",
+  "text-box-trim",
+  "text-box-edge",
+  "text-justify",
 ];
 
 export const passSingleUriContentProperties = [

--- a/packages/core/test/files/eal-generated-text-properties.html
+++ b/packages/core/test/files/eal-generated-text-properties.html
@@ -1,0 +1,203 @@
+<!-- Test case for Issue #1968: newer CSS text properties in EAL generated content -->
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>EAL generated text properties</title>
+    <style>
+      @page {
+        size: 200mm 140mm;
+        margin: 0;
+      }
+
+      html,
+      body {
+        margin: 0;
+      }
+
+      body {
+        font-family: Georgia, "Times New Roman", serif;
+      }
+
+      .body-anchor {
+        margin: 0;
+        font-size: 1px;
+        line-height: 1;
+        color: transparent;
+      }
+
+      @-epubx-page-template {
+        @-epubx-flow body {
+          -epubx-flow-consume: all;
+        }
+
+        .body-flow {
+          -epubx-flow-from: body;
+          top: 0;
+          left: 0;
+          width: 1px;
+          height: 1px;
+          overflow: hidden;
+        }
+
+        .heading {
+          content: "Issue #1968: EAL generated content should preserve newer CSS text properties";
+          height: 6mm;
+          font: 700 13px/1.2 Arial, sans-serif;
+          color: #102a43;
+        }
+
+        .panel-label {
+          height: 6mm;
+          font: 700 11px/1.2 Arial, sans-serif;
+          color: #243b53;
+        }
+
+        .panel {
+          padding: 3mm;
+          border: 1px solid #52606d;
+          background: #fffdf7;
+          box-sizing: border-box;
+          overflow: hidden;
+        }
+
+        .textbox-panel {
+          content: "Ágj";
+          height: 26mm;
+          padding: 0 2mm;
+          border-top: 5px solid #d64545;
+          border-bottom: 5px solid #d64545;
+          background:
+            linear-gradient(
+              to bottom,
+              rgba(214, 69, 69, 0.14) 0 8mm,
+              transparent 8mm calc(100% - 8mm),
+              rgba(214, 69, 69, 0.14) calc(100% - 8mm) 100%
+            ),
+            #fffdf7;
+          font: 700 52px/1.45 Georgia, "Times New Roman", serif;
+          color: #7b1e1e;
+          text-align: center;
+        }
+
+        .spacing-panel {
+          content: "「漢A1漢B2漢C3漢D4漢E5漢F6漢G7漢H8」\A『漢A1漢B2漢C3漢D4漢E5漢F6漢G7漢H8』";
+          height: 42mm;
+          font: 400 18px/1.8 "Hiragino Mincho ProN", "Yu Mincho", serif;
+          color: #102a43;
+          white-space: pre-line;
+        }
+
+        .default-text-box-label {
+          content: "Default line box";
+        }
+
+        .longhand-text-box-label {
+          content: "trimmed with longhands";
+        }
+
+        .shorthand-text-box-label {
+          content: "trimmed with shorthand";
+        }
+
+        .default-spacing-label {
+          content: "Default spacing and wrapping";
+        }
+
+        .styled-spacing-label {
+          content: "justify + no-autospace + trim-both";
+        }
+
+        .longhand-text-box {
+          text-box-trim: trim-both;
+          text-box-edge: text;
+        }
+
+        .shorthand-text-box {
+          text-box: trim-both text;
+        }
+
+        .styled-spacing {
+          text-align: justify;
+          text-justify: inter-character;
+          text-autospace: no-autospace;
+          text-spacing-trim: trim-both;
+        }
+
+        @-epubx-page-master {
+          @-epubx-partition class(body-flow) {
+          }
+
+          @-epubx-partition class(heading) {
+            top: 4mm;
+            left: 10mm;
+            right: 10mm;
+          }
+
+          @-epubx-partition class(panel-label) class(default-text-box-label) {
+            top: 16mm;
+            left: 10mm;
+            width: 54mm;
+          }
+
+          @-epubx-partition class(panel) class(textbox-panel) {
+            top: 23mm;
+            left: 10mm;
+            width: 54mm;
+          }
+
+          @-epubx-partition class(panel-label) class(longhand-text-box-label) {
+            top: 16mm;
+            left: 73mm;
+            width: 54mm;
+          }
+
+          @-epubx-partition class(panel) class(textbox-panel) class(longhand-text-box) {
+            top: 23mm;
+            left: 73mm;
+            width: 54mm;
+          }
+
+          @-epubx-partition class(panel-label) class(shorthand-text-box-label) {
+            top: 16mm;
+            left: 136mm;
+            width: 54mm;
+          }
+
+          @-epubx-partition class(panel) class(textbox-panel) class(shorthand-text-box) {
+            top: 23mm;
+            left: 136mm;
+            width: 54mm;
+          }
+
+          @-epubx-partition class(panel-label) class(default-spacing-label) {
+            top: 58mm;
+            left: 10mm;
+            width: 78mm;
+          }
+
+          @-epubx-partition class(panel) class(spacing-panel) {
+            top: 65mm;
+            left: 10mm;
+            width: 78mm;
+          }
+
+          @-epubx-partition class(panel-label) class(styled-spacing-label) {
+            top: 58mm;
+            left: 112mm;
+            width: 78mm;
+          }
+
+          @-epubx-partition class(panel) class(spacing-panel) class(styled-spacing) {
+            top: 65mm;
+            left: 112mm;
+            width: 78mm;
+          }
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <p class="body-anchor">anchor</p>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -16,6 +16,10 @@ module.exports = [
         file: "running_header_adaptive.html",
         title: "Running header emulation with Adaptive Layout",
       },
+      {
+        file: "eal-generated-text-properties.html",
+        title: "EAL generated text properties (Issue #1968)",
+      },
       { file: "case_sensitivity/html.html", title: "HTML case sensitivity" },
       { file: "ruby-broken-pagination.html", title: "Ruby broken pagination" },
       {

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -74,6 +74,117 @@ describe("css-validator", function () {
     });
   });
 
+  describe("browser shorthand expansion", function () {
+    it("expands place-items into longhands", function (done) {
+      parseCascade(
+        "div { place-items: center start; }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["align-items"]).toBeDefined();
+          expect(cascade.tags.div.style["justify-items"]).toBeDefined();
+          expect(cascade.tags.div.style["align-items"].value.toString()).toBe(
+            "center",
+          );
+          expect(cascade.tags.div.style["justify-items"].value.toString()).toBe(
+            "start",
+          );
+        },
+      );
+    });
+
+    it("preserves cascade order when longhands override browser shorthand expansion", function (done) {
+      parseCascade(
+        "div { place-items: center start; justify-items: stretch; }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["align-items"]).toBeDefined();
+          expect(cascade.tags.div.style["justify-items"]).toBeDefined();
+          expect(cascade.tags.div.style["align-items"].value.toString()).toBe(
+            "center",
+          );
+          expect(cascade.tags.div.style["justify-items"].value.toString()).toBe(
+            "stretch",
+          );
+        },
+      );
+    });
+
+    it("propagates CSS-wide values from browser shorthands to their longhands", function (done) {
+      parseCascade("div { place-items: initial; }", done, function (cascade) {
+        expect(cascade.tags.div).toBeDefined();
+        expect(cascade.tags.div.style["align-items"]).toBeDefined();
+        expect(cascade.tags.div.style["justify-items"]).toBeDefined();
+        expect(cascade.tags.div.style["align-items"].value).toBe(
+          adapt_css.ident.initial,
+        );
+        expect(cascade.tags.div.style["justify-items"].value).toBe(
+          adapt_css.ident.initial,
+        );
+      });
+    });
+
+    it("caches non-shorthand properties after the first browser probe miss", function () {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      spyOn(validatorSet, "expandBrowserShorthand").and.callThrough();
+
+      expect(validatorSet.getShorthand("color", "red")).toBeNull();
+      expect(validatorSet.getShorthand("color", "blue")).toBeNull();
+      expect(validatorSet.expandBrowserShorthand).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not cache a browser shorthand miss for unresolved var values", function () {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      spyOn(validatorSet, "expandBrowserShorthand").and.callFake(
+        function (name, value) {
+          if (name !== "place-items") {
+            return null;
+          }
+          if (value === "var(--items)") {
+            return null;
+          }
+          if (value === "center start") {
+            return {
+              propList: ["align-items", "justify-items"],
+              values: {
+                "align-items": "center",
+                "justify-items": "start",
+              },
+            };
+          }
+          return null;
+        },
+      );
+
+      expect(
+        validatorSet.getShorthand("place-items", "var(--items)"),
+      ).toBeNull();
+      expect(
+        validatorSet.getShorthand("place-items", "center start"),
+      ).not.toBeNull();
+      expect(validatorSet.expandBrowserShorthand).toHaveBeenCalledTimes(2);
+    });
+
+    it("accepts browser shorthands with comma-list syntax", function (done) {
+      parseCascade(
+        "div { transition: opacity 1s ease, transform 2s linear; }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["transition-property"]).toBeDefined();
+          expect(cascade.tags.div.style["transition-duration"]).toBeDefined();
+          expect(
+            cascade.tags.div.style["transition-property"].value.toString(),
+          ).toBe("opacity,transform");
+          expect(
+            cascade.tags.div.style["transition-duration"].value.toString(),
+          ).toBe("1s,2s");
+        },
+      );
+    });
+  });
+
   describe("invalid selector list recovery", function () {
     it("drops an invalid selector list instead of salvaging later selectors", function (done) {
       parseCascade(


### PR DESCRIPTION
Add browser-backed shorthand expansion in `ValidatorSet` and the cascade pipeline so browser-supported shorthands can be expanded lazily and mixed correctly with their longhands in generated content. This removes the need for dedicated validator classes for properties such as `text-box`.

Tighten `passContentProperties` so generated DOM content only receives the browser-applied longhands and native properties it still needs, and document why `text-autospace` and `text-spacing-trim` are intentionally omitted while generated content still uses `TextPolyfill.processGeneratedContent()`.

Add and register an EAL regression test in
`packages/core/test/files/eal-generated-text-properties.html` to make the effects of `text-box`, `text-justify`, `text-autospace`, and `text-spacing-trim` visible in generated content.

Closes #1968

Assisted-by: GitHub Copilot Chat:gpt-5.5

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1968; when the AI proposed adding a dedicated `text-box` shorthand definition, the human author questioned whether that was necessary given `ValidationTxt`'s `SHORTHANDS` mechanism, then pushed for a more general solution — recognizing any browser-supported shorthand automatically rather than requiring a new validator class per property — and confirmed the resulting simplification let existing longhand definitions be deleted entirely.
- The human author iteratively refined `passContentProperties`, explaining from Vivliostyle's architecture (`text-polyfill.ts` implements `text-autospace`/`text-spacing-trim` independent of the browser) why certain properties should be excluded, and asked for explanatory comments on the new logic, later catching an inconsistency where two shorthand properties remained in a list meant to exclude shorthands.
- The human author ran `/draft-commit`, revised the proposed title twice for clarity, and went through four rounds of `/address-pr-comments`, including diagnosing a CI-only Firefox test failure together with the AI.

</details>
