### PR TITLE
feat: Add paginationprogress event to CoreViewer

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -108,6 +108,7 @@ export class AdaptiveViewer {
   opfView: Epub.OPFView;
   cmykReserveMap: CmykStore.CmykReserveMapEntry[] | undefined;
   cmykReserveMapUrl: string | undefined;
+  private paginationProgressHookRegistered = false;
 
   constructor(
     public readonly window: Window,
@@ -221,6 +222,22 @@ export class AdaptiveViewer {
     Logging.logger.addListener(logLevel.ERROR, (info) => {
       this.callback({ t: "error", content: info });
     });
+  }
+
+  /**
+   * Register the PAGINATION_PROGRESS plugin hook lazily, so that viewers
+   * without a progress listener do not pay the cost of the progress
+   * calculation.
+   */
+  ensurePaginationProgressListener() {
+    if (this.paginationProgressHookRegistered) {
+      return;
+    }
+    this.paginationProgressHookRegistered = true;
+    const hook: Plugin.PaginationProgressHook = (payload) => {
+      this.callback({ t: "paginationprogress", ...payload });
+    };
+    Plugin.registerHook(Plugin.HOOKS.PAGINATION_PROGRESS, hook);
   }
 
   private callback(message: Base.JSON): void {

--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -108,7 +108,7 @@ export class AdaptiveViewer {
   opfView: Epub.OPFView;
   cmykReserveMap: CmykStore.CmykReserveMapEntry[] | undefined;
   cmykReserveMapUrl: string | undefined;
-  private paginationProgressHookRegistered = false;
+  private paginationProgressHook: Plugin.PaginationProgressHook | null = null;
 
   constructor(
     public readonly window: Window,
@@ -230,14 +230,24 @@ export class AdaptiveViewer {
    * calculation.
    */
   ensurePaginationProgressListener() {
-    if (this.paginationProgressHookRegistered) {
+    if (this.paginationProgressHook) {
       return;
     }
-    this.paginationProgressHookRegistered = true;
     const hook: Plugin.PaginationProgressHook = (payload) => {
       this.callback({ t: "paginationprogress", ...payload });
     };
+    this.paginationProgressHook = hook;
     Plugin.registerHook(Plugin.HOOKS.PAGINATION_PROGRESS, hook);
+  }
+
+  removePaginationProgressListener() {
+    if (this.paginationProgressHook) {
+      Plugin.removeHook(
+        Plugin.HOOKS.PAGINATION_PROGRESS,
+        this.paginationProgressHook,
+      );
+      this.paginationProgressHook = null;
+    }
   }
 
   private callback(message: Base.JSON): void {

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -38,6 +38,8 @@ export interface Payload {
   epageCount: number;
   metadata: unknown;
   docTitle: string;
+  fraction: number;
+  pages: number;
 }
 
 const PageProgression = Constants.PageProgression;
@@ -226,6 +228,9 @@ export class CoreViewer {
    * @param listener Listener function.
    */
   addListener(type: string, listener: (payload: Payload) => void) {
+    if (type === "paginationprogress") {
+      this.adaptViewer_.ensurePaginationProgressListener();
+    }
     this.eventTarget.addEventListener(
       type,
       listener as Base.EventListener,

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -249,6 +249,12 @@ export class CoreViewer {
       listener as Base.EventListener,
       false,
     );
+    if (
+      type === "paginationprogress" &&
+      !this.eventTarget.listeners[type]?.length
+    ) {
+      this.adaptViewer_.removePaginationProgressListener();
+    }
   }
 
   /**


### PR DESCRIPTION
Vivliostyle CLIで利用するために、`PAGINATION_PROGRESS` (#1651) を`coreViewer.addListener("paginationprogress", ...)`に露出させるPRです。リスナーのないviewerには進捗計算のコストが掛からないように、フックは`addListener`が行われた場合にのみ登録されるようにしています。