### PR TITLE
fix: Prevent endless pagination on invalid page layouts

### DIFF
--- a/docs/ja/layout-regression-test.md
+++ b/docs/ja/layout-regression-test.md
@@ -14,6 +14,11 @@
 テストソースリストは `packages/core/test/files/file-list.js` です。
 トリアージ決定の永続データは `scripts/layout-regression-triage.yaml` に保存されます。
 
+`file-list.js` の各エントリには `skipLayoutRegression: true` を指定でき、
+テストケースの start page には残したまま、デフォルトの
+`yarn test:layout-regression` 実行から除外できます。この指定をした
+エントリも、`--file` や `--title-includes` で明示指定すれば実行できます。
+
 ## セットアップ
 
 依存パッケージと Playwright ブラウザを一度だけインストール:
@@ -67,6 +72,9 @@ yarn test:layout-regression \
   --file footnotes/footnote-marker-outside-style.html \
   --file table/table_colspan.html
 ```
+
+`--file` と `--title-includes` では、`file-list.js` で
+`skipLayoutRegression: true` が指定されたエントリも実行対象に含まれます。
 
 同じオプションを複数指定した場合は OR 条件、
 異なる種類のフィルターを併用した場合は AND 条件で評価されます。

--- a/docs/layout-regression-test.md
+++ b/docs/layout-regression-test.md
@@ -14,6 +14,11 @@ It checks:
 The test source list is `packages/core/test/files/file-list.js`.
 Persistent triage decisions are stored in `scripts/layout-regression-triage.yaml`.
 
+Entries in `file-list.js` can set `skipLayoutRegression: true` to stay on the
+test case start page while being excluded from default
+`yarn test:layout-regression` runs. Such entries can still be executed
+explicitly with `--file` or `--title-includes`.
+
 ## Setup
 
 Install dependencies and Playwright browsers once:
@@ -67,6 +72,9 @@ yarn test:layout-regression \
   --file footnotes/footnote-marker-outside-style.html \
   --file table/table_colspan.html
 ```
+
+`--file` and `--title-includes` also include entries marked with
+`skipLayoutRegression: true` in `file-list.js`.
 
 When multiple values are passed for the same option, they are OR conditions.
 When different filter options are combined, they are AND conditions.

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -315,6 +315,9 @@ export class StyleInstance
   pageSheetSize: { [key: string]: { width: number; height: number } } = {};
   pageSheetHeight: number = 0;
   pageSheetWidth: number = 0;
+  private invalidPageAreaOnCurrentPage: boolean = false;
+  private repeatedInvalidPageAreaLayoutPosition: Vtree.LayoutPosition | null =
+    null;
   private semanticFootnoteFirstRefOffsets: Map<string, number | null> =
     new Map();
   private semanticFootnoteFirstRefOffsetsInitialized = { value: false };
@@ -2296,9 +2299,11 @@ export class StyleInstance
     );
 
     if (
-      boxInstance instanceof CssPage.PageRuleMasterInstance &&
-      (layoutContainer.width <= 0 || layoutContainer.height <= 0)
+      (layoutContainer.width <= 0 || layoutContainer.height <= 0) &&
+      (boxInstance instanceof CssPage.PageRuleMasterInstance ||
+        (flowName && flowName.isIdent()))
     ) {
+      this.invalidPageAreaOnCurrentPage = true;
       Logging.logger.warn("Negative or zero page area size");
     }
 
@@ -2575,6 +2580,63 @@ export class StyleInstance
     return true;
   }
 
