### PR TITLE
fix: prevent rendering hang with footnote-policy: line

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2001,7 +2001,26 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             // float fragment is added. (Issue #1675)
             Asserts.assert(newFragment);
             const isInsidePageFloat = !!context.generatingNodePosition;
-            context.addPageFloatFragment(newFragment, isInsidePageFloat);
+            // Issue #2024: Placing a `footnote-policy: line` footnote shrinks
+            // the body area and invalidates the page so the body reflows. On
+            // each page-layout retry the same footnote is placed again; if it
+            // invalidated every time, the layout would never converge and the
+            // renderer would hang. Allow exactly one invalidation per such
+            // footnote per page; suppress the redundant invalidations after
+            // that so pagination can complete.
+            const isLineFootnote =
+              !isInsidePageFloat &&
+              float instanceof Footnote &&
+              float.footnotePolicy === Css.ident.line;
+            const alreadyInvalidatedForLineFootnote =
+              isLineFootnote && context.hasInvalidatedForLineFootnote(float);
+            context.addPageFloatFragment(
+              newFragment,
+              isInsidePageFloat || alreadyInvalidatedForLineFootnote,
+            );
+            if (isLineFootnote && !alreadyInvalidatedForLineFootnote) {
+              context.markInvalidatedForLineFootnote(float);
+            }
             context.discardStashedFragments(float.floatReference);
             if (newPosition) {
               const continuation = new PageFloats.PageFloatContinuation(

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -391,6 +391,27 @@ export class PageFloatLayoutContext
   private footnoteAnchorsSeen: Set<PageFloatID> = new Set();
 
   /**
+   * Tracks `footnote-policy: line` footnote IDs that have already triggered
+   * one invalidation (body reflow) on the current page. Like
+   * footnoteAnchorsSeen, this set survives invalidate() calls. Placing such a
+   * footnote shrinks the body area and invalidates the page to reflow the
+   * body; without this guard the same footnote is re-placed and re-invalidated
+   * on every page-layout retry, which never converges and hangs the renderer.
+   * Allowing exactly one invalidation per footnote per page bounds the retries
+   * so pagination converges. (Issue #2024)
+   */
+  private lineFootnoteInvalidatedOnce: Set<PageFloatID> = new Set();
+
+  /**
+   * Tracks `footnote-policy: line` footnote IDs for which finish() has already
+   * forbidden the float and invalidated the page once. Without this guard,
+   * finish() forbids and invalidates on every page-layout retry (the float is
+   * re-deferred each pass), which never converges and hangs the renderer.
+   * Like footnoteAnchorsSeen, this set survives invalidate(). (Issue #2024)
+   */
+  private lineFootnoteFinishInvalidatedOnce: Set<PageFloatID> = new Set();
+
+  /**
    * Reference to the outer column's context for page float area contexts.
    * Used only for getParent() navigation to propagate nested page floats
    * and footnotes to region/page level. Unlike `parent`, this does NOT
@@ -698,6 +719,34 @@ export class PageFloatLayoutContext
     return !!this.container?.element?.contains(anchorViewNode);
   }
 
+  /**
+   * Whether a `footnote-policy: line` footnote has already triggered one
+   * invalidation (body reflow) on the current page. (Issue #2024)
+   */
+  hasInvalidatedForLineFootnote(float: PageFloat): boolean {
+    if (float.floatReference === this.floatReference) {
+      return this.lineFootnoteInvalidatedOnce.has(float.getId());
+    }
+    return this.getParent(float.floatReference).hasInvalidatedForLineFootnote(
+      float,
+    );
+  }
+
+  /**
+   * Mark that a `footnote-policy: line` footnote has triggered one
+   * invalidation on the current page, so subsequent placements on the same
+   * page suppress the redundant invalidation. (Issue #2024)
+   */
+  markInvalidatedForLineFootnote(float: PageFloat): void {
+    if (float.floatReference === this.floatReference) {
+      this.lineFootnoteInvalidatedOnce.add(float.getId());
+    } else {
+      this.getParent(float.floatReference).markInvalidatedForLineFootnote(
+        float,
+      );
+    }
+  }
+
   isAnchorAlreadyAppeared(floatId: PageFloatID) {
     const deferredFloats = this.getDeferredPageFloatContinuations();
     if (deferredFloats.some((cont) => cont.float.getId() === floatId)) {
@@ -995,16 +1044,22 @@ export class PageFloatLayoutContext
         "footnotePolicy" in float &&
         float.footnotePolicy === Css.ident.line &&
         this.hasCurrentAnchor(float.getId()) &&
-        !existingFragment
+        !existingFragment &&
+        !this.lineFootnoteFinishInvalidatedOnce.has(float.getId())
       ) {
         // Once the anchor line has already appeared on the page, a deferred
         // footnote-policy: line footnote can no longer move independently.
         // If a fragment already started on this page, the deferred part is
         // just the continuation and should remain allowed to split.
+        // Forbid and invalidate at most once per footnote per page: the float
+        // is re-deferred on every page-layout retry, so re-invalidating here
+        // each time would never converge and would hang the renderer.
+        // (Issue #2024)
         if (this.locked) {
           this.invalidate();
           return;
         }
+        this.lineFootnoteFinishInvalidatedOnce.add(float.getId());
         this.removeFloatDeferredToNext(float);
         this.forbid(float);
         this.invalidate();


### PR DESCRIPTION
Placing a `footnote-policy: line` footnote shrinks the body area and invalidates the page so the body reflows. On each page-layout retry the same footnote was placed and invalidated again, so the layout never converged and the renderer hung on some documents.

Allow exactly one invalidation per such footnote per page in both paths that can re-invalidate it: the fragment-added path in Column and the finish() forbid path in PageFloatLayoutContext. The guard sets survive invalidate(), bounding the retries so pagination converges.

Reproduction test:
https://gist.githubusercontent.com/MurakamiShinyu/27f12a663e30570d0c33fa36cf533935/raw/bug-footnote.html

Note: this commit fixes only the rendering hang. With the above document, footnote 45 still disappears -- a long footnote whose anchor sits near a page boundary is dropped instead of fragmenting across pages. That long-footnote fragmentation drop is a separate, pre-existing problem (it also occurs with footnote-policy: auto) and will be tracked as a separate issue.

Closes #2024

Assisted-by: GitHub Copilot Chat:claude-opus-4.8

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2024 (a real-world document with many long footnotes that hung the renderer), providing a research memo with initial findings.
- Over an extended investigation, the human author repeatedly caught the AI misjudging its own verification (e.g. reporting a footnote as fixed when it was still missing, or a layout diff as passing when it was not) by comparing against the stable/canary viewer, and redirected the AI to re-check.
- The human author decided to scope this PR to the rendering-hang fix only, had the AI build an isolated regression test for just the hang, and had the AI revert an earlier over-broad commit (`git reset HEAD~`) that bundled an unreproducible drop-specific test.
- The human author asked the AI to draft a follow-up issue (#2026) for the remaining footnote-fragmentation/drop problem and reviewed its wording before filing; the AI implemented the final bounded-invalidation fix, which the human author verified live on the canary viewer.

</details>
