### PR TITLE
fix: Fix `outline-offset` handling in `@page` rules

### DIFF
--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -656,6 +656,7 @@ export const propertiesAppliedToPartition = (() => {
     "outline-width": true,
     "outline-style": true,
     "outline-color": true,
+    "outline-offset": true,
     "border-radius": true,
     "border-top-left-radius": true,
     "border-top-right-radius": true,

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1744,6 +1744,7 @@ export const passPreProperties = [
   "outline-style",
   "outline-color",
   "outline-width",
+  "outline-offset",
   "overflow",
   "visibility",
 ];

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -80,6 +80,10 @@ module.exports = [
         title: "Unbreakable box at the end of a flow",
       },
       { file: "outline.html", title: "Outline" },
+      {
+        file: "outline-offset-at-page.html",
+        title: "outline-offset on @page (Issue #2000)",
+      },
       { file: "font-feature-settings.html", title: "Font feature settings" },
       {
         file: "font-variation-settings.html",

--- a/packages/core/test/files/outline-offset-at-page.html
+++ b/packages/core/test/files/outline-offset-at-page.html
@@ -1,0 +1,34 @@
+<!-- Test case for Issue #2000: outline-offset at @page not working -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>outline-offset on @page</title>
+    <style>
+      @page {
+        size: 160mm 110mm;
+        margin: 18mm;
+        border: 4mm solid #d96b00;
+        outline: 6mm solid #1f9d43;
+        outline-offset: 12mm;
+      }
+
+      html,
+      body {
+        margin: 0;
+        font: 16px/1.5 serif;
+      }
+
+      body {
+        color: #222;
+      }
+
+      p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <p>There should be a green outline aligned with the page edge.</p>
+  </body>
+</html>


### PR DESCRIPTION
Add `outline-offset` to `propertiesAppliedToPartition` so the value is copied from the `@page` style to the page partition, and include it in `passPreProperties` so the rendered page element receives the browser `outline-offset` style alongside the other outline longhands.

Add `packages/core/test/files/outline-offset-at-page.html` and register it in `file-list.js` to cover the page-edge alignment case for `outline-offset` on `@page`.

Closes #2000

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2000; the AI implemented the fix and added a regression test.
- While verifying, the human author tested a negative `outline-offset` value and reported that it did not produce the expected inset from the page edge; the AI investigated this additional edge case as part of verification.
- `/draft-commit` finalized the PR after human review.

</details>
