### PR TITLE
fix: Restore Theme Base TOC styling with `target-counter()`

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4437,13 +4437,17 @@ export class CascadeInstance {
 
       for (let i = 0; ; i++) {
         if (i >= LIMIT_LOOP) {
-          value = Css.isCustomPropName(name) ? Css.ident.initial : Css.empty;
+          value = Css.isCustomPropName(name)
+            ? Css.ident.initial
+            : Css.ident.unset;
           break;
         }
         const after = value.visit(visitor);
         if (visitor.error) {
           // invalid or unresolved variable found
-          value = Css.isCustomPropName(name) ? Css.ident.initial : Css.empty;
+          value = Css.isCustomPropName(name)
+            ? Css.ident.initial
+            : Css.ident.unset;
           visitor.error = false;
           break;
         }
@@ -6316,6 +6320,44 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     } else {
       return new Css.CommaList(func.values.slice(1));
     }
+  }
+
+  override visitSpaceList(list: Css.SpaceList): Css.Val {
+    const values = this.visitValues(list.values);
+    if (this.error) {
+      return Css.empty;
+    }
+    if (values === list.values) {
+      return list;
+    }
+    const flattenedValues: Css.Val[] = [];
+    for (const value of values) {
+      if (value instanceof Css.SpaceList) {
+        flattenedValues.push(...value.values);
+      } else {
+        flattenedValues.push(value);
+      }
+    }
+    return new Css.SpaceList(flattenedValues);
+  }
+
+  override visitCommaList(list: Css.CommaList): Css.Val {
+    const values = this.visitValues(list.values);
+    if (this.error) {
+      return Css.empty;
+    }
+    if (values === list.values) {
+      return list;
+    }
+    const flattenedValues: Css.Val[] = [];
+    for (const value of values) {
+      if (value instanceof Css.CommaList) {
+        flattenedValues.push(...value.values);
+      } else {
+        flattenedValues.push(value);
+      }
+    }
+    return new Css.CommaList(flattenedValues);
   }
 }
 

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -259,6 +259,10 @@ module.exports = [
         title: "target-counter() with default page type",
       },
       {
+        file: "issue2043-theme-base-toc/publication.json",
+        title: "theme-base TOC vars with target-counter() (Issue #2043)",
+      },
+      {
         file: "target-counter-named-page-style.html",
         title: "target-counter() named page style (Issue #1966)",
       },

