### PR TITLE
fix: Prevent long footnotes from being dropped during target-counter() rerendering

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1954,12 +1954,17 @@ export class OPFView implements Vgen.CustomRendererFactory {
     viewItem.layoutPositions[nextLayoutPosition.page] = nextLayoutPosition;
     const nextPage = viewItem.pages[nextLayoutPosition.page];
     const offsetChanged = !!oldPage && renderedPage.offset !== oldPage.offset;
+    const hasActivePageFloatState =
+      viewItem.instance.hasActiveRootPageFloatLayoutContext();
+    // Even if the source layout position is unchanged, active root page-float
+    // state can still change following pages through deferred continuations.
     const positionChanged =
       !previousLayoutPosition ||
       !nextLayoutPosition.isSamePosition(previousLayoutPosition) ||
       nextLayoutPosition.highestSeenOffset !==
         previousLayoutPosition.highestSeenOffset ||
-      offsetChanged;
+      offsetChanged ||
+      hasActivePageFloatState;
     const inCounterResolveScope = this.isInCounterResolveScope();
     const relayoutDecision = this.evaluateNextPageRelayout(
       oldPage,
@@ -2056,9 +2061,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
           const hasRenderedTargetPage = !!targetViewItem.pages[refs.pageIndex];
           const shouldIsolateRootPageFloatLayoutContext =
             hasRenderedTargetPage && hasRenderedFollowingPage;
+          const previousPageFloatLayoutContext =
+            shouldIsolateRootPageFloatLayoutContext && refs.pageIndex > 0
+              ? targetViewItem.pages[refs.pageIndex - 1]?.pageFloatLayoutContext
+              : null;
           const originalRootPageFloatLayoutContext =
             shouldIsolateRootPageFloatLayoutContext
-              ? targetViewItem.instance.beginIsolatedRootPageFloatLayoutContext()
+              ? targetViewItem.instance.beginIsolatedRootPageFloatLayoutContext(
+                  previousPageFloatLayoutContext,
+                )
               : null;
 
           this.counterStore.pushPageCounters(refs.pageCounters);

--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -387,11 +387,16 @@ export class FootnoteLayoutStrategy
     const context = pageFloatLayoutContext.getPageFloatLayoutContext(
       float.floatReference,
     );
+    const container = context.getContainer(float.floatReference);
+    const containerElement = container.element;
     const fragments = context.floatFragments.filter(
-      (fr) => fr instanceof FootnoteFragment,
+      (fr) =>
+        fr instanceof FootnoteFragment &&
+        (float.floatReference !== PageFloats.FloatReference.REGION ||
+          !(fr.area as Layout.PageFloatArea).parentElement ||
+          (fr.area as Layout.PageFloatArea).parentElement === containerElement),
     );
-    Asserts.assert(fragments.length <= 1);
-    return fragments[0] || null;
+    return fragments.find((fr) => fr.hasFloat(float)) || fragments[0] || null;
   }
 
   /** @override */

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -759,6 +759,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   bodyFrame.breakLoop();
                   return;
                 }
