### PR TITLE
fix: Keep clear page and column blocks visible after page floats

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3366,6 +3366,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       return false;
     }
 
+    const clear =
+      nodeContext.clearSide === "same"
+        ? nodeContext.floatSide
+        : nodeContext.clearSide;
+    const useRawSpacerGeometry = /^(page|column|region)$/.test(clear);
     // measure where the edge of the element would be without clearance
     const margin = this.getComputedMargin(nodeContext.viewNode as Element);
     const spacer = nodeContext.viewNode.ownerDocument.createElement("div");
@@ -3378,18 +3383,21 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       spacer.style.height = "1px";
       spacer.style.marginTop = `${margin.top}px`;
     }
+    const getSpacerBox = () =>
+      useRawSpacerGeometry
+        ? this.clientLayout.getElementClientRect(spacer)
+        : LayoutHelper.getElementClientRectAdjusted(
+            this.clientLayout,
+            spacer,
+            this.vertical,
+          );
     nodeContext.viewNode.parentNode.insertBefore(spacer, nodeContext.viewNode);
-    let spacerBox = LayoutHelper.getElementClientRectAdjusted(
-      this.clientLayout,
-      spacer,
-      this.vertical,
-    );
+    // Use raw spacer geometry for page/column/region clears. Browser
+    // column-breaking adjustment can move the following cleared block outside
+    // the page area. (Issue #2010)
+    let spacerBox = getSpacerBox();
     const edge = this.getBeforeEdge(spacerBox);
     const dir = this.getBoxDir();
-    const clear =
-      nodeContext.clearSide === "same"
-        ? nodeContext.floatSide
-        : nodeContext.clearSide;
     const clearLR =
       /^(top|bottom|inside|outside|(block|inline)-(start|end))$/.test(clear)
         ? PageFloats.resolveInlineFloatDirection(
@@ -3476,11 +3484,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       } else {
         spacer.style.height = `${height}px`;
       }
