### PR TITLE
fix: Fix `@page` counter-set for page-based counters

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1005,18 +1005,6 @@ export class CounterStore {
         this.definePageCounter(resetCounterName, resetMap[resetCounterName]);
       }
     }
-    if (setMap) {
-      // Apply counter-set after reset to match counter update order
-      // (reset -> set -> increment).
-      for (const setCounterName in setMap) {
-        if (!this.currentPageCounters[setCounterName]) {
-          this.definePageCounter(setCounterName, setMap[setCounterName]);
-        } else {
-          const counterValues = this.currentPageCounters[setCounterName];
-          counterValues[counterValues.length - 1] = setMap[setCounterName];
-        }
-      }
-    }
     for (const incrementCounterName in incrementMap) {
       if (skipIncrement[incrementCounterName]) {
         continue;
@@ -1027,6 +1015,18 @@ export class CounterStore {
       const counterValues = this.currentPageCounters[incrementCounterName];
       counterValues[counterValues.length - 1] +=
         incrementMap[incrementCounterName];
+    }
+    if (setMap) {
+      // Match the standard counter update order:
+      // counter-reset -> counter-increment -> counter-set.
+      for (const setCounterName in setMap) {
+        if (!this.currentPageCounters[setCounterName]) {
+          this.definePageCounter(setCounterName, setMap[setCounterName]);
+        } else {
+          const counterValues = this.currentPageCounters[setCounterName];
+          counterValues[counterValues.length - 1] = setMap[setCounterName];
+        }
+      }
     }
   }
 

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -2706,10 +2706,14 @@ export class StyleInstance
       if (!pageChangeSnapshot) {
         pageChangeSnapshot = pageStartSnapshot;
       }
+      const currentPageChangeSnapshot =
+        pageChangeSnapshot && pageChangeSnapshot.offset === pageChangeOffset
+          ? pageChangeSnapshot
+          : null;
       this.counterStore.setCurrentPageDocCounters(
         pageStartSnapshot?.counters ?? null,
-        pageChangeSnapshot?.changes ?? null,
-        pageChangeSnapshot?.changeTypes,
+        currentPageChangeSnapshot?.changes ?? null,
+        currentPageChangeSnapshot?.changeTypes,
       );
       this.counterStore.setCurrentPage(page);
       this.counterStore.updatePageCounters(cascadedPageStyle, this);

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -450,6 +450,16 @@ module.exports = [
         title: "nth() page selector & page counter reset",
       },
       {
+        file: "nth-page/page-counter-set-reset.html",
+        title:
+          "Page counter set/reset in page and element contexts (Issue #1978)",
+      },
+      {
+        file: "nth-page/custom-page-counter-set-reset.html",
+        title:
+          "Custom page counter set/reset in page and element contexts (Issue #1978)",
+      },
+      {
         file: [
           "nth-page/nth-page.html",
           "nth-page/nth-page-counter-reset.html",

--- a/packages/core/test/files/nth-page/custom-page-counter-set-reset.html
+++ b/packages/core/test/files/nth-page/custom-page-counter-set-reset.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Custom page counter set/reset in page and element contexts</title>
+    <!-- Test case for Issue #1978: custom page counter set/reset in page and element contexts -->
+    <style>
+      @page :first {
+        counter-reset: my-page;
+      }
+
+      @page {
+        size: 320px 260px;
+        margin: 36px;
+        counter-increment: my-page;
+
+        @top-center {
+          font: 12px/1.2 Arial, sans-serif;
+        }
+
+        @bottom-center {
+          font: 12px/1.2 Arial, sans-serif;
+        }
+      }
+
+      @page control-frontmatter {
+        @top-center {
+          content: "A control";
+        }
+
+        @bottom-center {
+          content: "A " counter(my-page, lower-roman);
+        }
+      }
+
+      @page control-main {
+        @top-center {
+          content: "A control";
+        }
+
+        @bottom-center {
+          content: "A " counter(my-page);
+        }
+      }
+
+      @page :nth(1 of control-main) {
+        counter-reset: my-page;
+      }
+
+      @page set-at-page-frontmatter {
+        @top-center {
+          content: "B page counter-set";
+        }
+
+        @bottom-center {
+          content: "B " counter(my-page, lower-roman);
+        }
+      }
+
+      @page set-at-page-main {
+        @top-center {
+          content: "B page counter-set";
+        }
+
+        @bottom-center {
+          content: "B " counter(my-page);
+        }
+      }
+
+      @page :nth(1 of set-at-page-main) {
+        counter-set: my-page 1;
+      }
+
+      @page reset-at-element-frontmatter {
+        @top-center {
+          content: "C element counter-reset";
+        }
+
+        @bottom-center {
+          content: "C " counter(my-page, lower-roman);
+        }
+      }
+
+      @page reset-at-element-main {
+        @top-center {
+          content: "C element counter-reset";
+        }
+
+        @bottom-center {
+          content: "C " counter(my-page);
+        }
+      }
+
+      @page set-at-element-frontmatter {
+        @top-center {
+          content: "D element counter-set";
+        }
+
+        @bottom-center {
+          content: "D " counter(my-page, lower-roman);
+        }
+      }
+
+      @page set-at-element-main {
+        @top-center {
+          content: "D element counter-set";
+        }
+
+        @bottom-center {
+          content: "D " counter(my-page);
+        }
+      }
+
+      @page :nth(1 of control-frontmatter) {
+        counter-reset: my-page;
+      }
+
+      @page :nth(1 of set-at-page-frontmatter) {
+        counter-reset: my-page;
+      }
+
+      @page :nth(1 of reset-at-element-frontmatter) {
+        counter-reset: my-page;
+      }
+
+      @page :nth(1 of set-at-element-frontmatter) {
+        counter-reset: my-page;
+      }
+
+      html {
+        font: 14px/1.4 Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: 18px;
+      }
+
+      p {
+        margin: 0 0 10px;
+      }
+
+      .frontmatter > p,
+      .main > p {
+        border: 1px solid #bbb;
+        padding: 8px;
+      }
+
+      .main {
+        break-before: page;
+      }
+
+      .break-before {
+        break-before: page;
+      }
+
+      .scenario-start {
+        break-before: page;
+      }
+
+      .control-frontmatter {
+        page: control-frontmatter;
+      }
+
+      .control-main {
+        page: control-main;
+      }
+
+      .set-at-page-frontmatter {
+        page: set-at-page-frontmatter;
+      }
+
+      .set-at-page-main {
+        page: set-at-page-main;
+      }
+
+      .reset-at-element-frontmatter {
+        page: reset-at-element-frontmatter;
+      }
+
+      .reset-at-element-main {
+        page: reset-at-element-main;
+        counter-reset: my-page 1;
+      }
+
+      .set-at-element-frontmatter {
+        page: set-at-element-frontmatter;
+      }
+
+      .set-at-element-main {
+        page: set-at-element-main;
+        counter-set: my-page 1;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="frontmatter control-frontmatter">
+      <h1>A. Control with @page counter-reset</h1>
+      <p>Footer sequence should be A i.</p>
+      <p class="break-before">Footer sequence should be A ii.</p>
+    </section>
+    <section class="main control-main">
+      <p>Footer sequence should be A 1.</p>
+      <p class="break-before">Footer sequence should be A 2.</p>
+    </section>
+
+    <section class="frontmatter set-at-page-frontmatter scenario-start">
+      <h1>B. @page counter-set should also show 1 then 2</h1>
+      <p>Footer sequence should be B i.</p>
+      <p class="break-before">Footer sequence should be B ii.</p>
+    </section>
+    <section class="main set-at-page-main">
+      <p>Footer sequence should be B 1.</p>
+      <p class="break-before">Footer sequence should be B 2.</p>
+    </section>
+
+    <section class="frontmatter reset-at-element-frontmatter scenario-start">
+      <h1>C. Element counter-reset should show 1 then 2</h1>
+      <p>Footer sequence should be C i.</p>
+      <p class="break-before">Footer sequence should be C ii.</p>
+    </section>
+    <section class="main reset-at-element-main">
+      <p>Footer sequence should be C 1.</p>
+      <p class="break-before">Footer sequence should be C 2.</p>
+    </section>
+
+    <section class="frontmatter set-at-element-frontmatter scenario-start">
+      <h1>D. Element counter-set should show 1 then 2</h1>
+      <p>Footer sequence should be D i.</p>
+      <p class="break-before">Footer sequence should be D ii.</p>
+    </section>
+    <section class="main set-at-element-main">
+      <p>Footer sequence should be D 1.</p>
+      <p class="break-before">Footer sequence should be D 2.</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/nth-page/page-counter-set-reset.html
+++ b/packages/core/test/files/nth-page/page-counter-set-reset.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page counter set/reset in page and element contexts</title>
+    <!-- Test case for Issue #1978: page counter set/reset in page and element contexts -->
+    <style>
+      @page {
+        size: 320px 260px;
+        margin: 36px;
+
+        @top-center {
+          font: 12px/1.2 Arial, sans-serif;
+        }
+
+        @bottom-center {
+          font: 12px/1.2 Arial, sans-serif;
+        }
+      }
+
+      @page control-frontmatter {
+        @top-center {
+          content: "A control";
+        }
+
+        @bottom-center {
+          content: "A " counter(page, lower-roman);
+        }
+      }
+
+      @page control-main {
+        @top-center {
+          content: "A control";
+        }
+
+        @bottom-center {
+          content: "A " counter(page);
+        }
+      }
+
+      @page :nth(1 of control-main) {
+        counter-reset: page;
+      }
+
+      @page set-at-page-frontmatter {
+        @top-center {
+          content: "B page counter-set";
+        }
+
+        @bottom-center {
+          content: "B " counter(page, lower-roman);
+        }
+      }
+
+      @page set-at-page-main {
+        @top-center {
+          content: "B page counter-set";
+        }
+
+        @bottom-center {
+          content: "B " counter(page);
+        }
+      }
+
+      @page :nth(1 of set-at-page-main) {
+        counter-set: page 1;
+      }
+
+      @page reset-at-element-frontmatter {
+        @top-center {
+          content: "C element counter-reset";
+        }
+
+        @bottom-center {
+          content: "C " counter(page, lower-roman);
+        }
+      }
+
+      @page reset-at-element-main {
+        @top-center {
+          content: "C element counter-reset";
+        }
+
+        @bottom-center {
+          content: "C " counter(page);
+        }
+      }
+
+      @page set-at-element-frontmatter {
+        @top-center {
+          content: "D element counter-set";
+        }
+
+        @bottom-center {
+          content: "D " counter(page, lower-roman);
+        }
+      }
+
+      @page set-at-element-main {
+        @top-center {
+          content: "D element counter-set";
+        }
+
+        @bottom-center {
+          content: "D " counter(page);
+        }
+      }
+
+      @page :nth(1 of control-frontmatter) {
+        counter-reset: page;
+      }
+
+      @page :nth(1 of set-at-page-frontmatter) {
+        counter-reset: page;
+      }
+
+      @page :nth(1 of reset-at-element-frontmatter) {
+        counter-reset: page;
+      }
+
+      @page :nth(1 of set-at-element-frontmatter) {
+        counter-reset: page;
+      }
+
+      html {
+        font: 14px/1.4 Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: 18px;
+      }
+
+      p {
+        margin: 0 0 10px;
+      }
+
+      .frontmatter > p,
+      .main > p {
+        border: 1px solid #bbb;
+        padding: 8px;
+      }
+
+      .main {
+        break-before: page;
+      }
+
+      .break-before {
+        break-before: page;
+      }
+
+      .scenario-start {
+        break-before: page;
+      }
+
+      .control-frontmatter {
+        page: control-frontmatter;
+      }
+
+      .control-main {
+        page: control-main;
+      }
+
+      .set-at-page-frontmatter {
+        page: set-at-page-frontmatter;
+      }
+
+      .set-at-page-main {
+        page: set-at-page-main;
+      }
+
+      .reset-at-element-frontmatter {
+        page: reset-at-element-frontmatter;
+      }
+
+      .reset-at-element-main {
+        page: reset-at-element-main;
+        counter-reset: page 1;
+      }
+
+      .set-at-element-frontmatter {
+        page: set-at-element-frontmatter;
+      }
+
+      .set-at-element-main {
+        page: set-at-element-main;
+        counter-set: page 1;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="frontmatter control-frontmatter">
+      <h1>A. Control with @page counter-reset</h1>
+      <p>Footer sequence should be A i.</p>
+      <p class="break-before">Footer sequence should be A ii.</p>
+    </section>
+    <section class="main control-main">
+      <p>Footer sequence should be A 1.</p>
+      <p class="break-before">Footer sequence should be A 2.</p>
+    </section>
+
+    <section class="frontmatter set-at-page-frontmatter scenario-start">
+      <h1>B. @page counter-set should also show 1 then 2</h1>
+      <p>Footer sequence should be B i.</p>
+      <p class="break-before">Footer sequence should be B ii.</p>
+    </section>
+    <section class="main set-at-page-main">
+      <p>Footer sequence should be B 1.</p>
+      <p class="break-before">Footer sequence should be B 2.</p>
+    </section>
+
+    <section class="frontmatter reset-at-element-frontmatter scenario-start">
+      <h1>C. Element counter-reset should show 1 then 2</h1>
+      <p>Footer sequence should be C i.</p>
+      <p class="break-before">Footer sequence should be C ii.</p>
+    </section>
+    <section class="main reset-at-element-main">
+      <p>Footer sequence should be C 1.</p>
+      <p class="break-before">Footer sequence should be C 2.</p>
+    </section>
+
+    <section class="frontmatter set-at-element-frontmatter scenario-start">
+      <h1>D. Element counter-set should show 1 then 2</h1>
+      <p>Footer sequence should be D i.</p>
+      <p class="break-before">Footer sequence should be D ii.</p>
+    </section>
+    <section class="main set-at-element-main">
+      <p>Footer sequence should be D 1.</p>
+      <p class="break-before">Footer sequence should be D 2.</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Apply page-context counter updates in the standard CSS order so `counter-set` overrides `counter-increment` on the same page for both the builtin `page` counter and custom page-like counters such as `my-page`.

Ignore stale document counter-change snapshots unless they match the current page-change offset so earlier `counter-reset`/`counter-set` changes do not leak into later pages.

Add regression tests for both the builtin and custom page-counter cases and register them in `file-list.js`.

Closes #1978

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1978 (`counter-set`/`counter-reset` not working as expected for page counters).
- The AI built a minimal reproduction, investigated the page-counter update ordering in `counters.ts`, implemented the ordering and stale-snapshot fixes, and added regression tests for both the builtin `page` counter and custom page-like counters.

</details>
