### PR TITLE
fix: Collect pagination-progress offsets before the initial render

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2412,26 +2412,34 @@ export class OPFView implements Vgen.CustomRendererFactory {
         : viewItem.layoutPositions.length - 1;
       this.finishPageContainer(viewItem, page, pageIndex);
       this.counterStore.finishPage(page.spineIndex, pageIndex);
-      this.reportPaginationProgress(viewItem, pos);
 
-      // If the position of the page break changed, re-layout the following
-      // page when needed.
-      this.maybeRelayoutFollowingPage(viewItem, pos, oldPage, page)
-        .thenAsync(() =>
-          this.resolveUnresolvedReferencesForPage(
-            viewItem,
-            page,
-            pageIndex,
-            pos,
-          ),
-        )
-        .then((resolvedPage) => {
-          restorePageNumberContext();
-          frame.finish({
-            pageAndPosition: makePageAndPosition(resolvedPage, pageIndex),
-            nextLayoutPosition: pos,
+      const collectResult = Plugin.getHooksForName(
+        Plugin.HOOKS.PAGINATION_PROGRESS,
+      ).length
+        ? this.collectTotalOffsets()
+        : Task.newResult(true);
+      collectResult.then(() => {
+        this.reportPaginationProgress(viewItem, pos);
+
+        // If the position of the page break changed, re-layout the following
+        // page when needed.
+        this.maybeRelayoutFollowingPage(viewItem, pos, oldPage, page)
+          .thenAsync(() =>
+            this.resolveUnresolvedReferencesForPage(
+              viewItem,
+              page,
+              pageIndex,
+              pos,
+            ),
+          )
+          .then((resolvedPage) => {
+            restorePageNumberContext();
+            frame.finish({
+              pageAndPosition: makePageAndPosition(resolvedPage, pageIndex),
+              nextLayoutPosition: pos,
+            });
           });
-        });
+      });
     });
     return frame.result();
   }
