### PR TITLE
fix: Repeat Table Headers on Nested Rowspan Continuations

### DIFF
--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1990,6 +1990,21 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
       return column.buildDeepElementView(nodeContext);
     } else {
       if (leadingEdge) {
+        const repetitiveElements = formattingContext.getRepetitiveElements();
+        // Issue #1980: a table can resume at a new page/column from the middle
+        // of its body, so it never passes through the table-root retry path
+        // below. Header-only tables would then drop their repeated thead on the
+        // first continuation page unless we preserve the header here. Keep
+        // footer-bearing tables on the normal skip logic, because existing
+        // fixtures intentionally drop header/footer when space is too tight.
+        if (
+          repetitiveElements &&
+          nodeContext.sourceNode !== formattingContext.tableSourceNode &&
+          !nodeContext.after &&
+          !repetitiveElements.isFooterRegistered()
+        ) {
+          repetitiveElements.preventSkippingHeader();
+        }
         RepetitiveElementImpl.appendHeaderToAncestors(
           nodeContext.parent,
           column,
@@ -2327,6 +2342,8 @@ export class LayoutRetryer extends LayoutRetryers.AbstractLayoutRetryer {
     if (!repetitiveElements || !repetitiveElements.doneInitialLayout) {
       return new LayoutEntireTable(this.tableFormattingContext, this.processor);
     } else {
+      // The unconditional preserve-header path stays limited to table-root
+      // retries; mid-table continuations are handled at the leading edge above.
       if (
         nodeContext.sourceNode ===
           this.tableFormattingContext.tableSourceNode &&

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -723,6 +723,10 @@ module.exports = [
         title:
           "Table header repeat with complex multipage tables (Issue #1873)",
       },
+      {
+        file: "table/table-header-repeat-nested-rowspan.html",
+        title: "Table header repeat with nested rowspans (Issue #1980)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/table/table-header-repeat-nested-rowspan.html
+++ b/packages/core/test/files/table/table-header-repeat-nested-rowspan.html
@@ -1,0 +1,421 @@
+<!-- Test case for Issue #1980: table headers disappear on continuation pages for a complex multipage table -->
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="utf-8" />
+<title>Test: Table header repeat with nested rowspans</title>
+<style>
+:root {
+  --color-grey: grey;
+  --color-header: rgb(203 203 203);
+}
+
+@page {
+  size: A4 portrait;
+  margin-left: 25mm;
+  margin-right: 20mm;
+  margin-top: 40mm;
+  margin-bottom: 30mm;
+}
+
+@media print {
+  :root {
+    font-size: 10pt;
+  }
+}
+
+html {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+td,
+th {
+  vertical-align: top;
+  padding: 0.5em;
+}
+
+caption,
+figcaption {
+  padding: 1em;
+}
+
+caption {
+  font-weight: bold;
+}
+
+.fill {
+  background-color: var(--color-grey);
+}
+
+.simple-list {
+  margin-top: 0;
+  margin-bottom: 0;
+  list-style: none;
+  padding: 0;
+}
+
+.outer {
+  width: 100%;
+}
+
+.outer > tbody > tr > td {
+  font-size: 0.8rem;
+}
+
+.outer > thead > tr > th {
+  text-align: left;
+  background-color: var(--color-header);
+}
+
+.outer > thead > tr > th,
+.outer > tbody > tr > td {
+  border: 1px solid black;
+}
+
+.outer > thead > tr:nth-of-type(2) > th:nth-of-type(1) {
+  width: 4%;
+}
+
+.outer > thead > tr:nth-of-type(2) > th:nth-of-type(2) {
+  width: 16%;
+}
+
+.inner {
+  border: 0 none;
+  text-align: left;
+}
+
+.inner,
+.inner td {
+  width: 100%;
+}
+</style>
+</head>
+<body>
+<table class="outer">
+  <caption>Caption</caption>
+  <thead>
+    <tr>
+      <th colspan="3">Header Row 1</th>
+    </tr>
+    <tr>
+      <th rowspan="2">R</th>
+      <th rowspan="2">Header Row 2<br />Col 2</th>
+      <th>Header Row 2<br />Col 3</th>
+    </tr>
+    <tr>
+      <th>Header Row 3 Col 3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 1</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4 LONGTEXT</li>
+        </ul>
+      </td>
+      <td>Row 2</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4 LONGTEXT</li>
+        </ul>
+      </td>
+      <td>Row 3</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 4</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 5</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 6</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 7</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4 LONGTEXT</li>
+        </ul>
+      </td>
+      <td>Row 8</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4 LONGTEXT</li>
+        </ul>
+      </td>
+      <td>Row 9</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 10</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 11</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 12</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 13</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 14</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 15</td>
+    </tr>
+    <tr>
+      <td class="fill"></td>
+      <td>
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 16</td>
+    </tr>
+    <tr>
+      <td class="fill" rowspan="2"></td>
+      <td rowspan="2">
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 17</td>
+    </tr>
+    <tr>
+      <td>
+        <table class="inner">
+          <tbody>
+            <tr>
+              <td>IR1C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR2C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR3C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR4C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR5C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR6C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td class="fill" rowspan="2"></td>
+      <td rowspan="2">
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 19</td>
+    </tr>
+    <tr>
+      <td>
+        <table class="inner">
+          <tbody>
+            <tr>
+              <td>IR1C1<br />cont.</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td class="fill" rowspan="2"></td>
+      <td rowspan="2">
+        <ul class="simple-list">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+        </ul>
+      </td>
+      <td>Row 21</td>
+    </tr>
+    <tr>
+      <td>
+        <table class="inner">
+          <tbody>
+            <tr>
+              <td>IR1C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR2C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR3C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR4C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR5C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+            <tr>
+              <td>IR6C1</td>
+              <td>C2<br />cont.</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Handle table fragments that resume at a page or column leading edge from the middle of a table body. Header-only tables could skip their repeated `thead` on the first continuation page because they did not pass through the table-root retry path that preserves repeated headers.

Preserve the header for leading-edge mid-table continuations only when the table has no repeated footer, so existing cases that intentionally drop table headers and footers to make room for body rows keep their current behavior.

Add `packages/core/test/files/table/table-header-repeat-nested-rowspan.html` and register it in `packages/core/test/files/file-list.js` to cover the Issue #1980 reproduction.

Closes #1980

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for issue #1980 (a table with repeated headers, nested `rowspan`, and complex content dropping the header on a continuation page), referencing the earlier related fix for issue #1873 as a comparison point.
- The AI built a minimal reproduction fixture, verified the bug visually with the integrated browser, and traced the root cause to the leading-edge continuation path in `table.ts`/`repetitive-element.ts` bypassing the header-preservation logic used elsewhere; the human author confirmed the fix (headers repeating correctly on both continuation pages) and directed the commit message.

</details>
