### PR TITLE
fix: Compute pagination progress fraction against all spine items

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1140,6 +1140,10 @@ export class OPFDoc {
         const item = this.spine[i++];
         item.epage = epage;
         this.store.load(item.src).then((xmldoc) => {
+          if (!xmldoc) {
+            loopFrame.continueLoop();
+            return;
+          }
           // According to the old comment,
           // "Estimate that offset=2700 roughly corresponds to 1024 bytes of compressed size."
           // However, it should depend on the language.
@@ -1764,7 +1768,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
         }
         const item = this.opf.spine[spineIndex];
         this.opf.store.load(item.src).then((xmldoc) => {
-          totals[spineIndex] = xmldoc.getTotalOffset();
+          if (xmldoc) {
+            totals[spineIndex] = xmldoc.getTotalOffset();
+          }
           loopFrame.continueLoop();
         });
       })

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1744,7 +1744,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
    * their total offsets, so that the pagination progress fraction is
    * computed against the whole publication.
    */
-  collectTotalOffsets(): Task.Result<boolean> {
+  private collectTotalOffsets(): Task.Result<boolean> {
     if (this.paginationProgress.totalOffsetsReady) {
       return Task.newResult(true);
     }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1539,6 +1539,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
   private paginationProgress = {
     totalOffsetsBySpine: [] as number[],
     renderedOffsetsBySpine: [] as number[],
+    totalOffsetsReady: false,
     lastReportedPages: 0,
     lastReportedFraction: 0,
   };
@@ -1738,11 +1739,47 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return totalOffset;
   }
 
+  /**
+   * Load all spine items (fetch and parse only, without layout) and record
+   * their total offsets, so that the pagination progress fraction is
+   * computed against the whole publication.
+   */
+  collectTotalOffsets(): Task.Result<boolean> {
+    if (this.paginationProgress.totalOffsetsReady) {
+      return Task.newResult(true);
+    }
+    const totals = this.paginationProgress.totalOffsetsBySpine;
+    let i = 0;
+    const frame: Task.Frame<boolean> = Task.newFrame("collectTotalOffsets");
+    frame
+      .loopWithFrame((loopFrame) => {
+        if (i === this.opf.spine.length) {
+          loopFrame.breakLoop();
+          return;
+        }
+        const spineIndex = i++;
+        if (totals[spineIndex] != null) {
+          loopFrame.continueLoop();
+          return;
+        }
+        const item = this.opf.spine[spineIndex];
+        this.opf.store.load(item.src).then((xmldoc) => {
+          totals[spineIndex] = xmldoc.getTotalOffset();
+          loopFrame.continueLoop();
+        });
+      })
+      .then(() => {
+        this.paginationProgress.totalOffsetsReady = true;
+        frame.finish(true);
+      });
+    return frame.result();
+  }
+
   private getTotalOffsetAll(): number {
     let total = 0;
-    for (const item of this.spineItems) {
-      if (item) {
-        total += this.getTotalOffsetForViewItem(item);
+    for (const totalOffset of this.paginationProgress.totalOffsetsBySpine) {
+      if (totalOffset) {
+        total += totalOffset;
       }
     }
     return total;
@@ -2583,35 +2620,44 @@ export class OPFView implements Vgen.CustomRendererFactory {
   renderAllPages(): Task.Result<PageAndPosition | null> {
     const frame: Task.Frame<PageAndPosition | null> =
       Task.newFrame("renderAllPages");
-    this.renderPagesUpto(
-      {
-        spineIndex: this.opf.spine.length - 1,
-        pageIndex: Number.POSITIVE_INFINITY,
-        offsetInItem: -1,
-      },
-      false,
-    ).then((result) => {
-      // Wait until all images are loaded (Issue #1321)
-      frame
-        .loopWithFrame((loopFrame) => {
-          if (
-            this.spineItems.some((viewItem) =>
-              viewItem?.pages.some((page) =>
-                page?.fetchers.some((fetcher) => !fetcher.arrived),
-              ),
-            )
-          ) {
-            frame.sleep(100).then(() => {
-              loopFrame.continueLoop();
-            });
-          } else {
-            loopFrame.breakLoop();
-          }
-        })
-        .then(() => {
-          frame.finish(result);
-        });
-    });
+    const collectResult = Plugin.getHooksForName(
+      Plugin.HOOKS.PAGINATION_PROGRESS,
+    ).length
+      ? this.collectTotalOffsets()
+      : Task.newResult(true);
+    collectResult
+      .thenAsync(() =>
+        this.renderPagesUpto(
+          {
+            spineIndex: this.opf.spine.length - 1,
+            pageIndex: Number.POSITIVE_INFINITY,
+            offsetInItem: -1,
+          },
+          false,
+        ),
+      )
+      .then((result) => {
+        // Wait until all images are loaded (Issue #1321)
+        frame
+          .loopWithFrame((loopFrame) => {
+            if (
+              this.spineItems.some((viewItem) =>
+                viewItem?.pages.some((page) =>
+                  page?.fetchers.some((fetcher) => !fetcher.arrived),
+                ),
+              )
+            ) {
+              frame.sleep(100).then(() => {
+                loopFrame.continueLoop();
+              });
+            } else {
+              loopFrame.breakLoop();
+            }
+          })
+          .then(() => {
+            frame.finish(result);
+          });
+      });
     return frame.result();
   }
 

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -19,6 +19,7 @@
 import * as adapt_epub from "../../../src/vivliostyle/epub";
 import * as adapt_task from "../../../src/vivliostyle/task";
 import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
+import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
 
 describe("epub", function () {
   describe("EPUBDocStore", function () {
@@ -362,6 +363,114 @@ describe("epub", function () {
           },
         },
       ]);
+    });
+  });
+  describe("OPFView pagination progress", function () {
+    function createFakeView(totalOffsets) {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      view.spineItems = [];
+      view.paginationProgress = {
+        totalOffsetsBySpine: [],
+        renderedOffsetsBySpine: [],
+        totalOffsetsReady: false,
+        lastReportedPages: 0,
+        lastReportedFraction: 0,
+      };
+      view.opf = {
+        spine: totalOffsets.map(function (offset, i) {
+          return { src: "doc-" + i, spineIndex: i };
+        }),
+        store: {
+          load: function (src) {
+            var index = Number(src.replace("doc-", ""));
+            return adapt_task.newResult({
+              getTotalOffset: function () {
+                return totalOffsets[index];
+              },
+            });
+          },
+        },
+      };
+      return view;
+    }
+
+    function createFakeViewItem(view, spineIndex, totalOffset) {
+      return {
+        item: view.opf.spine[spineIndex],
+        xmldoc: {
+          getTotalOffset: function () {
+            return totalOffset;
+          },
+        },
+        instance: {
+          getPosition: function () {
+            return 0;
+          },
+        },
+        pages: [{ fetchers: [] }],
+      };
+    }
+
+    var payloads;
+    var hook = function (payload) {
+      payloads.push(payload);
+    };
+
+    beforeEach(function () {
+      payloads = [];
+      vivliostyle_plugin.registerHook(
+        vivliostyle_plugin.HOOKS.PAGINATION_PROGRESS,
+        hook,
+      );
+    });
+
+    afterEach(function () {
+      vivliostyle_plugin.removeHook(
+        vivliostyle_plugin.HOOKS.PAGINATION_PROGRESS,
+        hook,
+      );
+    });
+
+    it("reports the fraction of the paginated content in a single document", function () {
+      var view = createFakeView([100]);
+      var viewItem = createFakeViewItem(view, 0, 100);
+      view.spineItems[0] = viewItem;
+
+      // A page finished at the half of the document
+      viewItem.instance.getPosition = function () {
+        return 50;
+      };
+      view.reportPaginationProgress(viewItem, { page: 1 });
+      expect(payloads[0].fraction).toBeCloseTo(0.5, 5);
+      expect(payloads[0].pages).toBe(1);
+
+      // The last page finished (no next layout position)
+      view.reportPaginationProgress(viewItem, null);
+      expect(payloads[1].fraction).toBe(1);
+    });
+
+    it("does not report 100% until the last of multiple documents is paginated", function (done) {
+      var view = createFakeView([100, 100, 100]);
+
+      spyOn(view, "renderPagesUpto").and.callFake(function () {
+        // Each spine item is loaded and fully paginated in order
+        for (var i = 0; i < 3; i++) {
+          var viewItem = createFakeViewItem(view, i, 100);
+          view.spineItems[i] = viewItem;
+          view.reportPaginationProgress(viewItem, null);
+        }
+        return adapt_task.newResult(null);
+      });
+
+      adapt_task.start(function () {
+        view.renderAllPages().then(function () {
+          expect(payloads[0].fraction).toBeCloseTo(1 / 3, 5);
+          expect(payloads[1].fraction).toBeCloseTo(2 / 3, 5);
+          expect(payloads[2].fraction).toBe(1);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
     });
   });
 });


### PR DESCRIPTION
The `PAGINATION_PROGRESS` plugin hook (#1651) computes the fraction against the total offsets of the spine items loaded so far. In a multi-document publication, the fraction reaches 100% as soon as the first document is paginated, and the monotonic clamp keeps it there for the rest of the load.

This PR loads all spine items (fetch and parse only, following the pattern of `OPFDoc.countEPages`) before `renderAllPages` starts rendering, so the denominator covers the whole publication. The collection runs only when a `PAGINATION_PROGRESS` hook is registered; publications without a progress consumer pay no extra cost.

CC @depth42 