@@ -2637,44 +2645,35 @@ export class OPFView implements Vgen.CustomRendererFactory {
   renderAllPages(): Task.Result<PageAndPosition | null> {
     const frame: Task.Frame<PageAndPosition | null> =
       Task.newFrame("renderAllPages");
-    const collectResult = Plugin.getHooksForName(
-      Plugin.HOOKS.PAGINATION_PROGRESS,
-    ).length
-      ? this.collectTotalOffsets()
-      : Task.newResult(true);
-    collectResult
-      .thenAsync(() =>
-        this.renderPagesUpto(
-          {
-            spineIndex: this.opf.spine.length - 1,
-            pageIndex: Number.POSITIVE_INFINITY,
-            offsetInItem: -1,
-          },
-          false,
-        ),
-      )
-      .then((result) => {
-        // Wait until all images are loaded (Issue #1321)
-        frame
-          .loopWithFrame((loopFrame) => {
-            if (
-              this.spineItems.some((viewItem) =>
-                viewItem?.pages.some((page) =>
-                  page?.fetchers.some((fetcher) => !fetcher.arrived),
-                ),
-              )
-            ) {
-              frame.sleep(100).then(() => {
-                loopFrame.continueLoop();
-              });
-            } else {
-              loopFrame.breakLoop();
-            }
-          })
-          .then(() => {
-            frame.finish(result);
-          });
-      });
+    this.renderPagesUpto(
+      {
+        spineIndex: this.opf.spine.length - 1,
+        pageIndex: Number.POSITIVE_INFINITY,
+        offsetInItem: -1,
+      },
+      false,
+    ).then((result) => {
+      // Wait until all images are loaded (Issue #1321)
+      frame
+        .loopWithFrame((loopFrame) => {
+          if (
+            this.spineItems.some((viewItem) =>
+              viewItem?.pages.some((page) =>
+                page?.fetchers.some((fetcher) => !fetcher.arrived),
+              ),
+            )
+          ) {
+            frame.sleep(100).then(() => {
+              loopFrame.continueLoop();
+            });
+          } else {
+            loopFrame.breakLoop();
+          }
+        })
+        .then(() => {
+          frame.finish(result);
+        });
+    });
     return frame.result();
   }
 

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -452,21 +452,63 @@ describe("epub", function () {
     it("does not report 100% until the last of multiple documents is paginated", function (done) {
       var view = createFakeView([100, 100, 100]);
 
-      spyOn(view, "renderPagesUpto").and.callFake(function () {
-        // Each spine item is loaded and fully paginated in order
-        for (var i = 0; i < 3; i++) {
-          var viewItem = createFakeViewItem(view, i, 100);
-          view.spineItems[i] = viewItem;
-          view.reportPaginationProgress(viewItem, null);
-        }
-        return adapt_task.newResult(null);
-      });
-
       adapt_task.start(function () {
-        view.renderAllPages().then(function () {
+        view.collectTotalOffsets().then(function () {
+          // Each spine item is loaded and fully paginated in order
+          for (var i = 0; i < 3; i++) {
+            var viewItem = createFakeViewItem(view, i, 100);
+            view.spineItems[i] = viewItem;
+            view.reportPaginationProgress(viewItem, null);
+          }
           expect(payloads[0].fraction).toBeCloseTo(1 / 3, 5);
           expect(payloads[1].fraction).toBeCloseTo(2 / 3, 5);
           expect(payloads[2].fraction).toBe(1);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("reports the initial render fraction against the whole publication, not just the first document", function (done) {
+      var view = createFakeView([100, 100, 100]);
+      // renderSinglePage() dependencies, stubbed to isolate the collect + report
+      view.counterStore = { finishPage: function () {} };
+      view.isInCounterResolveScope = function () {
+        return false;
+      };
+      view.preparePageCountersForRender = function () {
+        return null;
+      };
+      view.makePage = function () {
+        return { spineIndex: 0, offset: 0, fetchers: [] };
+      };
+      view.resolvePageTypeForRenderSlot = function () {};
+      view.finishPageContainer = function () {};
+      view.maybeRelayoutFollowingPage = function () {
+        return adapt_task.newResult(true);
+      };
+      view.resolveUnresolvedReferencesForPage = function (viewItem, page) {
+        return adapt_task.newResult(page);
+      };
+
+      var viewItem = createFakeViewItem(view, 0, 100);
+      view.spineItems[0] = viewItem;
+      viewItem.instance.getPageNumberContextDepth = function () {
+        return 0;
+      };
+      viewItem.instance.pushPageNumberContext = function () {};
+      viewItem.instance.restorePageNumberContextDepth = function () {};
+      // A page finished at the half of the first document
+      viewItem.instance.getPosition = function () {
+        return 50;
+      };
+      viewItem.instance.layoutNextPage = function () {
+        return adapt_task.newResult({ page: 1 });
+      };
+
+      adapt_task.start(function () {
+        view.renderSinglePage(viewItem, { page: 0 }).then(function () {
+          expect(payloads[0].fraction).toBeCloseTo(1 / 6, 5);
           done();
         });
         return adapt_task.newResult(true);


### PR DESCRIPTION
以前の実装では`renderAllPages`の先頭で`collectTotalOffsets`を1回行うようにしていましたが、初期1ページのレイアウトが`renderPagesUpto`で行われ`renderAllPages`を通らないため、1回だけ`reportPaginationProgress`が`collectTotalOffsets`より先に行われてしまい、この回の集計の分母は1ページ目が含まれる先頭文書だけになっていました。`fraction`には単調化があるので、極端な例として第1文書が1ページだけの場合、1ページ目の時点で`fraction`が100%に固定されてしまいます。

`collectTotalOffsets`を`reportPaginationProgress`と同じ`renderSinglePage`内で行うことで、初期1ページレイアウト時にも`collectTotalOffsets`がおこなわれるようにします。`renderSinglePage`は毎ページ呼ばれるホットパスですが実際の収集は一度だけ行われます。560ページほどの相互参照を多用する書籍で性能比較しましたが、目に見える性能劣化は発生していません。