### PR TITLE
fix: Fix `counter()` resolution in `@page` margin box content

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -19,6 +19,7 @@
  */
 import * as Asserts from "./asserts";
 import * as Base from "./base";
+import * as Css from "./css";
 import * as CssCascade from "./css-cascade";
 import * as CssProp from "./css-prop";
 import * as CssStyler from "./css-styler";
@@ -748,6 +749,9 @@ export class CounterStore {
   } = Object.create(null);
   currentPageCounters: CssCascade.CounterValues = Object.create(null);
   previousPageCounters: CssCascade.CounterValues = Object.create(null);
+  // Issue #1999: remember the page-counter base from before a page-local
+  // override so later pages can resume the inherited sequence.
+  pageCountersBeforeOverride: CssCascade.CounterValues = Object.create(null);
   currentPageCountersStack: CssCascade.CounterValues[] = [];
   pageIndicesById: {
     [key: string]: { spineIndex: number; pageIndex: number };
@@ -908,11 +912,15 @@ export class CounterStore {
     }
     const skipIncrement: { [key: string]: boolean } = Object.create(null);
     let resetMap: { [key: string]: number };
+    let resetIsNone = false;
     const reset = cascadedPageStyle["counter-reset"] as CssCascade.CascadeValue;
     if (reset) {
       const resetVal = reset.evaluate(context);
       if (resetVal) {
-        resetMap = CssProp.toCounters(resetVal, { reset: true });
+        resetIsNone = resetVal === Css.ident.none;
+        if (!resetIsNone) {
+          resetMap = CssProp.toCounters(resetVal, { reset: true });
+        }
       }
     }
     if (resetMap && "pages" in resetMap) {
@@ -976,6 +984,16 @@ export class CounterStore {
     // Start from previous page counters, then reconcile with document counters
     // so page-scoped and document-scoped counters stay consistent.
     const baseCounters = cloneCounterValues(this.previousPageCounters);
+    if (resetIsNone) {
+      // Issue #1999: clearing a page-local override must restore the
+      // pre-override page-counter base instead of leaking the previous page's
+      // overridden value into the next page.
+      for (const counterName in this.pageCountersBeforeOverride) {
+        baseCounters[counterName] = Array.from(
+          this.pageCountersBeforeOverride[counterName],
+        );
+      }
+    }
     if (this.currentPageDocCounters) {
       for (const counterName in this.currentPageDocCounters) {
         if (this.isPageControlledCounter(counterName)) {
@@ -991,6 +1009,13 @@ export class CounterStore {
               const counterValues = baseCounters[counterName];
               counterValues[counterValues.length - 1] += info.delta;
             }
+          } else if (!baseCounters[counterName]) {
+            // When a counter first becomes page-controlled, seed it from the
+            // inherited document state so the page's own increment starts from
+            // the current document value rather than from zero.
+            baseCounters[counterName] = Array.from(
+              this.currentPageDocCounters[counterName],
+            );
           }
           continue;
         }
@@ -1000,8 +1025,24 @@ export class CounterStore {
       }
     }
     this.currentPageCounters = baseCounters;
+    const countersBeforeOverride: CssCascade.CounterValues =
+      Object.create(null);
+    const rememberCounterBase = (counterName: string): void => {
+      if (
+        !Object.prototype.hasOwnProperty.call(
+          countersBeforeOverride,
+          counterName,
+        )
+      ) {
+        const counterValues = baseCounters[counterName];
+        if (counterValues) {
+          countersBeforeOverride[counterName] = Array.from(counterValues);
+        }
+      }
+    };
     if (resetMap) {
       for (const resetCounterName in resetMap) {
+        rememberCounterBase(resetCounterName);
         this.definePageCounter(resetCounterName, resetMap[resetCounterName]);
       }
     }
@@ -1020,6 +1061,7 @@ export class CounterStore {
       // Match the standard counter update order:
       // counter-reset -> counter-increment -> counter-set.
       for (const setCounterName in setMap) {
+        rememberCounterBase(setCounterName);
         if (!this.currentPageCounters[setCounterName]) {
           this.definePageCounter(setCounterName, setMap[setCounterName]);
         } else {
@@ -1027,6 +1069,11 @@ export class CounterStore {
           counterValues[counterValues.length - 1] = setMap[setCounterName];
         }
       }
+    }
+    for (const counterName in countersBeforeOverride) {
+      this.pageCountersBeforeOverride[counterName] = Array.from(
+        countersBeforeOverride[counterName],
+      );
     }
   }
 

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2258,6 +2258,35 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     )?.style?.pageScope;
   }
 
+  private hasLocalCounterResetOrSet(counterName: string): boolean {
+    return (
+      this.hasLocalCounter(counterName, "counter-reset", { reset: true }) ||
+      this.hasLocalCounter(counterName, "counter-set", { defaultValue: 0 })
+    );
+  }
+
+  private hasLocalCounterIncrement(counterName: string): boolean {
+    return this.hasLocalCounter(counterName, "counter-increment", {});
+  }
+
+  private hasLocalCounter(
+    counterName: string,
+    propName: "counter-reset" | "counter-set" | "counter-increment",
+    options: { reset?: boolean; defaultValue?: number },
+  ): boolean {
+    const currentStyle = this.cascade.currentStyle;
+    const cascVal = currentStyle?.[propName] as CascadeValue;
+    if (!cascVal) {
+      return false;
+    }
+    const value = cascVal.evaluate(this.cascade.context);
+    if (!value || Css.isDefaultingValue(value)) {
+      return false;
+    }
+    const counters = CssProp.toCounters(value, options);
+    return Object.prototype.hasOwnProperty.call(counters, counterName);
+  }
+
   /**
    * Helper method to evaluate CSS values containing counter() and other functions,
    * then convert to string.
@@ -2345,6 +2374,8 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     type: string,
     cascadeDocCounters: number[],
     separator?: string,
+    localCounterResetOrSet: boolean = false,
+    localCounterIncrement: boolean = false,
   ): string {
     const isList = typeof separator === "string";
     const formatCounterValues = (values: number[]): string => {
@@ -2356,6 +2387,11 @@ export class ContentPropVisitor extends Css.FilterVisitor {
       if (this.pseudoName === "footnote-call" && this.element) {
         setFootnoteCounterValues(this.element, counterName, values);
       }
+    };
+    const counterValuesEqual = (a: number[], b: number[]): boolean => {
+      return (
+        a.length === b.length && a.every((value, index) => value === b[index])
+      );
     };
     if (this.pseudoName === "footnote-call" && this.element) {
       const storedDuplicateSemanticFootnoteCounter =
@@ -2377,17 +2413,52 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     }
 
     if (!this.element) {
-      const pageCounters = store.currentPageCounters?.[counterName] || [];
-      if (pageCounters.length) {
-        counterValues = pageCounters;
+      // Issue #1999: a page or margin-box local reset/set shadows the page
+      // counter state while resolving this generated content.
+      if (localCounterResetOrSet && cascadeDocCounters.length) {
+        counterValues = cascadeDocCounters;
         storeFootnoteCounterValuesIfNeeded(counterValues);
         return formatCounterValues(counterValues);
       }
+      if (
+        store.isPageControlledCounter?.(counterName) &&
+        localCounterIncrement &&
+        cascadeDocCounters.length
+      ) {
+        // Issue #1999: increment-only inside page/margin-box content is a
+        // delta from the page-start counter value, not a fresh local counter.
+        const pageCounters = store.currentPageCounters?.[counterName] || [];
+        const pageStartVal = pageCounters.length
+          ? pageCounters[pageCounters.length - 1]
+          : 0;
+        counterValues = [
+          pageStartVal + cascadeDocCounters[cascadeDocCounters.length - 1],
+        ];
+        storeFootnoteCounterValuesIfNeeded(counterValues);
+        return formatCounterValues(counterValues);
+      }
+      if (!store.isPageControlledCounter?.(counterName)) {
+        const pageCounters = store.currentPageCounters?.[counterName] || [];
+        if (pageCounters.length) {
+          counterValues = pageCounters;
+          storeFootnoteCounterValuesIfNeeded(counterValues);
+          return formatCounterValues(counterValues);
+        }
+      }
     }
 
+    const pageDocCounters = store.currentPageDocCounters?.[counterName] || [];
+    const useLocalPageCounters =
+      !this.element &&
+      cascadeDocCounters.length &&
+      !counterValuesEqual(cascadeDocCounters, pageDocCounters);
     const docCounters = this.element
       ? cascadeDocCounters
-      : store.currentPageDocCounters?.[counterName] || cascadeDocCounters;
+      : useLocalPageCounters
+        ? cascadeDocCounters
+        : pageDocCounters.length
+          ? pageDocCounters
+          : cascadeDocCounters;
 
     if (store.isPageControlledCounter?.(counterName)) {
       const docStartCounters =
@@ -2430,6 +2501,10 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     const cascadeDocCounters = (
       this.cascade.counters[counterName] || []
     ).slice();
+    const localCounterResetOrSet =
+      !this.element && this.hasLocalCounterResetOrSet(counterName);
+    const localCounterIncrement =
+      !this.element && this.hasLocalCounterIncrement(counterName);
     // When a counter store is available, return a native expression so
     // page/document counters resolve at layout time.
     const counterStore = this.getCounterStore();
@@ -2446,6 +2521,9 @@ export class ContentPropVisitor extends Css.FilterVisitor {
             counterName,
             type,
             cascadeDocCounters,
+            undefined,
+            localCounterResetOrSet,
+            localCounterIncrement,
           ),
         isPageCounter
           ? `page-counter-${counterName}`
@@ -2482,6 +2560,10 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     const cascadeDocCounters = (
       this.cascade.counters[counterName] || []
     ).slice();
+    const localCounterResetOrSet =
+      !this.element && this.hasLocalCounterResetOrSet(counterName);
+    const localCounterIncrement =
+      !this.element && this.hasLocalCounterIncrement(counterName);
     const counterStore = this.getCounterStore();
     if (counterStore) {
       const isPageCounter =
@@ -2497,6 +2579,8 @@ export class ContentPropVisitor extends Css.FilterVisitor {
             type,
             cascadeDocCounters,
             separator,
+            localCounterResetOrSet,
+            localCounterIncrement,
           ),
         isPageCounter
           ? `page-counters-${counterName}`
@@ -3404,12 +3488,12 @@ export class CascadeInstance {
     }
     // Ignore counter-* on 'display: none' elements and their descendants
     if (displayVal === Css.ident.none) {
-      this.currentElement.setAttribute("data-viv-display-none", "true");
+      this.currentElement?.setAttribute("data-viv-display-none", "true");
       this.lastCounterChanges = [];
       this.lastCounterChangeTypes = Object.create(null);
       this.counterScoping.push(null);
       return;
-    } else if (this.currentElement.closest("[data-viv-display-none]")) {
+    } else if (this.currentElement?.closest("[data-viv-display-none]")) {
       this.lastCounterChanges = [];
       this.lastCounterChangeTypes = Object.create(null);
       this.counterScoping.push(null);

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -747,13 +747,21 @@ export class StyleInstance
     const searchRootOffset = searchRoot
       ? this.xmldoc.getElementOffset(searchRoot)
       : pageStartOffset;
-    // Document start: page starts at or before the body/root element offset.
+    // Issue #1999: on the first page, @page counters must start from the
+    // body/root snapshot instead of treating document start as a synthetic
+    // page-boundary counter change.
     const isDocumentStart = pageStartOffset <= searchRootOffset;
     const resolvedStartElement =
       startElement === searchRoot && isDocumentStart
         ? this.getFirstInFlowChildElement(searchRoot)
         : startElement;
     if (!resolvedStartElement) {
+      if (isDocumentStart) {
+        return {
+          counterOffset: searchRootOffset,
+          changeOffset: searchRootOffset,
+        };
+      }
       return { counterOffset: pageStartOffset, changeOffset: pageStartOffset };
     }
     const changeOffset = this.xmldoc.getElementOffset(resolvedStartElement);

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1677,6 +1677,15 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
     cascade.pushRule(this.pageBox.classes, null, style);
     const content = style["content"] as CssCascade.CascadeValue;
     if (content) {
+      const savedLastCounterChanges = Array.from(cascade.lastCounterChanges);
+      const savedLastCounterChangeTypes = {
+        ...cascade.lastCounterChangeTypes,
+      };
+      // Issue #1999: isolate temporary counter scoping while capturing
+      // page/margin-box content so sibling margin boxes do not inherit each
+      // other's local counter operations.
+      cascade.counterScoping.push(null);
+      cascade.pushCounters(style);
       style["content"] = content.filterValue(
         new CssCascade.ContentPropVisitor(
           cascade,
@@ -1684,6 +1693,10 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
           cascade.counterResolver,
         ),
       );
+      cascade.popCounters();
+      cascade.popCounters();
+      cascade.lastCounterChanges = savedLastCounterChanges;
+      cascade.lastCounterChangeTypes = savedLastCounterChangeTypes;
     }
     this.init(cascade.context);
     for (const child of this.pageBox.children) {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1258,7 +1258,17 @@ export class ViewFactory
       return frame.result();
     }
     const isRoot = this.nodeContext.parent == null;
-    this.nodeContext.flexContainer = display === Css.ident.flex;
+    const blockSize =
+      computedStyle[this.nodeContext.vertical ? "width" : "height"];
+    // Issue #1999: fixed-size grid boxes used as synthetic page references
+    // must stay whole. Once fragmented, continuation fragments lose the block
+    // size and later reference pages collapse.
+    const isFixedSizeGridContainer =
+      (display === Css.ident.grid || display === Css.ident.inline_grid) &&
+      !!blockSize &&
+      !(blockSize === Css.ident.auto || Css.isDefaultingValue(blockSize));
+    this.nodeContext.flexContainer =
+      display === Css.ident.flex || isFixedSizeGridContainer;
     this.createShadows(
       element,
       isRoot,


### PR DESCRIPTION
Use the body/root snapshot at document start when initializing page counters, preserve the pre-override page counter base across `counter-reset: none`, and seed newly page-controlled counters from inherited document state. This keeps page-scoped counters stable across the `content-010` to `content-012` WPT cases.

- https://wpt.live/css/css-page/margin-boxes/content-010-print.html
- https://wpt.live/css/css-page/margin-boxes/content-011-print.html
- https://wpt.live/css/css-page/margin-boxes/content-012-print.html

Resolve page and margin-box `counter-reset`, `counter-set`, and increment-only operations in local generated-content scope, isolate sibling margin boxes while filtering `content`, and keep fixed-size grid reference pages unfragmented so later reference pages do not lose their block size.

Closes #1999

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/fix-wpt-reftest-failure` to investigate the `content-010`–`content-012` WPT failures; the AI traced the root cause to page counters being initialized incorrectly and implemented the fix.
- The human author asked for clarifying inline comments explaining the fix's intent for issue #1999; the AI added them.
- `/draft-commit` and `/address-pr-comments` finalized the PR after reviewer feedback.

</details>
