### PR TITLE
fix: Fix Vertical vo=Tr character rotation on Chromium

### DIFF
--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -297,6 +297,28 @@ function normalizeLang(lang: string): string | null {
   return null;
 }
 
+const CHROMIUM_VO_TR_FALLBACK_PATTERN = /^[‘’“”〰﹙﹚﹛﹜﹝﹞〚〛；]\p{M}*$/u;
+const CHROMIUM_VO_TR_FALLBACK_OPEN_PATTERN = /^[‘“﹙﹛﹝〚]\p{M}*$/u;
+
+function isChromiumVoTrFallback(text: string, vertical: boolean): boolean {
+  return (
+    Base.browserType === "chromium" &&
+    vertical &&
+    CHROMIUM_VO_TR_FALLBACK_PATTERN.test(text)
+  );
+}
+
+function getChromiumVoTrFallbackTagName(
+  text: string,
+): "viv-ts-open" | "viv-ts-close" {
+  // Reuse the existing open/close wrapper tags only to isolate the character.
+  // Fallback-only nodes return before text-spacing/hanging classes are assigned,
+  // so this tag choice does not change spacing behavior.
+  return CHROMIUM_VO_TR_FALLBACK_OPEN_PATTERN.test(text)
+    ? "viv-ts-open"
+    : "viv-ts-close";
+}
+
 class TextSpacingPolyfill {
   getPolyfilledInheritedProps() {
     return ["hanging-punctuation", "text-autospace", "text-spacing-trim"];
@@ -324,7 +346,7 @@ class TextSpacingPolyfill {
       }
       const textArr = node.textContent
         .replace(
-          /(?![()\[\]{}])[\p{Ps}\p{Pe}\p{Pf}\p{Pi}、。，．：；､｡\u3000]\p{M}*(?=\P{M})|.(?=(?![()\[\]{}])[\p{Ps}\p{Pe}\p{Pf}\p{Pi}、。，．：；､｡\u3000])|(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*(?=(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}])|(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}]\p{M}*(?=(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF])/gsu,
+          /(?![()\[\]{}])[\p{Ps}\p{Pe}\p{Pf}\p{Pi}、。，．：；､｡\u3000\u3030]\p{M}*(?=\P{M})|.(?=(?![()\[\]{}])[\p{Ps}\p{Pe}\p{Pf}\p{Pi}、。，．：；､｡\u3000\u3030])|(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF]\p{M}*(?=(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}])|(?![\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF\uFF01-\uFF60])[\p{L}\p{Nd}]\p{M}*(?=(?!\p{P})[\p{sc=Han}\u3041-\u30FF\u31C0-\u31FF])/gsu,
           "$&\x00",
         )
         .split("\x00");
@@ -830,10 +852,12 @@ class TextSpacingPolyfill {
     }
 
     let punctProcessing = false;
+    let chromiumVoTrFallbackOnly = false;
     let hangingFirst = false;
     let hangingLast = false;
     let hangingEnd = false;
     let tagName: "viv-ts-open" | "viv-ts-close";
