### PR TITLE
feat: Support typed CSS `attr()` values

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -283,8 +283,6 @@ caption-side = top | bottom;
 clip = rect(ALENGTH{4}) | rect(SPACE(ALENGTH{4})) | auto;
 color = COLOR;
 LIST_STYLE_TYPE = IDENT;
-TYPE_OR_UNIT_IN_ATTR = string | color | url | integer | number | length | angle | time | frequency;
-ATTR = attr(SPACE(IDENT TYPE_OR_UNIT_IN_ATTR?) [ STRING | IDENT | COLOR | INT | NUM | PLENGTH | ANGLE | POS_TIME | FREQUENCY]?);
 CONTENT_LIST = [ STRING | URI | counter(IDENT LIST_STYLE_TYPE?) |
     counters(IDENT STRING LIST_STYLE_TYPE?) | ATTR |
     target-counter([ STRING | URI ] IDENT LIST_STYLE_TYPE?) |

--- a/packages/core/src/vivliostyle/counter-style.ts
+++ b/packages/core/src/vivliostyle/counter-style.ts
@@ -648,100 +648,121 @@ abstract class CounterStyle {
     return new Symbolic(store, descriptors);
   }
 
-  static readonly #DECIMAL_DESCRIPTORS: CssCascade.ElementStyle = {
-    system: new CssCascade.CascadeValue(Css.getName("numeric"), 0),
-    symbols: new CssCascade.CascadeValue(
-      new Css.SpaceList([
-        new Css.Str("0"),
-        new Css.Str("1"),
-        new Css.Str("2"),
-        new Css.Str("3"),
-        new Css.Str("4"),
-        new Css.Str("5"),
-        new Css.Str("6"),
-        new Css.Str("7"),
-        new Css.Str("8"),
-        new Css.Str("9"),
-      ]),
-      0,
-    ),
-  };
+  static #DECIMAL_DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getDecimalDescriptors(): CssCascade.ElementStyle {
+    return (CounterStyle.#DECIMAL_DESCRIPTORS ??= {
+      system: new CssCascade.CascadeValue(Css.getName("numeric"), 0),
+      symbols: new CssCascade.CascadeValue(
+        new Css.SpaceList([
+          new Css.Str("0"),
+          new Css.Str("1"),
+          new Css.Str("2"),
+          new Css.Str("3"),
+          new Css.Str("4"),
+          new Css.Str("5"),
+          new Css.Str("6"),
+          new Css.Str("7"),
+          new Css.Str("8"),
+          new Css.Str("9"),
+        ]),
+        0,
+      ),
+    });
+  }
   static createDecimal(store: CounterStyleStoreMap): CounterStyle {
     return new Numeric(
       store,
-      CounterStyle.#DECIMAL_DESCRIPTORS as NumericDescriptors,
+      CounterStyle.#getDecimalDescriptors() as NumericDescriptors,
     );
   }
 
-  static readonly #DISC_DESCRIPTORS: CssCascade.ElementStyle = {
-    system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
-    symbols: new CssCascade.CascadeValue(new Css.Str("\u2022"), 0),
-    suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
-  };
+  static #DISC_DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getDiscDescriptors(): CssCascade.ElementStyle {
+    return (CounterStyle.#DISC_DESCRIPTORS ??= {
+      system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
+      symbols: new CssCascade.CascadeValue(new Css.Str("\u2022"), 0),
+      suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
+    });
+  }
   static createDisc(store: CounterStyleStoreMap): CounterStyle {
     return new Cyclic(
       store,
-      CounterStyle.#DISC_DESCRIPTORS as CyclicDescriptors,
+      CounterStyle.#getDiscDescriptors() as CyclicDescriptors,
     );
   }
 
-  static readonly #SQUARE_DESCRIPTORS: CssCascade.ElementStyle = {
-    system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
-    symbols: new CssCascade.CascadeValue(new Css.Str("\u25AA"), 0),
-    suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
-  };
+  static #SQUARE_DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getSquareDescriptors(): CssCascade.ElementStyle {
+    return (CounterStyle.#SQUARE_DESCRIPTORS ??= {
+      system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
+      symbols: new CssCascade.CascadeValue(new Css.Str("\u25AA"), 0),
+      suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
+    });
+  }
   static createSquare(store: CounterStyleStoreMap): CounterStyle {
     return new Cyclic(
       store,
-      CounterStyle.#SQUARE_DESCRIPTORS as CyclicDescriptors,
+      CounterStyle.#getSquareDescriptors() as CyclicDescriptors,
     );
   }
 
-  static readonly #CIRCLE_DESCRIPTORS: CssCascade.ElementStyle = {
-    system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
-    symbols: new CssCascade.CascadeValue(new Css.Str("\u25E6"), 0),
-    suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
-  };
+  static #CIRCLE_DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getCircleDescriptors(): CssCascade.ElementStyle {
+    return (CounterStyle.#CIRCLE_DESCRIPTORS ??= {
+      system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
+      symbols: new CssCascade.CascadeValue(new Css.Str("\u25E6"), 0),
+      suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
+    });
+  }
   static createCircle(store: CounterStyleStoreMap): CounterStyle {
     return new Cyclic(
       store,
-      CounterStyle.#CIRCLE_DESCRIPTORS as CyclicDescriptors,
+      CounterStyle.#getCircleDescriptors() as CyclicDescriptors,
     );
   }
 
-  static readonly #DISCLOSURE_OPEN_DESCRIPTORS: CssCascade.ElementStyle = {
-    system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
-    symbols: new CssCascade.CascadeValue(new Css.Str("\u25BE"), 0),
-    suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
-  };
+  static #DISCLOSURE_OPEN_DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getDisclosureOpenDescriptors(): CssCascade.ElementStyle {
+    return (CounterStyle.#DISCLOSURE_OPEN_DESCRIPTORS ??= {
+      system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
+      symbols: new CssCascade.CascadeValue(new Css.Str("\u25BE"), 0),
+      suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
+    });
+  }
   static createDisclosureOpen(store: CounterStyleStoreMap): CounterStyle {
     return new Cyclic(
       store,
-      CounterStyle.#DISCLOSURE_OPEN_DESCRIPTORS as CyclicDescriptors,
+      CounterStyle.#getDisclosureOpenDescriptors() as CyclicDescriptors,
     );
   }
 
