### PR TITLE
fix: Fix `target-counter()` crash after spread blank pages

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2269,6 +2269,20 @@ export class OPFView implements Vgen.CustomRendererFactory {
       Task.newFrame("renderSinglePage");
 
     const pageIndexToRender = pos ? Math.max(pos.page, 0) : 0;
+    const pageNumberContextDepth =
+      viewItem.instance.getPageNumberContextDepth();
+    // Issue #2013: preserve the current render slot's page number so
+    // page-number remains available during target-counter() rerender cleanup.
+    viewItem.instance.pushPageNumberContext(pageIndexToRender + 1);
+    const restorePageNumberContext = (): void => {
+      viewItem.instance.restorePageNumberContextDepth(pageNumberContextDepth);
+    };
+    // Task errors bypass the success callback below, so unwind this fallback
+    // page-number context here before re-raising to the parent frame.
+    frame.handler = (handlerFrame, err) => {
+      restorePageNumberContext();
+      handlerFrame.task.raise(err, handlerFrame.parent);
+    };
     const inCounterResolveScopeAtStart = this.isInCounterResolveScope();
     const oldPage = this.preparePageCountersForRender(
       viewItem,
@@ -2309,6 +2323,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
           ),
         )
         .then((resolvedPage) => {
+          restorePageNumberContext();
           frame.finish({
             pageAndPosition: makePageAndPosition(resolvedPage, pageIndex),
             nextLayoutPosition: pos,

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -162,7 +162,7 @@ export class Style {
           const styleInstance = this as StyleInstance;
           return (
             styleInstance.pageNumberOffset +
-            styleInstance.currentLayoutPosition.page
+            styleInstance.getCurrentPageNumberForPageScope()
           );
         },
         "page-number",
@@ -307,6 +307,7 @@ export class StyleInstance
   faces: Font.DocumentFaces;
   pageBoxInstances: { [key: string]: PageMaster.PageBoxInstance } = {};
   pageManager: CssPage.PageManager = null;
+  private pageNumberContextStack: number[] = [];
   private rootPageFloatLayoutContext: PageFloats.PageFloatLayoutContext;
   pageBreaks: { [key: string]: boolean } = {};
   pageProgression: Constants.PageProgression | null = null;
@@ -626,6 +627,30 @@ export class StyleInstance
       supportsReceiver,
     );
     return supported;
+  }
+
+  getCurrentPageNumberForPageScope(): number {
+    if (this.currentLayoutPosition) {
+      return this.currentLayoutPosition.page;
+    }
+    // Issue #2013: target-counter() rerender can evaluate page-number after
+    // currentLayoutPosition has been cleared, so fall back to the active
+    // render-slot page number captured by OPFView.renderSinglePage().
+    return (
+      this.pageNumberContextStack[this.pageNumberContextStack.length - 1] ?? 0
+    );
+  }
+
+  getPageNumberContextDepth(): number {
+    return this.pageNumberContextStack.length;
+  }
+
+  pushPageNumberContext(pageNumber: number): void {
+    this.pageNumberContextStack.push(pageNumber);
+  }
+
+  restorePageNumberContextDepth(depth: number): void {
+    this.pageNumberContextStack.length = depth;
   }
 
   /**

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -134,6 +134,10 @@ module.exports = [
         title: "Content in page margin box",
       },
       {
+        file: "target-counter-blank-page-typeerror.html",
+        title: "target-counter after spread blank page (Issue #2013)",
+      },
+      {
         file: "page-margin-box-images.html",
         title: "Page margin box images (Issue #1867)",
       },

--- a/packages/core/test/files/target-counter-blank-page-typeerror.html
+++ b/packages/core/test/files/target-counter-blank-page-typeerror.html
@@ -1,0 +1,45 @@
+<!-- Test case for Issue #2013: target-counter on a page after a spread-induced blank page -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Issue #2013</title>
+    <style>
+      @page {
+        size: 140mm 180mm;
+        margin: 12mm;
+      }
+
+      body {
+        font-family: serif;
+        line-height: 1.4;
+      }
+
+      nav {
+        break-before: right;
+      }
+
+      nav li a::after {
+        content: leader(dotted) target-counter(attr(href url), page);
+      }
+
+      section {
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Issue #2013</h1>
+    <p>This page forces the table of contents onto a right page.</p>
+    <nav>
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#target">Target</a></li>
+      </ol>
+    </nav>
+    <section>
+      <h2 id="target">Target</h2>
+      <p>Target page.</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Preserve the active render-slot page number while `target-counter()` rerenders pages so `page-number` no longer dereferences `currentLayoutPosition` after it has been cleared. Restore that fallback context on both success and task error unwinding to avoid leaking stale page numbers across nested rerenders.

Add `target-counter-blank-page-typeerror.html` to reproduce the `break-before: right` blank-page case and register it in the core test file list.

Closes #2013

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2013; the AI diagnosed the `TypeError` and implemented a page-number-context stack guard covering both the success and error-unwinding paths.
- The human author asked the AI to explain why the task error-handler addition was necessary, and asked for a clarifying code comment describing the issue #2013 intent; the AI provided the explanation and added the comment.
- `/draft-commit` finalized the PR after human review.

</details>
