### PR TITLE
fix: Restore target-counter references for redirected chapter URLs

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -72,6 +72,20 @@ export function stripFragmentAndQuery(url: string): string {
   return url;
 }
 
+export const TOC_BOX_QUERY_SUFFIX = "?viv-toc-box";
+
+export function isTocBoxURL(url: string): boolean {
+  return url.endsWith(TOC_BOX_QUERY_SUFFIX);
+}
+
+export function stripTocBoxURL(url: string): string {
+  return isTocBoxURL(url) ? url.slice(0, -TOC_BOX_QUERY_SUFFIX.length) : url;
+}
+
+export function toTocBoxURL(url: string): string {
+  return isTocBoxURL(url) ? url : stripFragment(url) + TOC_BOX_QUERY_SUFFIX;
+}
+
 /**
  * Base URL relative to which URLs of resources are resolved.
  */

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -855,9 +855,41 @@ export class OPFDoc {
   createDocumentURLTransformer(): Base.DocumentURLTransformer {
     const self = this;
     class OPFDocumentURLTransformer implements Base.DocumentURLTransformer {
+      private canonicalDocumentURLCache = new Map<string, string>();
+
+      private getCanonicalDocumentURL(url: string): string {
+        // Issue #2036: a server may redirect a spine item URL (for example,
+        // stripping `.html`). Canonicalize redirected aliases back to the
+        // spine source URL so transformed ids and same-document references use
+        // one stable document identity.
+        const strippedURL = Base.stripFragment(Base.stripTocBoxURL(url));
+        const cachedURL = this.canonicalDocumentURLCache.get(strippedURL);
+        if (cachedURL) {
+          return cachedURL;
+        }
+        for (const item of self.spine) {
+          const itemURL = Base.stripFragment(Base.stripTocBoxURL(item.src));
+          if (itemURL === strippedURL) {
+            this.canonicalDocumentURLCache.set(strippedURL, itemURL);
+            return itemURL;
+          }
+          const loadedURL = self.store?.get(itemURL)?.url;
+          if (
+            loadedURL &&
+            Base.stripFragment(Base.stripTocBoxURL(loadedURL)) === strippedURL
+          ) {
+            this.canonicalDocumentURLCache.set(strippedURL, itemURL);
+            return itemURL;
+          }
+        }
+        this.canonicalDocumentURLCache.set(strippedURL, strippedURL);
+        return strippedURL;
+      }
+
       /** @override */
       transformFragment(fragment: string, baseURL: string): string {
-        const url = baseURL + (fragment ? `#${fragment}` : "");
+        const canonicalBaseURL = this.getCanonicalDocumentURL(baseURL);
+        const url = canonicalBaseURL + (fragment ? `#${fragment}` : "");
         return transformedIdPrefix + Base.escapeNameStrToHex(url, ":");
       }
 
@@ -865,10 +897,17 @@ export class OPFDoc {
       transformURL(url: string, baseURL: string): string {
         const r = url.match(/^([^#]*)#?(.*)$/);
         if (r) {
-          const path = r[1] || baseURL.replace(/\?viv-toc-box$/, "");
+          const path = this.getCanonicalDocumentURL(
+            r[1] || Base.stripTocBoxURL(baseURL),
+          );
           const fragment = decodeURIComponent(r[2]);
           if (path) {
-            if (self.spine.some((item) => item.src === path)) {
+            if (
+              self.spine.some(
+                (item) =>
+                  Base.stripFragment(Base.stripTocBoxURL(item.src)) === path,
+              )
+            ) {
               return `#${this.transformFragment(fragment, path)}`;
             }
           }

--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -207,9 +207,9 @@ export class ResourceStore<Resource> implements Net.ResourceStore<Resource> {
     const frame: Task.Frame<Resource> = Task.newFrame("fetch");
 
     // Hack for TOCView.showTOC()
-    const isTocBox = url.endsWith("?viv-toc-box");
+    const isTocBox = Base.isTocBoxURL(url);
     if (isTocBox) {
-      url = url.replace("?viv-toc-box", "");
+      url = Base.stripTocBoxURL(url);
     }
     const userAgentXmlUrl = Base.resolveURL(
       "user-agent.xml",
@@ -234,8 +234,8 @@ export class ResourceStore<Resource> implements Net.ResourceStore<Resource> {
       }
       if (isTocBox) {
         // Hack for TOCView.showTOC()
-        url += "?viv-toc-box";
-        response.url += "?viv-toc-box";
+        url = Base.toTocBoxURL(url);
+        response.url = Base.toTocBoxURL(response.url);
       } else if (isUserAgentXml) {
         // Restore "user-agent.xml" URL
         response.url = url = userAgentXmlUrl;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -3384,7 +3384,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
     const url = response.url;
 
     // Hack for TOCView.showTOC()
-    const isTocBox = url.endsWith("?viv-toc-box");
+    const isTocBox = Base.isTocBoxURL(url);
 
     XmlDoc.parseXMLResource(response, this).then(
       (xmldoc: XmlDoc.XMLDocHolder) => {

--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -268,7 +268,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
 
     // The (X)HTML doc for the TOC box may be reused for the TOC page in the book,
     // but they need different styles. So, add "?viv-toc-box" to distinguish with TOC page URL.
-    const tocBoxUrl = Base.stripFragment(this.url) + "?viv-toc-box";
+    const tocBoxUrl = Base.toTocBoxURL(this.url);
 
     this.store.load(tocBoxUrl).then((xmldoc) => {
       for (const tocElem of findTocElements(xmldoc.document)) {

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -249,7 +249,13 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
    */
   getElement(url: string): Element | null {
     const m = url.match(/([^#]*)#(.+)$/);
-    if (!m || (m[1] && m[1] != this.url)) {
+    if (!m) {
+      return null;
+    }
+    // Issue #2036: a transformed TOC link can restore to the spine source URL
+    // while this document was loaded under a redirected alias. Accept either
+    // form as long as the store resolves both URLs to this same XMLDocHolder.
+    if (m[1] && m[1] != this.url && this.store?.get(m[1]) !== this) {
       return null;
     }
     const id = m[2];

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -148,6 +148,32 @@ describe("epub", function () {
           restored = transformer.restoreURL("#" + transformed);
           expect(restored).toEqual([baseURL, fragment]);
         });
+
+        it("canonicalizes a redirected loaded document URL to the spine source URL", function () {
+          var store = {
+            get: function (url) {
+              return url === "http://example.com:8000/foo/bar1.html"
+                ? { url: "http://example.com:8000/foo/bar1" }
+                : null;
+            },
+          };
+          var redirectedOpfDoc = new adapt_epub.OPFDoc(store, null);
+          redirectedOpfDoc.spine = redirectedOpfDoc.items = [
+            { src: "http://example.com:8000/foo/bar1.html" },
+          ];
+          var redirectedTransformer =
+            redirectedOpfDoc.createDocumentURLTransformer();
+
+          var redirectedBaseURL = "http://example.com:8000/foo/bar1";
+          var redirectedTransformed = redirectedTransformer.transformFragment(
+            fragment,
+            redirectedBaseURL,
+          );
+
+          expect(
+            redirectedTransformer.restoreURL(redirectedTransformed),
+          ).toEqual(["http://example.com:8000/foo/bar1.html", fragment]);
+        });
       });
 
       describe("transformURL", function () {
@@ -176,6 +202,34 @@ describe("epub", function () {
 
           transformed = transformer.transformURL(baseURL + "#" + fragment);
           expect(transformed).toBe(baseURL + "#" + fragment);
+        });
+
+        it("transforms a redirected same-document URL using the canonical spine URL", function () {
+          var store = {
+            get: function (url) {
+              return url === "http://example.com:8000/foo/bar1.html"
+                ? { url: "http://example.com:8000/foo/bar1" }
+                : null;
+            },
+          };
+          var redirectedOpfDoc = new adapt_epub.OPFDoc(store, null);
+          redirectedOpfDoc.spine = redirectedOpfDoc.items = [
+            { src: "http://example.com:8000/foo/bar1.html" },
+          ];
+          var redirectedTransformer =
+            redirectedOpfDoc.createDocumentURLTransformer();
+          var redirectedBaseURL = "http://example.com:8000/foo/bar1";
+
+          var transformed = redirectedTransformer.transformURL(
+            "#" + fragment,
+            redirectedBaseURL,
+          );
+          expect(transformed.charAt(0)).toBe("#");
+
+          expect(redirectedTransformer.restoreURL(transformed)).toEqual([
+            "http://example.com:8000/foo/bar1.html",
+            fragment,
+          ]);
         });
       });
     });

--- a/packages/core/test/spec/vivliostyle/xmldoc-spec.js
+++ b/packages/core/test/spec/vivliostyle/xmldoc-spec.js
@@ -56,6 +56,29 @@ describe("xml-doc", function () {
         var e = holder.getElement("foobar#baz");
         expect(e).toBeFalsy();
       });
+
+      it("returns an element for a stored alias URL of the same document", function () {
+        var doc = new DOMParser().parseFromString(
+          "<foo><bar id='baz'></bar></foo>",
+          "text/xml",
+        );
+        var holder;
+        var store = {
+          get: function (requestedUrl) {
+            return requestedUrl === "http://example.com/doc.html"
+              ? holder
+              : null;
+          },
+        };
+        holder = new adapt_xmldoc.XMLDocHolder(
+          store,
+          "http://example.com/doc",
+          doc,
+        );
+
+        var e = holder.getElement("http://example.com/doc.html#baz");
+        expect(e instanceof Element).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
Canonicalize redirected spine document URLs back to their original spine item URLs before generating transformed ids, so same-document `target-counter()` and related references keep a stable document identity even when a server such as `serve` strips `.html` during redirect.

Accept alias document URLs in `XMLDocHolder.getElement()` so transformed TOC links still resolve after the restored spine URL differs from the redirected load URL. Also factor the `?viv-toc-box` handling into shared `Base` helpers and add regression coverage for both redirected URL canonicalization and alias target lookup.

Closes #2036

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2036 and helped recover the session when a Playwright verification run stalled.
- The human author proposed a simpler fix directly — skip the URL reassignment when a redirect only strips `.html` — instead of the AI's initial approach, and asked the AI to implement it.
- The human author then discovered during manual testing that the change broke TOC navigation in the viewer UI; the AI diagnosed and fixed it.
- The human author flagged repeated `.replace(/\?viv-toc-box$/, "")` calls as a refactoring opportunity; the AI consolidated them into shared `Base` helpers, and a final review pass added clarifying comments before `/draft-commit` and `/address-pr-comments`.

</details>
