### PR TITLE
fix: Prevent inherited spacing properties from affecting text-spacing fillers

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1558,6 +1558,7 @@ viv-ts-close.viv-hang-end::after {
   font: 1em/0 "-viv-ts-sp";
   text-rendering: geometricPrecision;
   word-spacing: normal;
+  letter-spacing: normal;
   text-orientation: mixed;
   visibility: hidden;
 }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -441,6 +441,10 @@ module.exports = [
         file: "text-spacing/text-spacing-trim-start-code.html",
         title: "text-spacing-trim after code element (Issue #1863)",
       },
+      {
+        file: "text-spacing/inherited-spacing-properties.html",
+        title: "Text-spacing fillers with inherited spacing properties",
+      },
     ],
   },
   {

--- a/packages/core/test/files/text-spacing/inherited-spacing-properties.html
+++ b/packages/core/test/files/text-spacing/inherited-spacing-properties.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>text-spacingフィラーと継承プロパティのテスト</title>
+    <style>
+      p {
+        border: 1px solid silver;
+        text-align: justify;
+        text-spacing: auto;
+      }
+      b {
+        font-weight: bold;
+        color: maroon;
+      }
+      i {
+        font-style: normal;
+        font-size: 80%;
+        color: navy;
+      }
+      .ls {
+        letter-spacing: 0.2em;
+      }
+      .ffs1 {
+        font-feature-settings: "ss01";
+      }
+      .ffs2 {
+        font-feature-settings: "ss02";
+      }
+      .fsa {
+        font-size-adjust: 0.3;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>text-spacingフィラーと継承プロパティ</h1>
+    <p>
+      text-spacingの詰め・和欧文間スペースの量は、周囲のletter-spacingや
+      font-feature-settingsの指定に影響されない。
+    </p>
+    <h2>基準(継承指定なし)</h2>
+    <p lang="zh-hans">
+      〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+        >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+      >
+    </p>
+    <h2>letter-spacing: 0.2em</h2>
+    <p lang="zh-hans" class="ls">
+      〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+        >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+      >
+    </p>
+    <h2>font-feature-settings: "ss01"</h2>
+    <p lang="zh-hans" class="ffs1">
+      〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+        >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+      >
+    </p>
+    <h2>font-feature-settings: "ss02"</h2>
+    <p lang="zh-hans" class="ffs2">
+      〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+        >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+      >
+    </p>
+    <h2>font-size-adjust: 0.3</h2>
+    <p lang="zh-hans" class="fsa">
+      〈标点符号〉是，〈句点〉・〈読点〉「括弧（類）」、他！　「《英（数）》字ABC-123等。」〈标点符号〉是，<b>〈句点〉</b>・<b>〈読点〉「括弧（類）」</b>、他！　<b
+        >「<i>《英（数）》</i>字<i>ABC-123</i>等。」</b
+      >
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
refs: https://github.com/vivliostyle/vivliostyle.js/pull/2035#discussion_r3512137180

fix/text-spacing-fontsブランチの上に積んでいます。

`text-spacing`の内部生成要素は周囲から`letter-spacing` / `font-feature-settings` / `font-size-adjust`を継承するため、幅が文書側の指定に依存して変動する問題がありました。それぞれ値を明示して継承を遮断します。