+                if (position.pluginProps["lineFootnoteOverflow"]) {
+                  bodyFrame.breakLoop();
+                  return;
+                }
                 bodyFrame.continueLoop();
               });
             } else if (!position.inline) {
@@ -1793,36 +1797,26 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           const floatChunkPosition = new VtreeImpl.ChunkPosition(
             c.nodePosition,
           );
-          // Save the break position count before layout. Note: doLayout()
-          // resets breakPositions to [], so after layout() returns,
-          // breakPositions contains only items from this single call.
-          // prevBreakPositionCount captures the count from the PREVIOUS
-          // iteration's result (before this call's reset), which serves as
-          // a baseline: if the new count doesn't exceed it, the current
-          // continuation placed less content than the previous one,
-          // indicating a marker-only fragment. (Issue #1956)
-          const prevBreakPositionCount = floatArea.breakPositions
-            ? floatArea.breakPositions.length
-            : 0;
+          const prevRootViewNodeCount = floatArea.getRootViewNodeCount();
           floatArea.layout(floatChunkPosition, true).then((newPosition) => {
             result.newPosition = newPosition;
             if (!newPosition || allowFragmented) {
               // For footnotes: if fragmented, check if meaningful content was
-              // placed for this continuation. If no new BoxBreakPosition was
-              // added beyond the previous iteration's count (which acts as a
-              // baseline since doLayout() resets the array each time), fail the
-              // layout so the footnote is deferred to the next page, preventing
-              // the marker from appearing alone at the page bottom.
+              // placed for this continuation. doLayout() resets
+              // breakPositions for each layout call, so this check must be
+              // self-contained for the current continuation; comparing with a
+              // previous continuation rejects valid later footnotes in a shared
+              // footnote area. (Issue #1956, #2026)
               if (
                 newPosition &&
                 floatArea.isFootnote &&
                 floatArea.breakPositions
               ) {
                 const hasNewLineContent =
-                  floatArea.breakPositions.length > prevBreakPositionCount &&
-                  floatArea.breakPositions
-                    .slice(prevBreakPositionCount)
-                    .some((bp) => bp instanceof BoxBreakPosition);
+                  floatArea.breakPositions.some(
+                    (bp) => bp instanceof BoxBreakPosition,
+                  ) &&
+                  floatArea.hasNonPseudoTextContentAfter(prevRootViewNodeCount);
                 if (!hasNewLineContent) {
                   failed = true;
                   loopFrame.breakLoop();
@@ -1922,6 +1916,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   ): Task.Result<boolean> {
     const context = this.pageFloatLayoutContext;
     const float = continuation.float;
+    const isFootnote = float instanceof Footnote;
+    const layoutLineFootnoteSeparately =
+      isFootnote &&
+      float.footnotePolicy === Css.ident.line &&
+      !!pageFloatFragment &&
+      !pageFloatFragment.hasFloat(float);
 
     // Snapshot insidePageFloatArea fragments before the layout attempt.
     // If this float's layout is cancelled, any NEW insidePageFloatArea
@@ -1940,7 +1940,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       }
     }
 
-    context.stashEndFloatFragments(float);
+    if (!layoutLineFootnoteSeparately) {
+      context.stashEndFloatFragments(float);
+    }
 
     function cancelLayout(floatArea, pageFloatFragment) {
       if (pageFloatFragment) {
@@ -1975,7 +1977,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       context.restoreStashedFragments(float.floatReference);
       context.deferPageFloat(continuation);
     }
-    const isFootnote = float instanceof Footnote;
     const frame: Task.Frame<boolean> = Task.newFrame("layoutPageFloatInner");
     this.layoutSinglePageFloatFragment(
       [continuation],
@@ -1984,7 +1985,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       isFootnote || !context.hasFloatFragments(),
       strategy,
       anchorEdge,
-      pageFloatFragment,
+      layoutLineFootnoteSeparately ? null : pageFloatFragment,
     ).then((result) => {
       const floatArea = result.floatArea;
       const newFragment = result.pageFloatFragment;
@@ -2000,25 +2001,63 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             // layout. The region will be invalidated later when the outer page
             // float fragment is added. (Issue #1675)
             Asserts.assert(newFragment);
+            let fragmentForContext = newFragment;
+            if (layoutLineFootnoteSeparately && pageFloatFragment) {
+              // Existing shared footnote areas can receive a later
+              // line-policy footnote. Layout it in a scratch area first, then
+              // merge the rendered nodes and resize the existing area so the
+              // shared fragment keeps one physical footnote box.
+              const footnoteArea = pageFloatFragment.area as PageFloatArea;
+              const previousRootViewNodeCount =
+                footnoteArea.getRootViewNodeCount();
+              footnoteArea.appendContentFrom(newFragment.area as PageFloatArea);
+              context.removePageFloatFragment(newFragment, true);
+              const logicalFloatSide = context.setFloatAreaDimensions(
+                footnoteArea,
+                float.floatReference,
+                pageFloatFragment.floatSide,
+                anchorEdge,
+                false,
+                true,
+                context.getPageFloatPlacementCondition(
+                  float,
+                  float.floatSide,
+                  float.clearSide,
+                ),
+              );
+              if (!logicalFloatSide) {
+                footnoteArea.removeContentAfter(previousRootViewNodeCount);
+                cancelLayout(floatArea, newFragment);
+                frame.finish(false);
+                return;
+              }
+              pageFloatFragment.addContinuations(newFragment.continuations);
+              fragmentForContext = pageFloatFragment;
+            }
             const isInsidePageFloat = !!context.generatingNodePosition;
-            // Issue #2024: Placing a `footnote-policy: line` footnote shrinks
-            // the body area and invalidates the page so the body reflows. On
-            // each page-layout retry the same footnote is placed again; if it
-            // invalidated every time, the layout would never converge and the
-            // renderer would hang. Allow exactly one invalidation per such
-            // footnote per page; suppress the redundant invalidations after
-            // that so pagination can complete.
-            const isLineFootnote =
+            // Issue #2024, #2026: Placing a `footnote-policy: line` footnote
+            // shrinks the body area and invalidates the page so the body
+            // reflows. On each page-layout retry the same footnote is placed
+            // again; if it invalidated every time, layout may fail to converge
+            // or the final fragment area can be cleared by a later retry.
+            // Allow exactly one invalidation per line-policy footnote per
+            // retry size; suppress redundant invalidations after that so
+            // pagination can complete with the footnote area attached.
+            const isLineFootnoteForInvalidation =
               !isInsidePageFloat &&
               float instanceof Footnote &&
               float.footnotePolicy === Css.ident.line;
             const alreadyInvalidatedForLineFootnote =
-              isLineFootnote && context.hasInvalidatedForLineFootnote(float);
+              isLineFootnoteForInvalidation &&
+              context.hasInvalidatedForLineFootnote(float);
             context.addPageFloatFragment(
-              newFragment,
+              fragmentForContext,
               isInsidePageFloat || alreadyInvalidatedForLineFootnote,
             );
-            if (isLineFootnote && !alreadyInvalidatedForLineFootnote) {
+            if (
+              isLineFootnoteForInvalidation &&
+              !alreadyInvalidatedForLineFootnote
+            ) {
               context.markInvalidatedForLineFootnote(float);
             }
             context.discardStashedFragments(float.floatReference);
@@ -2248,7 +2287,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       if (pageFloatFragment && pageFloatFragment.hasFloat(float)) {
         context.registerPageFloatAnchor(float, nodeContextAfter.viewNode);
         return Task.newResult(nodeContextAfter as Vtree.NodeContext);
-      } else if (
+      }
+      if (
         context.isForbidden(float) ||
         context.hasPrecedingFloatsDeferredToNext(float)
       ) {
@@ -2306,9 +2346,15 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         if (isNaN(edge) && nodeContext.floatSide === "footnote") {
           edge = getFootnoteEdgeFromViewNode(nodeContextAfter.viewNode);
         }
-        if (this.isOverflown(edge)) {
+        const skipOverflowPrecheck =
+          nodeContext.floatSide === "footnote" &&
+          (float as Footnote).footnotePolicy === Css.ident.line;
+        if (!skipOverflowPrecheck && this.isOverflown(edge)) {
           return Task.newResult(nodeContextAfter);
         } else {
+          if (nodeContext.floatSide === "footnote") {
+            context.registerPageFloatAnchor(float, nodeContextAfter.viewNode);
+          }
           return this.layoutPageFloatInner(
             continuation,
             strategy,
@@ -2325,6 +2371,30 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             // This ensures footnote-call and following content are processed
             // in the same postLayoutBlock, allowing correct text-spacing.
             if (nodeContext.floatSide === "footnote") {
+              const footnote = float as Footnote;
+              if (
+                footnote.footnotePolicy === Css.ident.line &&
+                context.hasInvalidatedForLineFootnote(float)
+              ) {
+                if (context.isInvalidated()) {
+                  return Task.newResult(null as Vtree.NodeContext);
+                }
+                const continuingFragment = strategy.findPageFloatFragment(
+                  float,
+                  context,
+                );
+                if (
+                  continuingFragment?.hasFloat(float) &&
+                  continuingFragment.continues
+                ) {
+                  const overflowNodeContext = nodeContextAfter.modify();
+                  overflowNodeContext.overflow = true;
+                  overflowNodeContext.pluginProps["lineFootnoteOverflow"] = 1;
+                  this.breakPositions = [];
+                  this.saveEdgeBreakPosition(overflowNodeContext, null, true);
+                  return Task.newResult(overflowNodeContext);
+                }
+              }
               return Task.newResult(nodeContextAfter);
             }
             // When inside a page float area, return nodeContextAfter to continue
@@ -5291,7 +5361,10 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
       layoutConstraint,
       pageFloatLayoutContext,
     );
+    this.parentElement = parentContainer.element;
   }
+
+  readonly parentElement: Element | null;
 
   override openAllViews(
     position: Vtree.NodePosition,
@@ -5374,6 +5447,53 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
         }
       }
     }
+  }
+
+  getRootViewNodeCount(): number {
+    return this.rootViewNodes.length;
+  }
+
+  hasNonPseudoTextContentAfter(rootViewNodeIndex: number): boolean {
+    const hasNonPseudoText = (node: Node): boolean => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        return !!node.textContent?.trim();
+      }
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        return false;
+      }
+      if (PseudoElement.getPseudoName(node as Element)) {
+        return false;
+      }
+      return Array.from(node.childNodes).some(hasNonPseudoText);
+    };
+    return this.rootViewNodes.slice(rootViewNodeIndex).some(hasNonPseudoText);
+  }
+
+  appendContentFrom(other: PageFloatArea): void {
+    other.rootViewNodes.forEach((node) => {
+      this.element.appendChild(node);
+    });
+    this.rootViewNodes.push(...other.rootViewNodes);
+    this.floatMargins.push(...other.floatMargins);
+    other.rootViewNodes.splice(0);
+    other.floatMargins.splice(0);
+    if (other.element.parentNode) {
+      other.element.parentNode.removeChild(other.element);
+    }
+    this.applyCompactFootnoteDisplay();
+    this.updateComputedBlockSizeForFootnoteArea(true);
+  }
+
+  removeContentAfter(rootViewNodeIndex: number): void {
+    const removedRootViewNodes = this.rootViewNodes.splice(rootViewNodeIndex);
+    this.floatMargins.splice(rootViewNodeIndex);
+    removedRootViewNodes.forEach((node) => {
+      if (node.parentNode) {
+        node.parentNode.removeChild(node);
+      }
+    });
+    this.applyCompactFootnoteDisplay();
+    this.updateComputedBlockSizeForFootnoteArea(true);
   }
 
   getContentInlineSize(): number {
@@ -5481,13 +5601,25 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
     this.updateComputedBlockSizeForFootnoteArea();
   }
 
-  private updateComputedBlockSizeForFootnoteArea(): void {
+  private updateComputedBlockSizeForFootnoteArea(
+    useActualBlockStart: boolean = false,
+  ): void {
     if (this.rootViewNodes.length === 0) {
       this.computedBlockSize = 0;
       return;
     }
 
     const dir = this.getBoxDir();
+    let contentBeforeEdge = this.beforeEdge;
+    if (useActualBlockStart) {
+      const areaBox = LayoutHelper.getElementClientRectAdjusted(
+        this.clientLayout,
+        this.element,
+        this.vertical,
+      );
+      contentBeforeEdge =
+        this.getBeforeEdge(areaBox) + dir * this.getInsetBefore();
+    }
     this.computedBlockSize = Math.max(
       0,
       ...this.rootViewNodes.map((node) => {
@@ -5499,7 +5631,7 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
         const margin = this.getComputedMargin(node);
         const marginAfter = this.vertical ? margin.left : margin.bottom;
         return (
-          dir * (this.getAfterEdge(box) - this.beforeEdge) +
+          dir * (this.getAfterEdge(box) - contentBeforeEdge) +
           Math.max(0, marginAfter)
         );
       }),

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -56,7 +56,7 @@ import * as TextPolyfill from "./text-polyfill";
 import * as Vgen from "./vgen";
 import * as Vtree from "./vtree";
 import * as XmlDoc from "./xml-doc";
-import { Layout as LayoutType } from "./types";
+import { Layout as LayoutType, PageFloats as PageFloatsType } from "./types";
 import {
   UserAgentBaseCss,
   UserAgentCounterStylesCss,
@@ -1417,7 +1417,13 @@ export class StyleInstance
     // 1. Determine current position in the document: Find the minimal
     // consumed-offset for all elements not fully-consumed in each primary flow.
     // Current position is maximum of the results among all primary flows.
-    const currentPosition = this.getPosition(cp);
+    let currentPosition = this.getPosition(cp);
+    if (currentPosition == Number.POSITIVE_INFINITY) {
+      if (this.hasActiveRootPageFloatLayoutContext()) {
+        currentPosition =
+          cp.highestSeenOffset ?? this.styler.getReachedOffset();
+      }
+    }
     if (currentPosition == Number.POSITIVE_INFINITY) {
       // end of primary content is reached
       return null;
@@ -1548,7 +1554,9 @@ export class StyleInstance
     column.flowRootFormattingContext = flow.formattingContext;
   }
 
-  beginIsolatedRootPageFloatLayoutContext(): PageFloats.PageFloatLayoutContext {
+  beginIsolatedRootPageFloatLayoutContext(
+    previousPageFloatLayoutContext?: PageFloatsType.PageFloatLayoutContext | null,
+  ): PageFloats.PageFloatLayoutContext {
     const originalRootPageFloatLayoutContext = this.rootPageFloatLayoutContext;
     this.rootPageFloatLayoutContext = new PageFloats.PageFloatLayoutContext(
       null,
@@ -1559,6 +1567,11 @@ export class StyleInstance
       null,
       null,
     );
+    if (previousPageFloatLayoutContext) {
+      this.rootPageFloatLayoutContext.addPageFloatLayoutContextAsPreviousSibling(
+        previousPageFloatLayoutContext,
+      );
+    }
     return originalRootPageFloatLayoutContext;
   }
 
@@ -1576,6 +1589,12 @@ export class StyleInstance
         .length > 0 ||
       this.rootPageFloatLayoutContext.getFloatsDeferredToNextInChildContexts()
         .length > 0
+    );
+  }
+
+  private hasOnlyDeferredPageFloats(cp: Vtree.LayoutPosition): boolean {
+    return (
+      this.noMorePrimaryFlows(cp) && this.hasActiveRootPageFloatLayoutContext()
     );
   }
 
@@ -2798,7 +2817,11 @@ export class StyleInstance
     page.isBlankPage = cp.isBlankPage;
     cp.page++;
 
-    const pageStartPageType = this.getPageStartPageTypeOverride(cp);
+    const hasOnlyDeferredPageFloats = this.hasOnlyDeferredPageFloats(cp);
+
+    const pageStartPageType = hasOnlyDeferredPageFloats
+      ? undefined
+      : this.getPageStartPageTypeOverride(cp);
     if (pageStartPageType === "") {
       page.pageType = "";
     } else if (pageStartPageType) {
@@ -2806,9 +2829,14 @@ export class StyleInstance
     }
     if (page.pageType == null) {
       const firstPageType = cp.page === 1 ? this.resolveFirstPageType() : null;
+      const continuedPageType =
+        this.styler.cascade.currentPageType ??
+        this.styler.cascade.previousPageType;
       const fallbackPageType = page.isBlankPage
         ? this.styler.cascade.previousPageType
-        : (firstPageType ?? this.styler.cascade.currentPageType);
+        : hasOnlyDeferredPageFloats
+          ? continuedPageType
+          : (firstPageType ?? this.styler.cascade.currentPageType);
       page.pageType = fallbackPageType;
       if (!page.pageType) {
         // Issue #1991: `currentPageType` can still be empty when a page starts
@@ -2984,6 +3012,7 @@ export class StyleInstance
         });
       })
       .then(() => {
+        page.pageFloatLayoutContext = pageFloatLayoutContext;
         pageMaster.adjustPageLayout(this, page, this.clientLayout);
         if (!isTocBox) {
           this.processLinger();
@@ -3004,7 +3033,10 @@ export class StyleInstance
         cp.highestSeenOffset = this.styler.getReachedOffset();
         const triggers = this.style.store.getTriggersForDoc(this.xmldoc);
         page.finish(triggers, this.clientLayout);
-        if (this.noMorePrimaryFlows(cp)) {
+        if (
+          this.noMorePrimaryFlows(cp) &&
+          !this.hasActiveRootPageFloatLayoutContext()
+        ) {
           cp = null;
         }
         frame.finish(cp);

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -391,16 +391,21 @@ export class PageFloatLayoutContext
   private footnoteAnchorsSeen: Set<PageFloatID> = new Set();
 
   /**
-   * Tracks `footnote-policy: line` footnote IDs that have already triggered
-   * one invalidation (body reflow) on the current page. Like
-   * footnoteAnchorsSeen, this set survives invalidate() calls. Placing such a
+   * Tracks the footnoteMaxBlockSize value used when a `footnote-policy: line`
+   * footnote triggered invalidation (body reflow) on the current page. Like
+   * footnoteAnchorsSeen, this map survives invalidate() calls. Placing such a
    * footnote shrinks the body area and invalidates the page to reflow the
    * body; without this guard the same footnote is re-placed and re-invalidated
    * on every page-layout retry, which never converges and hangs the renderer.
-   * Allowing exactly one invalidation per footnote per page bounds the retries
-   * so pagination converges. (Issue #2024)
+   * Allowing exactly one invalidation per line-policy footnote per retry size
+   * bounds the retries while still reflowing body after footnoteMaxBlockSize
+   * changes.
+   * (Issue #2024, #2026)
    */
-  private lineFootnoteInvalidatedOnce: Set<PageFloatID> = new Set();
+  private lineFootnoteInvalidationMaxBlockSize: Map<
+    PageFloatID,
+    number | null
+  > = new Map();
 
   /**
    * Tracks `footnote-policy: line` footnote IDs for which finish() has already
@@ -478,6 +483,18 @@ export class PageFloatLayoutContext
   setOuterContext(outerContext: PageFloatLayoutContext) {
     this.outerContext = outerContext;
     this.floatStore = outerContext.floatStore;
+  }
+
+  /**
+   * Expose a previous rendered page's context to a temporary isolated root.
+   * The context is stored as a pseudo-child so normal previous-sibling lookup
+   * can seed deferred floats without making it this context's real parent.
+   * (Issue #2026)
+   */
+  addPageFloatLayoutContextAsPreviousSibling(
+    context: PageFloats.PageFloatLayoutContext,
+  ) {
+    this.children.push(context as PageFloatLayoutContext);
   }
 
   private getPreviousSiblingOf(
@@ -720,12 +737,15 @@ export class PageFloatLayoutContext
   }
 
   /**
-   * Whether a `footnote-policy: line` footnote has already triggered one
-   * invalidation (body reflow) on the current page. (Issue #2024)
+   * Whether this `footnote-policy: line` footnote has already triggered
+   * invalidation (body reflow) at the current retry size. (Issue #2024, #2026)
    */
   hasInvalidatedForLineFootnote(float: PageFloat): boolean {
     if (float.floatReference === this.floatReference) {
-      return this.lineFootnoteInvalidatedOnce.has(float.getId());
+      return (
+        this.lineFootnoteInvalidationMaxBlockSize.get(float.getId()) ===
+        this.footnoteMaxBlockSize
+      );
     }
     return this.getParent(float.floatReference).hasInvalidatedForLineFootnote(
       float,
@@ -733,13 +753,16 @@ export class PageFloatLayoutContext
   }
 
   /**
-   * Mark that a `footnote-policy: line` footnote has triggered one
-   * invalidation on the current page, so subsequent placements on the same
-   * page suppress the redundant invalidation. (Issue #2024)
+   * Mark that this `footnote-policy: line` footnote has triggered invalidation
+   * at the current retry size, so subsequent placements suppress redundant
+   * invalidation. (Issue #2024, #2026)
    */
   markInvalidatedForLineFootnote(float: PageFloat): void {
     if (float.floatReference === this.floatReference) {
-      this.lineFootnoteInvalidatedOnce.add(float.getId());
+      this.lineFootnoteInvalidationMaxBlockSize.set(
+        float.getId(),
+        this.footnoteMaxBlockSize,
+      );
     } else {
       this.getParent(float.floatReference).markInvalidatedForLineFootnote(
         float,
@@ -964,17 +987,20 @@ export class PageFloatLayoutContext
         if (this.locked) {
           this.invalidate();
         } else {
-          // Issue #1879: For footnotes in multi-column, try reducing the
-          // footnote size instead of forbidding. When a page-level footnote
-          // is too large, it reduces column/page heights so much that the
-          // anchor can't be reached (feedback loop). Halving the size and
-          // retrying lets the footnote fragment at a size that still allows
-          // the anchor to be reached during re-layout.
-          const hasMultiColumn =
+          // Issue #1879, #2026: For multicol or `footnote-policy: line`
+          // footnotes, try reducing the footnote size instead of forbidding
+          // when the footnote's own area pushes its anchor out of reach.
+          // Halving the size and retrying lets the footnote fragment at a size
+          // that still allows the anchor to be reached during re-layout.
+          const isLinePolicyFootnote =
+            isFootnote &&
+            "footnotePolicy" in notAllowedFloat &&
+            notAllowedFloat.footnotePolicy === Css.ident.line;
+          const retryFootnoteSizing =
             isFootnote &&
             this.footnoteAnchorsSeen.has(notAllowedFloat.getId()) &&
-            this.hasMultiColumnFootnoteContext();
-          if (hasMultiColumn) {
+            (isLinePolicyFootnote || this.hasMultiColumnFootnoteContext());
+          if (retryFootnoteSizing) {
             const currentOuter =
               fragment.area.computedBlockSize +
               fragment.area.getInsetBefore() +
@@ -1032,6 +1058,31 @@ export class PageFloatLayoutContext
   }
 
   finish() {
+    for (let i = this.floatFragments.length - 1; i >= 0; i--) {
+      const fragment = this.floatFragments[i];
+      // A line-policy footnote fragment whose anchor moved off this page is
+      // stale unless it is continuing from the previous page. Remove it before
+      // finishing so retries do not keep an orphaned footnote area.
+      const staleLineFootnote = fragment.continuations.some((continuation) => {
+        const float = continuation.float;
+        return (
+          "footnotePolicy" in float &&
+          float.footnotePolicy === Css.ident.line &&
+          !this.hasCurrentAnchor(float.getId()) &&
+          !this.floatsDeferredFromPrevious.some(
+            (previous) => previous.float === float,
+          )
+        );
+      });
+      if (staleLineFootnote) {
+        if (this.locked) {
+          this.invalidate();
+          return;
+        }
+        this.removePageFloatFragment(fragment);
+        return;
+      }
+    }
     if (this.checkAndForbidNotAllowedFloat()) {
       return;
     }
@@ -1040,7 +1091,6 @@ export class PageFloatLayoutContext
       const float = continuation.float;
       const existingFragment = this.findPageFloatFragment(float);
       if (
-        this.floatReference === FloatReference.PAGE &&
         "footnotePolicy" in float &&
         float.footnotePolicy === Css.ident.line &&
         this.hasCurrentAnchor(float.getId()) &&
@@ -1249,6 +1299,18 @@ export class PageFloatLayoutContext
     }
   }
 
+  private isFragmentInCurrentContainer(fragment: PageFloatFragment): boolean {
+    if (this.floatReference !== FloatReference.REGION) {
+      return true;
+    }
+    const area = fragment.area as Partial<LayoutType.PageFloatArea>;
+    return (
+      !area.parentElement ||
+      !this.container?.element ||
+      area.parentElement === this.container.element
+    );
+  }
+
   stashEndFloatFragments(float: PageFloat) {
     const floatReference = float.floatReference;
     if (floatReference !== this.floatReference) {
@@ -1269,6 +1331,7 @@ export class PageFloatLayoutContext
           fragment.floatSide,
         )[0];
         if (
+          this.isFragmentInCurrentContainer(fragment) &&
           (fragmentFloatSide === logicalFloatSide ||
             (logicalFloatSide === "snap-block" &&
               fragmentFloatSide === "block-end") ||
@@ -1325,6 +1388,7 @@ export class PageFloatLayoutContext
     clientLayout: Vtree.ClientLayout,
     condition?: (p1: PageFloatFragment, p2: PageFloatLayoutContext) => boolean,
     includeParent: boolean = true,
+    excludedArea?: LayoutType.PageFloatArea,
   ): number {
     Asserts.assert(this.container);
     const logicalSide = this.toLogical(side);
@@ -1337,6 +1401,7 @@ export class PageFloatLayoutContext
       layoutContext,
       clientLayout,
       condition,
+      excludedArea,
     );
     if (includeParent && this.parent && this.parent.container) {
       const parentLimit = this.parent.getLimitValue(
@@ -1346,6 +1411,7 @@ export class PageFloatLayoutContext
         clientLayout,
         condition,
         includeParent,
+        excludedArea,
       );
       switch (physicalSide) {
         case "top":
@@ -1369,6 +1435,7 @@ export class PageFloatLayoutContext
     layoutContext: Vtree.LayoutContext,
     clientLayout: Vtree.ClientLayout,
     condition?: (p1: PageFloatFragment, p2: PageFloatLayoutContext) => boolean,
+    excludedArea?: LayoutType.PageFloatArea,
   ): number {
     Asserts.assert(this.container);
     const limits = this.getLimitValuesInner(
@@ -1377,6 +1444,7 @@ export class PageFloatLayoutContext
       condition,
       logicalSide,
       logicalSide2,
+      excludedArea,
     );
     switch (logicalSide) {
       case "block-start":
@@ -1410,6 +1478,7 @@ export class PageFloatLayoutContext
     condition?: (p1: PageFloatFragment, p2: PageFloatLayoutContext) => boolean,
     logicalSide?: string,
     logicalSide2?: string,
+    excludedArea?: LayoutType.PageFloatArea,
   ): {
     top: number;
     left: number;
@@ -1459,6 +1528,12 @@ export class PageFloatLayoutContext
     const fragments = this.floatFragments;
     if (fragments.length > 0) {
       limits = fragments.reduce((l, f) => {
+        if (f.area === excludedArea) {
+          return l;
+        }
+        if (!this.isFragmentInCurrentContainer(f)) {
+          return l;
+        }
         if (condition && !condition(f, this)) {
           return l;
         }
@@ -1621,30 +1696,43 @@ export class PageFloatLayoutContext
     const blockSideForInlineLimit = logicalFloatSides.find((s) =>
       s.includes("block"),
     );
+    const includeParentLimits = true;
 
     let blockStart = this.getLimitValue(
       "block-start",
       inlineSideForBlockLimit,
       area.layoutContext,
       area.clientLayout,
+      undefined,
+      includeParentLimits,
+      area,
     );
     let blockEnd = this.getLimitValue(
       "block-end",
       inlineSideForBlockLimit,
       area.layoutContext,
       area.clientLayout,
+      undefined,
+      includeParentLimits,
+      area,
     );
     let inlineStart = this.getLimitValue(
       "inline-start",
       blockSideForInlineLimit,
       area.layoutContext,
       area.clientLayout,
+      undefined,
+      includeParentLimits,
+      area,
     );
     let inlineEnd = this.getLimitValue(
       "inline-end",
       blockSideForInlineLimit,
       area.layoutContext,
       area.clientLayout,
+      undefined,
+      includeParentLimits,
+      area,
     );
     const blockOffset = area.vertical ? area.originX : area.originY;
     const inlineOffset = area.vertical ? area.originY : area.originX;
@@ -1889,10 +1977,8 @@ export class PageFloatLayoutContext
       logicalFloatSides.some((s) => s === "block-end") ||
       (logicalFloatSides.length === 1 && logicalFloatSides[0] === "inline-end")
     ) {
-      area.setBlockPosition(
-        blockEnd - outerBlockSize * area.getBoxDir(),
-        blockSize,
-      );
+      const blockPosition = blockEnd - outerBlockSize * area.getBoxDir();
+      area.setBlockPosition(blockPosition, blockSize);
     }
 
     return logicalFloatSides.join(" ");

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -567,9 +567,13 @@ export namespace Layout {
     adjustContentRelativeSize: boolean;
     readonly floatSide: string;
     readonly parentContainer: Vtree.Container;
+    readonly parentElement: Element | null;
 
     convertPercentageSizesToPx(target: Element): void;
     fixFloatSizeAndPosition(nodeContext: Vtree.NodeContext): void;
+    getRootViewNodeCount(): number;
+    hasNonPseudoTextContentAfter(rootViewNodeIndex: number): boolean;
+    appendContentFrom(other: PageFloatArea): void;
     getContentBlockMarginAfter(): number;
     getContentInlineSize(): number;
   }
@@ -699,6 +703,9 @@ export namespace PageFloats {
     getContainer(floatReference?: FloatReference): Vtree.Container;
     setContainer(container: Vtree.Container);
     setOuterContext(outerContext: PageFloatLayoutContext): void;
+    addPageFloatLayoutContextAsPreviousSibling(
+      context: PageFloatLayoutContext,
+    ): void;
     addPageFloat(float: PageFloat): void;
     getPageFloatLayoutContext(
       floatReference: FloatReference,

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -140,6 +140,7 @@ export class Page extends Base.SimpleEventTarget {
     left: { [key: string]: Container };
     right: { [key: string]: Container };
   } = { top: {}, bottom: {}, left: {}, right: {} };
+  pageFloatLayoutContext: PageFloats.PageFloatLayoutContext | null = null;
   pageType: string | null = null;
 
   constructor(

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -1031,6 +1031,11 @@ module.exports = [
           "footnote-policy: line break before anchor line (vertical writing-mode) (Issue #2006)",
       },
       {
+        file: "footnotes/footnote-fragmentation-target-counter.html",
+        title:
+          "Long footnote fragmentation with target-counter() (Issue #2026)",
+      },
+      {
         file: "footnotes/named-page-deferred-text.html",
         title: "Named page with deferred text after footnote (Issue #1991)",
       },

--- a/packages/core/test/files/footnotes/footnote-fragmentation-target-counter.html
+++ b/packages/core/test/files/footnotes/footnote-fragmentation-target-counter.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2026: a long fragmented footnote with target-counter() must not be dropped during rerendering. Reduced from the original issue Gist. -->
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Long footnote fragmentation with target-counter()</title>
+    <style>
+      @page {
+        size: 140mm 215mm;
+        margin: 20mm 20mm 16mm;
+
+        @bottom-center {
+          font-size: 8pt;
+          content: counter(page);
+        }
+
+        @footnote {
+          border-top: 0.5pt solid black;
+          margin-top: 6.6666mm;
+          padding-top: 2mm;
+        }
+      }
+
+      :root {
+        font-family: Georgia, "Times New Roman", serif;
+        font-size: 9.5pt;
+        line-height: 140%;
+        widows: 2;
+        orphans: 2;
+        hyphens: auto;
+      }
+
+      p {
+        margin: 0 0 3mm;
+        text-align: justify;
+      }
+
+      span[data-type="FOOTNOTE"] {
+        float: footnote;
+        font-size: 7.5pt;
+        line-height: 130%;
+        text-align: justify;
+      }
+
+      span[data-type="FOOTNOTE"]::footnote-call {
+        content: counter(footnote);
+        font-size: 70%;
+        line-height: 60%;
+        vertical-align: super;
+      }
+
+      span[data-type="FOOTNOTE"]::footnote-marker {
+        content: counter(footnote) ".";
+      }
+
+      a.signetpageref::before {
+        content: target-counter(attr(href url), page);
+      }
+    </style>
+  </head>
+  <body>
+    <p>Passons à présent à DesdémoneDesdémone (<i>Othello</i>)mort de. Sa dévotion désintéressée envers Othello et sa douceur font d’elle un sujet particulièrement indigne des souffrances tragiquesOthellomeurtre de Desdémone. Sa mort semble profondément choquante. Il faut se demander s’il y a quoi que ce soit dans sa nature qui puisse en quelque façon justifier son destin. Est-elle détruite gratuitement, comme une spectatrice sans défense entraînée dans l’effondrement de la vie d’Othello ?</p>
+
+    <p>La réponse dépend de la façon dont on comprend son amour. Quelle était la source de son engagement dans cette étrange romance ? Indiscutablement, il venait des discours d’Othello. Mais cela ne suffit pas : nous devons découvrir ce que ces discours suscitaient en elle. Nous apprenons de la bouche de son père qu’elle était d’ordinaire une jeune fille calme et timide, d’un caractère doux et gentil. Mais, dans le même temps, nous savons qu’elle était indépendante, qu’elle savait ce qu’elle voulait. Elle « repoussait les galants les plus somptueux et les mieux frisés » de Venise ; les meilleurs partis de la région ne lui suffisaient pas<span data-type="FOOTNOTE">
+I, 3, 113-115 [F.-V. Hugo, p. 252] ; I, 2, 83.
+</span>. Elle voulait aimer quelque chose qui surpasserait le caractère vénitien.</p>
+
+    <p>C’est ce qu’Othello lui a apporté. Ses histoires de pays étranges et de grandes aventures semblaient lui donner la preuve d’une expérience et d’une connaissance éloignées des conventions. Elle sentait que sa vie limitée ne lui suffisait pas ; nous voyons en elle une passion embryonnaire pour l’universel, un désir de ne pas être dupée par la vie. Mais elle est désorientée. Elle perçoit ce qui est simplement différent et étrange comme étant le plus significatif et le plus réel. Qu’Othello les croie ou non, ses histoires contiennent beaucoup d’éléments qui ne sauraient être vrais ; elles sont, comme le dit Iago, fantastiques<span data-type="FOOTNOTE">
+I, 3, 166-168 ; II, 1, 255-257.
+</span>. Elles séduisent l’imagination de Desdémone, qui a été noyée dans la solitude et la timidité. Elle est exactement comme la décrit son nom — superstitieuse<span data-type="FOOTNOTE">
+Pour cette étymologie, je suis l’analyse de ShaftesburyShaftesbury, Anthony Ashley Cooper, comte de en considérant que son nomDesdémone (<i>Othello</i>)signification du nom est dérivé du grec <i>δεισιδαίμων</i>, alors que des interprètes plus tardifs l’ont unanimement compris comme provenant de <i>δυσδαίμων</i>, qui signifie « malheureux », « infortuné ». Bien évidemment, on ne peut pas s’appuyer trop fortement sur l’étymologie supposée d’un nom pour interpréter une pièce, surtout quand cette interprétation elle-même est discutable. Mais il semble certain que Shakespeare choisissait souvent des noms qui connotaient les caractères de ses personnages (voir J. RuskinRuskin, John, <i>Munera Pulveris</i>, <i>in</i> <i>Works</i>, G. Allen, Londres, 1905, p. 257), et dans ce cas les deux étymologies correspondent extrêmement bien. Ma préférence pour le premier sens « superstitieuse » se fonde sur une observation générale de la nature de Desdémone et la pertinence qu’il y a à lui attribuer un tel terme. Autant que je sache, il n’y a pas de raisons philologiques qui permettent de trancher en faveur d’une interprétation plutôt qu’une autre, de sorte qu’il nous faut nous appuyer sur notre interprétation de la pièce pour justifier le sens qu’on donne à son nom. Si l’interprétation est convaincante, le nom lui donne un certain poids en plus. Les autres interprètes qui ont traité de ce problème ont fondé leur choix presque exclusivement sur l’idée que Desdémone était malchanceuse et que cela constituait son essence ; la signification de son nom ne ferait qu’exprimer cette malchancesuperstition. La tâche de cet essai a été de prouver ce n’est pas seulement la mauvaise fortune qui constitue le cœur de sa tragédie. Le lecteur doit juger pour lui-même de la plausibilité des deux étymologies, car l’érudition ne peut pas aller plus loin. Comme cela arrive fréquemment dans le domaine savant, une affirmation concernant la certitude d’une interprétation discutable semble fournir une preuve scientifique à des problématiques qui dépendent réellement de cette interprétation. C’est seulement si un Shaftesbury a tort avec certitude dans sa compréhension d’Othello qu’on peut décider ultimement si DesdémoneDesdémone (<i>Othello</i>)signification du nom signifiait « infortunée » aux yeux de Shakespeare. Quels que soient les arguments en faveur d’une hypothèse ou de l’autre, ils sont ambigus. La source que Shakespeare a utilisée pour <i>Othello</i>, la nouvelle de Cinthio, ne contenait qu’un seul nom, celui de Desdémone, que Shakespeare a repris dans sa pièce. Chez Cinthio, le nom signifie presque sans aucun doute « infortunée » ; mais cela ne prouve pas que Shakespeare n’a pas pu en modifier le sens, de la même façon qu’il réinterprète entièrement le personnage pour lui donner une nouvelle importance. L’élément pertinent est que Shakespeare modifie l’orthographe du nom de Cinthio : dans la <i>novella</i>, il s’agit de « <i>Dis</i>demona » Desdémone (<i>Othello</i>)signification du nom. Le <i>i </i>et le <i>y </i>sont les translitérations conventionnelles de la lettre grecque <i>υ</i>, ce qui indique clairement que l’étymologie du nom est <i>δυσδαίμων.</i> Le fait que Shakespeare substitue le <i>e</i> au <i>i</i>, à moins que ce ne soit pour des raisons non évidentes d’euphonie, rapprocherait le nom du grec <i>δεισιδαίμων</i>. Depuis Théophraste, si ce n’est avant, le <i>δεισιδαίμων</i>, ou l’homme superstitieux, est un des types humains conventionnels, un personnage qui est dépeint dans la littérature dans le but d’instruire le public sur les erreurs dangereuses et communes. PlutarquePlutarque a écrit un traité sur le sujet que Shakespeare aurait facilement pu lire. Dans l’œuvre de Plutarque, l’homme superstitieux est distingué de l’athée — qui est présenté comme ayant des opinions divergentes et fausses sur la nature des dieux. Les deux personnages décrits par Plutarque ont des similitudes frappantes avec Desdémone et Iago. Enfin, ces deux étymologies ne sont pas nécessairement mutuellement exclusives (voir p. <a class="signetpageref" href="#signet-Chap02_destinee"></a> du présent ouvrage). Voir John UptonUpton, John, <i>Critical Observations on Shakespeare</i>, Londres, 1746, p. 288 ; John Wesley HalesHales, John Wesley, <i>Notes and Essays on Shakespeare</i>, Londres, 1884, p. 111 ; Albert TeschTesch, Albert « Zum Namen Desdemona », <i>Germanisch-Romanische Monatsschrift</i>, XVII, 1929, 578-588.
+</span>. Sa dévotion envers Othello l’honore, et son choix de chercher un sens au-delà des opinions consacrées lui octroie une dignité que les citoyens ordinaires ne peuvent avoir. Mais c’était un choix qu’elle a conçu dans l’erreur : Othello était une création de son esprit. Elle croit les discours relatant ses hauts faits. Paradoxalement, son amour la poussait à rechercher chez Othello quelque chose d’indépendant et de libre, alors que ce même amour a rendu son mari dépendant et a relié son apparente universalité à quelque chose de particulier. Ils sont passés l’un à côté de l’autre, pour ainsi dire, sur le chemin de l’amour. Ce qu’il y a de plus paradoxal, c’est que pour se libérer de Venise, elle a aimé une création de Venise. Au lieu de gagner sa liberté, elle s’est retrouvée enchaînée encore plus solidement à ce qu’elle essayait de fuir ; Othello n’existait que dans l’esprit de Venise. DesdémoneDesdémone (<i>Othello</i>)mort de s’est donnée entièrement et avec passion à quelque chose qui dépassait la réalité physique, mais quelque chose qu’elle a conçu dans l’erreur. En abandonnant tout au nom du cosmopolitismecosmopolitismedans <i>Othello</i>, elle prenait le parti de l’expression la plus caractéristique de la communauté politique — les mythes qui entourent ses chefs. Desdémone, le seul personnage dans la pièce qui soit indifférent à l’opinion populaire, devient prisonnière de l’opinion qui s’est formée autour d’Othello.</p>
+
+    <p>La superstition de DesdémoneDesdémone (<i>Othello</i>)mort de n’est pas la seule cause de sa mortOthellomeurtre de Desdémone. Sa fidélitéfidélitéde Desdémone est également une condition nécessaire. Non seulement elle était attirée par les histoires d’Othello, mais elle croyait et voulait garder foi en lui quoi qu’il fît. L’apparence que revêtent ses actions n’a pas d’importance ; il faut le suivre et l’aimer en dépit de ses actes, car ses fins sont impénétrables. Elle croit en lui si entièrement qu’elle doit nier la validité du sens commun pour justifier son action. Ce qui apparaît comme une injustice d’un point de vue ordinaire doit apparaître à Desdémone comme la justice punissant quelque vice ou péché supposé de sa part ou de celle des autres. S’il faut le croire, quoiqu’il agisse de façon contraire aux normes humaines ordinaires, alors elle doit dire que ces normes sont dénuées de sens ou bien erronées dans ce contexte plus élevé. Elle accepte la nouvelle façon de juger les âmes qui a résulté de la jalousie d’Othello ; l’apparence manifeste des choses est rejetée, et une norme mystérieuse dépendant des caprices d’Othello devient la règle. Bien entendu, la véritable source de cette norme est le besoin que ressent Othello de se faire aimer de manière absolue et inconditionnelle. Mais cette source véritable est transformée et représentée comme un sens secret de la vie, un secret qui ne peut être révélé que par Othello. Chez Desdémone commence une sorte d’introspection : elle ne regarde plus le sens superficiel des mots et des actes, sa conscience lui ordonne de rechercher des fautes que sa raison ne voit pas. Cassio a fait peu ou prou la même chose lorsqu’il a été révoqué par Othello ; toutes les valeurs morales viennent d’Othello, et ce qu’il n’approuve pas est mauvais. Ce n’est pas Othello qui dépend de la nature, mais la nature qui dépend d’Othello. Ceci conduit à de nouvelles habitudes mentales, de nouvelles vertus.</p>
+
+    <p>Lors de sa conversation avec ÉmiliaÉmilia (<i>Othello</i>), Desdémone expose clairement son principe : la fidélité, et rien que la fidélité — tout y est subordonné. C’est un principe noble, sans aucun doute, mais qui n’est certainement pas aussi raisonnable que celui d’Émilia, qui fait dépendre la fidélité des actes de son mari. Son éthique est accommodante, elle n’attache pas tant d’importance à la chasteté. En elle-même, elle n’est pas une personne aussi raffinée que Desdémone, mais peut-être qu’on ne peut atteindre la noblesse véritable et non tragique par la sanctification de la fidélité maritale. Émilia, tout inférieure qu’elle soit, peut permettre de mettre ceci en valeur. Pour ÉmiliaÉmilia (<i>Othello</i>), le monde simple des significations du sens commun et la justice évidente des faits doivent dicter la fidélité : celle-ci ne saurait être inconditionnelle. Pour Desdémone, tout doit être interprété de façon à préserver sa foi<span data-type="FOOTNOTE">
+IV, 3, 66-116 ; IV, 3, 24-26 ; IV, 2, 81 ; IV, 2, 131-145 ; IV, 2, 177-193 ; III, 3, 89-96 ; III, 3, 103 ; III, 4, 162-176.
+</span>.</p>
+
+    <p>La foi de Desdémonesuperstition envers Othello la conduit à un certain mépris vis-à-vis de la véritévéritéet Désdémoneamourvérité et, ce qui n’a pas été assez souvent observé. Nous la voyons recourir à la tromperie à trois reprises dans la pièce, avec à chaque fois une incidence plus grande sur son destin. Tout d’abord, elle cache à son père sa relation avec Othello et le met devant le fait accompli. Quelle que soit l’indulgence avec laquelle nous puissions considérer son amour pour Othello, il n’y a aucun doute sur le fait qu’elle est coupable de désobéissance, et que son amour entre en conflit avec ses devoirs les plus sacrés. L’amour pour Othello conduit le meilleur enfant de la cité à mépriser ces devoirs, sans hésiter à enfreindre la loi pour lui. À chaque fois que sa loyauté se trouve tiraillée, Desdémone prend sans hésitation le parti d’Othello ; il semble que cette jeune fille timide a pris tant de force et d’assurance, ou que son amouramourfanatisme de l’ l’a rendue si fanatique qu’elle est devenue capable de commettre de sang-froid ce que d’autres seraient incapables de faire. Il faut rappeler que la conséquence de cette tromperie fut la mort de son père<span data-type="FOOTNOTE">
+V, 2, 255-261.
+</span>. Dans le deuxième cas, elle a menti à Othello à propos du mouchoirmouchoirdans <i>Othello</i>. C’est peut-être là que sa nature superstitieuse nous apparaît le plus clairement ; elle était si effrayée par l’importance qu’Othello attachait à ce mouchoir et par le conte qu’il lui a raconté à son propos qu’elle n’a pas osé lui faire savoir qu’elle l’avait perdu. Cette contre-vérité a conduit directement à sa propre mort<span data-type="FOOTNOTE">
+III, 4, 95-104.
+</span>. Enfin, elle semble proférer un mensonge même lorsqu’elle est à l’agonieDesdémone (<i>Othello</i>)déclarations d'agonie de. Elle dit qu’Othello ne l’a pas tuée. Elle essaie encore de préserver la réputation de son mari, car elle mourrait en vain s’il était mauvais. La réputation d’Othello vit en elle et non en lui. Jusqu’à la fin, elle doit voir les choses telles qu’elle veut les voir et non telles qu’elles sontDesdémone (<i>Othello</i>)déclarations d'agonie de. Croire c’est voir<span data-type="FOOTNOTE">
+V, 2, 147-156. Othello a étouffé Desdémone au vers 105 et il est persuadé qu’elle est morte jusqu’au vers 117. Que Shakespeare ait voulu dire qu’elle est revenue à la vie ou qu’Othello se soit trompé et qu’elle n’était pas encore tout à fait morte, les paroles de DesdémoneDesdémone (<i>Othello</i>)déclarations d'agonie de — des phrases cohérentes prononcées après un étranglement — constituent un événement remarquable, qui dépasse l’ordre naturel des choses. C’est une difficulté qui a souvent été soulignée. Je suggère que ce dernier effort suprême de la pauvre créature avait pour but de donner une impression de surnaturel au public, et qu’essayer de rationaliser cela, en changeant les circonstances de sa mort ou d’une autre façon, revient à manquer le sens du passage. C’est précisément en raison de l’invraisemblance de ce que fait Desdémone que nous prenons conscience de l’intensité de sa dévotion et de sa foi. Elle donne au passage une portée qui dépasse l’humain, dans une pièce qui se distingue par son contexte purement humain, une pièce dont les réverbérations cosmiques qui caractérisent les autres grandes tragédies de Shakespeare sont absentes. Au théâtre, particulièrement chez Shakespeare, les invraisemblances sont des outils permettant d’exprimer des réalités plus grandes mais indicibles.
+</span>.</p>
+
+    <p>La mort de Desdémone est dans une large mesure imputable à ses propres erreurs. C’étaient de nobles erreurs, des erreurs qui l’ont élevée au-dessus de l’humanité ordinaire, mais qui méritaient d’être punies. Du point de vue de la vie de tous les jours, Desdémone pèche en trahissant son père. Nous prenons son parti car elle le fait au nom de quelque chose de plus grand. Mais peut-être que dans une troisième perspective, la plus importante, nous devons prendre la défense de la société civile, et considérer son abandon comme le résultat d’une incompréhension monstrueuse. Peut-être qu’on ne peut atteindre le véritable cosmopolitisme qu’en renonçant aux vœux les plus chers de la vie pratique. Le mariage fait partie de la vie politique, de la société civile. On ne peut le purifier de sa dimension politique sans le vider de sa substance.</p>
+
+    <p>On a comparé Desdémone à CordéliaCordélia (<i>Le Roi Lear</i>) et à MirandaMiranda (<i>La Tempête</i>), à juste titre. Elle est indépendante, courageuse et gentille, comme la première ; elle a une douce candeur, comme la seconde (sur le même mode que le célèbre « <i>oh brave new world</i> »). Mais il manque à Desdémone cet amour de la vérité qui permet à Cordélia de si bien comprendre sa situation. Desdémone ne reconnaît jamais son erreur, et elle dit, en faisant référence à un autre sens possible de son nom : « Telle est ma misérable destinée<span data-type="FOOTNOTE">
+IV, 2, 150 [F.-V. Hugo, <i>ibid</i>. p. 358].
+</span> ! » <span id="signet-Chap02_destinee">Shakespeare</span>Shakespeare, en exploitant pleinement le sens de ce nom, nous présente sa « misérable destinée » comme le résultat de sa « superstitionsuperstition ». À la différence de Miranda, elle n’a pas de ProspéroProspéro (<i>La Tempête</i>) pour guider son imagination et la mettre sur le droit chemin. Sa compréhension naïve des choses engendre des monstres. Dans cette pièce sombre, Shakespeare ne nous montre aucune échappatoire au problème de Desdémone. Elle mène une vie noble, mais une vie qui va à l’encontre du droit et de la raison.</p>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/page-floats-spec.js
+++ b/packages/core/test/spec/vivliostyle/page-floats-spec.js
@@ -1154,6 +1154,89 @@ describe("page-floats", function () {
       });
     });
 
+    describe("#hasInvalidatedForLineFootnote", function () {
+      it("invalidates again when the line footnote retry size changes", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          null,
+          "foo",
+          null,
+          null,
+          null,
+        );
+        var float = new PageFloat(
+          dummyNodePosition(),
+          FloatReference.PAGE,
+          "block-end",
+          null,
+          "foo",
+        );
+
+        pageContext.addPageFloat(float);
+        expect(pageContext.hasInvalidatedForLineFootnote(float)).toBe(false);
+
+        pageContext.markInvalidatedForLineFootnote(float);
+        expect(pageContext.hasInvalidatedForLineFootnote(float)).toBe(true);
+
+        pageContext.footnoteMaxBlockSize = 100;
+        expect(pageContext.hasInvalidatedForLineFootnote(float)).toBe(false);
+
+        pageContext.markInvalidatedForLineFootnote(float);
+        expect(pageContext.hasInvalidatedForLineFootnote(float)).toBe(true);
+      });
+    });
+
+    describe("#addPageFloatLayoutContextAsPreviousSibling", function () {
+      it("seeds isolated roots with continuations from the previous page", function () {
+        var previousPageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var isolatedRootContext = new PageFloatLayoutContext(
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var float = new PageFloat(
+          dummyNodePosition(),
+          FloatReference.PAGE,
+          "block-end",
+          null,
+          "body",
+        );
+        previousPageContext.addPageFloat(float);
+        var continuation = new PageFloatContinuation(float, {});
+        previousPageContext.deferPageFloat(continuation);
+
+        isolatedRootContext.addPageFloatLayoutContextAsPreviousSibling(
+          previousPageContext,
+        );
+        var isolatedPageContext = new PageFloatLayoutContext(
+          isolatedRootContext,
+          FloatReference.PAGE,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+        expect(isolatedPageContext.getDeferredPageFloatContinuations()).toEqual(
+          [continuation],
+        );
+      });
+    });
+
     describe("#deferPageFloat", function () {
       var pageContext, regionContext, columnContext, float;
       beforeEach(function () {
@@ -1545,6 +1628,61 @@ describe("page-floats", function () {
 
         expect(context.removePageFloatFragment).not.toHaveBeenCalled();
         expect(context.floatsDeferredToNext).toEqual([cont3, cont4]);
+      });
+
+      it("retries footnote sizing outside multi-column when the footnote pushes its anchor away", function () {
+        var pageContext = new PageFloatLayoutContext(
+          rootContext,
+          FloatReference.PAGE,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+        var float = new PageFloat(
+          dummyNodePosition(),
+          FloatReference.PAGE,
+          "block-end",
+          null,
+          "body",
+        );
+        float.footnotePolicy = adapt_css.ident.line;
+        pageContext.addPageFloat(float);
+        pageContext.footnoteAnchorsSeen.add(float.getId());
+        spyOn(pageContext, "hasMultiColumnFootnoteContext").and.returnValue(
+          false,
+        );
+        var area = {
+          isFootnote: true,
+          computedBlockSize: 100,
+          getInsetBefore: function () {
+            return 5;
+          },
+          getInsetAfter: function () {
+            return 5;
+          },
+          element: {
+            parentNode: {
+              removeChild: jasmine.createSpy("removeChild"),
+            },
+          },
+        };
+        var fragment = new PageFloatFragment(
+          float.floatReference,
+          float.floatSide,
+          null,
+          [new PageFloatContinuation(float, {})],
+          area,
+          true,
+        );
+        pageContext.addPageFloatFragment(fragment, true);
+
+        expect(pageContext.checkAndForbidNotAllowedFloat()).toBe(true);
+
+        expect(pageContext.footnoteMaxBlockSize).toBe(55);
+        expect(pageContext.isForbidden(float)).toBe(false);
+        expect(pageContext.findPageFloatFragment(float)).toBe(null);
       });
 
       it("forbids deferred line-policy footnotes on page contexts while the anchor is present", function () {


### PR DESCRIPTION
Store each rendered page's page-float layout context and seed isolated `target-counter()` rerenders from the previous rendered page so deferred footnote continuations survive page replacement.

Keep pagination active while root page-float state remains, clean up stale footnote fragments whose anchors moved off the page, and safely merge shared footnote scratch areas when placing `footnote-policy: line` content. Add unit coverage plus a reduced layout-regression fixture for the long-footnote `target-counter()` case.

Closes #2026

Assisted-by: GitHub Copilot Chat:gpt-5.5

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2026 (the footnote drop/improper-break follow-up from #2024); the AI iterated on the page-float context handling for footnote placement.
- The human author repeatedly found new layout regressions during manual testing (footnote areas overlapping page margin boxes, rendering stopping partway through a document, differences between the integrated browser and external Chrome) and directed the AI to keep investigating until the layout-regression suite was clean.
- Once the fix worked, the human author asked the AI to build a minimal regression test case, then iteratively simplify it (removing unrelated attributes/elements, consolidating `@page` rules) for long-term maintainability.
- The human author requested a final self-review of the whole fix for safety, redundancy, and comment clarity before `/draft-commit` and `/address-pr-comments`.

</details>
