### PR TITLE
fix: Fix nested named page starts and `:nth()` page-group matching

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3656,7 +3656,9 @@ export class CascadeInstance {
       this.elementStack.push(element);
     }
 
-    // do not apply page rules
+    // Do not apply @page rules to element styles, but preserve the current
+    // page-type progression state for layout code that reuses this instance.
+    const savedCurrentPageType = this.currentPageType;
     this.currentPageType = null;
     this.currentElement = element;
     this.currentElementOffset = elementOffset;
@@ -3735,6 +3737,7 @@ export class CascadeInstance {
     }
     followingSiblingTypeCountsStack.push({});
     this.applyActions();
+    this.currentPageType = savedCurrentPageType;
 
     // Substitute var()
     this.applyVarFilter([this.currentStyle], styler, element);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3780,6 +3780,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 break;
               }
               if (!nodeContext.after) {
+                setBreakAtTheEdge(nodeContext.breakBefore);
+                suppressWeakerLeadingColumnBreaks(nodeContext);
+                consumeSatisfiedLeadingColumnBreak(nodeContext);
                 // Leading edge of non-empty block -> finished going through
                 // all starting edges of the box
                 if (needForcedBreak()) {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -945,6 +945,41 @@ export class StyleInstance
       : startElement;
   }
 
+  private getEffectiveFirstPageType(element: Element | null): string | null {
+    let currentElement = element;
+    let effectivePageType = currentElement
+      ? this.getPageGroupPageType(currentElement)
+      : null;
+    while (currentElement) {
+      const child = this.getFirstInFlowChildElement(currentElement);
+      if (!child) {
+        return effectivePageType;
+      }
+      const childPageType = this.getPageGroupPageType(child);
+      if (childPageType) {
+        effectivePageType = childPageType;
+      }
+      currentElement = child;
+    }
+    return effectivePageType;
+  }
+
+  private getEffectivePageGroupStartElement(startElement: Element): Element {
+    let effectiveStartElement = startElement;
+    let currentElement: Element | null = startElement;
+    while (currentElement) {
+      const child = this.getFirstInFlowChildElement(currentElement);
+      if (!child) {
+        return effectiveStartElement;
+      }
+      if (this.getPageGroupPageType(child)) {
+        effectiveStartElement = child;
+      }
+      currentElement = child;
+    }
+    return effectiveStartElement;
+  }
+
   /**
    * Resolve the page type for the first page by examining the first in-flow
    * element's CSS `page` property. This is needed because `currentPageType`
@@ -960,10 +995,7 @@ export class StyleInstance
    */
   private resolveFirstPageType(): string | null {
     const firstElement = this.getFirstDocumentFlowElement();
-    if (!firstElement) {
-      return null;
-    }
-    return this.getPageGroupPageType(firstElement);
+    return this.getEffectiveFirstPageType(firstElement);
   }
 
   private shouldStartPageGroup(
@@ -1045,14 +1077,21 @@ export class StyleInstance
       !isSpreadDeferredBlankPage;
 
     const pageStartOffset = this.getPageStartOffset(layoutPosition);
-    const startElement = this.getPageStartElement(
+    const rawStartElement = this.getPageStartElement(
       layoutPosition,
       pageStartOffset,
     );
 
-    if (!startElement) {
+    if (!rawStartElement) {
       return;
     }
+
+    const startElement =
+      this.getEffectivePageGroupStartElement(rawStartElement);
+    const effectivePageStartOffset =
+      startElement === rawStartElement
+        ? pageStartOffset
+        : this.xmldoc.getElementOffset(startElement);
 
     const startDocument = startElement.ownerDocument;
     const isNewPageGroupDocument =
@@ -1081,7 +1120,7 @@ export class StyleInstance
               this.shouldStartPageGroup(
                 currentElement,
                 pageType,
-                pageStartOffset,
+                effectivePageStartOffset,
               )))
         ) {
           pageIndex += 1;
@@ -2716,11 +2755,10 @@ export class StyleInstance
       page.pageType = pageStartPageType;
     }
     if (page.pageType == null) {
-      const fallbackPageType =
-        (page.isBlankPage
-          ? this.styler.cascade.previousPageType
-          : this.styler.cascade.currentPageType) ??
-        (cp.page === 1 ? this.resolveFirstPageType() : null);
+      const firstPageType = cp.page === 1 ? this.resolveFirstPageType() : null;
+      const fallbackPageType = page.isBlankPage
+        ? this.styler.cascade.previousPageType
+        : (firstPageType ?? this.styler.cascade.currentPageType);
       page.pageType = fallbackPageType;
       if (!page.pageType) {
         // Issue #1991: `currentPageType` can still be empty when a page starts

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -187,6 +187,123 @@ export class ViewFactory
     );
   }
 
+  private getExplicitPageType(
+    style: CssCascade.ElementStyle | null | undefined,
+  ): string | null {
+    const pageValue = style?.["page"] as CssCascade.CascadeValue;
+    if (!pageValue || Css.isDefaultingValue(pageValue.value)) {
+      return null;
+    }
+    const pageType = pageValue.evaluate(this.context, "page").toString();
+    return !pageType || pageType.toLowerCase() === "auto" ? null : pageType;
+  }
+
+  private isNormalFlowElement(element: Element): boolean {
+    const style = this.styler.getStyle(element, false);
+    const displayValue = (
+      style?.["display"] as CssCascade.CascadeValue
+    )?.evaluate(this.styler.context, "display");
+    const display =
+      displayValue && !Css.isDefaultingValue(displayValue)
+        ? (displayValue as Css.Ident)
+        : Css.ident.inline;
+    if (display === Css.ident.none) {
+      return false;
+    }
+    const positionValue = (
+      style?.["position"] as CssCascade.CascadeValue
+    )?.evaluate(this.styler.context, "position");
+    const position =
+      positionValue && !Css.isDefaultingValue(positionValue)
+        ? positionValue
+        : Css.ident.static;
+    if (
+      Display.isRunning(position) ||
+      Display.isAbsolutelyPositioned(position)
+    ) {
+      return false;
+    }
+    const floatValue = (style?.["float"] as CssCascade.CascadeValue)?.evaluate(
+      this.styler.context,
+      "float",
+    );
+    const float =
+      floatValue && !Css.isDefaultingValue(floatValue)
+        ? floatValue
+        : Css.ident.none;
+    return float === Css.ident.none;
+  }
+
+  private getFirstInFlowChildElement(root: Element): Element | null {
+    let child = root.firstChild;
+    while (child) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        if (!Vtree.canIgnore(child)) {
+          return null;
+        }
+        child = child.nextSibling;
+        continue;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) {
+        child = child.nextSibling;
+        continue;
+      }
+      const element = child as Element;
+      if (this.isNormalFlowElement(element)) {
+        return element;
+      }
+      child = child.nextSibling;
+    }
+    return null;
+  }
+
+  private getEffectiveStartPageType(
+    element: Element,
+    pageType: string | null,
+  ): string | null {
+    let effectivePageType = pageType;
+    let currentElement: Element | null = element;
+    while (currentElement) {
+      const child = this.getFirstInFlowChildElement(currentElement);
+      if (!child) {
+        return effectivePageType;
+      }
+      const childPageType = this.getExplicitPageType(
+        this.styler.getStyle(child, false),
+      );
+      if (childPageType) {
+        effectivePageType = childPageType;
+      }
+      currentElement = child;
+    }
+    return effectivePageType;
+  }
+
+  private syncTextNodePageTypeBoundary(nodeContext: Vtree.NodeContext): void {
+    if (
+      nodeContext.sourceNode.nodeType !== Node.TEXT_NODE ||
+      Vtree.canIgnore(nodeContext.sourceNode) ||
+      nodeContext.fragmentIndex !== 1
+    ) {
+      return;
+    }
+    const pageType = nodeContext.pageType;
+    if (this.styler.cascade.currentPageType === pageType) {
+      return;
+    }
+    if (!Break.isSpreadBreakValue(nodeContext.breakBefore)) {
+      nodeContext.breakBefore = Break.resolveEffectiveBreakValue(
+        nodeContext.breakBefore,
+        "page",
+      );
+    }
+    if (pageType !== this.styler.cascade.previousPageType) {
+      this.styler.cascade.previousPageType =
+        this.styler.cascade.currentPageType;
+    }
+    this.styler.cascade.currentPageType = pageType;
+  }
+
   private syncSemanticFootnoteCounterToTarget(element: Element): void {
     if (
       element.localName !== "a" ||
@@ -1402,8 +1519,11 @@ export class ViewFactory
         }
         // Named page type
         const pageVal: Css.Val = computedStyle["page"];
-        let pageType =
-          pageVal && !Css.isDefaultingValue(pageVal) && pageVal.toString();
+        const specifiedPageType =
+          pageVal && !Css.isDefaultingValue(pageVal)
+            ? pageVal.toString()
+            : null;
+        let pageType = specifiedPageType;
         if (
           !pageType &&
           !this.nodeContext.parent &&
@@ -1419,11 +1539,22 @@ export class ViewFactory
         } else {
           this.nodeContext.pageType = pageType;
         }
+        const hasExplicitPageType =
+          specifiedPageType != null &&
+          specifiedPageType.toLowerCase() !== "auto";
+        const effectivePageType = hasExplicitPageType
+          ? this.nodeContext.fragmentIndex === 1
+            ? this.getEffectiveStartPageType(element, pageType)
+            : (this.styler.cascade.currentPageType ?? pageType)
+          : pageType;
         if (
-          this.styler.cascade.currentPageType !== pageType &&
+          this.styler.cascade.currentPageType !== effectivePageType &&
           // Fixed positioned or running elements should not affect page type
           // unless page type is explicitly set
-          !(!pageType && computedStyle["position"] === Css.ident.fixed)
+          !(
+            !hasExplicitPageType &&
+            computedStyle["position"] === Css.ident.fixed
+          )
         ) {
           if (
             this.nodeContext.fragmentIndex === 1 &&
@@ -1432,11 +1563,11 @@ export class ViewFactory
             this.nodeContext.breakBefore = "page";
           }
           // Fix for issue #1309
-          if (pageType !== this.styler.cascade.previousPageType) {
+          if (effectivePageType !== this.styler.cascade.previousPageType) {
             this.styler.cascade.previousPageType =
               this.styler.cascade.currentPageType;
           }
-          this.styler.cascade.currentPageType = pageType;
+          this.styler.cascade.currentPageType = effectivePageType;
         }
       }
       this.nodeContext.captionSide =
@@ -2906,6 +3037,7 @@ export class ViewFactory
     if (!nodeContext || nodeContext.after) {
       return Task.newResult(nodeContext);
     }
+    this.syncTextNodePageTypeBoundary(nodeContext);
     const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("nextInTree");
     this.setCurrent(nodeContext, true, atUnforcedBreak).then(
       (processChildren) => {

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -665,6 +665,7 @@ export class NodeContext implements Vtree.NodeContext {
     this.fragmentIndex = 1;
     this.afterIfContinues = null;
     this.footnotePolicy = null;
+    this.pageType = this.parent ? this.parent.pageType : null;
   }
 
   private cloneItem(): NodeContext {
@@ -706,6 +707,7 @@ export class NodeContext implements Vtree.NodeContext {
     np.fragmentIndex = this.fragmentIndex;
     np.afterIfContinues = this.afterIfContinues;
     np.footnotePolicy = this.footnotePolicy;
+    np.pageType = this.pageType;
     return np;
   }
 

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -263,6 +263,10 @@ module.exports = [
         title: "target-counter() with :nth(1 of Page) (Issue #1990)",
       },
       {
+        file: "target-counter-nested-page-group-nth.html",
+        title: "target-counter() with nested :nth(1 of page type)",
+      },
+      {
         file: "target-counter-missing-page.html",
         title: "target-counter() missing page (Issue #1498)",
       },
@@ -517,6 +521,18 @@ module.exports = [
       {
         file: "named-pages/page-child-first-page.html",
         title: "Named Page on Child Element at Page Start",
+      },
+      {
+        file: "named-pages/page-name-propagation.html",
+        title: "Named page propagation (Issue #1998)",
+      },
+      {
+        file: "named-pages/page-rule-override-first-page.html",
+        title: "@page override on first page (Issue #2002)",
+      },
+      {
+        file: "nested-page-group-nth.html",
+        title: "Nested named page with :nth(1 of page type)",
       },
     ],
   },

--- a/packages/core/test/files/named-pages/page-name-propagation.html
+++ b/packages/core/test/files/named-pages/page-name-propagation.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1998: named page propagation should ignore wrapper-only page changes until content actually uses them -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Named page propagation</title>
+    <style>
+      @page {
+        size: 160mm 110mm;
+        margin: 16mm;
+        background: #f7f3ea;
+        @top-center {
+          content: "default";
+        }
+        @bottom-center {
+          content: "page " counter(page);
+        }
+      }
+
+      @page a {
+        background: #fff2a8;
+        @top-center {
+          content: "page a";
+        }
+      }
+
+      @page b {
+        background: #dbeafe;
+        @top-center {
+          content: "page b";
+        }
+      }
+
+      @page c {
+        background: #fecaca;
+        @top-center {
+          content: "page c";
+        }
+      }
+
+      @page d {
+        background: #dcfce7;
+        @top-center {
+          content: "page d";
+        }
+      }
+
+      @page e {
+        background: #e9d5ff;
+        @top-center {
+          content: "page e";
+        }
+      }
+
+      html,
+      body {
+        margin: 0;
+        font: 18px/1.45 sans-serif;
+      }
+
+      div {
+        border: 2px solid rgba(0, 0, 0, 0.5);
+        padding: 6px 10px;
+        margin: 0 0 6px;
+      }
+
+      p {
+        margin: 0;
+      }
+
+      .a {
+        page: a;
+      }
+
+      .b {
+        page: b;
+      }
+
+      .c {
+        page: c;
+      }
+
+      .d {
+        page: d;
+      }
+
+      .e {
+        page: e;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="a">
+      <p>a should share page a with b.</p>
+    </div>
+    <div class="b">
+      <div class="e">
+        <div class="a">
+          <p>
+            b should stay on page a because the first content inside the b and
+            e wrappers overrides them back to page a.
+          </p>
+        </div>
+      </div>
+      <div class="c">
+        <p>c should start page c.</p>
+      </div>
+    </div>
+    <div class="d">
+      <p>d should start page d.</p>
+    </div>
+  </body>
+</html>

--- a/packages/core/test/files/named-pages/page-rule-override-first-page.html
+++ b/packages/core/test/files/named-pages/page-rule-override-first-page.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2002: a specific first-page named page must override a more general body named page -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@page override on first page</title>
+    <style>
+      @page {
+        size: 160mm 110mm;
+        margin: 12mm;
+      }
+
+      @page body {
+        background: red;
+        @top-center {
+          content: "body page";
+        }
+      }
+
+      @page front-cover {
+        background: green;
+        @top-center {
+          content: "front-cover page";
+        }
+      }
+
+      body[data-page-name="body"] {
+        page: body;
+        margin: 0;
+        font: 18px/1.4 sans-serif;
+      }
+
+      #front-cover {
+        page: front-cover;
+        break-after: page;
+        min-height: 70mm;
+        padding: 6mm;
+      }
+
+      #content {
+        padding: 6mm;
+      }
+
+      p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body data-page-name="body">
+    <div id="front-cover">
+      <p>The first page should be green.</p>
+    </div>
+    <div id="content">
+      <p>The second page should be red.</p>
+    </div>
+  </body>
+</html>

--- a/packages/core/test/files/nested-page-group-nth.html
+++ b/packages/core/test/files/nested-page-group-nth.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!-- Test case for nested named page + :nth(1 of <page-type>) without target-counter() -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>nested page group nth</title>
+    <style>
+      @page {
+        size: 140mm 120mm;
+        margin: 14mm;
+
+        @top-center {
+          content: "default";
+          font-size: 10pt;
+        }
+      }
+
+      @page typical {
+        background: #f2d46b;
+
+        @top-center {
+          content: "typical";
+        }
+      }
+
+      @page chapterhead {
+        background: #7dcf88;
+
+        @top-center {
+          content: "chapterhead";
+        }
+      }
+
+      @page :nth(1 of chapterhead) {
+        background: #da5248;
+
+        @top-center {
+          content: "first of chapterhead";
+          color: white;
+          font-weight: bold;
+        }
+      }
+
+      body {
+        font-family: serif;
+        font-size: 12pt;
+        line-height: 1.5;
+      }
+
+      main {
+        page: typical;
+      }
+
+      .chapter {
+        page: chapterhead;
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="chapter">
+        <h1>Nested page type only</h1>
+        <p>This first page should match <code>:nth(1 of chapterhead)</code>.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/packages/core/test/files/target-counter-nested-page-group-nth.html
+++ b/packages/core/test/files/target-counter-nested-page-group-nth.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<!-- Test case for target-counter() + nested named page + :nth(1 of <page-type>) -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>target-counter nested page group nth</title>
+    <style>
+      @page {
+        size: 140mm 120mm;
+        margin: 14mm;
+
+        @top-center {
+          content: "default";
+          font-size: 10pt;
+        }
+
+        @bottom-center {
+          content: counter(page);
+          font-size: 10pt;
+        }
+      }
+
+      @page typical {
+        background: #f2d46b;
+
+        @top-center {
+          content: "typical";
+        }
+      }
+
+      @page chapterhead {
+        background: #7dcf88;
+
+        @top-center {
+          content: "chapterhead";
+        }
+      }
+
+      @page :nth(1 of chapterhead) {
+        background: #da5248;
+
+        @top-center {
+          content: "first of chapterhead";
+          color: white;
+          font-weight: bold;
+        }
+      }
+
+      body {
+        font-family: serif;
+        font-size: 12pt;
+        line-height: 1.5;
+      }
+
+      main {
+        page: typical;
+      }
+
+      .chapter {
+        page: chapterhead;
+        break-before: page;
+      }
+
+      .toc a::after {
+        content: leader(".") target-counter(attr(href), page);
+      }
+
+      .note {
+        font-weight: bold;
+      }
+
+      .filler {
+        margin: 0 0 1em;
+      }
+
+      .target {
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="chapter">
+        <h1>Nested page type + target-counter()</h1>
+        <p class="note">
+          This first page should stay red because it is
+          <code>:nth(1 of chapterhead)</code>.
+        </p>
+        <div class="toc">
+          <p><a href="#target">Target section</a></p>
+        </div>
+        <p>
+          The link above uses <code>target-counter()</code> and rerenders this
+          page after the target page number becomes known.
+        </p>
+        <p class="filler">
+          The named page on this chapter section is nested under
+          <code>&lt;main style="page: typical"&gt;</code>, so the first page
+          type must come from the child section instead of the wrapper.
+        </p>
+        <p class="filler">
+          If rerender rebuilds page-group indices or page-start state from the
+          wrong baseline, this first page can stop matching
+          <code>:nth(1 of chapterhead)</code> after the cross-reference
+          resolves.
+        </p>
+        <p class="filler">
+          Additional filler keeps the same chapter section spanning multiple
+          pages so the rerendered page must remain page 1 of the chapterhead
+          page group while later pages become page 2, page 3, and so on.
+        </p>
+        <p class="filler">
+          This exercises the same target-counter() rerender path as issue
+          #1990, but with the page type coming from a nested child instead of
+          the outer wrapper.
+        </p>
+        <p class="filler">
+          The first page should therefore keep the red
+          <code>:nth(1 of chapterhead)</code> style even after the target page
+          number is resolved and the page is re-laid out.
+        </p>
+        <p class="filler">
+          Later pages in this same chapter section should still belong to the
+          same chapterhead page group without resetting the index to 1.
+        </p>
+        <p class="filler">
+          More filler text keeps the content flowing long enough that the link
+          target appears on a later chapterhead page.
+        </p>
+        <p class="filler">
+          Re-rendering the first page must not inherit page-group counts from
+          pages that come after it, and it must not fall back to the wrapper's
+          <code>typical</code> page type.
+        </p>
+        <h2 id="target" class="target">Target section</h2>
+        <p>This later page provides the resolved page number.</p>
+        <p class="filler">
+          The chapter section continues with the same explicit page type so the
+          resolved target remains within the chapterhead page group.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Resolve the effective named page from the first in-flow child chain so a wrapper `page` value no longer masks nested child page types on the first page or at a page-group boundary. This keeps named-page propagation and first-page overrides aligned with the actual content that starts the page.

Preserve `currentPageType` during cascade reuse, carry `pageType` through node context cloning and reset, and honor leading-edge breaks for inline text so fragmentation and `target-counter()` rerenders keep the correct named page and `:nth(1 of <page-type>)` index.

Add retained local regression fixtures for issue #1998, issue #2002, and the nested `target-counter()` rerender variant, and register them in `file-list.js`.

Refs #1990
Closes #1998
Closes #2002

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1998; during investigation they identified a related `firstPageType` problem and the similar issue #2002, and directed the AI to fix them in a specified order within the same PR.
- The human author asked the AI to verify that the earlier named-page/`target-counter()` rerender fix from PR #1995 (issue #1990) still worked correctly with the new nested page-type handling.
- The human author asked the AI to curate the `file-list.js` test registrations, keeping the useful new cases and removing redundant ones.
- `/draft-commit` and two rounds of `/address-pr-comments` finalized the PR.

</details>