--- a/packages/core/test/files/issue2043-theme-base-toc/chapter-one.html
+++ b/packages/core/test/files/issue2043-theme-base-toc/chapter-one.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chapter One</title>
+    <style>
+      @page {
+        size: 120mm 160mm;
+        margin: 12mm;
+
+        @bottom-center {
+          content: counter(page);
+          font-size: 9pt;
+        }
+      }
+
+      html {
+        font: 12pt/1.5 serif;
+      }
+
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <section id="chapter-one">
+      <h1>Chapter One</h1>
+      <p>This target should be referenced from the first control TOC entry.</p>
+      <p>Filler.</p>
+      <p>Filler.</p>
+      <p>Filler.</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/issue2043-theme-base-toc/chapter-three.html
+++ b/packages/core/test/files/issue2043-theme-base-toc/chapter-three.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chapter Three</title>
+    <style>
+      @page {
+        size: 120mm 160mm;
+        margin: 12mm;
+
+        @bottom-center {
+          content: counter(page);
+          font-size: 9pt;
+        }
+      }
+
+      html {
+        font: 12pt/1.5 serif;
+      }
+
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <section id="chapter-three">
+      <h1>Chapter Three</h1>
+      <p>This target should be referenced from the theme-base pattern entry.</p>
+      <p>Filler.</p>
+      <p>Filler.</p>
+      <p>Filler.</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/issue2043-theme-base-toc/chapter-two.html
+++ b/packages/core/test/files/issue2043-theme-base-toc/chapter-two.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chapter Two</title>
+    <style>
+      @page {
+        size: 120mm 160mm;
+        margin: 12mm;
+
+        @bottom-center {
+          content: counter(page);
+          font-size: 9pt;
+        }
+      }
+
+      html {
+        font: 12pt/1.5 serif;
+      }
+
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <section id="chapter-two">
+      <h1>Chapter Two</h1>
+      <p>This target should be referenced from the var()-content control.</p>
+      <p>Filler.</p>
+      <p>Filler.</p>
+      <p>Filler.</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/issue2043-theme-base-toc/index.html
+++ b/packages/core/test/files/issue2043-theme-base-toc/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2043: theme-base TOC styles on cross-document links -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Issue 2043 Theme Base TOC</title>
+    <link rel="publication" type="application/ld+json" href="publication.json" />
+    <style>
+      :root {
+        --toc-anchor-color: inherit;
+        --toc-page-counter-display: inline;
+        --toc-page-counter-style: decimal;
+        --toc-page-leader-content: leader('.') ' ';
+      }
+
+      @page {
+        size: 136mm 190mm;
+        margin: 9mm;
+
+        @bottom-center {
+          content: counter(page);
+          font-size: 8pt;
+        }
+      }
+
+      html {
+        font: 10.5pt/1.35 serif;
+        widows: 1;
+        orphans: 1;
+      }
+
+      body {
+        margin: 0;
+        color: black;
+      }
+
+      h1,
+      h2,
+      p {
+        margin: 0 0 0.55em;
+      }
+
+      nav[role='doc-toc'] ol {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      nav[role='doc-toc'] li {
+        margin: 0 0 0.3em;
+      }
+
+      nav[role='doc-toc'] li > a {
+        color: var(--toc-anchor-color);
+        text-decoration: none;
+      }
+
+      nav[role='doc-toc'] li > a::after {
+        content: var(--toc-page-leader-content)
+          target-counter(attr(href), page, var(--toc-page-counter-style));
+        display: var(--toc-page-counter-display);
+      }
+
+      nav[role='doc-toc'] ol.control-direct li > a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      nav[role='doc-toc'] ol.control-direct li > a::after {
+        content: leader('.') ' ' target-counter(attr(href), page);
+      }
+
+      nav[role='doc-toc'] ol.control-literal li > a {
+        color: black;
+        text-decoration: none;
+      }
+
+      nav[role='doc-toc'] ol.control-literal li > a::after {
+        content: var(--toc-page-leader-content)
+          target-counter(attr(href), page);
+      }
+
+      nav[role='doc-toc'] li > a.control-plain {
+        color: black;
+        text-decoration: none;
+      }
+
+      nav[role='doc-toc'] li > a.control-plain::after {
+        content: leader('.') ' '
+          target-counter(attr(href), page, var(--toc-page-counter-style));
+      }
+
+      nav[role='doc-toc'] li > a.control-string {
+        color: black;
+        text-decoration: none;
+      }
+
+      nav[role='doc-toc'] li > a.control-string::after {
+        content: ' ... 7';
+      }
+
+      nav[role='doc-toc'] ol.control-var-content li > a {
+        color: black;
+        text-decoration: none;
+      }
+
+      nav[role='doc-toc'] ol.control-var-content li > a::after {
+        content: var(--toc-page-leader-content)
+          target-counter(attr(href), page, var(--toc-page-counter-style));
+        display: var(--toc-page-counter-display);
+      }
+
+      .group-title {
+        margin: 0.8em 0 0.25em;
+        font-size: 0.9em;
+        font-weight: bold;
+      }
+    </style>
+  </head>
+  <body>
+    <nav role="doc-toc" aria-label="Table of Contents">
+      <h1>Contents</h1>
+      <p>
+        Expected on page 1: direct CSS and var()-based content both work, and
+        the theme-base pattern also keeps the link text black.
+      </p>
+      <p class="group-title">Control: direct inherit + direct target-counter()</p>
+      <ol class="control-direct">
+        <li><a href="chapter-one.html#chapter-one">Chapter One</a></li>
+      </ol>
+      <p class="group-title">Control: leader var + direct target-counter()</p>
+      <ol class="control-literal">
+        <li><a href="chapter-one.html#chapter-one">Chapter One Literal</a></li>
+      </ol>
+      <p class="group-title">Control: direct leader + counter-style var</p>
+      <ol>
+        <li>
+          <a class="control-plain" href="chapter-two.html#chapter-two"
+            >Chapter Two Plain</a
+          >
+        </li>
+      </ol>
+      <p class="group-title">Control: plain anchor selector + fixed string after</p>
+      <ol>
+        <li><a class="control-string" href="#">Chapter Fixed String</a></li>
+      </ol>
+      <p class="group-title">Control: var()-based content with explicit black</p>
+      <ol class="control-var-content">
+        <li><a href="chapter-two.html#chapter-two">Chapter Two</a></li>
+      </ol>
+      <p class="group-title">Theme-base pattern: var(inherit) + var()-based content</p>
+      <ol>
+        <li><a href="chapter-three.html#chapter-three">Chapter Three</a></li>
+      </ol>
+    </nav>
+  </body>
+</html>

--- a/packages/core/test/files/issue2043-theme-base-toc/publication.json
+++ b/packages/core/test/files/issue2043-theme-base-toc/publication.json
@@ -1,0 +1,18 @@
+{
+  "@context": ["https://schema.org", "https://www.w3.org/ns/pub-context"],
+  "conformsTo": "https://www.w3.org/TR/pub-manifest/",
+  "type": "Book",
+  "name": "Issue 2043 Theme Base TOC",
+  "readingOrder": [
+    {
+      "url": "index.html",
+      "name": "Table of Contents",
+      "rel": "contents",
+      "type": "LinkedResource"
+    },
+    "chapter-one.html",
+    "chapter-two.html",
+    "chapter-three.html"
+  ],
+  "resources": []
+}

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1502,6 +1502,33 @@ describe("css-cascade", function () {
       expect(style.color.value.toString()).toBe("green");
     });
 
+    it("treats unresolved var() in ordinary properties as unset", function () {
+      var element = document.createElement("div");
+      var style = {
+        color: createCascadeValue("var(--missing)"),
+      };
+
+      applyVarFilter(style, element);
+
+      expect(style.color.value).toBe(adapt_css.ident.unset);
+    });
+
+    it("treats inherited custom property keywords that resolve nowhere as unset in ordinary properties", function () {
+      var element = document.createElement("a");
+      var root = document.createElement("div");
+      root.appendChild(element);
+      var rootStyle = {
+        "--toc-anchor-color": createCascadeValue("inherit"),
+      };
+      var style = {
+        color: createCascadeValue("var(--toc-anchor-color)"),
+      };
+
+      applyVarFilter(style, element, [{ element: root, style: rootStyle }]);
+
+      expect(style.color.value).toBe(adapt_css.ident.unset);
+    });
+
     it("expands all with var-substituted CSS-wide values into browser-backed longhands", function () {
       var element = document.createElement("div");
       var validatorSet = adapt_cssvalid.baseValidatorSet();


### PR DESCRIPTION
Flatten nested `Css.SpaceList` and `Css.CommaList` values after `var()` substitution in `VarFilterVisitor` so `content` values like `var(--toc-page-leader-content) target-counter(...)` remain valid after expansion.

Treat unresolved or invalid `var()` results in ordinary properties as `unset` instead of dropping the declaration, which restores `color: var(--toc-anchor-color)` to browser-compatible behavior and keeps Theme Base TOC links from falling back to the UA link color.

Add regression coverage for ordinary-property `var()` failure handling and register a publication-based Issue #2043 repro in `file-list.js` to cover the cross-document TOC path.

Closes #2043

Assisted-by: GitHub Copilot Chat:gpt-5.4

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2043; the AI diagnosed a `var()` substitution flattening bug in `VarFilterVisitor`.
- The human author asked detailed clarifying questions (whether two test-case variants reproduced the same bug, why `target-counter()` output showed "??"), and pressed the AI to analyze why an earlier PR (#1975) introduced the regression and confirm the current fix addressed the actual cause rather than just working around it.
- The human author requested a full layout-regression run and had the AI remove a redundant duplicate test file.
- The human author further probed the `unset` fallback behavior for unresolved `var()` values with a hands-on experiment and had the AI explain the discrepancy, then asked the AI to draft a separate issue report for the `vivliostyle/themes` repository to track the related `theme-base` problem.

</details>
