### PR TITLE
fix: Fix attribute selector case sensitivity

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1272,10 +1272,10 @@ ol[type=a], li[type=a] { list-style-type: lower-alpha; }
 ol[type=A], li[type=A] { list-style-type: upper-alpha; }
 ol[type=i], li[type=i] { list-style-type: lower-roman; }
 ol[type=I], li[type=I] { list-style-type: upper-roman; }
-ul[type=none], li[type=none] { list-style-type: none; }
-ul[type=disc], li[type=disc] { list-style-type: disc; }
-ul[type=circle], li[type=circle] { list-style-type: circle; }
-ul[type=square], li[type=square] { list-style-type: square; }
+ul[type=none i], li[type=none i] { list-style-type: none; }
+ul[type=disc i], li[type=disc i] { list-style-type: disc; }
+ul[type=circle i], li[type=circle i] { list-style-type: circle; }
+ul[type=square i], li[type=square i] { list-style-type: square; }
 u,
 ins {
   text-decoration: underline;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -1035,34 +1035,77 @@ function checkAttribute(
   element: Element,
   ns: string | null,
   name: string,
-  pred: (element: Element, ns: string, name: string) => boolean,
+  pred: (attribute: Attr) => boolean,
 ): boolean {
   if (!element) {
     return false;
   }
+  const htmlAttributeNamesAreCaseInsensitive =
+    element.ownerDocument?.contentType === "text/html";
+  const selectorName = htmlAttributeNamesAreCaseInsensitive
+    ? asciiLowerCase(name)
+    : name;
   if (ns !== null) {
-    return pred(element, ns, name);
+    const attribute = element.getAttributeNodeNS(ns || null, selectorName);
+    return !!attribute && pred(attribute);
   }
-  // For wildcard namespace
-  for (const qname of element.getAttributeNames()) {
-    if (qname === name || qname.endsWith(`:${name}`)) {
-      if (
-        pred(
-          element,
-          qname === name ? "" : element.lookupNamespaceURI(qname.split(":")[0]),
-          name,
-        )
-      ) {
-        return true;
-      }
+  for (const attribute of Array.from(element.attributes)) {
+    const attributeName = htmlAttributeNamesAreCaseInsensitive
+      ? asciiLowerCase(attribute.localName)
+      : attribute.localName;
+    if (attributeName === selectorName && pred(attribute)) {
+      return true;
     }
   }
   return false;
 }
 
+function asciiLowerCase(value: string): string {
+  return value.replace(/[A-Z]/g, (char) => char.toLowerCase());
+}
+
+function isAttributeValueCaseInsensitive(
+  caseSensitivity: CssParser.AttributeSelectorCaseSensitivity,
+): boolean {
+  return caseSensitivity === "i";
+}
+
+function escapeRegExpForAttributeValue(
+  value: string,
+  caseSensitivity: CssParser.AttributeSelectorCaseSensitivity,
+): string {
+  return Array.from(value, (char) => {
+    const escapedChar = Base.escapeRegExp(char);
+    if (!isAttributeValueCaseInsensitive(caseSensitivity)) {
+      return escapedChar;
+    }
+    const lowerChar = asciiLowerCase(char);
+    const upperChar = lowerChar.toUpperCase();
+    if (lowerChar !== upperChar && /^[a-z]$/i.test(char)) {
+      return `[${lowerChar}${upperChar}]`;
+    }
+    return escapedChar;
+  }).join("");
+}
+
+function createAttributeValueRegExp(pattern: string): RegExp {
+  return new RegExp(pattern);
+}
+
+function attributeValueEquals(
+  actualValue: string,
+  expectedValue: string,
+  caseSensitivity: CssParser.AttributeSelectorCaseSensitivity,
+): boolean {
+  if (isAttributeValueCaseInsensitive(caseSensitivity)) {
+    return asciiLowerCase(actualValue) === asciiLowerCase(expectedValue);
+  }
+  return actualValue === expectedValue;
+}
+
 export class CheckAttributePresentAction extends ChainedAction {
   constructor(
-    public readonly ns: string,
+    public readonly ns: string | null,
     public readonly name: string,
   ) {
     super();
@@ -1074,7 +1117,7 @@ export class CheckAttributePresentAction extends ChainedAction {
         cascadeInstance.currentElement,
         this.ns,
         this.name,
-        (element, ns, name) => element.hasAttributeNS(ns, name),
+        () => true,
       )
     ) {
       this.chained.apply(cascadeInstance);
@@ -1084,9 +1127,10 @@ export class CheckAttributePresentAction extends ChainedAction {
 
 export class CheckAttributeEqAction extends ChainedAction {
   constructor(
-    public readonly ns: string,
+    public readonly ns: string | null,
     public readonly name: string,
     public readonly value: string,
+    public readonly caseSensitivity: CssParser.AttributeSelectorCaseSensitivity = null,
   ) {
     super();
   }
@@ -1097,7 +1141,12 @@ export class CheckAttributeEqAction extends ChainedAction {
         cascadeInstance.currentElement,
         this.ns,
         this.name,
-        (element, ns, name) => element.getAttributeNS(ns, name) == this.value,
+        (attribute) =>
+          attributeValueEquals(
+            attribute.value,
+            this.value,
+            this.caseSensitivity,
+          ),
       )
     ) {
       this.chained.apply(cascadeInstance);
@@ -1124,7 +1173,7 @@ export class CheckAttributeEqAction extends ChainedAction {
 
 export class CheckNamespaceSupportedAction extends ChainedAction {
   constructor(
-    public readonly ns: string,
+    public readonly ns: string | null,
     public readonly name: string,
   ) {
     super();
@@ -1136,8 +1185,7 @@ export class CheckNamespaceSupportedAction extends ChainedAction {
         cascadeInstance.currentElement,
         this.ns,
         this.name,
-        (element, ns, name) =>
-          !!supportedNamespaces[element.getAttributeNS(ns, name)],
+        (attribute) => !!supportedNamespaces[attribute.value],
       )
     ) {
       this.chained.apply(cascadeInstance);
@@ -1155,9 +1203,10 @@ export class CheckNamespaceSupportedAction extends ChainedAction {
 
 export class CheckAttributeRegExpAction extends ChainedAction {
   constructor(
-    public readonly ns: string,
+    public readonly ns: string | null,
     public readonly name: string,
     public readonly regexp: RegExp,
+    public readonly caseSensitivity: CssParser.AttributeSelectorCaseSensitivity = null,
   ) {
     super();
   }
@@ -1168,8 +1217,7 @@ export class CheckAttributeRegExpAction extends ChainedAction {
         cascadeInstance.currentElement,
         this.ns,
         this.name,
-        (element, ns, name) =>
-          !!element.getAttributeNS(ns, name)?.match(this.regexp),
+        (attribute) => !!attribute.value.match(this.regexp),
       )
     ) {
       this.chained.apply(cascadeInstance);
@@ -4806,16 +4854,16 @@ export class CascadeParserHandler
   }
 
   override attributeSelector(
-    ns: string,
+    ns: string | null,
     name: string,
     op: TokenType,
     value: string | null,
+    modifier?: CssParser.AttributeSelectorCaseSensitivity,
   ): void {
     if (this.invalidContinuationAfterPseudoelement(`[${name}]`)) {
       return;
     }
     this.specificity += 256;
-    name = name.toLowerCase();
     value = value || "";
     let action;
     switch (op) {
@@ -4823,7 +4871,7 @@ export class CascadeParserHandler
         action = new CheckAttributePresentAction(ns, name);
         break;
       case TokenType.EQ:
-        action = new CheckAttributeEqAction(ns, name, value);
+        action = new CheckAttributeEqAction(ns, name, value, modifier ?? null);
         break;
       case TokenType.TILDE_EQ:
         if (!value || value.match(/\s/)) {
@@ -4832,7 +4880,10 @@ export class CascadeParserHandler
           action = new CheckAttributeRegExpAction(
             ns,
             name,
-            new RegExp(`(^|\\s)${Base.escapeRegExp(value)}(\$|\\s)`),
+            createAttributeValueRegExp(
+              `(^|\\s)${escapeRegExpForAttributeValue(value, modifier ?? null)}(\$|\\s)`,
+            ),
+            modifier ?? null,
           );
         }
         break;
@@ -4840,7 +4891,10 @@ export class CascadeParserHandler
         action = new CheckAttributeRegExpAction(
           ns,
           name,
-          new RegExp(`^${Base.escapeRegExp(value)}(\$|-)`),
+          createAttributeValueRegExp(
+            `^${escapeRegExpForAttributeValue(value, modifier ?? null)}(\$|-)`,
+          ),
+          modifier ?? null,
         );
         break;
       case TokenType.HAT_EQ:
@@ -4850,7 +4904,10 @@ export class CascadeParserHandler
           action = new CheckAttributeRegExpAction(
             ns,
             name,
-            new RegExp(`^${Base.escapeRegExp(value)}`),
+            createAttributeValueRegExp(
+              `^${escapeRegExpForAttributeValue(value, modifier ?? null)}`,
+            ),
+            modifier ?? null,
           );
         }
         break;
@@ -4861,7 +4918,10 @@ export class CascadeParserHandler
           action = new CheckAttributeRegExpAction(
             ns,
             name,
-            new RegExp(`${Base.escapeRegExp(value)}\$`),
+            createAttributeValueRegExp(
+              `${escapeRegExpForAttributeValue(value, modifier ?? null)}\$`,
+            ),
+            modifier ?? null,
           );
         }
         break;
@@ -4872,7 +4932,10 @@ export class CascadeParserHandler
           action = new CheckAttributeRegExpAction(
             ns,
             name,
-            new RegExp(Base.escapeRegExp(value)),
+            createAttributeValueRegExp(
+              escapeRegExpForAttributeValue(value, modifier ?? null),
+            ),
+            modifier ?? null,
           );
         }
         break;

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -72,6 +72,8 @@ export enum StylesheetFlavor {
   AUTHOR = "Author",
 }
 
+export type AttributeSelectorCaseSensitivity = "i" | "s" | null;
+
 export class ParserHandler implements CssTokenizer.TokenizerHandler {
   flavor: StylesheetFlavor;
 
@@ -104,10 +106,11 @@ export class ParserHandler implements CssTokenizer.TokenizerHandler {
   idSelector(id: string): void {}
 
   attributeSelector(
-    ns: string,
+    ns: string | null,
     name: string,
     op: TokenType,
     value: string | null,
+    modifier?: AttributeSelectorCaseSensitivity,
   ): void {}
 
   descendantSelector(): void {}
@@ -289,12 +292,13 @@ export class DispatchParserHandler extends ParserHandler {
   }
 
   override attributeSelector(
-    ns: string,
+    ns: string | null,
     name: string,
     op: TokenType,
     value: string | null,
+    modifier?: AttributeSelectorCaseSensitivity,
   ): void {
-    this.slave.attributeSelector(ns, name, op, value);
+    this.slave.attributeSelector(ns, name, op, value, modifier);
   }
 
   override descendantSelector(): void {
@@ -1877,7 +1881,7 @@ export class Parser {
           }
 
         // fall through
-        case Action.SELECTOR_ATTR:
+        case Action.SELECTOR_ATTR: {
           tokenizer.consume();
           token = tokenizer.token();
           if (token.type == TokenType.IDENT) {
@@ -1931,9 +1935,10 @@ export class Parser {
               break;
             case TokenType.C_BRK:
               handler.attributeSelector(
-                ns as string,
+                ns as string | null,
                 text as string,
                 TokenType.EOF,
+                null,
                 null,
               );
               if (parsingFunctionParam) {
@@ -1948,18 +1953,31 @@ export class Parser {
               handler.error("E_CSS_ATTR_OP_EXPECTED", token);
               continue;
           }
+          const attributeName = text as string;
+          let valueModifier: AttributeSelectorCaseSensitivity = null;
           switch (token.type) {
             case TokenType.IDENT:
-            case TokenType.STR:
-              handler.attributeSelector(
-                ns as string,
-                text as string,
-                num,
-                token.text,
-              );
+            case TokenType.STR: {
+              const attributeValue = token.text;
               tokenizer.consume();
               token = tokenizer.token();
+              if (token.type == TokenType.IDENT) {
+                const modifier = token.text.toLowerCase();
+                if (modifier == "i" || modifier == "s") {
+                  valueModifier = modifier as AttributeSelectorCaseSensitivity;
+                  tokenizer.consume();
+                  token = tokenizer.token();
+                }
+              }
+              handler.attributeSelector(
+                ns as string | null,
+                attributeName,
+                num,
+                attributeValue,
+                valueModifier,
+              );
               break;
+            }
             default:
               this.actions = actionsErrorSelector;
               handler.error("E_CSS_ATTR_VAL_EXPECTED", token);
@@ -1977,6 +1995,7 @@ export class Parser {
           }
           tokenizer.consume();
           continue;
+        }
         case Action.SELECTOR_CHILD:
           handler.childSelector();
           this.actions = actionsSelectorCont;

--- a/packages/core/test/files/case_sensitivity/attribute-selectors.xhtml
+++ b/packages/core/test/files/case_sensitivity/attribute-selectors.xhtml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test case for Issue #1972: attribute selectors case-sensitivity -->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Attribute selector case sensitivity</title>
+    <style>
+      @page {
+        size: 200mm 150mm;
+        margin: 12mm;
+      }
+
+      body {
+        font: 16px/1.4 sans-serif;
+      }
+
+      .case {
+        margin: 0 0 8mm;
+        padding: 4mm;
+        border: 1px solid #b8b8b8;
+        color: #8f1d1d;
+        background: #ffe9e9;
+      }
+
+      #xml-name[data-Case] {
+        color: #0b5d2a;
+        background: #e7f6ea;
+      }
+
+      #xml-name[data-case] {
+        color: #8f1d1d;
+        background: #ffe9e9;
+      }
+
+      #flag-i[data-state="open" i] {
+        color: #0b5d2a;
+        background: #e7f6ea;
+      }
+
+      #flag-s[data-state="OPEN" s] {
+        color: #0b5d2a;
+        background: #e7f6ea;
+      }
+
+      #flag-s[data-state="open" s] {
+        color: #8f1d1d;
+        background: #ffe9e9;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="xml-name" class="case" data-Case="XML">
+      This block should be green. In XHTML, <code>[data-Case]</code> should
+      match exactly, but <code>[data-case]</code> should not match
+      <code>data-Case="XML"</code>.
+    </div>
+
+    <div id="flag-i" class="case" data-state="OPEN">
+      This block should be green. The i flag should make the value match ASCII
+      case-insensitively.
+    </div>
+
+    <div id="flag-s" class="case" data-state="OPEN">
+      This block should be green. The <code>s</code> flag should match
+      <code>[data-state="OPEN" s]</code>, but should not match
+      <code>[data-state="open" s]</code>.
+    </div>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -38,6 +38,10 @@ module.exports = [
       { file: "crop-marks.html", title: "Printer marks" },
       { file: "empty_page.html", title: "Empty page" },
       {
+        file: "case_sensitivity/attribute-selectors.xhtml",
+        title: "Attribute selector case sensitivity (Issue #1972)",
+      },
+      {
         file: ["multiple_html/first.html", "multiple_html/second.html"],
         title: "Multiple HTML files",
       },

--- a/packages/core/test/files/lists-attributes.html
+++ b/packages/core/test/files/lists-attributes.html
@@ -51,6 +51,10 @@
 
     <section id="test-ul" style="break-before: page;">
       <h2>Test UL</h2>
+      <p>
+        This section checks the existing lowercase <code>type</code>
+        attribute values on <code>ul</code> and <code>li</code>.
+      </p>
       <ul>
         <li>disc
           <ul>
@@ -82,6 +86,32 @@
           </ul>
         </li>
         <li type="disc">disc</li>
+      </ul>
+
+      <h3>Case-insensitive UL type values</h3>
+      <p>
+        This section must render the same markers as the lowercase test above.
+        If only this section differs, the cause is likely case-sensitive
+        matching of <code>ul</code>/<code>li</code> <code>type</code>
+        attribute values.
+      </p>
+      <ul type="SqUaRe">
+        <li>square</li>
+        <li type="CiRcLe">circle
+          <ul>
+            <li>circle
+              <ul>
+                <li>square
+                  <ul type="cIrClE">
+                    <li>circle</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li type="DiSc">disc</li>
+        <li type="NoNe">must have no marker</li>
       </ul>
     </section>
   </body>

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -878,6 +878,24 @@ describe("css-cascade", function () {
           expect(action.ns).toBe("ns");
           expect(action.name).toBe("foo");
           expect(action.value).toBe("bar");
+          expect(action.caseSensitivity).toBeNull();
+        });
+
+        it("stores the attribute selector modifier when present", function () {
+          handler.attributeSelector(
+            "ns",
+            "foo",
+            adapt_csstok.TokenType.EQ,
+            "bar",
+            "i",
+          );
+
+          expect(handler.chain.length).toBe(1);
+          var action = handler.chain[0];
+          expect(action).toEqual(
+            jasmine.any(adapt_csscasc.CheckAttributeEqAction),
+          );
+          expect(action.caseSensitivity).toBe("i");
         });
       });
 
@@ -1004,6 +1022,42 @@ describe("css-cascade", function () {
           expect("a-bar-b".match(regexp)).toBeFalsy();
         });
 
+        it("creates an ASCII-case-insensitive regexp when the i modifier is passed", function () {
+          handler.attributeSelector(
+            "ns",
+            "foo",
+            adapt_csstok.TokenType.HAT_EQ,
+            "bar",
+            "i",
+          );
+
+          expect(handler.chain.length).toBe(1);
+          var action = handler.chain[0];
+          expect(action).toEqual(
+            jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
+          );
+          expect("BAR".match(action.regexp)).toBeTruthy();
+          expect("Bar-baz".match(action.regexp)).toBeTruthy();
+        });
+
+        it("does not use Unicode case folding for the i modifier", function () {
+          handler.attributeSelector(
+            "ns",
+            "foo",
+            adapt_csstok.TokenType.HAT_EQ,
+            "ä",
+            "i",
+          );
+
+          expect(handler.chain.length).toBe(1);
+          var action = handler.chain[0];
+          expect(action).toEqual(
+            jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
+          );
+          expect("äbc".match(action.regexp)).toBeTruthy();
+          expect("Äbc".match(action.regexp)).toBeFalsy();
+        });
+
         it("represents nothing when the value is an empty string", function () {
           handler.attributeSelector(
             "ns",
@@ -1113,6 +1167,92 @@ describe("css-cascade", function () {
   });
 
   describe("CascadeInstance", function () {
+    describe("attribute selectors", function () {
+      it("matches XML attribute names case-sensitively", function () {
+        var doc = new DOMParser().parseFromString(
+          "<root data-Case='value' />",
+          "text/xml",
+        );
+        var element = doc.documentElement;
+        var action = new adapt_csscasc.CheckAttributePresentAction(
+          "",
+          "data-Case",
+        );
+        var chained = (action.chained = jasmine.createSpyObj("chained", [
+          "apply",
+        ]));
+
+        action.apply({ currentElement: element });
+        expect(chained.apply).toHaveBeenCalled();
+
+        action = new adapt_csscasc.CheckAttributePresentAction("", "data-case");
+        chained = action.chained = jasmine.createSpyObj("chained", ["apply"]);
+
+        action.apply({ currentElement: element });
+        expect(chained.apply).not.toHaveBeenCalled();
+      });
+
+      it("matches attribute values ASCII-case-insensitively with the i flag", function () {
+        var doc = new DOMParser().parseFromString(
+          "<!DOCTYPE html><html><body><div data-state='OPEN'></div></body></html>",
+          "text/html",
+        );
+        var element = doc.body.firstElementChild;
+        var action = new adapt_csscasc.CheckAttributeEqAction(
+          "",
+          "data-state",
+          "open",
+          "i",
+        );
+        var chained = (action.chained = jasmine.createSpyObj("chained", [
+          "apply",
+        ]));
+
+        action.apply({ currentElement: element });
+        expect(chained.apply).toHaveBeenCalled();
+      });
+
+      it("does not use Unicode case folding for the i flag", function () {
+        var doc = new DOMParser().parseFromString(
+          "<!DOCTYPE html><html><body><div data-state='Ä'></div></body></html>",
+          "text/html",
+        );
+        var element = doc.body.firstElementChild;
+        var action = new adapt_csscasc.CheckAttributeEqAction(
+          "",
+          "data-state",
+          "ä",
+          "i",
+        );
+        var chained = (action.chained = jasmine.createSpyObj("chained", [
+          "apply",
+        ]));
+
+        action.apply({ currentElement: element });
+        expect(chained.apply).not.toHaveBeenCalled();
+      });
+
+      it("keeps exact attribute value matching with the s flag", function () {
+        var doc = new DOMParser().parseFromString(
+          "<!DOCTYPE html><html><body><div data-state='OPEN'></div></body></html>",
+          "text/html",
+        );
+        var element = doc.body.firstElementChild;
+        var action = new adapt_csscasc.CheckAttributeEqAction(
+          "",
+          "data-state",
+          "open",
+          "s",
+        );
+        var chained = (action.chained = jasmine.createSpyObj("chained", [
+          "apply",
+        ]));
+
+        action.apply({ currentElement: element });
+        expect(chained.apply).not.toHaveBeenCalled();
+      });
+    });
+
     describe("markerAllowedProps", function () {
       it("includes text-orientation for vertical writing mode support", function () {
         expect(adapt_csscasc.CascadeInstance.markerAllowedProps).toContain(

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -27,6 +27,7 @@ describe("css-parser", function () {
 
     beforeEach(function () {
       spyOn(handler, "error");
+      spyOn(handler, "attributeSelector");
       spyOn(handler, "idSelector");
       spyOn(handler, "pseudoclassSelector");
       spyOn(handler, "startFuncWithSelector");
@@ -825,6 +826,19 @@ describe("css-parser", function () {
             expect(handler.error).not.toHaveBeenCalled();
             expect(handler.startFuncWithSelector).toHaveBeenCalledWith("not");
             expect(handler.endFuncWithSelector).toHaveBeenCalled();
+          });
+        });
+
+        it("accepts ASCII-case-insensitive attribute selector flags", function (done) {
+          parse(done, ":not([attr='OPEN' I]) {}", function () {
+            expect(handler.error).not.toHaveBeenCalled();
+            expect(handler.attributeSelector).toHaveBeenCalledWith(
+              "",
+              "attr",
+              adapt_csstok.TokenType.EQ,
+              "OPEN",
+              "i",
+            );
           });
         });
         it("can take class selector", function (done) {


### PR DESCRIPTION
Support the `i` and `s` attribute selector modifiers in `css-parser.ts` and `css-cascade.ts`, and stop lowercasing attribute selector names so XML/XHTML documents keep case-sensitive attribute-name matching.

Update attribute matching to resolve names from the live element based on document type, apply explicit ASCII-insensitive value matching for the `i` flag, and keep exact matching for the `s` flag.

Adjust the user agent CSS in `assets.ts` so `ul[type]` values such as `disc`, `circle`, `square`, and `none` are matched case-insensitively, and expand the `case_sensitivity/attribute-selectors.xhtml` and `lists-attributes.html` test files to distinguish matching failures from attribute-value casing issues.

Closes #1972

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1972 (attribute selector case sensitivity); the AI implemented the `i`/`s` modifier support and case-handling fixes.
- The human author asked for the test case to also verify non-matching cases (not just matches), noticed and fixed the `ul[type]` default-style case-sensitivity issue themselves, asked for the existing `lists-attributes` test to be reused as a base, and requested a clearer two-section test layout (lowercase-only baseline, then a case-sensitivity section) so failures would be easy to diagnose.
- The human author ran `/draft-commit`, asked for a `yarn lint` error to be fixed, and ran `/address-pr-comments`.

</details>
