### PR TITLE
chore(deps): bump typescript from 5.6.3 to 5.9.3 in /packages/core/test

### DIFF
--- a/packages/core/test/package.json
+++ b/packages/core/test/package.json
@@ -20,7 +20,7 @@
     "karma-webpack": "^4.0.2",
     "raw-loader": "^4.0.0",
     "ts-loader": "^8.0.4",
-    "typescript": "^5.6.3",
+    "typescript": "^5.9.3",
     "webpack": "^4.43.0"
   },
   "private": true

--- a/packages/core/test/yarn.lock
+++ b/packages/core/test/yarn.lock
@@ -3333,10 +3333,10 @@ typescript@^3.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^5.6.3:
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
-  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"


### PR DESCRIPTION
coreのテストだけlockfileのTypeScriptが古くなっていました。5.6.3 -> 5.9.3では`Element.textContent`の型が`string | null`と`string`で異なります。