### PR TITLE
fix: Preserve named pages after deferred footnote text

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -791,9 +791,36 @@ export class StyleInstance
     );
     const searchRootOffset = this.xmldoc.getElementOffset(searchRoot);
     const isDocumentStart = pageStartOffset <= searchRootOffset;
-    return startElement === searchRoot && isDocumentStart
-      ? this.getFirstInFlowChildElement(searchRoot)
-      : startElement;
+    if (startElement === searchRoot && isDocumentStart) {
+      return this.getFirstInFlowChildElement(searchRoot);
+    }
+
+    const startElementOffset = startElement
+      ? this.xmldoc.getElementOffset(startElement)
+      : Number.POSITIVE_INFINITY;
+    if (startElementOffset > pageStartOffset) {
+      // Issue #1991: a continuation page can start in deferred text before any
+      // new in-flow element begins, so recover the containing normal-flow
+      // element from the raw offset instead of jumping to the next element.
+      const nodeAtOffset = this.xmldoc.getNodeByOffset(pageStartOffset);
+      if (!Vtree.canIgnore(nodeAtOffset)) {
+        let currentElement =
+          nodeAtOffset.nodeType === Node.ELEMENT_NODE
+            ? (nodeAtOffset as Element)
+            : nodeAtOffset.parentElement;
+        while (currentElement) {
+          if (
+            this.xmldoc.getElementOffset(currentElement) <= pageStartOffset &&
+            this.isNormalFlowElement(currentElement)
+          ) {
+            return currentElement;
+          }
+          currentElement = currentElement.parentElement;
+        }
+      }
+    }
+
+    return startElement;
   }
 
   private isForcedPageBreakValue(value: string | null): boolean {
@@ -2682,8 +2709,6 @@ export class StyleInstance
     page.isBlankPage = cp.isBlankPage;
     cp.page++;
 
-    // Choose the effective page type before selecting `@page` styles so page
-    // backgrounds and margin boxes use the same named-page context as content.
     const pageStartPageType = this.getPageStartPageTypeOverride(cp);
     if (pageStartPageType === "") {
       page.pageType = "";
@@ -2691,12 +2716,23 @@ export class StyleInstance
       page.pageType = pageStartPageType;
     }
     if (page.pageType == null) {
-      page.pageType =
+      const fallbackPageType =
         (page.isBlankPage
           ? this.styler.cascade.previousPageType
           : this.styler.cascade.currentPageType) ??
-        (cp.page === 1 ? this.resolveFirstPageType() : null) ??
-        "";
+        (cp.page === 1 ? this.resolveFirstPageType() : null);
+      page.pageType = fallbackPageType;
+      if (!page.pageType) {
+        // Issue #1991: `currentPageType` can still be empty when a page starts
+        // mid-paragraph after deferred footnote text. Use the direct page-start
+        // resolver only as the last fallback so existing named-page/group flows
+        // keep their normal continuation behavior.
+        const directPageStartPageType = this.getPageStartPageType(cp);
+        if (directPageStartPageType) {
+          page.pageType = directPageStartPageType;
+        }
+      }
+      page.pageType = page.pageType ?? "";
       // Fix for issue #1309
       this.styler.cascade.previousPageType =
         this.styler.cascade.currentPageType;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -982,6 +982,10 @@ module.exports = [
         title: "footnote-policy: line fragmentation (Issue #1899)",
       },
       {
+        file: "footnotes/named-page-deferred-text.html",
+        title: "Named page with deferred text after footnote (Issue #1991)",
+      },
+      {
         file: "footnotes/footnote-area-at-footnote.html",
         title: "Footnote area with @footnote",
       },

--- a/packages/core/test/files/footnotes/named-page-deferred-text.html
+++ b/packages/core/test/files/footnotes/named-page-deferred-text.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1991: named page should survive deferred text after footnote-policy:auto -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Named page with deferred text after footnote</title>
+    <style>
+      @page {
+        size: 360px 240px;
+        margin: 20px;
+
+        @top-center {
+          content: "default";
+          font: 10px sans-serif;
+          color: #a33;
+        }
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font: 10px sans-serif;
+        }
+      }
+
+      @page chapter {
+        background: #f4dc5d;
+
+        @top-center {
+          content: "chapter";
+          font: 10px sans-serif;
+          color: #000;
+        }
+
+        @bottom-center {
+          content: "chapter " counter(page);
+          font: 10px sans-serif;
+        }
+
+        @footnote {
+          border-top: 1px solid #444;
+          margin-top: 4px;
+          padding-top: 4px;
+        }
+      }
+
+      :root {
+        font: 16px/20px "Courier New", monospace;
+        widows: 1;
+        orphans: 1;
+        counter-reset: footnote;
+      }
+
+      body,
+      section,
+      div,
+      p {
+        margin: 0;
+        padding: 0;
+      }
+
+      .chapter {
+        page: chapter;
+      }
+
+      .filler {
+        height: 76px;
+      }
+
+      .footnote {
+        float: footnote;
+        counter-increment: footnote;
+        font: 12px/16px Georgia, serif;
+      }
+
+      .footnote::footnote-call,
+      .footnote::footnote-marker {
+        content: "[" counter(footnote) "]";
+        color: blue;
+        font-size: 10px;
+        vertical-align: super;
+      }
+
+      .next {
+        break-before: page;
+        font: 14px/20px sans-serif;
+        padding-top: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="chapter">
+      <div class="filler">
+        Every page in this section should stay yellow. The following paragraph
+        contains a footnote with the default auto policy.
+      </div>
+      <p>
+        This single paragraph starts on the first chapter page and should
+        continue on the next chapter page after the footnote reduces the space
+        available near the bottom of the page.<span class="footnote"
+          >This footnote is tall enough to consume the remaining page space and
+          force the surrounding chapter paragraph to continue on the following
+          page. Even when that continuation happens, the named page set on the
+          chapter section should remain active for the continued page.</span
+        > The continuation text after the call is intentionally long and kept in
+        the same paragraph so the next page begins in the middle of this named
+        page section rather than at a new element boundary. That next page must
+        still use the chapter named page and therefore keep the yellow
+        background instead of falling back to the default white page. The same
+        chapter paragraph keeps flowing with plain inline text only, without any
+        later in-flow element that could re-establish the named page by chance.
+        This makes the test sensitive to whether the page-start resolver can
+        recover the enclosing named-page ancestor from a continuation offset in
+        the middle of a paragraph. If the bug is present, the continuation page
+        turns white even though the section has not ended. If the bug is fixed,
+        every page produced by this chapter paragraph remains yellow until the
+        next section starts on its own default page.
+      </p>
+    </section>
+
+    <section class="next">
+      <p>This page should be white because it starts after the chapter ends.</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Recover the containing normal-flow element when a continuation page starts inside deferred text before the next in-flow element, and use `getPageStartPageType()` only as the last fallback when `currentPageType` is empty. This keeps `footnote-policy: auto` continuations inside a named-page section from falling back to the default `@page` while preserving existing named-page and page-group continuation behavior.

Add `footnotes/named-page-deferred-text.html` and register it in `file-list.js` to cover the regression with a dedicated repro case.

Closes #1991

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1991; the AI investigated the named-page continuation logic, implemented the fix, and added a regression test.
- The human author asked for clarifying inline comments explaining the fix's intent for future maintainers; the AI added them.
- The human author used `/draft-commit` and ran `/address-pr-comments` twice to work through reviewer feedback before merging.

</details>