-  static readonly #DISCLOSURE_CLOSED_DESCRIPTORS: CssCascade.ElementStyle = {
-    system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
-    symbols: new CssCascade.CascadeValue(new Css.Str("\u25B8"), 0),
-    suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
-  };
+  static #DISCLOSURE_CLOSED_DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getDisclosureClosedDescriptors(): CssCascade.ElementStyle {
+    return (CounterStyle.#DISCLOSURE_CLOSED_DESCRIPTORS ??= {
+      system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
+      symbols: new CssCascade.CascadeValue(new Css.Str("\u25B8"), 0),
+      suffix: new CssCascade.CascadeValue(new Css.Str(" "), 0),
+    });
+  }
   static createDisclosureClosed(store: CounterStyleStoreMap): CounterStyle {
     return new Cyclic(
       store,
-      this.#DISCLOSURE_CLOSED_DESCRIPTORS as CyclicDescriptors,
+      this.#getDisclosureClosedDescriptors() as CyclicDescriptors,
     );
   }
 
-  static readonly #NONE_DESCRIPTORS: CssCascade.ElementStyle = {
-    system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
-    symbols: new CssCascade.CascadeValue(new Css.Str(""), 0),
-    suffix: new CssCascade.CascadeValue(new Css.Str(""), 0),
-  };
+  static #NONE_DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getNoneDescriptors(): CssCascade.ElementStyle {
+    return (CounterStyle.#NONE_DESCRIPTORS ??= {
+      system: new CssCascade.CascadeValue(Css.getName("cyclic"), 0),
+      symbols: new CssCascade.CascadeValue(new Css.Str(""), 0),
+      suffix: new CssCascade.CascadeValue(new Css.Str(""), 0),
+    });
+  }
   static createNone(store: CounterStyleStoreMap): CounterStyle {
     return new Cyclic(
       store,
-      CounterStyle.#NONE_DESCRIPTORS as CyclicDescriptors,
+      CounterStyle.#getNoneDescriptors() as CyclicDescriptors,
     );
   }
 
@@ -1327,131 +1348,136 @@ const chineseLonghandNameList = [
   "cjk-ideographic",
 ] as const;
 
+function createChineseLonghandDescriptors(
+  negative: string,
+): CssCascade.ElementStyle {
+  return {
+    suffix: new CssCascade.CascadeValue(new Css.Str("\u3001"), 0),
+    fallback: new CssCascade.CascadeValue(Css.getName("cjk-decimal"), 0),
+    range: new CssCascade.CascadeValue(
+      new Css.SpaceList([new Css.Int(-9999), new Css.Int(9999)]),
+      0,
+    ),
+    negative: new CssCascade.CascadeValue(new Css.Str(negative), 0),
+  };
+}
+
 /**
  * @see https://drafts.csswg.org/css-counter-styles-3/#limited-chinese
  */
 class ChineseLonghand extends CounterStyle {
-  static readonly #SIMP_CHINESE_INFORMAL: ChineseLonghandSetting = {
-    chars: {
-      digits: [
-        "\u96F6",
-        "\u4E00",
-        "\u4E8C",
-        "\u4E09",
-        "\u56DB",
-        "\u4E94",
-        "\u516D",
-        "\u4E03",
-        "\u516B",
-        "\u4E5D",
-      ],
-      markers: ["", "\u5341", "\u767E", "\u5343"],
-      informal: true,
-    },
-    descriptors: {
-      suffix: new CssCascade.CascadeValue(new Css.Str("\u3001"), 0),
-      fallback: new CssCascade.CascadeValue(Css.getName("cjk-decimal"), 0),
-      range: new CssCascade.CascadeValue(
-        new Css.SpaceList([new Css.Int(-9999), new Css.Int(9999)]),
-        0,
-      ),
-      negative: new CssCascade.CascadeValue(new Css.Str("\u8D1F"), 0),
-    },
-  };
-  static readonly #SIMP_CHINESE_FORMAL: ChineseLonghandSetting = {
-    chars: {
-      digits: [
-        "\u96F6",
-        "\u58F9",
-        "\u8D30",
-        "\u53C1",
-        "\u8086",
-        "\u4F0D",
-        "\u9646",
-        "\u67D2",
-        "\u634C",
-        "\u7396",
-      ],
-      markers: ["", "\u62FE", "\u4F70", "\u4EDF"],
-      informal: false,
-    },
-    descriptors: {
-      suffix: new CssCascade.CascadeValue(new Css.Str("\u3001"), 0),
-      fallback: new CssCascade.CascadeValue(Css.getName("cjk-decimal"), 0),
-      range: new CssCascade.CascadeValue(
-        new Css.SpaceList([new Css.Int(-9999), new Css.Int(9999)]),
-        0,
-      ),
-      negative: new CssCascade.CascadeValue(new Css.Str("\u8D1F"), 0),
-    },
-  };
-  static readonly #TRAD_CHINESE_INFORMAL: ChineseLonghandSetting = {
-    chars: {
-      digits: [
-        "\u96F6",
-        "\u4E00",
-        "\u4E8C",
-        "\u4E09",
-        "\u56DB",
-        "\u4E94",
-        "\u516D",
-        "\u4E03",
-        "\u516B",
-        "\u4E5D",
-      ],
-      markers: ["", "\u5341", "\u767E", "\u5343"],
-      informal: true,
-    },
-    descriptors: {
-      suffix: new CssCascade.CascadeValue(new Css.Str("\u3001"), 0),
-      fallback: new CssCascade.CascadeValue(Css.getName("cjk-decimal"), 0),
-      range: new CssCascade.CascadeValue(
-        new Css.SpaceList([new Css.Int(-9999), new Css.Int(9999)]),
-        0,
-      ),
-      negative: new CssCascade.CascadeValue(new Css.Str("\u8CA0"), 0),
-    },
-  };
-  static readonly #TRAD_CHINESE_FORMAL: ChineseLonghandSetting = {
-    chars: {
-      digits: [
-        "\u96F6",
-        "\u58F9",
-        "\u8CB3",
-        "\u53C3",
-        "\u8086",
-        "\u4F0D",
-        "\u9678",
-        "\u67D2",
-        "\u634C",
-        "\u7396",
-      ],
-      markers: ["", "\u62FE", "\u4F70", "\u4EDF"],
-      informal: false,
-    },
-    descriptors: {
-      suffix: new CssCascade.CascadeValue(new Css.Str("\u3001"), 0),
-      fallback: new CssCascade.CascadeValue(Css.getName("cjk-decimal"), 0),
-      range: new CssCascade.CascadeValue(
-        new Css.SpaceList([new Css.Int(-9999), new Css.Int(9999)]),
-        0,
-      ),
-      negative: new CssCascade.CascadeValue(new Css.Str("\u8CA0"), 0),
-    },
-  };
+  static readonly #SIMP_CHINESE_INFORMAL_CHARS = {
+    digits: [
+      "\u96F6",
+      "\u4E00",
+      "\u4E8C",
+      "\u4E09",
+      "\u56DB",
+      "\u4E94",
+      "\u516D",
+      "\u4E03",
+      "\u516B",
+      "\u4E5D",
+    ],
+    markers: ["", "\u5341", "\u767E", "\u5343"],
+    informal: true,
+  } as const;
+  static readonly #SIMP_CHINESE_FORMAL_CHARS = {
+    digits: [
+      "\u96F6",
+      "\u58F9",
+      "\u8D30",
+      "\u53C1",
+      "\u8086",
+      "\u4F0D",
+      "\u9646",
+      "\u67D2",
+      "\u634C",
+      "\u7396",
+    ],
+    markers: ["", "\u62FE", "\u4F70", "\u4EDF"],
+    informal: false,
+  } as const;
+  static readonly #TRAD_CHINESE_INFORMAL_CHARS = {
+    digits: [
+      "\u96F6",
+      "\u4E00",
+      "\u4E8C",
+      "\u4E09",
+      "\u56DB",
+      "\u4E94",
+      "\u516D",
+      "\u4E03",
+      "\u516B",
+      "\u4E5D",
+    ],
+    markers: ["", "\u5341", "\u767E", "\u5343"],
+    informal: true,
+  } as const;
+  static readonly #TRAD_CHINESE_FORMAL_CHARS = {
+    digits: [
+      "\u96F6",
+      "\u58F9",
+      "\u8CB3",
+      "\u53C3",
+      "\u8086",
+      "\u4F0D",
+      "\u9678",
+      "\u67D2",
+      "\u634C",
+      "\u7396",
+    ],
+    markers: ["", "\u62FE", "\u4F70", "\u4EDF"],
+    informal: false,
+  } as const;
   static readonly NAMES: ReadonlySet<(typeof chineseLonghandNameList)[number]> =
     new Set(chineseLonghandNameList);