+  private hasSameFlowPositions(
+    first: Vtree.LayoutPosition | null,
+    second: Vtree.LayoutPosition | null,
+  ): boolean {
+    if (first === second) {
+      return true;
+    }
+    if (!first || !second) {
+      return false;
+    }
+    const firstFlowNames = Object.keys(first.flowPositions);
+    const secondFlowNames = Object.keys(second.flowPositions);
+    if (firstFlowNames.length !== secondFlowNames.length) {
+      return false;
+    }
+    for (const flowName of firstFlowNames) {
+      if (
+        !first.flowPositions[flowName].isSamePosition(
+          second.flowPositions[flowName],
+        )
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private checkRepeatedInvalidPageArea(cp: Vtree.LayoutPosition): void {
+    const hasInvalidPageArea = this.invalidPageAreaOnCurrentPage;
+    this.invalidPageAreaOnCurrentPage = false;
+
+    if (!hasInvalidPageArea) {
+      this.repeatedInvalidPageAreaLayoutPosition = null;
+      return;
+    }
+    if (cp.isBlankPage || this.noMorePrimaryFlows(cp)) {
+      return;
+    }
+    if (!this.hasSameFlowPositions(this.layoutPositionAtPageStart, cp)) {
+      this.repeatedInvalidPageAreaLayoutPosition = null;
+      return;
+    }
+
+    const repeatedStall =
+      !!this.repeatedInvalidPageAreaLayoutPosition &&
+      this.hasSameFlowPositions(
+        this.repeatedInvalidPageAreaLayoutPosition,
+        this.layoutPositionAtPageStart,
+      );
+    this.repeatedInvalidPageAreaLayoutPosition =
+      this.layoutPositionAtPageStart.clone();
+
+    if (repeatedStall) {
+      throw new Error("Negative or zero page area size");
+    }
+  }
+
   layoutNextPage(
     page: Vtree.Page,
     cp?: Vtree.LayoutPosition,
@@ -2593,13 +2655,8 @@ export class StyleInstance
     if (this.lang) {
       page.bleedBox.setAttribute("lang", this.lang);
     }
+    this.invalidPageAreaOnCurrentPage = false;
     cp = this.currentLayoutPosition;
-
-    // Limit number of pages to prevent endless page generation
-    const LIMIT_PAGES = 10000;
-    if (cp.page > LIMIT_PAGES) {
-      throw new Error(`Too many pages generated (over ${LIMIT_PAGES} pages)`);
-    }
 
     const startSide = cp.startSideOfFlow("body");
     cp.isBlankPage =
@@ -2789,6 +2846,7 @@ export class StyleInstance
         if (!isTocBox) {
           this.processLinger();
           cp = this.currentLayoutPosition;
+          this.checkRepeatedInvalidPageArea(cp);
           Object.keys(cp.flowPositions).forEach((flowName) => {
             const flowPosition = cp.flowPositions[flowName];
             const breakAfter = flowPosition.breakAfter;

--- a/packages/core/test/files/eal-zero-size-flow-partition.html
+++ b/packages/core/test/files/eal-zero-size-flow-partition.html
@@ -1,0 +1,66 @@
+<!-- Test case for Issue #941: zero-size EAL flow partition must not loop forever -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>EAL zero-size flow partition</title>
+    <style>
+      @page {
+        size: 200mm 140mm;
+        margin: 0;
+      }
+
+      html,
+      body {
+        margin: 0;
+      }
+
+      body {
+        font-family: Georgia, "Times New Roman", serif;
+      }
+
+      .body-anchor {
+        margin: 0;
+        font-size: 1px;
+        line-height: 1;
+        color: transparent;
+      }
+
+      @-epubx-page-template {
+        @-epubx-flow body {
+          -epubx-flow-consume: all;
+        }
+
+        .body-flow {
+          -epubx-flow-from: body;
+          top: 0;
+          left: 0;
+          width: 0px;
+          height: 0px;
+          overflow: hidden;
+        }
+
+        .message {
+          content: "Zero-size EAL flow partition should stop instead of paginating forever.";
+          top: 10mm;
+          left: 10mm;
+          right: 10mm;
+          height: 10mm;
+          font: 700 13px/1.2 Arial, sans-serif;
+          color: #102a43;
+        }
+
+        @-epubx-page-master {
+          @-epubx-partition class(body-flow) {
+          }
+
+          @-epubx-partition class(message) {
+          }
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <p class="body-anchor">anchor</p>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -20,6 +20,17 @@ module.exports = [
         file: "eal-generated-text-properties.html",
         title: "EAL generated text properties (Issue #1968)",
       },
+      {
+        file: "eal-zero-size-flow-partition.html",
+        title:
+          "EAL zero-size flow partition must not loop forever (Issue #941)",
+        skipLayoutRegression: true,
+      },
+      {
+        file: "invalid-page-area.html",
+        title: "Invalid page area must not loop forever (Issue #941)",
+        skipLayoutRegression: true,
+      },
       { file: "case_sensitivity/html.html", title: "HTML case sensitivity" },
       { file: "ruby-broken-pagination.html", title: "Ruby broken pagination" },
       {

--- a/packages/core/test/files/invalid-page-area.html
+++ b/packages/core/test/files/invalid-page-area.html
@@ -1,0 +1,33 @@
+<!-- Test case for Issue #941: invalid page area must not trigger endless pagination -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Invalid page area</title>
+    <style>
+      @page {
+        size: 500px 500px;
+        margin: 250px;
+      }
+
+      html,
+      body {
+        margin: 0;
+      }
+
+      body {
+        font: 16px/1.4 serif;
+      }
+
+      p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      This paragraph should not cause endless pagination even though the page
+      area width and height are both zero.
+    </p>
+  </body>
+</html>

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -1304,6 +1304,8 @@ function collectTargets(fileList, opts, approvedViewerMap = new Map()) {
   const fileFilters = opts.files
     .map((v) => normalizeCase(normalizeTestFilePath(v)))
     .filter(Boolean);
+  const hasExplicitEntryFilter =
+    titleFilters.length > 0 || fileFilters.length > 0;
 
   const rows = [];
 
@@ -1376,6 +1378,10 @@ function collectTargets(fileList, opts, approvedViewerMap = new Map()) {
 
     for (const entry of group.files) {
       if (!entry?.file) {
+        continue;
+      }
+
+      if (entry.skipLayoutRegression && !hasExplicitEntryFilter) {
         continue;
       }
 


### PR DESCRIPTION
Detect repeated no-progress pagination after a non-positive CSS page area or zero-size EAL `flow-from` partition instead of relying on the global `LIMIT_PAGES` fallback. This makes permanent stalls fail fast with `Negative or zero page area size` without regressing transient zero-area pages that can recover on later pages.

Add `invalid-page-area.html` and `eal-zero-size-flow-partition.html` as Issue #941 repro tests, but keep them out of default `yarn test:layout-regression` runs with `skipLayoutRegression: true` because the expected success condition is a viewer error rather than a stable rendering. They remain available from the test start page and can still be targeted explicitly with `--file` or `--title-includes`.

Document the new layout-regression behavior in both `docs/layout-regression-test.md` and `docs/ja/layout-regression-test.md`.

Closes #941

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for issue #941, describing both symptoms of the existing `LIMIT_PAGES`-based fallback (slow detection, and inability to legitimately paginate beyond 10000 pages) and citing a memory note about a prior related fix (issue #1959) as context.
- The AI implemented a repeated-no-progress detection guard in `ops.ts`; the human author pointed out that the layout-regression test tool had no way to treat a viewer error as the expected success condition, and asked the AI to address that tooling gap (via `skipLayoutRegression`) alongside the core fix, then directed the documentation updates and commit message.

</details>
