### PR TITLE
fix: Fix named page boundaries for inline content

### DIFF
--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -753,7 +753,7 @@ export class StyleInstance
     const isDocumentStart = pageStartOffset <= searchRootOffset;
     const resolvedStartElement =
       startElement === searchRoot && isDocumentStart
-        ? this.getFirstInFlowChildElement(searchRoot)
+        ? (this.getFirstInFlowChildElement(searchRoot) ?? startElement)
         : startElement;
     if (!resolvedStartElement) {
       if (isDocumentStart) {
@@ -800,7 +800,7 @@ export class StyleInstance
     const searchRootOffset = this.xmldoc.getElementOffset(searchRoot);
     const isDocumentStart = pageStartOffset <= searchRootOffset;
     if (startElement === searchRoot && isDocumentStart) {
-      return this.getFirstInFlowChildElement(searchRoot);
+      return this.getFirstInFlowChildElement(searchRoot) ?? startElement;
     }
 
     const startElementOffset = startElement
@@ -819,7 +819,7 @@ export class StyleInstance
         while (currentElement) {
           if (
             this.xmldoc.getElementOffset(currentElement) <= pageStartOffset &&
-            this.isNormalFlowElement(currentElement)
+            this.isPageBoundaryCandidateElement(currentElement)
           ) {
             return currentElement;
           }
@@ -865,6 +865,9 @@ export class StyleInstance
   }
 
   private getPageGroupPageType(element: Element): string | null {
+    if (this.isInlineLevelElement(element)) {
+      return null;
+    }
     const style = this.styler.getStyle(element, false);
     if (!style) {
       return null;
@@ -882,15 +885,11 @@ export class StyleInstance
     );
     let currentElement = startElement;
     while (currentElement) {
-      const style = this.styler.getStyle(currentElement, false);
-      const pageValue = style && CssCascade.getProp(style, "page");
       // Resolve the page-start named page before page master selection, where
       // `styler.cascade.currentPageType` may still describe the previous page.
-      if (pageValue && !Css.isDefaultingValue(pageValue.value)) {
-        const pageType = pageValue.evaluate(this, "page").toString();
-        if (pageType && pageType.toLowerCase() !== "auto") {
-          return pageType;
-        }
+      const pageType = this.getPageGroupPageType(currentElement);
+      if (pageType) {
+        return pageType;
       }
       if (currentElement === this.xmldoc.root) {
         break;
@@ -930,7 +929,7 @@ export class StyleInstance
   private getPreviousInFlowSibling(element: Element): Element | null {
     let sibling = element.previousElementSibling;
     while (sibling) {
-      if (this.isNormalFlowElement(sibling)) {
+      if (this.isPageBoundaryCandidateElement(sibling)) {
         return sibling;
       }
       sibling = sibling.previousElementSibling;
@@ -949,7 +948,7 @@ export class StyleInstance
       searchRootOffset,
     );
     return startElement === searchRoot
-      ? this.getFirstInFlowChildElement(searchRoot)
+      ? (this.getFirstInFlowChildElement(searchRoot) ?? startElement)
       : startElement;
   }
 
@@ -1170,7 +1169,7 @@ export class StyleInstance
     offset: number,
   ): Element | null {
     if (
-      this.isNormalFlowElement(root) &&
+      this.isPageBoundaryCandidateElement(root) &&
       this.xmldoc.getElementOffset(root) >= offset
     ) {
       return root;
@@ -1183,6 +1182,9 @@ export class StyleInstance
           const element = node as Element;
           if (!this.isNormalFlowElement(element)) {
             return NodeFilter.FILTER_REJECT;
+          }
+          if (this.isInlineLevelElement(element)) {
+            return NodeFilter.FILTER_SKIP;
           }
           const nodeOffset = this.xmldoc.getElementOffset(element);
           if (nodeOffset < offset) {
@@ -1223,11 +1225,20 @@ export class StyleInstance
       }
       const element = child as Element;
       if (this.isNormalFlowElement(element)) {
+        if (this.isInlineLevelElement(element)) {
+          return null;
+        }
         return element;
       }
       child = child.nextSibling;
     }
     return null;
+  }
+
+  private isPageBoundaryCandidateElement(element: Element): boolean {
+    return (
+      this.isNormalFlowElement(element) && !this.isInlineLevelElement(element)
+    );
   }
 
   private isNormalFlowElement(element: Element): boolean {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -250,6 +250,17 @@ export class ViewFactory
       }
       const element = child as Element;
       if (this.isNormalFlowElement(element)) {
+        const style = this.styler.getStyle(element, false);
+        const displayValue = (
+          style?.["display"] as CssCascade.CascadeValue
+        )?.evaluate(this.styler.context, "display");
+        const display =
+          displayValue && !Css.isDefaultingValue(displayValue)
+            ? (displayValue as Css.Ident)
+            : Css.ident.inline;
+        if (Display.isInlineLevel(display)) {
+          return null;
+        }
         return element;
       }
       child = child.nextSibling;


### PR DESCRIPTION
Treat only non-inline normal-flow elements as named-page boundary candidates when resolving page starts and page-group page types. Stop first-child named page descent at leading inline content and fall back to the wrapper or root element instead of skipping ahead to a later block child.

This prevents inline elements such as `<img style="page:b">` and `<canvas style="page:b">` from overriding the surrounding named page at the start of a page, while preserving the nested named-page fixes for block-level content added in PR #2003.

This fixes the WPT reftests
`https://wpt.live/css/css-page/page-name-canvas-001-print.html` and `https://wpt.live/css/css-page/page-name-img-001-print.html`.

See PR #2003

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author identified this as a regression from PR #2003 via `/fix-wpt-reftest-failure`, citing the CSS Fragmentation spec's definition of named-page boundary candidates to hypothesize that inline-level elements should be excluded.
- The AI implemented the fix based on that hypothesis, distinguishing inline-level elements from other normal-flow elements.
- The human author corrected wording in the `/draft-commit` output; the AI applied the correction, and `/address-pr-comments` finalized the PR.

</details>