-      spacerBox = LayoutHelper.getElementClientRectAdjusted(
-        this.clientLayout,
-        spacer,
-        this.vertical,
-      );
+      spacerBox = getSpacerBox();
       const afterEdge = this.getAfterEdge(spacerBox);
       if (!nodeContext.floatSide) {
         if (this.vertical) {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -937,6 +937,18 @@ module.exports = [
         title: "Clear page floats (vertical writing-mode)",
       },
       {
+        file: "page_floats/page-float-clear-page.html",
+        title: "Page float with clear: page (Issue #2010)",
+      },
+      {
+        file: "page_floats/column-float-clear-column.html",
+        title: "Column float with clear: column (Issue #2010)",
+      },
+      {
+        file: "page_floats/column-float-clear-page.html",
+        title: "Column float with clear: page (Issue #2010)",
+      },
+      {
         file: "page_floats/clear_on_page_floats.html",
         title: "clear on page floats",
       },

--- a/packages/core/test/files/page_floats/column-float-clear-column.html
+++ b/packages/core/test/files/page_floats/column-float-clear-column.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Column float clear: column</title>
+    <style>
+      @page {
+        size: A5;
+        margin: 10mm;
+        border: 2px dotted gray;
+
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+      }
+      :root {
+        column-count: 2;
+        column-fill: auto;
+        font-family: Times, serif;
+        line-height: 1.2;
+      }
+      section {
+        break-before: column;
+      }
+      .column-float {
+        float-reference: column;
+        float: top;
+        box-sizing: border-box;
+        height: 150px;
+        margin-bottom: 10px;
+        padding: 10px;
+        border: 5px inset cyan;
+        text-align: center;
+        align-content: center;
+      }
+      .clear-column {
+        clear: column;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Test case for Issue #2010: block with clear: column after column floats must not disappear. -->
+    <section>
+      <h2>Section 1</h2>
+      <div class="column-float">Column Float 1 (in Section 1)</div>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+        dis parturient montes, nascetur ridiculus mus. Donec quam felis,
+        ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+        quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget,
+        arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.
+        Nullam dictum felis eu pede mollis pretium. Integer tincidunt.
+      </p>
+      <div class="column-float clear-column">
+        Column Float 2 (with clear:column, in Section 1)
+      </div>
+      <p>
+        Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla
+        mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo
+        eget bibendum sodales, augue velit cursus nunc.
+      </p>
+      <div class="column-float">Column Float 3 (in Section 1)</div>
+    </section>
+    <section class="clear-column">
+      <h2>Section 2 (with clear:column)</h2>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequuntur
+        adipisci, nulla illum distinctio officiis eaque animi dolorum soluta est
+        dicta. Non eius veritatis deleniti! Ipsam, nobis? Voluptate itaque
+        aliquam veritatis!
+      </p>
+      <div class="column-float">Column Float 4 (in Section 2)</div>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/page_floats/column-float-clear-page.html
+++ b/packages/core/test/files/page_floats/column-float-clear-page.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Column float clear: page</title>
+    <style>
+      @page {
+        size: A5;
+        margin: 10mm;
+        border: 2px dotted gray;
+
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+      }
+      :root {
+        column-count: 2;
+        column-fill: auto;
+        font-family: Times, serif;
+        line-height: 1.2;
+      }
+      section {
+        break-before: column;
+      }
+      .column-float {
+        float-reference: column;
+        float: top;
+        box-sizing: border-box;
+        height: 150px;
+        margin-bottom: 10px;
+        padding: 10px;
+        border: 5px inset cyan;
+        text-align: center;
+        align-content: center;
+      }
+      .clear-page {
+        clear: page;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Test case for Issue #2010: block with clear: page after column floats must not disappear. -->
+    <section>
+      <h2>Section 1</h2>
+      <div class="column-float">Column Float 1 (in Section 1)</div>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+        dis parturient montes, nascetur ridiculus mus. Donec quam felis,
+        ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+        quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget,
+        arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.
+        Nullam dictum felis eu pede mollis pretium. Integer tincidunt.
+      </p>
+      <div class="column-float clear-page">
+        Column Float 2 (with clear:page, in Section 1)
+      </div>
+      <p>
+        Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla
+        mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo
+        eget bibendum sodales, augue velit cursus nunc.
+      </p>
+      <div class="column-float">Column Float 3 (in Section 1)</div>
+    </section>
+    <section class="clear-page">
+      <h2>Section 2 (with clear:page)</h2>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequuntur
+        adipisci, nulla illum distinctio officiis eaque animi dolorum soluta est
+        dicta. Non eius veritatis deleniti! Ipsam, nobis? Voluptate itaque
+        aliquam veritatis!
+      </p>
+      <div class="column-float">Column Float 4 (in Section 2)</div>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/page_floats/page-float-clear-page.html
+++ b/packages/core/test/files/page_floats/page-float-clear-page.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Page float clear: page</title>
+    <style>
+      @page {
+        size: A5;
+        margin: 10mm;
+        border: 2px dotted gray;
+
+        @bottom-center {
+          content: "Page " counter(page);
+        }
+      }
+      :root {
+        font-family: Times, serif;
+        line-height: 1.2;
+      }
+      section {
+        break-before: page;
+      }
+      .page-float {
+        float-reference: page;
+        float: top;
+        box-sizing: border-box;
+        height: 150px;
+        margin-bottom: 10px;
+        padding: 10px;
+        border: 5px inset cyan;
+        text-align: center;
+        align-content: center;
+      }
+      .clear-page {
+        clear: page;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Test case for Issue #2010: block with clear: page after page floats must not disappear. -->
+    <section>
+      <h2>Section 1</h2>
+      <div class="page-float">Page Float 1 (in Section 1)</div>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+        dis parturient montes, nascetur ridiculus mus. Donec quam felis,
+        ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+        quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget,
+        arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.
+        Nullam dictum felis eu pede mollis pretium. Integer tincidunt.
+      </p>
+      <div class="page-float clear-page">
+        Page Float 2 (with clear:page, in Section 1)
+      </div>
+      <p>
+        Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla
+        mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo
+        eget bibendum sodales, augue velit cursus nunc.
+      </p>
+      <div class="page-float">Page Float 3 (in Section 1)</div>
+    </section>
+    <section class="clear-page">
+      <h2>Section 2 (with clear:page)</h2>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequuntur
+        adipisci, nulla illum distinctio officiis eaque animi dolorum soluta est
+        dicta. Non eius veritatis deleniti! Ipsam, nobis? Voluptate itaque
+        aliquam veritatis!
+      </p>
+      <div class="page-float">Page Float 4 (in Section 2)</div>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Use raw spacer geometry in `Column.applyClearance()` instead of browser column-breaking adjusted geometry when measuring clear spacer placement. The adjusted rect could move blocks with `clear: page` or `clear: column` outside the visible page area after page or column floats.

Add regression cases for `clear: page` after page floats, `clear: column` after
column floats, and `clear: page` after column floats.

Closes #2010

Assisted-by: GitHub Copilot Chat:gpt-5.5

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2010; the AI implemented a fix using browser column-breaking adjusted geometry.
- The AI initially reported the regression tests as passing; the human author caught that this was a misjudgment — the content was present in the DOM but rendered outside the visible page area — by comparing against the v2.35.0 viewer, and directed the AI to re-check.
- The AI re-diagnosed the issue and switched to raw spacer geometry, which the human author then verified as correct.
- `/draft-commit` and `/address-pr-comments` finalized the PR.

</details>
