### PR TITLE
fix: Exclude Fullwidth Semicolon from Chromium vo=Tr fallback

### DIFF
--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -297,7 +297,7 @@ function normalizeLang(lang: string): string | null {
   return null;
 }
 
-const CHROMIUM_VO_TR_FALLBACK_PATTERN = /^[‘’“”〰﹙﹚﹛﹜﹝﹞〚〛；]\p{M}*$/u;
+const CHROMIUM_VO_TR_FALLBACK_PATTERN = /^[‘’“”〰﹙﹚﹛﹜﹝﹞〚〛]\p{M}*$/u;
 const CHROMIUM_VO_TR_FALLBACK_OPEN_PATTERN = /^[‘“﹙﹛﹝〚]\p{M}*$/u;
 
 function isChromiumVoTrFallback(text: string, vertical: boolean): boolean {

--- a/packages/core/test/files/text-spacing/vo-tr-quotes-vertical.html
+++ b/packages/core/test/files/text-spacing/vo-tr-quotes-vertical.html
@@ -60,7 +60,7 @@
       </div>
       <div class="panel">
         <p class="label">Expected character rotation</p>
-        <p class="sample" id="reference"><span class="rotate-quote">“</span>縦書き<span class="rotate-quote">”</span> <span class="rotate-quote">‘</span>引用<span class="rotate-quote">’</span> <span class="rotate-quote">〰</span> <span class="rotate-quote">﹙</span>abc<span class="rotate-quote">﹚</span> <span class="rotate-quote">﹛</span>abc<span class="rotate-quote">﹜</span> <span class="rotate-quote">﹝</span>abc<span class="rotate-quote">﹞</span> <span class="rotate-quote">〚</span>abc<span class="rotate-quote">〛</span> <span class="rotate-quote">；</span></p>
+        <p class="sample" id="reference"><span class="rotate-quote">“</span>縦書き<span class="rotate-quote">”</span> <span class="rotate-quote">‘</span>引用<span class="rotate-quote">’</span> <span class="rotate-quote">〰</span> <span class="rotate-quote">﹙</span>abc<span class="rotate-quote">﹚</span> <span class="rotate-quote">﹛</span>abc<span class="rotate-quote">﹜</span> <span class="rotate-quote">﹝</span>abc<span class="rotate-quote">﹞</span> <span class="rotate-quote">〚</span>abc<span class="rotate-quote">〛</span> ；</p>
       </div>
     </div>
   </body>


### PR DESCRIPTION
Remove `U+FF1B` from the Chromium-only vertical `vo=Tr` fallback set and update the regression repro so the reference no longer forces that character to rotate.

This follows up on PR #2032 for #2023. Unlike the other fallback characters, `U+FF1B` is not always expected to use a rotated vertical form: [UAX#50](https://www.unicode.org/reports/tr50/) allows multiple vertical glyph variants, and some fonts provide an intentional non-rotated `vert` glyph. Forcing `sideways` would override that font behavior and could also change long-standing Chromium output without a clear correctness win.

Follow-up to PR #2032
Related to #2023

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- After merging PR #2032, the human author noticed that the fullwidth semicolon (`U+FF1B`) should not always be forced to rotate, per UAX#50 and font-specific non-rotated glyph variants, and asked for a follow-up fix.
- The AI removed `U+FF1B` from the fallback set and updated the regression reference; `/draft-commit` finalized the change.

</details>
