### PR TITLE
fix: Fix `all` resetting browser-backed shorthand longhands

### DIFF
--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1461,6 +1461,10 @@ const propsExcludedFromAll = [
   "block-end",
   "inline-start",
   "inline-end",
+  "inset-block-start",
+  "inset-block-end",
+  "inset-inline-start",
+  "inset-inline-end",
   "block-size",
   "inline-size",
   "max-block-size",
@@ -1511,13 +1515,12 @@ export class AllShorthandValidator extends SimpleShorthandValidator {
     super();
   }
 
+  refreshPropList(): void {
+    this.propList = this.validatorSet.getPropertiesForAll();
+  }
+
   override init(syntax: ShorthandSyntaxNode[], propList: string[]): void {
     super.init(syntax, propList);
-    for (const name in this.validatorSet.validators) {
-      if (!propsExcludedFromAll.includes(name)) {
-        this.propList.push(name);
-      }
-    }
   }
 
   override validateList(list: Css.Val[]): number {
@@ -1559,6 +1562,69 @@ export class ValidatorSet {
   readonly scope = new Exprs.LexicalScope(null);
   private browserShorthandStyle: CSSStyleDeclaration | null = null;
   private browserShorthandMisses: { [key: string]: true } = {};
+  private browserPropertyNamesForAll: string[] | null = null;
+  private allPropertyNames: string[] | null = null;
+
+  private invalidateAllPropertyNames(): void {
+    this.allPropertyNames = null;
+  }
+
+  private getBrowserPropertyNamesForAll(): string[] | null {
+    if (this.browserPropertyNamesForAll) {
+      return this.browserPropertyNamesForAll;
+    }
+    if (
+      typeof document === "undefined" ||
+      typeof getComputedStyle !== "function"
+    ) {
+      return null;
+    }
+    const root = document.documentElement;
+    if (!root) {
+      return null;
+    }
+    const computedStyle = getComputedStyle(root);
+    const names: string[] = [];
+    for (let i = 0; i < computedStyle.length; i++) {
+      const name = computedStyle.item(i);
+      if (
+        !name ||
+        Css.isCustomPropName(name) ||
+        propsExcludedFromAll.includes(name)
+      ) {
+        continue;
+      }
+      names.push(name);
+    }
+    this.browserPropertyNamesForAll = names;
+    return this.browserPropertyNamesForAll;
+  }
+
+  getPropertiesForAll(): string[] {
+    if (this.allPropertyNames) {
+      return this.allPropertyNames;
+    }
+    const names = new Set<string>();
+    for (const name in this.validators) {
+      if (!propsExcludedFromAll.includes(name)) {
+        names.add(name);
+      }
+    }
+    const browserPropertyNames = this.getBrowserPropertyNamesForAll();
+    if (browserPropertyNames) {
+      for (const name of browserPropertyNames) {
+        if (this.shorthands[name]) {
+          continue;
+        }
+        names.add(name);
+      }
+    }
+    const propList = Array.from(names);
+    if (browserPropertyNames) {
+      this.allPropertyNames = propList;
+    }
+    return propList;
+  }
 
   private getBrowserShorthandStyle(): CSSStyleDeclaration | null {
     if (this.browserShorthandStyle !== null) {
@@ -1608,6 +1674,12 @@ export class ValidatorSet {
     }
     const shorthand = this.shorthands[name];
     if (shorthand) {
+      if (
+        shorthand instanceof AllShorthandValidator &&
+        !this.allPropertyNames
+      ) {
+        shorthand.refreshPropList();
+      }
       return shorthand;
     }
     if (this.browserShorthandMisses[name]) {
@@ -1636,6 +1708,7 @@ export class ValidatorSet {
     );
     browserShorthand.setOwner(this);
     this.shorthands[name] = browserShorthand;
+    this.invalidateAllPropertyNames();
     return browserShorthand;
   }
 
@@ -2195,6 +2268,7 @@ export class ValidatorSet {
       }
       shorthandValidator.init(syntax, propList);
       this.shorthands[ruleName] = shorthandValidator;
+      this.invalidateAllPropertyNames();
     }
   }
 

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -18,6 +18,7 @@
 
 import * as adapt_css from "../../../src/vivliostyle/css";
 import * as adapt_csscasc from "../../../src/vivliostyle/css-cascade";
+import * as adapt_cssvalid from "../../../src/vivliostyle/css-validator";
 import * as adapt_exprs from "../../../src/vivliostyle/exprs";
 import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
 import * as adapt_csstok from "../../../src/vivliostyle/css-tokenizer";
@@ -1156,21 +1157,24 @@ describe("css-cascade", function () {
       return new adapt_csscasc.CascadeValue(parseValue(cssText), 1);
     }
 
-    function applyVarFilter(style, element, ancestorEntries) {
+    function applyVarFilter(style, element, ancestorEntries, validatorSet) {
       var styleMap = new Map();
       styleMap.set(element, style);
       (ancestorEntries || []).forEach(function (entry) {
         styleMap.set(entry.element, entry.style);
       });
 
+      validatorSet = validatorSet || {
+        getShorthand: function () {
+          return null;
+        },
+        defaultValues: {},
+      };
+
       var styler = {
         root: element,
-        validatorSet: {
-          getShorthand: function () {
-            return null;
-          },
-          defaultValues: {},
-        },
+        validatorSet: validatorSet,
+        scope: validatorSet.scope,
         getStyle: function (currentElement) {
           return styleMap.get(currentElement) || null;
         },
@@ -1356,6 +1360,24 @@ describe("css-cascade", function () {
       expect(style["--b"].value.toString()).toBe("green");
       expect(style["--a"].value.toString()).toBe("green");
       expect(style.color.value.toString()).toBe("green");
+    });
+
+    it("expands all with var-substituted CSS-wide values into browser-backed longhands", function () {
+      var element = document.createElement("div");
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      var style = {
+        all: createCascadeValue("var(--reset, initial)"),
+        transition: createCascadeValue("opacity 1s ease"),
+      };
+
+      applyVarFilter(style, element, null, validatorSet);
+
+      expect(style.all).toBeUndefined();
+      expect(style.transition).toBeDefined();
+      expect(style["transition-property"]).toBeDefined();
+      expect(style["transition-duration"]).toBeDefined();
+      expect(style["transition-property"].value).toBe(adapt_css.ident.initial);
+      expect(style["transition-duration"].value).toBe(adapt_css.ident.initial);
     });
   });
 });

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -184,6 +184,78 @@ describe("css-validator", function () {
       );
     });
 
+    it("lets all reset browser shorthand longhands that are not in ValidationTxt", function (done) {
+      parseCascade(
+        "div { transition: opacity 1s ease; all: initial; }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["transition-property"]).toBeDefined();
+          expect(cascade.tags.div.style["transition-duration"]).toBeDefined();
+          expect(cascade.tags.div.style["transition-property"].value).toBe(
+            adapt_css.ident.initial,
+          );
+          expect(cascade.tags.div.style["transition-duration"].value).toBe(
+            adapt_css.ident.initial,
+          );
+        },
+      );
+    });
+
+    it("does not enumerate browser properties while creating the base validator set", function () {
+      spyOn(window, "getComputedStyle").and.callThrough();
+
+      adapt_cssvalid.baseValidatorSet();
+
+      expect(window.getComputedStyle).not.toHaveBeenCalled();
+    });
+
+    it("reuses cached browser property names for repeated all lookups", function () {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      spyOn(validatorSet, "getBrowserPropertyNamesForAll").and.callThrough();
+
+      expect(validatorSet.getShorthand("all")).not.toBeNull();
+      expect(validatorSet.getShorthand("all")).not.toBeNull();
+      expect(validatorSet.getBrowserPropertyNamesForAll).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it("filters cached browser property names against later shorthand registrations", function () {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+
+      validatorSet.allPropertyNames = null;
+      validatorSet.browserPropertyNamesForAll = [
+        "inset",
+        "transition-property",
+      ];
+
+      expect(validatorSet.getPropertiesForAll()).not.toContain("inset");
+      expect(validatorSet.getPropertiesForAll()).toContain(
+        "transition-property",
+      );
+    });
+
+    it("does not keep browser shorthand names in all after refresh", function (done) {
+      parseCascade(
+        "div { all: initial; position: absolute; top: 0; right: 0; }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["inset"]).toBeUndefined();
+          expect(cascade.tags.div.style["inset-block-start"]).toBeUndefined();
+          expect(cascade.tags.div.style["inset-block-end"]).toBeUndefined();
+          expect(cascade.tags.div.style["inset-inline-start"]).toBeUndefined();
+          expect(cascade.tags.div.style["inset-inline-end"]).toBeUndefined();
+          expect(cascade.tags.div.style["position"].value.toString()).toBe(
+            "absolute",
+          );
+          expect(cascade.tags.div.style["top"].value.toString()).toBe("0");
+          expect(cascade.tags.div.style["right"].value.toString()).toBe("0");
+        },
+      );
+    });
+
     it("keeps self-referential custom property declarations through the parser path", function (done) {
       parseCascade("div { --a: var(--a, red); }", done, function (cascade) {
         expect(cascade.tags.div).toBeDefined();


### PR DESCRIPTION
Make `all` include browser-supported longhands that are not defined in `ValidationTxt`, so declarations such as `transition: ...; all: initial;` and `text-box: ...; all: initial;` reset those properties correctly.

Implement this by teaching `ValidatorSet` to build the `all` target list from both Vivliostyle-known validators and browser-enumerated computed-style properties, while still excluding properties that `all` must not touch. Refresh the cached `AllShorthandValidator` property list on lookup so the same behavior applies in shorthand-mixing and `var()`-related cascade paths.

Add a core regression test that verifies `all: initial` resets browser-native `transition-*` longhands even though they are absent from `ValidationTxt`.

Related to PR #1969

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author, having just landed PR #1969's browser-backed shorthand support, identified and reported this follow-on `all` shorthand gap with a concrete example (`text-box: trim-both; all: initial;` not being reset), and asked the AI to fix it.
- The human author ran `/draft-commit` and `/address-pr-comments` across four rounds of reviewer feedback.

</details>
