### PR TITLE
fix: Accept Space-Separated Legacy Shape Syntax

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -411,7 +411,9 @@ border-outside-width = BORDER_SIDE_WIDTH;
 inside = APLENGTH;
 outside = APLENGTH;
 
-SHAPE = auto | rectangle( PLENGTH{4} ) |  ellipse( PLENGTH{4} ) |  circle( PLENGTH{3} ) |
+SHAPE = auto | rectangle( PLENGTH{4} ) | rectangle( SPACE(PLENGTH{4}) ) |
+  ellipse( PLENGTH{4} ) | ellipse( SPACE(PLENGTH{4}) ) |
+  circle( PLENGTH{3} ) | circle( SPACE(PLENGTH{3}) ) |
     polygon( SPACE(PLENGTH+)+ );
 [epubx]shape-inside = SHAPE;
 [epubx,webkit]shape-outside = SHAPE;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -736,6 +736,10 @@ module.exports = [
         title:
           "Float in position:relative across page break, vertical writing mode (Issue #1885)",
       },
+      {
+        file: "shape-outside-ellipse.html",
+        title: "Legacy ellipse shape-outside with spaces (Issue #1425)",
+      },
       { file: "relative_floats.html", title: "Floats with position: relative" },
       {
         file: "float-in-relative-bug.html",

--- a/packages/core/test/files/shape-outside-ellipse.html
+++ b/packages/core/test/files/shape-outside-ellipse.html
@@ -1,0 +1,106 @@
+<!-- Test case for Issue #1425: legacy ellipse shape-outside accepts whitespace-separated arguments -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>shape-outside ellipse</title>
+    <style>
+      @page {
+        size: 140mm 180mm;
+        margin: 0;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font: 16px/1.45 Georgia, serif;
+      }
+
+      p {
+        margin: 0 0 0.8em;
+        text-align: justify;
+      }
+
+      h1 {
+        margin: 0 0 0.6em;
+        font: 700 26px/1.1 Helvetica, Arial, sans-serif;
+      }
+
+      #earth {
+        -epubx-flow-into: earth;
+        height: 100%;
+      }
+
+      #earth .planet {
+        width: 92%;
+        height: 92%;
+        margin: 4%;
+        border-radius: 50%;
+        background: radial-gradient(
+          circle at 35% 30%,
+          #edf7ff 0 14%,
+          #7fb2e5 14% 36%,
+          #163f72 58%,
+          #020712 100%
+        );
+      }
+
+      @-epubx-page-template {
+        @-epubx-page-master {
+          @-epubx-partition body {
+            -epubx-flow-from: body;
+            top: 12mm;
+            left: 12mm;
+            right: 12mm;
+            bottom: 12mm;
+            z-index: 1;
+          }
+
+          @-epubx-partition earth {
+            -epubx-flow-from: earth;
+            -epubx-required: true;
+            top: 36mm;
+            right: 12mm;
+            width: 58mm;
+            height: 58mm;
+            -epubx-shape-outside: ellipse(50% 50% 46% 46%);
+          }
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="earth" aria-hidden="true">
+      <div class="planet"></div>
+    </div>
+
+    <h1>Legacy ellipse with spaces</h1>
+    <p>
+      This paragraph should wrap around the circular figure on the right. The
+      test is intentionally small: it uses the legacy EPUB Adaptive Layout
+      ellipse syntax, but with whitespace-separated arguments instead of comma-
+      separated arguments.
+    </p>
+    <p>
+      If the value is rejected by the shape grammar, the exclusion shape is not
+      applied and the text flows through the figure's rectangular area instead
+      of respecting the ellipse. With the fix, the first several lines narrow
+      smoothly beside the figure and expand again below it.
+    </p>
+    <p>
+      The percentages match the historic Apollo 8 sample closely enough to act
+      as a regression test without copying the original layout. The expected
+      result is simply that the body text follows the right-hand curve rather
+      than colliding with the dark circular box.
+    </p>
+    <p>
+      This covers only the minimal compatibility change for Issue #1425. It
+      does not attempt to support the modern CSS Shapes syntax using the at
+      keyword.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Allow the legacy EPUB Adaptive Layout `SHAPE` grammar to accept whitespace-separated arguments for `rectangle()`, `ellipse()`, and `circle()` in addition to the existing form.

This keeps `-epubx-shape-outside` compatible with values such as `ellipse(50% 50% 46% 46%)` without expanding support to modern CSS Shapes syntax. Add a minimal regression sample and register it in `file-list.js`.

Closes #1425

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for issue #1425, and additionally asked the AI to evaluate the feasibility of a much larger, more ambitious rework: replacing the legacy `shapesToBands` implementation with the browser's native CSS Shapes support, also referencing issue #1487.
- The AI investigated the current `ShapeVisitor`/`shapesToBands`/`getInnerShape`/`getOuterShape` implementation and reported back on feasibility before any code changes were made; the human author then scoped the actual fix down to the minimal legacy-syntax compatibility change implemented here, deferring the larger native-CSS-Shapes rework.

</details>
