### PR TITLE
feat: Add document href to pagination progress payload

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -93,6 +93,7 @@ The hook receives a payload object:
 
 - `fraction` (number) — Fraction of the HTML content already paginated (0-1).
 - `pages` (number) — Number of pages created so far.
+- `href` (string) — URL of the document currently being paginated.
 
 ## profile
 

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -93,6 +93,7 @@ Note that even if the same function are registered multiple times, this method r
 
 - `fraction` (number) — 既にページ分割されたHTML内容の割合 (0-1)。
 - `pages` (number) — 作成済みページ数。
+- `href` (string) — 現在ページ分割中のドキュメントのURL。
 
 ## profile
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1851,6 +1851,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const payload = {
       fraction,
       pages: this.paginationProgress.lastReportedPages,
+      href: viewItem.item.src,
     };
     for (const hook of hooks) {
       try {

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -144,6 +144,7 @@ export enum HOOKS {
    * The hook is called with an object with the following properties:
    *  {number} fraction: Fraction of the HTML content already paginated (0-1)
    *  {number} pages: Number of pages created so far
+   *  {string} href: URL of the document currently being paginated
    */
   PAGINATION_PROGRESS = "PAGINATION_PROGRESS",
 }
@@ -193,6 +194,7 @@ export type PostLayoutBlockHook = (
 export type PaginationProgressHook = (p1: {
   fraction: number;
   pages: number;
+  href: string;
 }) => void;
 
 const hooks = {};


### PR DESCRIPTION
This PR adds the URL of the document currently being paginated to the `PAGINATION_PROGRESS` hook payload (#1651) as `href`, so that a progress display for a multi-document publication can name the document being typeset. The intended consumer is the PDF build progress display of Vivliostyle CLI.

CC @depth42