+    const needsChromiumVoTrFallback = isChromiumVoTrFallback(text, vertical);
 
     if (
       isFirstInBlock &&
@@ -881,6 +905,10 @@ class TextSpacingPolyfill {
       // fullwidth closing punctuation
       tagName = "viv-ts-close";
       punctProcessing = true;
+    } else if (needsChromiumVoTrFallback) {
+      tagName = getChromiumVoTrFallbackTagName(text);
+      punctProcessing = true;
+      chromiumVoTrFallbackOnly = true;
     }
 
     if (punctProcessing) {
@@ -894,6 +922,19 @@ class TextSpacingPolyfill {
       outerElem.appendChild(innerElem);
       textNode.parentNode.insertBefore(outerElem, textNode);
       innerElem.appendChild(textNode);
+
+      if (needsChromiumVoTrFallback) {
+        const textOrientation = document.defaultView.getComputedStyle(
+          innerElem.parentElement,
+        ).textOrientation;
+        if (textOrientation === "mixed") {
+          innerElem.style.textOrientation = "sideways";
+        }
+      }
+
+      if (chromiumVoTrFallbackOnly) {
+        return 0;
+      }
 
       // Check if the punctuation is almost full width
       function checkFullWidth(elem: HTMLElement): boolean {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -434,6 +434,10 @@ module.exports = [
         title: "Text-spacing on generated content (vertical writing-mode)",
       },
       {
+        file: "text-spacing/vo-tr-quotes-vertical.html",
+        title: "Vertical vo=Tr characters fallback (Issue #2023)",
+      },
+      {
         file: "text-spacing/text-spacing-trim-start-code.html",
         title: "text-spacing-trim after code element (Issue #1863)",
       },

--- a/packages/core/test/files/text-spacing/vo-tr-quotes-vertical.html
+++ b/packages/core/test/files/text-spacing/vo-tr-quotes-vertical.html
@@ -1,0 +1,67 @@
+<!-- Test case for Issue #2023: vertical vo=Tr characters should rotate on Chromium -->
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <title>Vertical vo=Tr characters fallback</title>
+    <style>
+      @page {
+        size: 180mm 120mm;
+        margin: 12mm;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
+      }
+
+      .panel {
+        display: inline-block;
+        vertical-align: top;
+        margin-inline-end: 8mm;
+      }
+
+      .sample {
+        writing-mode: vertical-rl;
+        text-orientation: mixed;
+        font-size: 22px;
+        line-height: 1.2;
+        border: 1px solid #999;
+        padding: 4mm;
+        height: 62mm;
+      }
+
+      .rotate-quote {
+        text-orientation: sideways;
+      }
+
+      h1 {
+        margin: 0 0 4mm;
+        font-size: 14px;
+      }
+
+      p {
+        margin: 0;
+      }
+
+      .label {
+        margin-block-end: 2mm;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Vertical vo=Tr characters fallback</h1>
+    <div class="layout">
+      <div class="panel">
+        <p class="label">Mixed with fallback</p>
+        <p class="sample" id="mixed">“縦書き” ‘引用’ 〰 ﹙abc﹚ ﹛abc﹜ ﹝abc﹞ 〚abc〛 ；</p>
+      </div>
+      <div class="panel">
+        <p class="label">Expected character rotation</p>
+        <p class="sample" id="reference"><span class="rotate-quote">“</span>縦書き<span class="rotate-quote">”</span> <span class="rotate-quote">‘</span>引用<span class="rotate-quote">’</span> <span class="rotate-quote">〰</span> <span class="rotate-quote">﹙</span>abc<span class="rotate-quote">﹚</span> <span class="rotate-quote">﹛</span>abc<span class="rotate-quote">﹜</span> <span class="rotate-quote">﹝</span>abc<span class="rotate-quote">﹞</span> <span class="rotate-quote">〚</span>abc<span class="rotate-quote">〛</span> <span class="rotate-quote">；</span></p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Extend the Chromium-only fallback in `text-polyfill.ts` so vertical `text-orientation: mixed` rotates the affected `vo=Tr` characters sideways instead of leaving them upright.

Add `U+3030` to the text-splitting preprocess step so it can be isolated and wrapped like the other affected punctuation characters. Reuse the existing `viv-ts-open` and `viv-ts-close` wrappers only for fallback isolation, returning before any `text-spacing-trim` or hanging punctuation classes are applied.

Add a regression repro page and register it in `file-list.js` so the mixed rendering can be compared against an explicit rotated reference.

Closes #2023

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2023; the AI implemented the Chromium fallback by reusing the existing text-spacing wrapper elements.
- The human author adjusted the regression test case (removing an unrelated `nowrap` rule) and asked the AI to explain its regex change, confirming that only `U+3030` needed to be added.
- The human author questioned whether reusing the `viv-ts-close` wrapper for this fallback could have side effects on `text-spacing-trim` behavior; the AI explained the reasoning, and the human author asked for a clarifying code comment to prevent future confusion.

</details>
