### PR TITLE
feat(core): add continuous scroll page view mode

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -53,6 +53,8 @@ export type ViewportSize = {
 export const VIEWPORT_STATUS_ATTRIBUTE = "data-vivliostyle-viewer-status";
 
 export const VIEWPORT_SPREAD_VIEW_ATTRIBUTE = "data-vivliostyle-spread-view";
+export const VIEWPORT_CONTINUOUS_SCROLL_ATTRIBUTE =
+  "data-vivliostyle-continuous-scroll";
 
 /**
  * @enum {string}
@@ -61,6 +63,11 @@ export enum PageViewMode {
   SINGLE_PAGE = "singlePage",
   SPREAD = "spread",
   AUTO_SPREAD = "autoSpread",
+  /**
+   * Render every page in its own element, stacked vertically so the whole
+   * document can be scrolled through like a PDF viewer (Issue #1235).
+   */
+  CONTINUOUS_SCROLL = "continuousScroll",
 }
 
 export type SingleDocumentParam = {
@@ -447,6 +454,11 @@ export class AdaptiveViewer {
       command["pageViewMode"] !== this.pageViewMode
     ) {
       this.pageViewMode = command["pageViewMode"] as PageViewMode;
+      // Continuous scroll mode needs every page rendered so they can all be
+      // stacked vertically (Issue #1235).
+      if (this.pageViewMode === PageViewMode.CONTINUOUS_SCROLL) {
+        this.renderAllPages = true;
+      }
       this.needResize = true;
     }
     if (
@@ -624,6 +636,75 @@ export class AdaptiveViewer {
     }
   }
 
+  /**
+   * Hide every rendered page (used when switching away from continuous
+   * scroll mode back to single page / spread view).
+   */
+  private hideAllPages() {
+    this.opfView.forAllPages((page) => {
+      Base.setCSSProperty(page.container, "display", "none");
+    });
+  }
+
+  /**
+   * Continuous scroll view mode (Issue #1235): reveal every rendered page so
+   * they are stacked vertically (each in its own element) like a PDF viewer,
+   * then scroll the current page into view.
+   */
+  private showAllPages(currentPage: Vtree.Page): Task.Result<null> {
+    this.viewportElement.setAttribute(
+      VIEWPORT_CONTINUOUS_SCROLL_ATTRIBUTE,
+      "true",
+    );
+    this.currentSpread = null;
+    this.opfView.forAllPages((page) => {
+      Base.setCSSProperty(page.container, "visibility", "visible");
+      Base.setCSSProperty(page.container, "display", "block");
+      page.container.style.marginLeft = "";
+      page.container.style.marginRight = "";
+    });
+    this.currentPage = currentPage;
+    // Attach interaction listeners to (and ensure visibility of) the current
+    // page; removePageListeners()/forCurrentPages() keep this in sync.
+    this.showSinglePage(currentPage);
+    this.setContinuousScrollZoom();
+    this.scrollToPage(currentPage);
+    return Task.newResult(null);
+  }
+
+  /**
+   * Scroll the viewport so the given page is brought into view, without
+   * replacing the content of a shared element (continuous scroll mode).
+   */
+  private scrollToPage(page: Vtree.Page) {
+    if (page.container && typeof page.container.scrollIntoView === "function") {
+      page.container.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }
+
+  /**
+   * Size the zoom box to fit the full stack of pages for continuous scroll
+   * mode. The widest page determines the width; the heights are summed so the
+   * viewport can scroll through every page.
+   */
+  private setContinuousScrollZoom() {
+    let maxWidth = 0;
+    let totalHeight = 0;
+    let count = 0;
+    this.opfView.forAllPages((page) => {
+      maxWidth = Math.max(maxWidth, page.dimensions.width);
+      totalHeight += page.dimensions.height;
+      count++;
+    });
+    if (count === 0 || !this.viewport) {
+      return;
+    }
+    // When fitting to screen, fit the page width (not the whole document
+    // height) so vertical scrolling stays comfortable.
+    const zoom = this.fitToScreen ? this.viewport.width / maxWidth : this.zoom;
+    this.viewport.zoom(maxWidth, totalHeight, zoom);
+  }
+
   private reportPosition(): Task.Result<boolean> {
     const frame: Task.Frame<boolean> = Task.newFrame("reportPosition");
     Asserts.assert(this.pagePosition);
@@ -668,12 +749,20 @@ export class AdaptiveViewer {
     }
   }
 
+  /**
+   * Whether the continuous scroll view mode is active (Issue #1235).
+   */
+  private isContinuousScroll(): boolean {
+    return this.pageViewMode === PageViewMode.CONTINUOUS_SCROLL;
+  }
+
   private resolveSpreadView(
     viewport: Vgen.Viewport,
     pageSize: { width: number; height: number } | null,
   ): boolean {
     switch (this.pageViewMode) {
       case PageViewMode.SINGLE_PAGE:
+      case PageViewMode.CONTINUOUS_SCROLL:
         return false;
       case PageViewMode.SPREAD:
         return true;
@@ -872,6 +961,24 @@ export class AdaptiveViewer {
   private showCurrent(page: Vtree.Page, sync?: boolean): Task.Result<null> {
     this.needRefresh = false;
     this.removePageListeners();
+
+    if (this.isContinuousScroll()) {
+      this.updateSpreadView(false);
+      return this.showAllPages(page);
+    }
+
+    // When leaving continuous scroll mode, hide the pages that were shown
+    // stacked so only the current page or spread remains visible.
+    if (
+      this.viewportElement.getAttribute(
+        VIEWPORT_CONTINUOUS_SCROLL_ATTRIBUTE,
+      ) === "true"
+    ) {
+      this.viewportElement.removeAttribute(
+        VIEWPORT_CONTINUOUS_SCROLL_ATTRIBUTE,
+      );
+      this.hideAllPages();
+    }
 
     const spreadView = this.resolveSpreadView(this.viewport, page.dimensions);
     if (spreadView !== this.pref.spreadView) {

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -87,6 +87,25 @@ export const VivliostyleViewportScreenCss = `
     margin-right: auto;
     transform-origin: center top;
   }
+
+  /* Continuous scroll view mode: stack every page vertically (Issue #1235). */
+  [data-vivliostyle-viewer-viewport][data-vivliostyle-continuous-scroll="true"] {
+    align-items: flex-start;
+  }
+
+  [data-vivliostyle-viewer-viewport][data-vivliostyle-continuous-scroll="true"]
+    [data-vivliostyle-spread-container] {
+    flex-direction: column;
+    align-items: center;
+    row-gap: 8px;
+  }
+
+  [data-vivliostyle-viewer-viewport][data-vivliostyle-continuous-scroll="true"]
+    [data-vivliostyle-spread-container]
+    [data-vivliostyle-page-container] {
+    margin: 0 auto;
+    transform-origin: center top;
+  }
 }
 `;
 

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -64,8 +64,10 @@ export type CoreViewerSettings = {
  * - pageBorderWidth: Width of a border between two pages in a single
  *   spread (px). Effective only in spread view mode. default: 1
  * - renderAllPages: Render all pages at the document load time. default: true
- * - pageViewMode: Page view mode (singlePage / spread / autoSpread).
- *   default: singlePage
+ * - pageViewMode: Page view mode (singlePage / spread / autoSpread /
+ *   continuousScroll). In continuousScroll mode every page is rendered in its
+ *   own element, stacked vertically so the document can be scrolled through
+ *   like a PDF viewer. default: singlePage
  * - zoom: Zoom factor with which pages are displayed. default: 1
  * - fitToScreen: Auto adjust zoom factor to fit the screen. default: false
  * - defaultPaperSize: Default paper size in px. Effective when `@page` size

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -3409,6 +3409,24 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return this.spineItems.some((item) => item && item.pages.length > 0);
   }
 
+  /**
+   * Iterate over every rendered page in document (spine) order.
+   * Used by the continuous scroll view mode, where all pages are shown
+   * stacked vertically instead of one page (or spread) at a time.
+   */
+  forAllPages(fn: (page: Vtree.Page) => void): void {
+    for (const item of this.spineItems) {
+      if (!item) {
+        continue;
+      }
+      for (const page of item.pages) {
+        if (page) {
+          fn(page);
+        }
+      }
+    }
+  }
+
   showTOC(autohide: boolean): Task.Result<Vtree.Page> {
     const opf = this.opf;
     const toc = opf.toc;

--- a/packages/viewer/src/bindings/i18n.ts
+++ b/packages/viewer/src/bindings/i18n.ts
@@ -81,6 +81,7 @@ const translations = {
       Auto: "Auto",
       Single_page: "Single page",
       Spread: "Spread",
+      Continuous_scroll: "Continuous scroll",
       TIP_Book_Mode:
         "On: for Book-like publications, with Table of Contents\nOff: for single HTML documents",
       TIP_Render_All_Pages:
@@ -218,6 +219,7 @@ const translations = {
       Auto: "自動",
       Single_page: "単ページ",
       Spread: "見開き",
+      Continuous_scroll: "連続スクロール",
       TIP_Book_Mode:
         "ON: 本のような出版物（目次付き）用\nOFF: 単体のHTML文書用",
       TIP_Render_All_Pages:

--- a/packages/viewer/src/html/vivliostyle-viewer.ejs
+++ b/packages/viewer/src/html/vivliostyle-viewer.ejs
@@ -136,6 +136,7 @@
                     <li><label><input type="radio" name="vivliostyle-settings_page-view-mode" value="autoSpread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span data-bind="text: t('Auto')"></span></label></li>
                     <li><label><input type="radio" name="vivliostyle-settings_page-view-mode" value="singlePage" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span data-bind="text: t('Single_page')"></span></label></li>
                     <li><label><input type="radio" name="vivliostyle-settings_page-view-mode" value="spread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span data-bind="text: t('Spread')"></span></label></li>
+                    <li><label><input type="radio" name="vivliostyle-settings_page-view-mode" value="continuousScroll" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span data-bind="text: t('Continuous_scroll')"></span></label></li>
                   </ul>
                 </fieldset>
                 <fieldset class="vivliostyle-menu-detail-group vivliostyle-menu-detail-group-inline">

--- a/packages/viewer/src/models/page-view-mode.ts
+++ b/packages/viewer/src/models/page-view-mode.ts
@@ -28,6 +28,8 @@ export class PageViewModeInstance {
         return "false";
       case PageViewMode.AUTO_SPREAD:
         return "auto";
+      case PageViewMode.CONTINUOUS_SCROLL:
+        return "continuousScroll";
       default:
         throw new Error("Invalid PageViewMode");
     }
@@ -40,6 +42,8 @@ export class PageViewModeInstance {
         return "singlePage"; // vivliostyle.viewer.PageViewMode.SINGLE_PAGE;
       case PageViewMode.AUTO_SPREAD:
         return "autoSpread"; // vivliostyle.viewer.PageViewMode.AUTO_SPREAD;
+      case PageViewMode.CONTINUOUS_SCROLL:
+        return "continuousScroll"; // vivliostyle.viewer.PageViewMode.CONTINUOUS_SCROLL;
       default:
         throw new Error("Invalid PageViewMode");
     }
@@ -50,6 +54,7 @@ const PageViewMode = {
   AUTO_SPREAD: new PageViewModeInstance(),
   SINGLE_PAGE: new PageViewModeInstance(),
   SPREAD: new PageViewModeInstance(),
+  CONTINUOUS_SCROLL: new PageViewModeInstance(),
   defaultMode(): CorePageViewMode {
     return this.AUTO_SPREAD;
   },
@@ -59,6 +64,8 @@ const PageViewMode = {
         return this.SPREAD;
       case "false":
         return this.SINGLE_PAGE;
+      case "continuousScroll":
+        return this.CONTINUOUS_SCROLL;
       case "auto":
       default:
         return this.AUTO_SPREAD;
@@ -72,6 +79,8 @@ const PageViewMode = {
         return this.SINGLE_PAGE;
       case CorePageViewMode.AUTO_SPREAD:
         return this.AUTO_SPREAD;
+      case CorePageViewMode.CONTINUOUS_SCROLL:
+        return this.CONTINUOUS_SCROLL;
       default:
         throw new Error(`Invalid PageViewMode name: ${name}`);
     }


### PR DESCRIPTION
## Summary
- adds a new `continuousScroll` value to `PageViewMode` for PDF-like vertical page scrolling
- reuses rendered page containers, reveals all pages in document order, and scrolls the active page into view on navigation
- adds viewport styling and core option documentation for the new mode

Fixes #1235

## Validation
- `yarn workspace @vivliostyle/core build`
- `yarn workspace @vivliostyle/core test` (600/600 Chrome Headless tests passed)

## Notes
- This PR cherry-picks the fix from fork commit `0955643c7b795fbc149d0e17806b1276f528b812` onto current upstream `master` to avoid unrelated stale-branch changes.