### PR TITLE
fix: Fix WPT CSS variable resolution edge cases

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4185,12 +4185,112 @@ export class CascadeInstance {
     element: Element | null,
   ): void {
     const elementStyle = elementStyles[0];
-    const visitor = new VarFilterVisitor(elementStyles, styler, element);
+    const sourceElementStyles = elementStyles.map((style) => ({ ...style }));
     const LIMIT_LOOP = 32; // prevent cyclic or too deep dependency
     const propsLH: ElementStyle = {}; // for shorthand -> longhand cascade
+    const pendingPseudoMap = getStyleMap(elementStyle, "_pseudos");
+    const propNames = Object.keys(elementStyle).filter(isPropName);
+
+    const applyVarFilterToProperty = (name: string): void => {
+      const cascVal = getProp(elementStyle, name);
+      let value = cascVal.value;
+      const lookupElementStyles = Css.isCustomPropName(name)
+        ? sourceElementStyles
+        : elementStyles;
+      const visitor = new VarFilterVisitor(
+        lookupElementStyles,
+        styler,
+        element,
+        Css.isCustomPropName(name) ? name : null,
+      );
+
+      if (
+        Css.isCustomPropName(name) &&
+        visitor.getFallbackCycleMembers(value, lookupElementStyles, element)
+      ) {
+        value = Css.ident.initial;
+      }
+
+      for (let i = 0; ; i++) {
+        if (i >= LIMIT_LOOP) {
+          value = Css.isCustomPropName(name) ? Css.ident.initial : Css.empty;
+          break;
+        }
+        const after = value.visit(visitor);
+        if (visitor.error) {
+          // invalid or unresolved variable found
+          value = Css.isCustomPropName(name) ? Css.ident.initial : Css.empty;
+          visitor.error = false;
+          break;
+        }
+        if (after === value) {
+          // no variable, or all variables substituted
+          break;
+        }
+        // variables substituted, but the substituted value may contain variables
+        value = after;
+      }
+      if (value !== cascVal.value) {
+        // all variables substituted
+        const validatorSet = (styler as any)
+          .validatorSet as CssValidator.ValidatorSet;
+        const shorthand = validatorSet?.getShorthand(name, value)?.clone();
+        if (shorthand) {
+          if (Css.isDefaultingValue(value)) {
+            for (const nameLH of shorthand.propList) {
+              const avLH = new CascadeValue(value, cascVal.priority);
+              const tvLH = getProp(elementStyle, nameLH);
+              setProp(propsLH, nameLH, cascadeValues(this.context, tvLH, avLH));
+            }
+            delete elementStyle[name];
+          } else {
+            // The var()-substituted value may have complex structure
+            // (e.g. SpaceList in SpaceList) that ShorthandValidator
+            // cannot handle directly, so normalize it through parseValue
+            // before expanding the shorthand to longhands.
+            const valueSH = CssParser.parseValue(
+              (styler as any).scope,
+              new CssTokenizer.Tokenizer(value.toString(), null),
+              "",
+            );
+            if (valueSH) {
+              valueSH.visit(shorthand);
+              if (!shorthand.error) {
+                for (const nameLH of shorthand.propList) {
+                  const avLH = new CascadeValue(
+                    shorthand.values[nameLH] ??
+                      validatorSet.defaultValues[nameLH] ??
+                      Css.ident.initial,
+                    cascVal.priority,
+                  );
+                  const tvLH = getProp(elementStyle, nameLH);
+                  setProp(
+                    propsLH,
+                    nameLH,
+                    cascadeValues(this.context, tvLH, avLH),
+                  );
+                }
+                delete elementStyle[name];
+              }
+            }
+          }
+        } else {
+          elementStyle[name] = new CascadeValue(value, cascVal.priority);
+        }
+      }
+      if (propsLH[name]) {
+        const av = getProp(elementStyle, name);
+        if (av && av.value !== Css.empty) {
+          setPropCascadeValue(propsLH, name, av, this.context);
+        }
+      }
+    };
 
     for (const name in elementStyle) {
       if (isMapName(name)) {
+        if (name === "_pseudos") {
+          continue;
+        }
         const pseudoMap = getStyleMap(elementStyle, name);
         for (const pseudoName in pseudoMap) {
           this.applyVarFilter(
@@ -4199,87 +4299,25 @@ export class CascadeInstance {
             element,
           );
         }
-      } else if (isPropName(name)) {
-        const cascVal = getProp(elementStyle, name);
-        let value = cascVal.value;
-
-        for (let i = 0; ; i++) {
-          if (i >= LIMIT_LOOP) {
-            value = Css.empty;
-            break;
-          }
-          const after = value.visit(visitor);
-          if (visitor.error) {
-            // invalid or unresolved variable found
-            value = Css.empty;
-            visitor.error = false;
-            break;
-          }
-          if (after === value) {
-            // no variable, or all variables substituted
-            break;
-          }
-          // variables substituted, but the substituted value may contain variables
-          value = after;
-        }
-        if (value !== cascVal.value) {
-          // all variables substituted
-          const validatorSet = (styler as any)
-            .validatorSet as CssValidator.ValidatorSet;
-          const shorthand = validatorSet?.getShorthand(name, value)?.clone();
-          if (shorthand) {
-            if (Css.isDefaultingValue(value)) {
-              for (const nameLH of shorthand.propList) {
-                const avLH = new CascadeValue(value, cascVal.priority);
-                const tvLH = getProp(elementStyle, nameLH);
-                setProp(
-                  propsLH,
-                  nameLH,
-                  cascadeValues(this.context, tvLH, avLH),
-                );
-              }
-              delete elementStyle[name];
-            } else {
-              // The var()-substituted value may have complex structure
-              // (e.g. SpaceList in SpaceList) that ShorthandValidator
-              // cannot handle directly, so normalize it through parseValue
-              // before expanding the shorthand to longhands.
-              const valueSH = CssParser.parseValue(
-                (styler as any).scope,
-                new CssTokenizer.Tokenizer(value.toString(), null),
-                "",
-              );
-              if (valueSH) {
-                valueSH.visit(shorthand);
-                if (!shorthand.error) {
-                  for (const nameLH of shorthand.propList) {
-                    const avLH = new CascadeValue(
-                      shorthand.values[nameLH] ??
-                        validatorSet.defaultValues[nameLH] ??
-                        Css.ident.initial,
-                      cascVal.priority,
-                    );
-                    const tvLH = getProp(elementStyle, nameLH);
-                    setProp(
-                      propsLH,
-                      nameLH,
-                      cascadeValues(this.context, tvLH, avLH),
-                    );
-                  }
-                  delete elementStyle[name];
-                }
-              }
-            }
-          } else {
-            elementStyle[name] = new CascadeValue(value, cascVal.priority);
-          }
-        }
-        if (propsLH[name]) {
-          const av = getProp(elementStyle, name);
-          if (av && av.value !== Css.empty) {
-            setPropCascadeValue(propsLH, name, av, this.context);
-          }
-        }
+      }
+    }
+    for (const name of propNames) {
+      if (Css.isCustomPropName(name)) {
+        applyVarFilterToProperty(name);
+      }
+    }
+    for (const name of propNames) {
+      if (!Css.isCustomPropName(name)) {
+        applyVarFilterToProperty(name);
+      }
+    }
+    if (pendingPseudoMap) {
+      for (const pseudoName in pendingPseudoMap) {
+        this.applyVarFilter(
+          [pendingPseudoMap[pseudoName], ...elementStyles],
+          styler,
+          element,
+        );
       }
     }
     // Update elementStyle with shorthand -> longhand cascade result
@@ -5690,21 +5728,298 @@ export const convertToPhysical = <T>(
  * Convert var() to its value
  */
 export class VarFilterVisitor extends Css.FilterVisitor {
+  private resolvingCustomProperties = [] as string[];
+  private varResolutionState = { cycleMembers: new Set<string>() };
+
   constructor(
     public elementStyles: ElementStyle[],
     public styler: CssStyler.AbstractStyler,
     public element: Element | null,
+    private readonly currentCustomPropertyName: string | null = null,
   ) {
     super();
+    if (currentCustomPropertyName) {
+      this.resolvingCustomProperties.push(currentCustomPropertyName);
+    }
+  }
+
+  private getRawCustomPropertyLookup(
+    name: string,
+    elementStyles: ElementStyle[],
+    element: Element | null,
+  ): {
+    found: boolean;
+    value: Css.Val | null;
+    elementStyles: ElementStyle[];
+    element: Element | null;
+  } {
+    let elem = element ?? ((this.styler as any).root as Element);
+    if (elementStyles?.length) {
+      for (let index = 0; index < elementStyles.length; index++) {
+        const style = elementStyles[index];
+        const val = (style[name] as CascadeValue)?.value;
+        if (!val) {
+          continue;
+        }
+        if (val === Css.ident.initial) {
+          return {
+            found: true,
+            value: null,
+            elementStyles: elementStyles.slice(index),
+            element,
+          };
+        }
+        if (
+          val === Css.ident.inherit ||
+          val === Css.ident.unset ||
+          val === Css.ident.revert
+        ) {
+          continue;
+        }
+        return {
+          found: true,
+          value: val,
+          elementStyles: elementStyles.slice(index),
+          element,
+        };
+      }
+      if (element) {
+        elem = element.parentElement;
+      }
+    }
+    for (; elem; elem = elem.parentElement) {
+      const style = this.styler.getStyle(elem, false);
+      const val = (style?.[name] as CascadeValue)?.value;
+      if (!val) {
+        continue;
+      }
+      if (val === Css.ident.initial) {
+        return {
+          found: true,
+          value: null,
+          elementStyles: style ? [style] : [],
+          element: elem,
+        };
+      }
+      if (
+        val === Css.ident.inherit ||
+        val === Css.ident.unset ||
+        val === Css.ident.revert
+      ) {
+        continue;
+      }
+      return {
+        found: true,
+        value: val,
+        elementStyles: style ? [style] : [],
+        element: elem,
+      };
+    }
+    return {
+      found: false,
+      value: null,
+      elementStyles: [],
+      element: null,
+    };
+  }
+
+  private collectReferencedCustomProperties(val: Css.Val): string[] {
+    const names = new Set<string>();
+    class ReferenceVisitor extends Css.Visitor {
+      override visitFunc(func: Css.Func): Css.Val {
+        const name = func.values[0] instanceof Css.Ident && func.values[0].name;
+        if (func.name === "var" && name && Css.isCustomPropName(name)) {
+          names.add(name);
+        }
+        return super.visitFunc(func);
+      }
+    }
+    val.visit(new ReferenceVisitor());
+    return Array.from(names);
+  }
+
+  private findReferencedCycleStart(
+    val: Css.Val,
+    elementStyles: ElementStyle[],
+    element: Element | null,
+    visited = new Set<string>(),
+  ): string | null {
+    for (const name of this.collectReferencedCustomProperties(val)) {
+      if (this.resolvingCustomProperties.includes(name)) {
+        return name;
+      }
+      if (visited.has(name)) {
+        continue;
+      }
+      visited.add(name);
+      const lookup = this.getRawCustomPropertyLookup(
+        name,
+        elementStyles,
+        element,
+      );
+      const cycleStartName =
+        lookup.value &&
+        this.findReferencedCycleStart(
+          lookup.value,
+          lookup.elementStyles,
+          lookup.element,
+          visited,
+        );
+      if (cycleStartName) {
+        return cycleStartName;
+      }
+    }
+    return null;
+  }
+
+  getFallbackCycleMembers(
+    val: Css.Val,
+    elementStyles: ElementStyle[],
+    element: Element | null,
+  ): Set<string> | null {
+    let cycleStartName: string | null = null;
+    const self = this;
+    class FallbackReferenceVisitor extends Css.Visitor {
+      override visitFunc(func: Css.Func): Css.Val {
+        if (func.name === "var") {
+          for (const fallbackVal of func.values.slice(1)) {
+            const referencedCycleStart = self.findReferencedCycleStart(
+              fallbackVal,
+              elementStyles,
+              element,
+            );
+            if (referencedCycleStart) {
+              cycleStartName = referencedCycleStart;
+              return null;
+            }
+          }
+        }
+        return super.visitFunc(func);
+      }
+    }
+    val.visit(new FallbackReferenceVisitor());
+    if (!cycleStartName) {
+      return null;
+    }
+    const cycleStartIndex =
+      this.resolvingCustomProperties.indexOf(cycleStartName);
+    return new Set(this.resolvingCustomProperties.slice(cycleStartIndex));
+  }
+
+  private resolveCustomProperty(
+    name: string,
+    val: Css.Val | null | undefined,
+    elementStyles: ElementStyle[],
+    element: Element | null,
+  ): { found: boolean; value: Css.Val | null; continueLookup: boolean } {
+    if (!val) {
+      return { found: false, value: null, continueLookup: false };
+    }
+    if (val === Css.ident.initial) {
+      return { found: true, value: null, continueLookup: false };
+    }
+    if (
+      val === Css.ident.inherit ||
+      val === Css.ident.unset ||
+      val === Css.ident.revert
+    ) {
+      return { found: true, value: null, continueLookup: true };
+    }
+    const fallbackCycleMembers = this.getFallbackCycleMembers(
+      val,
+      elementStyles,
+      element,
+    );
+    if (fallbackCycleMembers) {
+      fallbackCycleMembers.forEach((member) =>
+        this.varResolutionState.cycleMembers.add(member),
+      );
+      return { found: true, value: null, continueLookup: false };
+    }
+    return {
+      found: true,
+      value: this.resolveReferencedCustomProperty(
+        name,
+        val,
+        elementStyles,
+        element,
+      ),
+      continueLookup: false,
+    };
+  }
+
+  private resolveReferencedCustomProperty(
+    name: string,
+    value: Css.Val,
+    elementStyles: ElementStyle[],
+    element: Element | null,
+  ): Css.Val | null {
+    const cycleIndex = this.resolvingCustomProperties.indexOf(name);
+    if (cycleIndex >= 0) {
+      this.resolvingCustomProperties
+        .slice(cycleIndex)
+        .forEach((member) => this.varResolutionState.cycleMembers.add(member));
+      return null;
+    }
+
+    const previousCycleMembers = new Set(this.varResolutionState.cycleMembers);
+    this.varResolutionState.cycleMembers = new Set();
+    const nestedVisitor = new VarFilterVisitor(
+      elementStyles,
+      this.styler,
+      element,
+      name,
+    );
+    nestedVisitor.resolvingCustomProperties = this.resolvingCustomProperties;
+    nestedVisitor.resolvingCustomProperties.push(name);
+    nestedVisitor.varResolutionState = this.varResolutionState;
+
+    let resolvedValue = value;
+    const LIMIT_LOOP = 32;
+    for (let i = 0; ; i++) {
+      if (i >= LIMIT_LOOP) {
+        resolvedValue = null;
+        break;
+      }
+      const after = resolvedValue.visit(nestedVisitor);
+      if (nestedVisitor.error) {
+        resolvedValue = null;
+        break;
+      }
+      if (after === resolvedValue) {
+        break;
+      }
+      resolvedValue = after;
+    }
+
+    const hadCycleMembers = this.varResolutionState.cycleMembers;
+    this.varResolutionState.cycleMembers = new Set([
+      ...previousCycleMembers,
+      ...hadCycleMembers,
+    ]);
+    this.resolvingCustomProperties.pop();
+    return hadCycleMembers.has(name) ? null : resolvedValue;
   }
 
   private getVarValue(name: string): Css.Val {
     let elem = this.element ?? ((this.styler as any).root as Element);
     if (this.elementStyles?.length) {
-      for (const style of this.elementStyles) {
-        const val = (style[name] as CascadeValue)?.value;
-        if (val) {
-          return val;
+      for (let index = 0; index < this.elementStyles.length; index++) {
+        const style = this.elementStyles[index];
+        const resolved = this.resolveCustomProperty(
+          name,
+          (style[name] as CascadeValue)?.value,
+          this.elementStyles.slice(index),
+          this.element,
+        );
+        if (!resolved.found) {
+          continue;
+        }
+        if (resolved.value) {
+          return resolved.value;
+        }
+        if (!resolved.continueLookup) {
+          return null;
         }
       }
       if (this.element) {
@@ -5712,10 +6027,21 @@ export class VarFilterVisitor extends Css.FilterVisitor {
       }
     }
     for (; elem; elem = elem.parentElement) {
-      const val = (this.styler.getStyle(elem, false)?.[name] as CascadeValue)
-        ?.value;
-      if (val) {
-        return val;
+      const style = this.styler.getStyle(elem, false);
+      const resolved = this.resolveCustomProperty(
+        name,
+        (style?.[name] as CascadeValue)?.value,
+        style ? [style] : [],
+        elem,
+      );
+      if (!resolved.found) {
+        continue;
+      }
+      if (resolved.value) {
+        return resolved.value;
+      }
+      if (!resolved.continueLookup) {
+        return null;
       }
     }
     return null;
@@ -5733,6 +6059,13 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     const varVal = this.getVarValue(name);
     if (varVal) {
       return varVal;
+    }
+    if (
+      this.currentCustomPropertyName &&
+      this.varResolutionState.cycleMembers.has(this.currentCustomPropertyName)
+    ) {
+      this.error = true;
+      return Css.empty;
     }
     // fallback value
     if (func.values.length < 2) {

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -889,6 +889,7 @@ export class Parser {
         if (token.type !== TokenType.EOF) {
           this.handler.error("E_CSS_MISMATCHED_C_PAR", token);
           this.actions = actionsErrorDecl;
+          return null;
         }
       }
       const func = new Css.Func(
@@ -900,7 +901,7 @@ export class Parser {
       // Check invalid var()
       if (func.name === "var") {
         const name = func.values[0] instanceof Css.Ident && func.values[0].name;
-        if (!Css.isCustomPropName(name) || name === this.propName) {
+        if (!Css.isCustomPropName(name)) {
           this.handler.error(`E_CSS_INVALID_VAR ${func.toString()}`, token);
           this.actions = actionsErrorDecl;
         }
@@ -1169,10 +1170,13 @@ export class Parser {
     }
     tokenizer.consume();
     const endPosition = tokenN.position;
+    const rawValue = tokenizer.input.substring(startPosition, endPosition);
     const value =
       isFunc && name === "selector" && commaCount > 0
         ? "" // selector() with multiple selectors doesn't work
-        : tokenizer.input.substring(startPosition, endPosition).trim();
+        : Css.isCustomPropName(name)
+          ? rawValue
+          : rawValue.trim();
     const supportsTest = new Exprs.SupportsTest(
       this.handler.getScope(),
       name,

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1603,6 +1603,9 @@ export class ValidatorSet {
     name: string,
     value?: Css.Val | string,
   ): ShorthandValidator | null {
+    if (Css.isCustomPropName(name)) {
+      return null;
+    }
     const shorthand = this.shorthands[name];
     if (shorthand) {
       return shorthand;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -590,6 +590,10 @@ export class StyleInstance
       return false;
     }
 
+    if (Css.isCustomPropName(name)) {
+      return typeof CSS !== "undefined" && CSS.supports(`(${name}:${value})`);
+    }
+
     let supported = true;
 
     class SupportsReceiver implements CssValidator.PropertyReceiver {

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -18,6 +18,8 @@
 
 import * as adapt_css from "../../../src/vivliostyle/css";
 import * as adapt_csscasc from "../../../src/vivliostyle/css-cascade";
+import * as adapt_exprs from "../../../src/vivliostyle/exprs";
+import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
 import * as adapt_csstok from "../../../src/vivliostyle/css-tokenizer";
 import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
 import * as vivliostyle_test_util_mock_plugin from "../../util/mock/vivliostyle/plugin-mock";
@@ -1138,6 +1140,222 @@ describe("css-cascade", function () {
           );
         });
       });
+    });
+  });
+
+  describe("VarFilterVisitor regression coverage", function () {
+    function parseValue(cssText) {
+      return adapt_cssparse.parseValue(
+        new adapt_exprs.LexicalScope(null),
+        new adapt_csstok.Tokenizer(cssText, null),
+        "",
+      );
+    }
+
+    function createCascadeValue(cssText) {
+      return new adapt_csscasc.CascadeValue(parseValue(cssText), 1);
+    }
+
+    function applyVarFilter(style, element, ancestorEntries) {
+      var styleMap = new Map();
+      styleMap.set(element, style);
+      (ancestorEntries || []).forEach(function (entry) {
+        styleMap.set(entry.element, entry.style);
+      });
+
+      var styler = {
+        root: element,
+        validatorSet: {
+          getShorthand: function () {
+            return null;
+          },
+          defaultValues: {},
+        },
+        getStyle: function (currentElement) {
+          return styleMap.get(currentElement) || null;
+        },
+      };
+      var cascadeInstance = {
+        context: {},
+      };
+      cascadeInstance.applyVarFilter =
+        adapt_csscasc.CascadeInstance.prototype.applyVarFilter;
+      cascadeInstance.applyVarFilter([style], styler, element);
+    }
+
+    it("keeps self-referential custom properties guaranteed-invalid instead of using their fallback", function () {
+      var element = document.createElement("div");
+      var style = {
+        "--a": createCascadeValue("var(--a, red)"),
+        color: createCascadeValue("var(--a, green)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style["--a"].value).toBe(adapt_css.ident.initial);
+      expect(style.color.value.toString()).toBe("green");
+    });
+
+    it("keeps cross-cyclic custom properties guaranteed-invalid regardless of declaration order", function () {
+      [
+        {
+          "--a": createCascadeValue("var(--b)"),
+          "--b": createCascadeValue("var(--a, green)"),
+          color: createCascadeValue("var(--b, blue)"),
+        },
+        {
+          "--b": createCascadeValue("var(--a, green)"),
+          "--a": createCascadeValue("var(--b)"),
+          color: createCascadeValue("var(--b, blue)"),
+        },
+      ].forEach(function (style) {
+        var element = document.createElement("div");
+
+        applyVarFilter(style, element);
+
+        expect(style["--a"].value).toBe(adapt_css.ident.initial);
+        expect(style["--b"].value).toBe(adapt_css.ident.initial);
+        expect(style.color.value.toString()).toBe("blue");
+      });
+    });
+
+    it("keeps fallback available for properties that only reference a cyclic custom property", function () {
+      var element = document.createElement("div");
+      var style = {
+        "--a": createCascadeValue("var(--b)"),
+        "--b": createCascadeValue("var(--a)"),
+        "--x": createCascadeValue("var(--a, green)"),
+        color: createCascadeValue("var(--x, blue)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style["--a"].value).toBe(adapt_css.ident.initial);
+      expect(style["--b"].value).toBe(adapt_css.ident.initial);
+      expect(style["--x"].value.toString()).toBe("green");
+      expect(style.color.value.toString()).toBe("green");
+    });
+
+    it("treats fallback references as part of the custom property dependency cycle", function () {
+      var element = document.createElement("div");
+      var style = {
+        "--a": createCascadeValue("var(--b, var(--c))"),
+        "--b": createCascadeValue("green"),
+        "--c": createCascadeValue("var(--a)"),
+        color: createCascadeValue("var(--a, blue)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style["--a"].value).toBe(adapt_css.ident.initial);
+      expect(style["--c"].value).toBe(adapt_css.ident.initial);
+      expect(style.color.value.toString()).toBe("blue");
+    });
+
+    it("resolves ordinary properties after marking cyclic custom properties invalid", function () {
+      var element = document.createElement("div");
+      var style = {
+        color: createCascadeValue("var(--a, blue)"),
+        "--a": createCascadeValue("var(--b, var(--c))"),
+        "--b": createCascadeValue("green"),
+        "--c": createCascadeValue("var(--a)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style["--a"].value).toBe(adapt_css.ident.initial);
+      expect(style["--c"].value).toBe(adapt_css.ident.initial);
+      expect(style.color.value.toString()).toBe("blue");
+    });
+
+    it("propagates fallback-cycle membership back to the calling custom property", function () {
+      var element = document.createElement("div");
+      var style = {
+        "--a": createCascadeValue("var(--b, red)"),
+        "--b": createCascadeValue("var(--c, var(--a))"),
+        "--c": createCascadeValue("green"),
+        color: createCascadeValue("var(--a, blue)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style["--a"].value).toBe(adapt_css.ident.initial);
+      expect(style["--b"].value).toBe(adapt_css.ident.initial);
+      expect(style.color.value.toString()).toBe("blue");
+    });
+
+    it("keeps fallback-only cycle dependencies invalid even when the substituted branch is otherwise valid", function () {
+      var element = document.createElement("div");
+      var style = {
+        "--a": createCascadeValue("var(--c, var(--b))"),
+        "--b": createCascadeValue("var(--a)"),
+        "--c": createCascadeValue("red"),
+        color: createCascadeValue("var(--a, blue)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style["--a"].value).toBe(adapt_css.ident.initial);
+      expect(style["--b"].value).toBe(adapt_css.ident.initial);
+      expect(style.color.value.toString()).toBe("blue");
+    });
+
+    it("preserves originating element custom property context for pseudo-elements", function () {
+      var element = document.createElement("div");
+      var beforeStyle = {
+        color: createCascadeValue("var(--x)"),
+        "--x": createCascadeValue("var(--y)"),
+      };
+      var style = {
+        "--y": createCascadeValue("green"),
+        _pseudos: {
+          before: beforeStyle,
+        },
+      };
+
+      applyVarFilter(style, element);
+
+      expect(beforeStyle["--x"].value.toString()).toBe("green");
+      expect(beforeStyle.color.value.toString()).toBe("green");
+    });
+
+    it("does not treat owner-element fallback references as pseudo-element cycles", function () {
+      var element = document.createElement("div");
+      var style = {
+        _pseudos: {
+          before: {
+            "--a": createCascadeValue("var(--c, var(--b))"),
+            color: createCascadeValue("var(--a, blue)"),
+          },
+        },
+        "--b": createCascadeValue("var(--a, green)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style["--b"].value.toString()).toBe("green");
+      expect(style._pseudos.before["--a"].value.toString()).toBe("green");
+      expect(style._pseudos.before.color.value.toString()).toBe("green");
+    });
+
+    it("uses fallback when a custom property references an invalid inherited variable", function () {
+      var body = document.createElement("body");
+      var element = document.createElement("p");
+      body.appendChild(element);
+      var bodyStyle = {
+        "--c": createCascadeValue("var(--a)"),
+      };
+      var style = {
+        "--a": createCascadeValue("var(--b)"),
+        "--b": createCascadeValue("var(--c, green)"),
+        color: createCascadeValue("var(--a)"),
+      };
+
+      applyVarFilter(style, element, [{ element: body, style: bodyStyle }]);
+
+      expect(style["--b"].value.toString()).toBe("green");
+      expect(style["--a"].value.toString()).toBe("green");
+      expect(style.color.value.toString()).toBe("green");
     });
   });
 });

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -50,6 +50,14 @@ describe("css-parser", function () {
       });
     }
 
+    function parseSupports(done, text, fn) {
+      spyOn(handler, "startWhenRule").and.callThrough();
+      parse(done, text, function () {
+        expect(handler.startWhenRule).toHaveBeenCalled();
+        fn(handler.startWhenRule.calls.mostRecent().args[0]);
+      });
+    }
+
     function tokenize(text) {
       var tokenizer = new adapt_csstok.Tokenizer(text, handler);
       var tokens = [];
@@ -1337,6 +1345,24 @@ describe("css-parser", function () {
             expect(handler.error).toHaveBeenCalled();
             expect(handler.pseudoelementSelector).not.toHaveBeenCalled();
           });
+        });
+      });
+    });
+
+    describe("supports parsing", function () {
+      it("preserves whitespace-only custom property values in @supports tests", function (done) {
+        parseSupports(done, "@supports (--a: ) {}", function (expr) {
+          expect(expr.expr.name).toBe("--a");
+          expect(expr.expr.value).toBe(" ");
+          expect(expr.expr.toString()).toBe("(--a: )");
+        });
+      });
+
+      it("preserves leading and trailing whitespace in custom property @supports values", function (done) {
+        parseSupports(done, "@supports (--a:  red ) {}", function (expr) {
+          expect(expr.expr.name).toBe("--a");
+          expect(expr.expr.value).toBe("  red ");
+          expect(expr.expr.toString()).toBe("(--a:  red )");
         });
       });
     });

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -183,6 +183,16 @@ describe("css-validator", function () {
         },
       );
     });
+
+    it("keeps self-referential custom property declarations through the parser path", function (done) {
+      parseCascade("div { --a: var(--a, red); }", done, function (cascade) {
+        expect(cascade.tags.div).toBeDefined();
+        expect(cascade.tags.div.style["--a"]).toBeDefined();
+        expect(cascade.tags.div.style["--a"].value.toString()).toBe(
+          "var(--a,red)",
+        );
+      });
+    });
   });
 
   describe("invalid selector list recovery", function () {


### PR DESCRIPTION
Fix custom property resolution for WPT `css/css-variables` cases by:
- skipping browser shorthand probing for custom properties
- preserving whitespace-only custom property values
- distinguishing invalid custom properties from whitespace-only values
- resolving referenced custom properties in the owning element context
- handling cycle-driven invalidation without breaking non-cycle fallback

With this change, WPT `css/css-variables` cases pass except for `variable-generated-content-dynamic-001.html`.

Keep `variable-generated-content-dynamic-001.html` as a separate follow-up, since the remaining failure is caused by script timing / dynamic generated content handling rather than the CSS variables resolution logic.

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` after spotting two CSS-variables WPT regressions, hypothesizing PR #1969 as the cause; the AI confirmed those two plus found 16 other pre-existing (non-regression) failures, and the human asked it to fix them in order of efficiency.
- The human author decided a `scripts.ts` change for a dynamic-content edge case was out of scope (a separate script-timing issue) and asked the AI to revert that part, then asked for a full `test:reftest-diff` run to confirm the rest passed.
- The human author caught the AI's fix reintroducing a regression for whitespace-only CSS variable values, and separately caught a previously-passing case (`variable-declaration-51`) regressing again after a later change; the AI corrected both.
- The human author directed the commit message content (noting the one deliberately deferred case) and ran `/address-pr-comments` seven times across multiple rounds of reviewer feedback.

</details>
