### PR TITLE
fix: Fix missing list markers in WebKit

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -62,6 +62,72 @@ const xhtmlElementsRenderedAsDiv = new Set([
   "title",
 ]);
 
+function getWebKitMarkerListStyleType(markerContent: Css.Val): Css.Str | null {
+  if (markerContent instanceof Css.Str) {
+    return markerContent;
+  }
+  if (markerContent instanceof Css.SpaceList) {
+    const parts: string[] = [];
+    for (const item of markerContent.values) {
+      if (item instanceof Css.Str) {
+        parts.push(item.str);
+      } else {
+        return null;
+      }
+    }
+    if (parts.length > 0) {
+      return new Css.Str(parts.join(""));
+    }
+  }
+  return null;
+}
+
+function getWebKitMarkerListStyleImage(markerContent: Css.Val): Css.URL | null {
+  if (markerContent instanceof Css.URL) {
+    return markerContent;
+  }
+  if (
+    markerContent instanceof Css.SpaceList &&
+    markerContent.values[0] instanceof Css.URL &&
+    markerContent.values
+      .slice(1)
+      .every((item) => item instanceof Css.Str && item.str.trim() === "")
+  ) {
+    return markerContent.values[0];
+  }
+  return null;
+}
+
+function applyWebKitMarkerFallback(computedStyle: {
+  [key: string]: Css.Val;
+}): boolean {
+  if (Base.browserType !== "webkit") {
+    return false;
+  }
+
+  const markerContent = computedStyle["--viv-marker-content"];
+  if (!markerContent) {
+    return false;
+  }
+
+  const listStyleImage = getWebKitMarkerListStyleImage(markerContent);
+  if (listStyleImage) {
+    computedStyle["list-style-type"] = Css.ident.none;
+    computedStyle["list-style-image"] = listStyleImage;
+    delete computedStyle["--viv-marker-content"];
+    return true;
+  }
+
+  const listStyleType = getWebKitMarkerListStyleType(markerContent);
+  if (listStyleType) {
+    computedStyle["list-style-type"] = listStyleType;
+    computedStyle["list-style-image"] = Css.ident.none;
+    return true;
+  }
+
+  return false;
+}
+
 export type CustomRenderer = (
   p1: Element,
   p2: Element,
@@ -1738,9 +1804,13 @@ export class ViewFactory
           tag = "li";
           if (computedStyle["--viv-marker-content"]) {
             // We control marker content via --viv-marker-content CSS custom
-            // property, so suppress the browser's default marker.
-            computedStyle["list-style-type"] = Css.ident.none;
-            computedStyle["list-style-image"] = Css.ident.none;
+            // property. WebKit cannot render content on ::marker, so fall
+            // back to list-style-* when the resolved marker can be expressed
+            // there. (Issue #2017)
+            if (!applyWebKitMarkerFallback(computedStyle)) {
+              computedStyle["list-style-type"] = Css.ident.none;
+              computedStyle["list-style-image"] = Css.ident.none;
+            }
           }
         } else {
           // Subsequent fragments: no marker


### PR DESCRIPTION
PR #1832 switched list markers to the browser's native `::marker` rendering, which caused WebKit to lose list markers because Safari does not support `content` on `::marker`.

Detect WebKit before clearing `list-style-type` and `list-style-image`, and map resolved `--viv-marker-content` back to native list styles when it can be represented there. Other browsers continue to use the native `::marker` path.

Closes #2017

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2017; the AI implemented the WebKit `::marker` fallback.
- The human author manually verified the fix in Safari, confirming the related "Counter style and list-style" test category rendered correctly.
- The human author corrected wording in the `/draft-commit` output, then used `/address-pr-comments` to check and resolve a specific reviewer comment.

</details>
