### PR TITLE
fix: Fix `:nth(1 of Page)` after `target-counter()` rerender

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1482,7 +1482,7 @@ export type OPFViewItem = {
   item: OPFItem;
   xmldoc: XmlDoc.XMLDocHolder;
   instance: OPS.StyleInstance;
-  layoutPositions: Vtree.LayoutPosition[];
+  layoutPositions: Array<Vtree.LayoutPosition | null>;
   pages: Vtree.Page[];
   complete: boolean;
   pageCounterStarts: CssCascade.CounterValues[];
@@ -2053,8 +2053,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
           // target-counter-and-page-floats.html)
           const hasRenderedFollowingPage =
             refs.pageIndex < targetViewItem.pages.length - 1;
+          const hasRenderedTargetPage = !!targetViewItem.pages[refs.pageIndex];
           const shouldIsolateRootPageFloatLayoutContext =
-            !!targetViewItem.pages[refs.pageIndex] && hasRenderedFollowingPage;
+            hasRenderedTargetPage && hasRenderedFollowingPage;
           const originalRootPageFloatLayoutContext =
             shouldIsolateRootPageFloatLayoutContext
               ? targetViewItem.instance.beginIsolatedRootPageFloatLayoutContext()
@@ -2063,6 +2064,14 @@ export class OPFView implements Vgen.CustomRendererFactory {
           this.counterStore.pushPageCounters(refs.pageCounters);
           this.counterStore.pushReferencesToSolve(refs.refs);
           const pos = targetViewItem.layoutPositions[refs.pageIndex];
+          if (hasRenderedTargetPage) {
+            // Same-page rerenders should recompute :nth(... of <page-type>)
+            // from the page-group state of earlier pages only.
+            targetViewItem.instance.preparePageGroupPageIndicesForRerender(
+              targetViewItem.layoutPositions,
+              refs.pageIndex,
+            );
+          }
 
           this.renderSinglePage(targetViewItem, pos).then((result) => {
             if (shouldIsolateRootPageFloatLayoutContext) {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -993,16 +993,17 @@ export class StyleInstance
   }
 
   private updatePageGroupPageIndices(
-    layoutPosition: Vtree.LayoutPosition,
+    layoutPosition: Vtree.LayoutPosition | null,
   ): void {
     const pageCascade = this.pageManager.pageCascadeInstance;
     pageCascade.pageTypePageIndices = Object.create(null);
-    const startSide = layoutPosition.startSideOfFlow("body");
-    const bodyFlowPosition = layoutPosition.flowPositions["body"];
+    const startSide = layoutPosition?.startSideOfFlow("body") || null;
+    const bodyFlowPosition = layoutPosition?.flowPositions["body"];
     const hasBodyFlowContent = !!(
       bodyFlowPosition && bodyFlowPosition.positions.length
     );
     const isSpreadDeferredBlankPage =
+      !!startSide &&
       Break.isSpreadBreakValue(startSide) &&
       !this.matchPageSide(startSide) &&
       !hasBodyFlowContent;
@@ -1010,10 +1011,10 @@ export class StyleInstance
     // documents for spread alignment (issue #666). It must not consume
     // :nth(An+B of <page-type>) page-group indices.
     const isBlankPageAtDocumentStart =
-      this.blankPageAtStart && layoutPosition.page === 1;
+      this.blankPageAtStart && (!layoutPosition || layoutPosition.page === 1);
     const canStartNewPageGroup =
       !isBlankPageAtDocumentStart &&
-      !layoutPosition.isBlankPage &&
+      !layoutPosition?.isBlankPage &&
       !isSpreadDeferredBlankPage;
 
     const pageStartOffset = this.getPageStartOffset(layoutPosition);
@@ -1070,6 +1071,23 @@ export class StyleInstance
         break;
       }
       currentElement = currentElement.parentElement;
+    }
+  }
+
+  preparePageGroupPageIndicesForRerender(
+    layoutPositions: Array<Vtree.LayoutPosition | null>,
+    pageIndexToRender: number,
+  ): void {
+    this.pageGroupPageCounts = Object.create(null);
+    this.currentPageGroupDocument = null;
+
+    for (
+      let previousPageIndex = 0;
+      previousPageIndex < pageIndexToRender;
+      previousPageIndex++
+    ) {
+      const previousLayoutPosition = layoutPositions[previousPageIndex] || null;
+      this.updatePageGroupPageIndices(previousLayoutPosition);
     }
   }
 

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -259,6 +259,10 @@ module.exports = [
         title: "target-counter() named pages with :left/:right (Issue #1497)",
       },
       {
+        file: "target-counter-page-group-nth.html",
+        title: "target-counter() with :nth(1 of Page) (Issue #1990)",
+      },
+      {
         file: "target-counter-missing-page.html",
         title: "target-counter() missing page (Issue #1498)",
       },

--- a/packages/core/test/files/target-counter-page-group-nth.html
+++ b/packages/core/test/files/target-counter-page-group-nth.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1990: target-counter() must not break :nth(1 of Page) -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-counter page group nth</title>
+    <style>
+      @page {
+        size: 140mm 120mm;
+        margin: 14mm;
+
+        @top-center {
+          content: "default";
+          font-size: 10pt;
+        }
+
+        @bottom-center {
+          content: counter(page);
+          font-size: 10pt;
+        }
+      }
+
+      @page Page {
+        background: #f2d46b;
+
+        @top-center {
+          content: "Page group Page";
+        }
+      }
+
+      @page :nth(1 of Page) {
+        background: #da5248;
+
+        @top-center {
+          content: "first of Page";
+          color: white;
+          font-weight: bold;
+        }
+      }
+
+      body {
+        font-family: serif;
+        font-size: 12pt;
+        line-height: 1.5;
+      }
+
+      main {
+        page: Page;
+      }
+
+      .toc a::after {
+        content: leader(".") target-counter(attr(href), page);
+      }
+
+      .target {
+        break-before: page;
+      }
+
+      .note {
+        font-weight: bold;
+      }
+
+      .filler {
+        margin: 0 0 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Issue #1990</h1>
+      <p class="note">
+        This first page should stay red because it is <code>:nth(1 of Page)</code>.
+      </p>
+      <p class="filler">
+        This prelude text keeps the same <code>&lt;main&gt;</code> flowing long
+        enough that the table of contents may start on the next page without an
+        explicit forced page break.
+      </p>
+      <p class="filler">
+        If page-group indices are rebuilt from the wrong baseline during a
+        target-counter() rerender, a later page in the same named-page element
+        can incorrectly start matching <code>:nth(1 of Page)</code>.
+      </p>
+      <div class="toc">
+        <p><a href="#target">Target section</a></p>
+      </div>
+      <p>
+        The link above uses <code>target-counter()</code> and forces a rerender
+        once the target page number becomes known.
+      </p>
+      <p>
+        If the bug is present, the first page becomes yellow after rerender
+        even though it remains the first page of the Page group.
+      </p>
+      <p class="filler">
+        This test expects the TOC above to start at the top of page 2 while
+        still remaining inside the same named-page element.
+      </p>
+      <p class="filler">
+        The TOC should not start a new Page page-group unless there is an
+        actual page-type boundary; reaching it by a natural page break must
+        still leave that page as page 2 of the same group.
+      </p>
+      <p class="filler">
+        This content keeps the same <code>&lt;main&gt;</code> flowing across
+        additional pages so the first page must keep
+        <code>:nth(1 of Page)</code> even when later pages of the same
+        named-page element already exist.
+      </p>
+      <p class="filler">
+        Later pages of this main element should remain part of the same Page
+        page-group, while only the first page stays red. If page-group indices
+        are rebuilt from the wrong baseline during target-counter() rerender, a
+        later page can incorrectly behave like page 1 in the group.
+      </p>
+      <p class="filler">
+        Vivliostyle needs to resolve the cross-reference after the target page
+        number is known, but that rerender must not inherit page-group counts
+        from pages that come after the page being rerendered.
+      </p>
+      <p class="filler">
+        Additional filler text keeps this named-page element flowing across
+        multiple pages with normal in-flow content. The regression appears when
+        the stored page-group count for the same <code>&lt;main&gt;</code>
+        already advanced past the first page before the rerender happens.
+      </p>
+      <p class="filler">
+        Rebuilding the page-group state from previous pages only should keep the
+        first page index at 1 and subsequent pages in increasing order, while
+        leaving the target section to start on a later page with a resolved
+        page number in the TOC.
+      </p>
+    </main>
+
+    <section class="target">
+      <h2 id="target">Target section</h2>
+      <p>This later page provides the resolved page number.</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Rebuild page-group indices from the pages before the rerender target so `:nth(... of <page-type>)` is evaluated against the correct baseline during `target-counter()` resolution.

Handle the null first-page layout slot when reconstructing page-group state so later pages in the same named-page element do not get recomputed as page 1 of the group.

Add a focused Issue #1990 reproduction for `target-counter()` with `:nth(1 of Page)` and register it in the core test file list.

Closes #1990

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1990 (`:nth(1 of Page)` breaking after `target-counter()` rerender); the AI implemented a fix that rebuilds page-group indices from the pages preceding the rerender target.
- The human author tested the fix and found it incomplete twice — once with a multi-page `<main>` scenario, and again with a page break before a `<div class="toc">` — and directed the AI to keep refining until both cases were correct.
- The human author asked the AI to verify the added test's prose (e.g. "first page"/"second page" wording) still matched the test content after edits, then ran `/draft-commit` and `/address-pr-comments`.
- After opening the PR, the human author ran a layout-regression comparison and found the new test produced no diff against canary when it should have shown a difference there; the AI fixed the test, and `/address-pr-comments` closed out the remaining review feedback.

</details>