-  static readonly #SETTINGS: ReadonlyMap<
+  static #SETTINGS: ReadonlyMap<
     SetElement<typeof ChineseLonghand.NAMES>,
     ChineseLonghandSetting
-  > = new Map([
-    ["simp-chinese-informal", ChineseLonghand.#SIMP_CHINESE_INFORMAL],
-    ["simp-chinese-formal", ChineseLonghand.#SIMP_CHINESE_FORMAL],
-    ["trad-chinese-informal", ChineseLonghand.#TRAD_CHINESE_INFORMAL],
-    ["trad-chinese-formal", ChineseLonghand.#TRAD_CHINESE_FORMAL],
-    // > This counter style is identical to trad-chinese-informal. (It exists for legacy reasons.)
-    ["cjk-ideographic", ChineseLonghand.#TRAD_CHINESE_INFORMAL],
-  ]);
+  > | null = null;
+  static #getSettings(): ReadonlyMap<
+    SetElement<typeof ChineseLonghand.NAMES>,
+    ChineseLonghandSetting
+  > {
+    return (ChineseLonghand.#SETTINGS ??= new Map([
+      [
+        "simp-chinese-informal",
+        {
+          chars: ChineseLonghand.#SIMP_CHINESE_INFORMAL_CHARS,
+          descriptors: createChineseLonghandDescriptors("\u8D1F"),
+        },
+      ],
+      [
+        "simp-chinese-formal",
+        {
+          chars: ChineseLonghand.#SIMP_CHINESE_FORMAL_CHARS,
+          descriptors: createChineseLonghandDescriptors("\u8D1F"),
+        },
+      ],
+      [
+        "trad-chinese-informal",
+        {
+          chars: ChineseLonghand.#TRAD_CHINESE_INFORMAL_CHARS,
+          descriptors: createChineseLonghandDescriptors("\u8CA0"),
+        },
+      ],
+      [
+        "trad-chinese-formal",
+        {
+          chars: ChineseLonghand.#TRAD_CHINESE_FORMAL_CHARS,
+          descriptors: createChineseLonghandDescriptors("\u8CA0"),
+        },
+      ],
+      [
+        "cjk-ideographic",
+        {
+          chars: ChineseLonghand.#TRAD_CHINESE_INFORMAL_CHARS,
+          descriptors: createChineseLonghandDescriptors("\u8CA0"),
+        },
+      ],
+    ]));
+  }
 
   #chars: ChineseLonghandSetting["chars"];
 
@@ -1459,7 +1485,7 @@ class ChineseLonghand extends CounterStyle {
     store: CounterStyleStoreMap,
     name: SetElement<typeof ChineseLonghand.NAMES>,
   ) {
-    const { chars, descriptors } = ChineseLonghand.#SETTINGS.get(name)!;
+    const { chars, descriptors } = ChineseLonghand.#getSettings().get(name)!;
     super(store, descriptors);
     this.#chars = chars;
   }
@@ -1539,13 +1565,16 @@ class ChineseLonghand extends CounterStyle {
  * @see https://drafts.csswg.org/css-counter-styles-3/#ethiopic-numeric-counter-style
  */
 class EthiopicNumeric extends CounterStyle {
-  static readonly #DESCRIPTORS = {
-    range: new CssCascade.CascadeValue(
-      new Css.SpaceList([new Css.Int(1), Css.getName("infinite")]),
-      0,
-    ),
-    suffix: new CssCascade.CascadeValue(new Css.Str("/ "), 0),
-  } as const;
+  static #DESCRIPTORS: CssCascade.ElementStyle | null = null;
+  static #getDescriptors(): CssCascade.ElementStyle {
+    return (EthiopicNumeric.#DESCRIPTORS ??= {
+      range: new CssCascade.CascadeValue(
+        new Css.SpaceList([new Css.Int(1), Css.getName("infinite")]),
+        0,
+      ),
+      suffix: new CssCascade.CascadeValue(new Css.Str("/ "), 0),
+    });
+  }
 
   static readonly #TENS = [
     "", // 0
@@ -1577,7 +1606,7 @@ class EthiopicNumeric extends CounterStyle {
   static readonly #TEN_THOUSAND = "\u137C"; // U+137C (even index separator / 10000)
 
   constructor(store: CounterStyleStoreMap) {
-    super(store, EthiopicNumeric.#DESCRIPTORS);
+    super(store, EthiopicNumeric.#getDescriptors());
   }
 
   protected override _getAutoRange(): Range {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2127,57 +2127,58 @@ export interface CounterResolver {
 }
 
 export class AttrValueFilterVisitor extends Css.FilterVisitor {
-  constructor(public element: Element) {
+  hadAttrFunction = false;
+
+  constructor(
+    public element: Element,
+    private readonly scope: Exprs.LexicalScope,
+    private readonly propName: string,
+    private readonly validatorSet?: CssValidator.ValidatorSet,
+  ) {
     super();
   }
 
-  private createValueFromString(str: string | null, type: string): Css.Val {
-    switch (type) {
-      case "url":
-        if (str) {
-          return new Css.URL(str); // TODO should convert to absolute path
-        }
-        return new Css.URL("about:invalid");
-      case "string":
-      default:
-        if (str) {
-          return new Css.Str(str);
-        }
-        return new Css.Str("");
+  validatePropertyValue(value: Css.Val): Css.Val {
+    if (Css.isDefaultingValue(value)) {
+      return value;
     }
+    const validator = this.validatorSet?.validators[this.propName];
+    if (validator) {
+      return value.visit(validator) ?? Css.ident.unset;
+    }
+    if (!this.propName || CSS.supports(this.propName, value.toString())) {
+      return value;
+    }
+    return Css.ident.unset;
   }
 
   override visitFunc(func: Css.Func): Css.Val {
-    if (func.name !== "attr") {
+    if (func.name.toLowerCase() !== "attr") {
       return super.visitFunc(func);
     }
-    let type = "string";
-    let attributeName: string | null = null;
-    let defaultValue: Css.Val = null;
-    if (func.values[0] instanceof Css.SpaceList) {
-      const values = (func.values[0] as Css.SpaceList).values;
-      if (values.length >= 2) {
-        type = values[1].stringValue();
-      }
-      attributeName = values[0].stringValue();
-    } else {
-      attributeName = func.values[0].stringValue();
+    this.hadAttrFunction = true;
+    const attr = CssValidator.parseAttrFunction(func);
+    if (!attr) {
+      return super.visitFunc(func);
     }
-    if (func.values.length > 1) {
-      defaultValue = this.createValueFromString(
-        func.values[1].stringValue(),
-        type,
-      );
-    } else {
-      defaultValue = this.createValueFromString(null, type);
+
+    const fallback = (
+      attr.fallback ?? CssValidator.getImplicitAttrFallback(attr.type)
+    ).visit(this);
+
+    if (!this.element || !this.element.hasAttribute(attr.attributeName)) {
+      return fallback;
     }
-    if (this.element && this.element.hasAttribute(attributeName)) {
-      return this.createValueFromString(
-        this.element.getAttribute(attributeName),
-        type,
-      );
+
+    const value = CssValidator.parseAttrValue(
+      this.scope,
+      this.element.getAttribute(attr.attributeName),
+      attr.type,
+    );
+    if (!value) {
+      return fallback;
     }
-    return defaultValue;
+    return value;
   }
 }
 
@@ -3744,7 +3745,7 @@ export class CascadeInstance {
     // Convert device-cmyk() to color(srgb ...)
     this.applyCmykFilter(this.currentStyle, this.currentElement);
 
-    this.applyAttrFilter(element);
+    this.applyAttrFilter(element, styler);
     const quotesCasc = baseStyle["quotes"] as CascadeValue;
     let itemToPushLast: QuotesScopeItem | null = null;
     if (quotesCasc) {
@@ -4202,26 +4203,50 @@ export class CascadeInstance {
   }
 
   private applyAttrFilterInner(
-    visitor: Css.Visitor,
+    styler: CssStyler.AbstractStyler,
+    element: Element,
     elementStyle: ElementStyle,
   ): void {
+    const scope = (styler as AbstractStyler & { scope: Exprs.LexicalScope })
+      .scope;
+    const validatorSet = (
+      styler as AbstractStyler & {
+        validatorSet: CssValidator.ValidatorSet;
+      }
+    ).validatorSet;
     for (const propName in elementStyle) {
       if (isPropName(propName) && !Css.isCustomPropName(propName)) {
-        elementStyle[propName] = (
-          elementStyle[propName] as CascadeValue
-        ).filterValue(visitor);
+        const cascVal = elementStyle[propName] as CascadeValue;
+        const visitor = new AttrValueFilterVisitor(
+          element,
+          scope,
+          propName,
+          validatorSet,
+        );
+        const filtered = cascVal.filterValue(visitor);
+        if (!visitor.hadAttrFunction) {
+          elementStyle[propName] = filtered;
+          continue;
+        }
+        const validatedValue = visitor.validatePropertyValue(filtered.value);
+        elementStyle[propName] =
+          validatedValue === filtered.value
+            ? filtered
+            : new CascadeValue(validatedValue, filtered.priority);
       }
     }
   }
 
-  private applyAttrFilter(element: Element): void {
-    const visitor = new AttrValueFilterVisitor(element);
+  private applyAttrFilter(
+    element: Element,
+    styler: CssStyler.AbstractStyler,
+  ): void {
     const currentStyle = this.currentStyle;
     const pseudoMap = getStyleMap(currentStyle, "_pseudos");
     for (const pseudoName in pseudoMap) {
-      this.applyAttrFilterInner(visitor, pseudoMap[pseudoName]);
+      this.applyAttrFilterInner(styler, element, pseudoMap[pseudoName]);
     }
-    this.applyAttrFilterInner(visitor, currentStyle);
+    this.applyAttrFilterInner(styler, element, currentStyle);
   }
 
   /**

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -514,6 +514,15 @@ export class PrimitiveValidator extends PropertyValidator {
   }
 
   override visitFunc(func: Css.Func): Css.Val {
+    if (func.name.toLowerCase() === "attr") {
+      const attr = parseAttrFunction(func);
+      if (
+        attr &&
+        validatorSupportsAttrType(attr.type, this.allowed, this.units)
+      ) {
+        return func;
+      }
+    }
     if (this.allowed & ALLOW_COLOR) {
       if (func.name === "device-cmyk" || func.name === "cmyk") {
         if (
@@ -579,6 +588,344 @@ export class PrimitiveValidator extends PropertyValidator {
 }
 
 const NO_IDENTS: ValueMap = Object.create(null);
+
+const ATTR_ANY_NUMBER = ALLOW_POS_NUM | ALLOW_NEGATIVE | ALLOW_ZERO;
+
+const ATTR_ANY_INTEGER = ALLOW_POS_INT | ALLOW_NEGATIVE | ALLOW_ZERO;
+
+const ATTR_ANY_NUMERIC =
+  ALLOW_POS_NUMERIC | ALLOW_NEGATIVE | ALLOW_ZERO | ALLOW_ZERO_PERCENT;
+
+function makeUnitMap(unitNames: string[]): ValueMap {
+  const units: ValueMap = Object.create(null);
+  for (const unit of unitNames) {
+    units[unit] = Css.empty;
+  }
+  return units;
+}
+
+const PERCENTAGE_UNITS = makeUnitMap(["%"]);
+
+const LENGTH_UNITS = makeUnitMap([
+  "em",
+  "ex",
+  "ch",
+  "rem",
+  "lh",
+  "rlh",
+  "vw",
+  "vh",
+  "vi",
+  "vb",
+  "vmin",
+  "vmax",
+  "pvw",
+  "pvh",
+  "pvi",
+  "pvb",
+  "pvmin",
+  "pvmax",
+  "cm",
+  "mm",
+  "in",
+  "px",
+  "pt",
+  "pc",
+  "q",
+]);
+
+const LENGTH_PERCENTAGE_UNITS = {
+  ...LENGTH_UNITS,
+  ...PERCENTAGE_UNITS,
+};
+
+const ANGLE_UNITS = makeUnitMap(["deg", "grad", "rad", "turn"]);
+
+const TIME_UNITS = makeUnitMap(["s", "ms"]);
+
+const FREQUENCY_UNITS = makeUnitMap(["hz", "khz"]);
+
+export type AttrType =
+  | { kind: "string" }
+  | { kind: "url" }
+  | { kind: "syntax"; syntax: string }
+  | { kind: "unit"; unit: string };
+
+export type AttrFunction = {
+  attributeName: string;
+  type: AttrType;
+  fallback: Css.Val | null;
+};
+
+function normalizeAttrSyntax(syntax: string): string {
+  return syntax.replace(/\s+/g, "").toLowerCase();
+}
+
+function canonicalAttrUnit(unit: string): string {
+  return unit.toLowerCase();
+}
+
+function parseAttrTypeValue(value: Css.Val): AttrType | null {
+  if (value instanceof Css.Ident) {
+    switch (value.name.toLowerCase()) {
+      case "string":
+      case "raw-string":
+        return { kind: "string" };
+      case "url":
+        return { kind: "url" };
+      case "color":
+      case "integer":
+      case "number":
+      case "length":
+      case "angle":
+      case "time":
+      case "frequency":
+        return { kind: "syntax", syntax: `<${value.name.toLowerCase()}>` };
+      default:
+        return { kind: "unit", unit: canonicalAttrUnit(value.name) };
+    }
+  }
+  if (value instanceof Css.Func && value.name.toLowerCase() === "type") {
+    if (value.values.length !== 1) {
+      return null;
+    }
+    const syntax = normalizeAttrSyntax(value.values[0].stringValue());
+    return syntax ? { kind: "syntax", syntax } : null;
+  }
+  return null;
+}
+
+export function parseAttrFunction(func: Css.Func): AttrFunction | null {
+  if (func.name.toLowerCase() !== "attr") {
+    return null;
+  }
+  if (func.values.length < 1 || func.values.length > 2) {
+    return null;
+  }
+
+  let attributeName: string;
+  let type: AttrType = { kind: "string" };
+  const attributeArg = func.values[0];
+  if (attributeArg instanceof Css.Ident) {
+    attributeName = attributeArg.name;
+  } else if (attributeArg instanceof Css.SpaceList) {
+    const values = attributeArg.values;
+    if (
+      values.length < 1 ||
+      values.length > 2 ||
+      !(values[0] instanceof Css.Ident)
+    ) {
+      return null;
+    }
+    attributeName = values[0].name;
+    if (values.length === 2) {
+      type = parseAttrTypeValue(values[1]);
+      if (!type) {
+        return null;
+      }
+    }
+  } else {
+    return null;
+  }
+
+  return {
+    attributeName,
+    type,
+    fallback: func.values[1] ?? null,
+  };
+}
+
+function hasAttrUnit(units: ValueMap, unit: string): boolean {
+  return !!units[canonicalAttrUnit(unit)];
+}
+
+function hasAnyAttrUnit(units: ValueMap, candidates: ValueMap): boolean {
+  return Object.keys(candidates).some((unit) => hasAttrUnit(units, unit));
+}
+
+function validatorSupportsAttrType(
+  type: AttrType,
+  allowed: number,
+  units: ValueMap,
+): boolean {
+  switch (type.kind) {
+    case "string":
+      return !!(allowed & ALLOW_STR);
+    case "url":
+      return !!(allowed & (ALLOW_URL | ALLOW_IMAGE));
+    case "unit":
+      return hasAttrUnit(units, type.unit);
+    case "syntax":
+      switch (type.syntax) {
+        case "<string>":
+          return !!(allowed & ALLOW_STR);
+        case "<url>":
+          return !!(allowed & (ALLOW_URL | ALLOW_IMAGE));
+        case "<color>":
+          return !!(allowed & ALLOW_COLOR);
+        case "<integer>":
+          return !!(
+            allowed &
+            (ALLOW_POS_INT | ALLOW_POS_NUM | ALLOW_NEGATIVE | ALLOW_ZERO)
+          );
+        case "<number>":
+          return !!(
+            allowed &
+            (ALLOW_POS_NUM | ALLOW_POS_INT | ALLOW_NEGATIVE | ALLOW_ZERO)
+          );
+        case "<length>":
+          return hasAnyAttrUnit(units, LENGTH_UNITS);
+        case "<length-percentage>":
+          return hasAnyAttrUnit(units, LENGTH_PERCENTAGE_UNITS);
+        case "<percentage>":
+          return hasAnyAttrUnit(units, PERCENTAGE_UNITS);
+        case "<angle>":
+          return hasAnyAttrUnit(units, ANGLE_UNITS);
+        case "<time>":
+          return hasAnyAttrUnit(units, TIME_UNITS);
+        case "<frequency>":
+          return hasAnyAttrUnit(units, FREQUENCY_UNITS);
+        default:
+          return false;
+      }
+  }
+  return false;
+}
+
+function createAttrPrimitiveValidator(
+  type: AttrType,
+): PrimitiveValidator | null {
+  switch (type.kind) {
+    case "string":
+      return null;
+    case "url":
+      return null;
+    case "unit":
+      return new PrimitiveValidator(ATTR_ANY_NUMERIC, NO_IDENTS, {
+        [canonicalAttrUnit(type.unit)]: Css.empty,
+      });
+    case "syntax":
+      switch (type.syntax) {
+        case "<color>":
+          return new PrimitiveValidator(ALLOW_COLOR, NO_IDENTS, NO_IDENTS);
+        case "<integer>":
+          return new PrimitiveValidator(ATTR_ANY_INTEGER, NO_IDENTS, NO_IDENTS);
+        case "<number>":
+          return new PrimitiveValidator(ATTR_ANY_NUMBER, NO_IDENTS, NO_IDENTS);
+        case "<length>":
+          return new PrimitiveValidator(
+            ATTR_ANY_NUMERIC,
+            NO_IDENTS,
+            LENGTH_UNITS,
+          );
+        case "<length-percentage>":
+          return new PrimitiveValidator(
+            ATTR_ANY_NUMERIC,
+            NO_IDENTS,
+            LENGTH_PERCENTAGE_UNITS,
+          );
+        case "<percentage>":
+          return new PrimitiveValidator(
+            ATTR_ANY_NUMERIC,
+            NO_IDENTS,
+            PERCENTAGE_UNITS,
+          );
+        case "<angle>":
+          return new PrimitiveValidator(
+            ATTR_ANY_NUMERIC,
+            NO_IDENTS,
+            ANGLE_UNITS,
+          );
+        case "<time>":
+          return new PrimitiveValidator(
+            ATTR_ANY_NUMERIC,
+            NO_IDENTS,
+            TIME_UNITS,
+          );
+        case "<frequency>":
+          return new PrimitiveValidator(
+            ATTR_ANY_NUMERIC,
+            NO_IDENTS,
+            FREQUENCY_UNITS,
+          );
+        default:
+          return null;
+      }
+  }
+  return null;
+}
+
+function isSupportedAttrType(type: AttrType): boolean {
+  switch (type.kind) {
+    case "string":
+    case "url":
+    case "unit":
+      return true;
+    case "syntax":
+      return (
+        type.syntax === "<string>" ||
+        type.syntax === "<url>" ||
+        !!createAttrPrimitiveValidator(type)
+      );
+  }
+  return false;
+}
+
+export function getImplicitAttrFallback(type: AttrType): Css.Val {
+  switch (type.kind) {
+    case "url":
+      return new Css.URL("about:invalid");
+    case "string":
+      return new Css.Str("");
+    default:
+      return Css.ident.unset;
+  }
+}
+
+export function parseAttrValue(
+  scope: Exprs.LexicalScope,
+  value: string | null,
+  type: AttrType,
+): Css.Val | null {
+  if (value == null) {
+    return null;
+  }
+
+  switch (type.kind) {
+    case "string":
+      return new Css.Str(value);
+    case "url":
+      return value ? new Css.URL(value) : new Css.URL("about:invalid");
+    case "unit": {
+      const parsed = CssParser.parseValue(
+        scope,
+        new CssTokenizer.Tokenizer(
+          `${value.trim()}${canonicalAttrUnit(type.unit)}`,
+          null,
+        ),
+        "",
+      );
+      const validator = createAttrPrimitiveValidator(type);
+      return parsed && validator ? parsed.visit(validator) : null;
+    }
+    case "syntax": {
+      if (type.syntax === "<string>") {
+        return new Css.Str(value);
+      }
+      if (type.syntax === "<url>") {
+        return value ? new Css.URL(value) : new Css.URL("about:invalid");
+      }
+      const parsed = CssParser.parseValue(
+        scope,
+        new CssTokenizer.Tokenizer(value, null),
+        "",
+      );
+      const validator = createAttrPrimitiveValidator(type);
+      return parsed && validator ? parsed.visit(validator) : null;
+    }
+  }
+  return null;
+}
 
 export const ALWAYS_FAIL = new PrimitiveValidator(0, NO_IDENTS, NO_IDENTS);
 
@@ -855,6 +1202,17 @@ export class FuncValidator extends ListValidator {
       return null;
     }
     return new Css.Func(func.name, arr);
+  }
+}
+
+class AttrFuncValidator extends PropertyValidator {
+  validateSingle(_inval: Css.Val): Css.Val {
+    return null;
+  }
+
+  override visitFunc(func: Css.Func): Css.Val {
+    const attr = parseAttrFunction(func);
+    return attr && isSupportedAttrType(attr.type) ? func : null;
   }
 }
 
@@ -1806,6 +2164,9 @@ export class ValidatorSet {
       case "SPACE":
         validator = new SpaceListValidator(val);
         break;
+      case "attr":
+        validator = new AttrFuncValidator();
+        break;
       default:
         validator = new FuncValidator(fn.toLowerCase(), val);
         break;
@@ -1817,6 +2178,7 @@ export class ValidatorSet {
     this.namedValidators["COLOR"] = this.primitive(
       new PrimitiveValidator(ALLOW_COLOR, NO_IDENTS, NO_IDENTS),
     );
+    this.namedValidators["ATTR"] = this.primitive(new AttrFuncValidator());
     this.namedValidators["IMAGE_FUNCTION"] = this.primitive(
       new PrimitiveValidator(ALLOW_IMAGE, NO_IDENTS, NO_IDENTS),
     );
@@ -1827,7 +2189,7 @@ export class ValidatorSet {
       new PrimitiveValidator(ALLOW_POS_NUM, NO_IDENTS, NO_IDENTS),
     );
     this.namedValidators["POS_PERCENTAGE"] = this.primitive(
-      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, { "%": Css.empty }),
+      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, PERCENTAGE_UNITS),
     );
     this.namedValidators["NEGATIVE"] = this.primitive(
       new PrimitiveValidator(ALLOW_NEGATIVE, NO_IDENTS, NO_IDENTS),
@@ -1839,53 +2201,16 @@ export class ValidatorSet {
       new PrimitiveValidator(ALLOW_ZERO_PERCENT, NO_IDENTS, NO_IDENTS),
     );
     this.namedValidators["POS_LENGTH"] = this.primitive(
-      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, {
-        em: Css.empty,
-        ex: Css.empty,
-        ch: Css.empty,
-        rem: Css.empty,
-        lh: Css.empty,
-        rlh: Css.empty,
-        vw: Css.empty,
-        vh: Css.empty,
-        vi: Css.empty,
-        vb: Css.empty,
-        vmin: Css.empty,
-        vmax: Css.empty,
-        pvw: Css.empty,
-        pvh: Css.empty,
-        pvi: Css.empty,
-        pvb: Css.empty,
-        pvmin: Css.empty,
-        pvmax: Css.empty,
-        cm: Css.empty,
-        mm: Css.empty,
-        in: Css.empty,
-        px: Css.empty,
-        pt: Css.empty,
-        pc: Css.empty,
-        q: Css.empty,
-      }),
+      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, LENGTH_UNITS),
     );
     this.namedValidators["POS_ANGLE"] = this.primitive(
-      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, {
-        deg: Css.empty,
-        grad: Css.empty,
-        rad: Css.empty,
-        turn: Css.empty,
-      }),
+      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, ANGLE_UNITS),
     );
     this.namedValidators["POS_TIME"] = this.primitive(
-      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, {
-        s: Css.empty,
-        ms: Css.empty,
-      }),
+      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, TIME_UNITS),
     );
     this.namedValidators["FREQUENCY"] = this.primitive(
-      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, {
-        Hz: Css.empty,
-        kHz: Css.empty,
-      }),
+      new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, FREQUENCY_UNITS),
     );
     this.namedValidators["RESOLUTION"] = this.primitive(
       new PrimitiveValidator(ALLOW_POS_NUMERIC, NO_IDENTS, {

--- a/packages/core/test/files/attr-type.html
+++ b/packages/core/test/files/attr-type.html
@@ -1,0 +1,68 @@
+<!-- Test case for Issue #1485: support typed values in CSS attr() -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      @page {
+        size: 200mm 150mm;
+        margin: 12mm;
+      }
+
+      body {
+        font-family: sans-serif;
+        font-size: 10px;
+        line-height: 1.4;
+      }
+
+      .sample {
+        border: 1px solid #999;
+        margin: 0 0 8px;
+        padding: 6px 8px;
+      }
+
+      .color-from-attr {
+        color: attr(data-color type(<color>), red);
+      }
+
+      .size-from-attr {
+        font-size: attr(data-size px, 18px);
+      }
+
+      .raw-string-from-attr::before {
+        content: attr(data-note raw-string, "raw fallback");
+        display: block;
+        font-weight: 700;
+      }
+
+      .opacity-from-attr {
+        background: #008000;
+        color: #fff;
+        opacity: attr(data-opacity number, 0.25);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="sample color-from-attr" data-color="blue">
+      This text should be blue.
+    </div>
+    <div class="sample color-from-attr">This text should fall back to red.</div>
+    <div class="sample size-from-attr" data-size="32">
+      This text should render at 32px.
+    </div>
+    <div class="sample size-from-attr">
+      This text should fall back to 18px.
+    </div>
+    <div class="sample raw-string-from-attr" data-note="Raw string from attr()">
+      The line above should come from raw-string.
+    </div>
+    <div class="sample raw-string-from-attr">
+      The line above should fall back to "raw fallback".
+    </div>
+    <div class="sample opacity-from-attr" data-opacity="0.8">
+      This green box should render at 80% opacity.
+    </div>
+    <div class="sample opacity-from-attr">
+      This green box should fall back to 25% opacity.
+    </div>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -88,6 +88,7 @@ module.exports = [
       { file: "background-shorthand.html", title: "Background shorthand" },
       { file: "prefixed_properties.html", title: "Prefixed properties" },
       { file: "filter_property.html", title: "Filter property" },
+      { file: "attr-type.html", title: "Typed attr() values (Issue #1485)" },
       { file: "content-attr.html", title: "Content attr()" },
       {
         file: "exclusion_with_printer_marks.html",

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1520,4 +1520,96 @@ describe("css-cascade", function () {
       expect(style["transition-duration"].value).toBe(adapt_css.ident.initial);
     });
   });
+
+  describe("AttrValueFilterVisitor regression coverage", function () {
+    function parseValue(cssText) {
+      return adapt_cssparse.parseValue(
+        new adapt_exprs.LexicalScope(null),
+        new adapt_csstok.Tokenizer(cssText, null),
+        "",
+      );
+    }
+
+    function createCascadeValue(cssText) {
+      return new adapt_csscasc.CascadeValue(parseValue(cssText), 1);
+    }
+
+    function applyAttrFilter(style, element, validatorSet) {
+      validatorSet = validatorSet || adapt_cssvalid.baseValidatorSet();
+
+      var styler = {
+        root: element,
+        validatorSet: validatorSet,
+        scope: validatorSet.scope,
+        getStyle: function () {
+          return style;
+        },
+      };
+      var cascadeInstance = {
+        currentStyle: style,
+      };
+      cascadeInstance.applyAttrFilter =
+        adapt_csscasc.CascadeInstance.prototype.applyAttrFilter;
+      cascadeInstance.applyAttrFilterInner =
+        adapt_csscasc.CascadeInstance.prototype.applyAttrFilterInner;
+      cascadeInstance.applyAttrFilter(element, styler);
+    }
+
+    it("treats missing typed attr() without fallback as unset", function () {
+      var element = document.createElement("div");
+      var style = {
+        opacity: createCascadeValue("attr(data-opacity number)"),
+      };
+
+      applyAttrFilter(style, element);
+
+      expect(style.opacity.value).toBe(adapt_css.ident.unset);
+    });
+
+    it("invalidates attr() fallback when the property validator rejects it", function () {
+      var element = document.createElement("div");
+      element.setAttribute("data-opacity", "not-a-number");
+      var style = {
+        opacity: createCascadeValue("attr(data-opacity number, red)"),
+      };
+
+      applyAttrFilter(style, element);
+
+      expect(style.opacity.value).toBe(adapt_css.ident.unset);
+    });
+
+    it("invalidates the whole property when nested attr() makes the final value invalid", function () {
+      var element = document.createElement("div");
+      var style = {
+        transform: createCascadeValue("translateX(attr(data-x px, red))"),
+      };
+
+      applyAttrFilter(style, element);
+
+      expect(style.transform.value).toBe(adapt_css.ident.unset);
+    });
+
+    it("keeps the whole property when nested attr() fallback yields a valid value", function () {
+      var element = document.createElement("div");
+      var style = {
+        transform: createCascadeValue("translateX(attr(data-x px, 5px))"),
+      };
+
+      applyAttrFilter(style, element);
+
+      expect(style.transform.value.toString()).toBe("translatex(5px)");
+    });
+
+    it("trims attribute whitespace before appending unit keywords", function () {
+      var element = document.createElement("div");
+      element.setAttribute("data-size", "50 ");
+      var style = {
+        "font-size": createCascadeValue("attr(data-size px, 10px)"),
+      };
+
+      applyAttrFilter(style, element);
+
+      expect(style["font-size"].value.toString()).toBe("50px");
+    });
+  });
 });

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -18,6 +18,7 @@
 
 import * as adapt_csscasc from "../../../src/vivliostyle/css-cascade";
 import * as adapt_css from "../../../src/vivliostyle/css";
+import * as adapt_exprs from "../../../src/vivliostyle/exprs";
 import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
 import * as adapt_cssvalid from "../../../src/vivliostyle/css-validator";
 import * as adapt_task from "../../../src/vivliostyle/task";
@@ -316,6 +317,55 @@ describe("css-validator", function () {
           expect(handler.invalid).toBe(true);
         },
       );
+    });
+  });
+
+  describe("typed attr() nested grammar regression", function () {
+    it("accepts typed attr() inside string-set content lists", function (done) {
+      parseCascade(
+        'div { string-set: chapter attr(data-title type(<string>), "fallback"); }',
+        done,
+        function (cascade) {
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["string-set"]).toBeDefined();
+        },
+      );
+    });
+
+    it("rejects unsupported attr() type() syntax inside string-set content lists", function (done) {
+      parseCascade(
+        'div { string-set: chapter attr(data-title type(<transform-list>), "fallback"); }',
+        done,
+        function (cascade, handler) {
+          expect(handler.invalid).toBe(true);
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["string-set"]).toBeUndefined();
+        },
+      );
+    });
+  });
+
+  describe("typed attr() helper regression", function () {
+    it("returns null for unsupported type() syntax", function () {
+      expect(
+        adapt_cssvalid.parseAttrValue(
+          new adapt_exprs.LexicalScope(null),
+          "rotate(30deg)",
+          { kind: "syntax", syntax: "<transform-list>" },
+        ),
+      ).toBeNull();
+    });
+
+    it("parses frequency syntax using lowercase normalized units", function () {
+      var value = adapt_cssvalid.parseAttrValue(
+        new adapt_exprs.LexicalScope(null),
+        "1kHz",
+        {
+          kind: "syntax",
+          syntax: "<frequency>",
+        },
+      );
+      expect(value && value.toString()).toBe("1khz");
     });
   });
 


### PR DESCRIPTION
Allow CSS `attr()` to use `type(<...>)`, unit keywords, `number`, and `raw-string` by parsing attr metadata in the validator and resolving attribute strings during cascade.

This keeps `attr()` compatible with target property validators, preserves nested uses such as `string-set`, and treats `raw-string` as the modern alias of legacy `string` so the WPT style-sharing cases keep passing. Also add local coverage for typed `attr()` behavior and defer `counter-style` descriptor initialization to avoid the startup-order failure exposed by the new code path.

Closes #1485

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1485 (support `type()` in CSS `attr()`); after the implementation worked, asked the AI to re-check the generated code for redundancy (specifically a units-checking helper that seemed duplicated elsewhere).
- The human author ran the WPT `css/css-values` suite themselves, reported 11 improvements and 1 regression (`raw-string` not recognized per the CSS Values Level 5 spec), and after the fix, re-ran the suite to confirm the regression was resolved.
- The human author ran `/address-pr-comments` across five rounds, directing specific implementation choices in response to reviewer suggestions (routing through `parseAttrFunction()` instead of modifying `assets.ts`, and defining `ATTR` alongside `COLOR` in `initBuiltInValidators` rather than as a separate declaration).

</details>
