### PR TITLE
fix: Fix `footnote-policy: line` page breaks

### DIFF
--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -20,6 +20,7 @@
 import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as Css from "./css";
+import * as LayoutHelper from "./layout-helper";
 import * as PageFloats from "./page-floats";
 import * as SemanticFootnote from "./semantic-footnote";
 import * as Task from "./task";
@@ -27,6 +28,7 @@ import * as Vtree from "./vtree";
 import { Layout } from "./types";
 
 const PageFloatFragment = PageFloats.PageFloatFragment;
+const LINE_POLICY_EDGE_EPSILON = 0.1;
 
 export class Footnote extends PageFloats.PageFloat {
   constructor(
@@ -69,6 +71,163 @@ function getLinePolicyConstraintNode(anchorNode: Node): Node {
   return anchorNode;
 }
 
+// These helpers intentionally work from live DOM nodes only. The line-policy
+// constraint runs after layout has produced view nodes, but it does not have a
+// Layout.Column/clientLayout available, so LayoutHelper.calculateEdge() cannot
+// be reused directly here.
+
+function getBlockDir(vertical: boolean): number {
+  return vertical ? -1 : 1;
+}
+
+function getBlockStartEdge(rect: Vtree.ClientRect, vertical: boolean): number {
+  return vertical ? rect.right : rect.top;
+}
+
+function getBlockEndEdge(rect: Vtree.ClientRect, vertical: boolean): number {
+  return vertical ? rect.left : rect.bottom;
+}
+
+function toMutableClientRect(rect: {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}): Vtree.ClientRect {
+  return {
+    left: rect.left,
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    width: rect.width,
+    height: rect.height,
+  } as Vtree.ClientRect;
+}
+
+function getAdjustedElementRect(
+  element: Element,
+  vertical: boolean,
+): Vtree.ClientRect | null {
+  const rect = toMutableClientRect(element.getBoundingClientRect());
+  LayoutHelper.adjustRectForColumnBreaking(rect, vertical);
+  if (rect.right < rect.left || rect.bottom < rect.top) {
+    return null;
+  }
+  return rect;
+}
+
+function getAdjustedNonEmptyRects(
+  rects: ArrayLike<{
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+  }>,
+  vertical: boolean,
+): Vtree.ClientRect[] {
+  const adjustedRects = Array.from(rects, toMutableClientRect);
+  LayoutHelper.adjustRectsForColumnBreaking(adjustedRects, vertical);
+  return adjustedRects.filter(
+    (rect) => rect.right > rect.left && rect.bottom > rect.top,
+  );
+}
+
+function getBlockEndEdgeFromRects(
+  rects: Vtree.ClientRect[],
+  vertical: boolean,
+): number {
+  if (!rects.length) {
+    return NaN;
+  }
+  return vertical
+    ? Math.min(...rects.map((rect) => rect.left))
+    : Math.max(...rects.map((rect) => rect.bottom));
+}
+
+function getFirstBlockEndEdgeFromRects(
+  rects: Vtree.ClientRect[],
+  vertical: boolean,
+): number {
+  if (!rects.length) {
+    return NaN;
+  }
+  const blockDir = getBlockDir(vertical);
+  const firstRect = rects.reduce((first, rect) =>
+    getBlockStartEdge(rect, vertical) * blockDir <
+    getBlockStartEdge(first, vertical) * blockDir
+      ? rect
+      : first,
+  );
+  return getBlockEndEdge(firstRect, vertical);
+}
+
+function getBlockEndEdgeFromViewNode(
+  viewNode: Node | null,
+  vertical: boolean,
+): number {
+  if (!viewNode) {
+    return NaN;
+  }
+  if (viewNode.nodeType === Node.ELEMENT_NODE) {
+    const rect = getAdjustedElementRect(viewNode as Element, vertical);
+    return rect ? getBlockEndEdge(rect, vertical) : NaN;
+  }
+  const text = viewNode.textContent || "";
+  if (!text.length) {
+    return NaN;
+  }
+  const range = viewNode.ownerDocument.createRange();
+  range.setStart(viewNode, 0);
+  range.setEnd(viewNode, text.length);
+  const rects = getAdjustedNonEmptyRects(range.getClientRects(), vertical);
+  return getBlockEndEdgeFromRects(rects, vertical);
+}
+
+function getNodeContextEdge(
+  nodeContext: Vtree.NodeContext,
+  vertical: boolean,
+): number {
+  const node = nodeContext.viewNode;
+  if (!node) {
+    return NaN;
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const element = node as Element;
+    if (nodeContext.after || !nodeContext.inline) {
+      const rect = getAdjustedElementRect(element, vertical);
+      if (rect) {
+        if (nodeContext.after) {
+          return getBlockEndEdge(rect, vertical);
+        }
+        return getBlockStartEdge(rect, vertical);
+      }
+    }
+    const rects = getAdjustedNonEmptyRects(element.getClientRects(), vertical);
+    // Leading edges of inline elements need the current line's block-end edge,
+    // not the element's union rect, otherwise line-policy geometry never fires
+    // for inline content and falls back to node-position equality.
+    return getFirstBlockEndEdgeFromRects(rects, vertical);
+  }
+  const text = node.textContent || "";
+  if (!text.length) {
+    return NaN;
+  }
+  let offset = nodeContext.offsetInNode;
+  if (nodeContext.after) {
+    offset += text.length;
+  }
+  offset = Math.max(0, Math.min(offset, text.length - 1));
+  const range = node.ownerDocument.createRange();
+  range.setStart(node, offset);
+  range.setEnd(node, offset + 1);
+  const rects = getAdjustedNonEmptyRects(range.getClientRects(), vertical);
+  return getBlockEndEdgeFromRects(rects, vertical);
+}
+
 /**
  * @extends PageFloatFragment
  */
@@ -98,19 +257,34 @@ export class FootnoteFragment extends PageFloatFragment {
 export class LineFootnotePolicyLayoutConstraint
   implements Layout.LayoutConstraint
 {
-  constructor(public readonly footnote: Footnote) {}
+  private readonly anchorEdge: number;
+
+  constructor(
+    public readonly footnote: Footnote,
+    anchorViewNode: Node | null,
+    private readonly vertical: boolean,
+  ) {
+    // Capture the rendered anchor line when the footnote becomes constrained.
+    // Using live DOM geometry keeps footnote-policy: line tied to the line that
+    // owns the call instead of falling back to whole-paragraph ancestry.
+    this.anchorEdge = getBlockEndEdgeFromViewNode(anchorViewNode, vertical);
+  }
 
   allowLayout(nodeContext: Vtree.NodeContext): boolean {
-    let sourceNode: Node | null = nodeContext.shadowContext
-      ? nodeContext.shadowContext.owner
-      : nodeContext.sourceNode;
-    while (sourceNode) {
-      if (sourceNode === this.footnote.policyAnchorNode) {
-        return false;
+    if (!isNaN(this.anchorEdge)) {
+      const edge = getNodeContextEdge(nodeContext, this.vertical);
+      if (!isNaN(edge)) {
+        // Normalize both values to block-progression order so vertical-rl uses
+        // the same "before the anchor line" comparison as horizontal-tb.
+        const blockDir = getBlockDir(this.vertical);
+        return (
+          edge * blockDir <
+          this.anchorEdge * blockDir - LINE_POLICY_EDGE_EPSILON
+        );
       }
-      sourceNode = sourceNode.parentNode;
     }
-    return true;
+    const nodePosition = nodeContext.toNodePosition();
+    return !Vtree.isSameNodePosition(nodePosition, this.footnote.nodePosition);
   }
 }
 
@@ -164,6 +338,9 @@ export class FootnoteLayoutStrategy
     ) {
       policyAnchorNode = shadowOwner;
     }
+    // Keep the broader source anchor for layoutPageFloat() edge recovery.
+    // The line-policy constraint itself is narrowed later by the rendered
+    // anchor view node captured in forbid().
     policyAnchorNode = getLinePolicyConstraintNode(policyAnchorNode);
     const float: PageFloats.PageFloat = new Footnote(
       nodePosition,
@@ -308,7 +485,15 @@ export class FootnoteLayoutStrategy
     const footnote = float as Footnote;
     switch (footnote.footnotePolicy) {
       case Css.ident.line: {
-        const constraint = new LineFootnotePolicyLayoutConstraint(footnote);
+        const anchors = pageFloatLayoutContext.collectPageFloatAnchors();
+        const anchorViewNode = anchors[footnote.getId()] || null;
+        // Reuse the rendered anchor view node collected during layout so the
+        // constraint can stop exactly at the current anchor line.
+        const constraint = new LineFootnotePolicyLayoutConstraint(
+          footnote,
+          anchorViewNode,
+          pageFloatLayoutContext.getContainer(footnote.floatReference).vertical,
+        );
         pageFloatLayoutContext.addLayoutConstraint(
           constraint,
           footnote.floatReference,

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -678,13 +678,32 @@ export class PageFloatLayoutContext
     );
   }
 
+  private findPageFloatAnchor(floatId: PageFloatID): Node | null {
+    // Match collectPageFloatAnchors(): descendant registrations override
+    // anchors recorded on ancestor contexts.
+    for (let i = this.children.length - 1; i >= 0; i--) {
+      const anchorViewNode = this.children[i].findPageFloatAnchor(floatId);
+      if (anchorViewNode) {
+        return anchorViewNode;
+      }
+    }
+    return this.floatAnchors[floatId] ?? null;
+  }
+
+  hasCurrentAnchor(floatId: PageFloatID) {
+    const anchorViewNode = this.findPageFloatAnchor(floatId);
+    if (!anchorViewNode) {
+      return false;
+    }
+    return !!this.container?.element?.contains(anchorViewNode);
+  }
+
   isAnchorAlreadyAppeared(floatId: PageFloatID) {
     const deferredFloats = this.getDeferredPageFloatContinuations();
     if (deferredFloats.some((cont) => cont.float.getId() === floatId)) {
       return true;
     }
-    const floatAnchors = this.collectPageFloatAnchors();
-    const anchorViewNode = floatAnchors[floatId];
+    const anchorViewNode = this.findPageFloatAnchor(floatId);
     if (!anchorViewNode) {
       return false;
     }
@@ -975,7 +994,7 @@ export class PageFloatLayoutContext
         this.floatReference === FloatReference.PAGE &&
         "footnotePolicy" in float &&
         float.footnotePolicy === Css.ident.line &&
-        this.footnoteAnchorsSeen.has(float.getId()) &&
+        this.hasCurrentAnchor(float.getId()) &&
         !existingFragment
       ) {
         // Once the anchor line has already appeared on the page, a deferred

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -1006,6 +1006,15 @@ module.exports = [
         title: "footnote-policy: line fragmentation (Issue #1899)",
       },
       {
+        file: "footnotes/footnote-policy-line-break.html",
+        title: "footnote-policy: line break before anchor line (Issue #2006)",
+      },
+      {
+        file: "footnotes/footnote-policy-line-break-vertical.html",
+        title:
+          "footnote-policy: line break before anchor line (vertical writing-mode) (Issue #2006)",
+      },
+      {
         file: "footnotes/named-page-deferred-text.html",
         title: "Named page with deferred text after footnote (Issue #1991)",
       },

--- a/packages/core/test/files/footnotes/footnote-policy-line-break-vertical.html
+++ b/packages/core/test/files/footnotes/footnote-policy-line-break-vertical.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2006: footnote-policy: line should break before the anchor line, not before the whole paragraph (vertical writing-mode) -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>footnote-policy: line break (vertical writing-mode)</title>
+    <style>
+      @page {
+        size: 260px 320px;
+        margin: 20px;
+
+        @bottom-center {
+          writing-mode: horizontal-tb;
+          content: "Page " counter(page);
+          font-size: 11px;
+        }
+
+        @footnote {
+          border-block-start: 1px solid black;
+          margin-block-start: 4px;
+          padding-block-start: 2px;
+        }
+      }
+
+      :root {
+        writing-mode: vertical-rl;
+        font-family: Menlo, Monaco, "Courier New", monospace;
+        widows: 1;
+        orphans: 1;
+      }
+
+      body,
+      p {
+        margin: 0;
+      }
+
+      .spacer {
+        block-size: 120px;
+        background: #f3f3f3;
+      }
+
+      .story {
+        inline-size: 220px;
+        font-size: 0;
+      }
+
+      .line {
+        display: inline-block;
+        inline-size: 100%;
+        font-size: 18px;
+        line-height: 22px;
+        white-space: nowrap;
+      }
+
+      .footnote {
+        float: footnote;
+        font-size: 14px;
+        line-height: 18px;
+        white-space: normal;
+      }
+
+      .footnote::footnote-call,
+      .footnote::footnote-marker {
+        content: counter(footnote);
+        color: blue;
+        font-size: 10px;
+        vertical-align: super;
+      }
+
+      .policy-line {
+        footnote-policy: line;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacer"></div>
+    <p class="story">
+      <span class="line">Line 1 remains.</span>
+      <span class="line">Line 2 remains.</span>
+      <span class="line">Line 3 remains.</span>
+      <span class="line"
+        >Line 4 has note<span class="footnote policy-line"
+          >This footnote wraps across three lines in the footnote area to force
+          a line-policy break.</span
+        > and moves.</span
+      >
+      <span class="line">Line 5 follows.</span>
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/footnotes/footnote-policy-line-break.html
+++ b/packages/core/test/files/footnotes/footnote-policy-line-break.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2006: footnote-policy: line should break before the anchor line, not before the whole paragraph -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>footnote-policy: line break</title>
+    <style>
+      @page {
+        size: 320px 260px;
+        margin: 20px;
+
+        @bottom-center {
+          content: "Page " counter(page);
+          font-size: 11px;
+        }
+
+        @footnote {
+          border-top: 1px solid black;
+          margin-top: 4px;
+          padding-top: 2px;
+        }
+      }
+
+      :root {
+        font-family: Menlo, Monaco, "Courier New", monospace;
+        widows: 1;
+        orphans: 1;
+      }
+
+      body,
+      p {
+        margin: 0;
+      }
+
+      .spacer {
+        height: 120px;
+        background: #f3f3f3;
+      }
+
+      .story {
+        width: 220px;
+        font-size: 0;
+      }
+
+      .line {
+        display: inline-block;
+        width: 100%;
+        font-size: 18px;
+        line-height: 22px;
+        white-space: nowrap;
+      }
+
+      .footnote {
+        float: footnote;
+        font-size: 14px;
+        line-height: 18px;
+        white-space: normal;
+      }
+
+      .footnote::footnote-call,
+      .footnote::footnote-marker {
+        content: counter(footnote);
+        color: blue;
+        font-size: 10px;
+        vertical-align: super;
+      }
+
+      .policy-line {
+        footnote-policy: line;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacer"></div>
+    <p class="story">
+      <span class="line">Line 1 remains.</span>
+      <span class="line">Line 2 remains.</span>
+      <span class="line">Line 3 remains.</span>
+      <span class="line"
+        >Line 4 has note<span class="footnote policy-line"
+          >This footnote wraps across three lines in the footnote area to force
+          a line-policy break.</span
+        > and moves.</span
+      >
+      <span class="line">Line 5 follows.</span>
+    </p>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/page-floats-spec.js
+++ b/packages/core/test/spec/vivliostyle/page-floats-spec.js
@@ -1105,6 +1105,55 @@ describe("page-floats", function () {
       });
     });
 
+    describe("#hasCurrentAnchor", function () {
+      it("prefers the descendant anchor over an ancestor anchor for the same float", function () {
+        var container = {
+          element: {
+            contains: jasmine.createSpy("contains"),
+          },
+        };
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          container,
+          "foo",
+          null,
+          null,
+          null,
+        );
+        var columnContext = new PageFloatLayoutContext(
+          pageContext,
+          FloatReference.COLUMN,
+          null,
+          "foo",
+          null,
+          null,
+          null,
+        );
+        var float = new PageFloat(
+          dummyNodePosition(),
+          FloatReference.COLUMN,
+          "block-start",
+          null,
+          "foo",
+        );
+        var staleAnchorViewNode = {};
+        var currentAnchorViewNode = {};
+
+        columnContext.addPageFloat(float);
+        container.element.contains.and.callFake(function (node) {
+          return node === staleAnchorViewNode;
+        });
+        pageContext.registerPageFloatAnchor(float, staleAnchorViewNode);
+        columnContext.registerPageFloatAnchor(float, currentAnchorViewNode);
+
+        expect(pageContext.hasCurrentAnchor(float.getId())).toBe(false);
+        expect(container.element.contains).toHaveBeenCalledWith(
+          currentAnchorViewNode,
+        );
+      });
+    });
+
     describe("#deferPageFloat", function () {
       var pageContext, regionContext, columnContext, float;
       beforeEach(function () {
@@ -1498,7 +1547,38 @@ describe("page-floats", function () {
         expect(context.floatsDeferredToNext).toEqual([cont3, cont4]);
       });
 
-      it("forbids deferred line-policy footnotes on page contexts after the anchor appeared", function () {
+      it("forbids deferred line-policy footnotes on page contexts while the anchor is present", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        spyOn(pageContext, "invalidate").and.callThrough();
+        var float = new PageFloat(
+          dummyNodePosition(),
+          FloatReference.PAGE,
+          "block-end",
+          null,
+          "body",
+        );
+        float.footnotePolicy = adapt_css.ident.line;
+        pageContext.addPageFloat(float);
+        var continuation = new PageFloatContinuation(float, {});
+        pageContext.floatsDeferredToNext = [continuation];
+        spyOn(pageContext, "hasCurrentAnchor").and.returnValue(true);
+
+        pageContext.finish();
+
+        expect(pageContext.isForbidden(float)).toBe(true);
+        expect(pageContext.floatsDeferredToNext).toEqual([]);
+        expect(pageContext.invalidate).toHaveBeenCalled();
+      });
+
+      it("does not forbid deferred line-policy footnotes on page contexts when the anchor moved off the page on retry", function () {
         var pageContext = new PageFloatLayoutContext(
           rootContext,
           FloatReference.PAGE,
@@ -1521,12 +1601,13 @@ describe("page-floats", function () {
         var continuation = new PageFloatContinuation(float, {});
         pageContext.floatsDeferredToNext = [continuation];
         pageContext.footnoteAnchorsSeen.add(float.getId());
+        spyOn(pageContext, "hasCurrentAnchor").and.returnValue(false);
 
         pageContext.finish();
 
-        expect(pageContext.isForbidden(float)).toBe(true);
+        expect(pageContext.isForbidden(float)).toBe(false);
         expect(pageContext.floatsDeferredToNext).toEqual([]);
-        expect(pageContext.invalidate).toHaveBeenCalled();
+        expect(pageContext.invalidate).not.toHaveBeenCalled();
       });
 
       it("does not forbid deferred line-policy footnotes on region contexts", function () {


### PR DESCRIPTION
Rework the `footnote-policy: line` constraint to use the rendered anchor line geometry instead of paragraph-level DOM ancestry, so the break occurs before the line that owns the footnote call rather than before the whole paragraph.

Normalize the comparison in block-progression order so vertical writing modes do not invert the constraint and trigger runaway pagination, and only re-forbid deferred page-level footnotes when their anchor is still present in the live DOM after re-layout.

Add horizontal and vertical regression files for Issue #2006 and update the `page-floats` spec coverage for the current-anchor and retry cases.

Closes #2006

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2006; the AI reworked the `footnote-policy: line` break logic to use rendered anchor line geometry.
- The human author adjusted the regression test case, then discovered a vertical-writing-mode infinite-pagination bug while testing; the AI diagnosed and fixed the block-progression-order comparison that caused it.
- The human author asked the AI to review the new code for redundancy against existing logic and refactor where appropriate.
- `/draft-commit` and two rounds of `/address-pr-comments` finalized the PR.

</details>
