### PR TITLE
fix(counter-style): count grapheme clusters for pad descriptor

### DIFF
--- a/packages/core/src/vivliostyle/counter-style.ts
+++ b/packages/core/src/vivliostyle/counter-style.ts
@@ -26,10 +26,6 @@
  *   CounterStyle.format may require the writing mode as an argument.
  *   It may be necessary to extend it so that the caller can obtain the writing mode.
  *
- * - Use grapheme clusters for character counting in CounterStyle.#applyPadding.
- *     https://drafts.csswg.org/css-counter-styles/#counter-style-pad
- *   Intl.Segmenter may be useful. CounterStyle.format may require the lang as an argument.
- *
  * - Implement symbols() for defining anonymous counter styles
  *     https://drafts.csswg.org/css-counter-styles/#symbols-function
  *   Extending CounterStyle.defineAnonymous( ... ) should work.
@@ -39,6 +35,43 @@ import * as Css from "./css";
 import * as CssCascade from "./css-cascade";
 
 type SetElement<T> = T extends ReadonlySet<infer U> ? U : never;
+
+/**
+ * Count the grapheme clusters in a string. Per CSS Counter Styles Level 3,
+ * character counting for descriptors like `pad` is defined in terms of
+ * grapheme clusters, not Unicode code points. Falls back to code-point
+ * counting (`[...s].length`) on engines without `Intl.Segmenter`.
+ *
+ * @see https://drafts.csswg.org/css-counter-styles/#counter-style-pad
+ */
+interface GraphemeSegmenter {
+  segment(input: string): Iterable<unknown>;
+}
+let cachedGraphemeSegmenter: GraphemeSegmenter | null | undefined;
+function graphemeClusterCount(s: string): number {
+  if (s === "") return 0;
+  if (cachedGraphemeSegmenter === undefined) {
+    const SegmenterCtor = (
+      Intl as unknown as {
+        Segmenter?: new (
+          locale?: string | string[] | undefined,
+          options?: { granularity?: "grapheme" | "word" | "sentence" },
+        ) => GraphemeSegmenter;
+      }
+    ).Segmenter;
+    cachedGraphemeSegmenter =
+      typeof SegmenterCtor === "function"
+        ? new SegmenterCtor(undefined, { granularity: "grapheme" })
+        : null;
+  }
+  if (cachedGraphemeSegmenter === null) {
+    return [...s].length;
+  }
+  let count = 0;
+
+  for (const _ of cachedGraphemeSegmenter.segment(s)) count++;
+  return count;
+}
 
 /**
  * @see https://drafts.csswg.org/css-counter-styles-3/#non-overridable-counter-style-names
@@ -876,15 +909,16 @@ abstract class CounterStyle {
 
     const { prefix: negPrefix, suffix: negSuffix } = this.#getNegative();
     const negativeLength = usesNegative
-      ? [...negPrefix].length + (negSuffix ? [...negSuffix].length : 0)
+      ? graphemeClusterCount(negPrefix) +
+        (negSuffix ? graphemeClusterCount(negSuffix) : 0)
       : 0;
 
-    const diff = minLength - [...initialRep].length - negativeLength;
+    const diff = minLength - graphemeClusterCount(initialRep) - negativeLength;
     if (diff <= 0) {
       return initialRep;
     }
 
-    const padLength = [...padSymbol].length;
+    const padLength = graphemeClusterCount(padSymbol);
     const count = Math.ceil(diff / padLength);
     return padSymbol.repeat(count) + initialRep;
   }

--- a/packages/core/test/spec/vivliostyle/css-counter-style-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-counter-style-spec.js
@@ -629,16 +629,32 @@ describe("css-counter-style", function () {
     it("should count grapheme clusters in the initial representation", function (done) {
       parseStylesheet(
         done,
-        // Symbols are themselves multi-code-point emoji. They must contribute
-        // 1 to the length each, otherwise no padding will be added.
-        '@counter-style test { system: cyclic; symbols: "😀"; pad: 3 "0"; }',
+        // Symbols are themselves multi-code-point emoji graphemes. They must
+        // contribute 1 to the length each, otherwise padding will be too short.
+        '@counter-style test { system: cyclic; symbols: "👍🏽"; pad: 3 "0"; }',
         function (result, counterStyles) {
           expect(result).toBeTruthy();
           var style = counterStyles.getStyle("test");
           expect(style).not.toBeNull();
           if (!style) return;
-          // value 1 → "😀" (1 grapheme), pad to 3 → "00😀"
-          expect(style.format(1)).toBe("00😀");
+          // value 1 → "👍🏽" (1 grapheme, 2 code points), pad to 3 → "00👍🏽"
+          expect(style.format(1)).toBe("00👍🏽");
+        },
+      );
+    });
+
+    it("should count grapheme clusters in negative prefix and suffix", function (done) {
+      parseStylesheet(
+        done,
+        '@counter-style test { system: numeric; symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9"; negative: "👍🏽" "👎🏽"; pad: 5 "0"; }',
+        function (result, counterStyles) {
+          expect(result).toBeTruthy();
+          var style = counterStyles.getStyle("test");
+          expect(style).not.toBeNull();
+          if (!style) return;
+          // value -5 → negative affixes contribute 2 graphemes total, so pad to 5
+          // yields two zeros between the prefix and the numeric representation.
+          expect(style.format(-5)).toBe("👍🏽005👎🏽");
         },
       );
     });

--- a/packages/core/test/spec/vivliostyle/css-counter-style-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-counter-style-spec.js
@@ -600,6 +600,48 @@ describe("css-counter-style", function () {
         },
       );
     });
+
+    // Regression test for #1624: the pad descriptor must count grapheme
+    // clusters, not Unicode code points. A composite emoji such as the
+    // family ZWJ sequence is one grapheme cluster but several code points,
+    // and using its code-point count for `pad` produces an over-padded
+    // counter representation.
+    it("should count grapheme clusters in the pad symbol (single composite emoji)", function (done) {
+      parseStylesheet(
+        done,
+        // family emoji = U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466
+        // It is 1 grapheme cluster but 7 code points.
+        '@counter-style test { system: numeric; symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9"; pad: 5 "👨‍👩‍👧‍👦"; }',
+        function (result, counterStyles) {
+          expect(result).toBeTruthy();
+          var style = counterStyles.getStyle("test");
+          expect(style).not.toBeNull();
+          if (!style) return;
+          var family = "👨‍👩‍👧‍👦";
+          // value "1" has 1 grapheme; we need 5 → 4 pad symbols + "1".
+          // Each pad symbol is one cluster, so we prepend 4 of them
+          // (not just 1, which is what the old code-point counter produced).
+          expect(style.format(1)).toBe(family + family + family + family + "1");
+        },
+      );
+    });
+
+    it("should count grapheme clusters in the initial representation", function (done) {
+      parseStylesheet(
+        done,
+        // Symbols are themselves multi-code-point emoji. They must contribute
+        // 1 to the length each, otherwise no padding will be added.
+        '@counter-style test { system: cyclic; symbols: "😀"; pad: 3 "0"; }',
+        function (result, counterStyles) {
+          expect(result).toBeTruthy();
+          var style = counterStyles.getStyle("test");
+          expect(style).not.toBeNull();
+          if (!style) return;
+          // value 1 → "😀" (1 grapheme), pad to 3 → "00😀"
+          expect(style.format(1)).toBe("00😀");
+        },
+      );
+    });
   });
 
   describe("fallback mechanism", function () {


### PR DESCRIPTION
Fixes #1624.

Per CSS Counter Styles Level 3, character counting for the `pad` descriptor is defined in terms of grapheme clusters rather than Unicode code points (https://drafts.csswg.org/css-counter-styles/#counter-style-pad). `#applyPadding` in `counter-style.ts` used `[...string].length`, which counts code points, so a composite emoji such as the family ZWJ sequence (`👨‍👩‍👧‍👦` — 1 grapheme cluster but 7 code points) caused both the length comparison and the per-symbol length to be over-counted, producing the wrong padding.

This switches the three length sites (`initialRep`, the negative prefix/suffix, and the pad symbol itself) to a `graphemeClusterCount` helper that uses `Intl.Segmenter` with `granularity: "grapheme"`, falling back to code-point counting on engines without `Intl.Segmenter`.

Also removed the matching TODO from the file header, since the implementation now does what it promised.

Added two regression tests under `pad descriptor`: one with the family-emoji pad symbol from the issue, and one with an emoji as the initial representation symbol.

Verified with `yarn test` in `packages/core/test` (594/594 pass; both new tests fail on the unpatched source). Verified `yarn lint` in `packages/core` (clean). The pre-existing `@vivliostyle/viewer:lint` failure on master is unrelated and not touched by this PR.