### PR TITLE
refactor: Make class property initialization explicit

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -79,33 +79,41 @@ export class AdaptiveViewer {
   pageSheetSizeAlreadySet: boolean = false;
   renderTask: Task.Task | null = null;
   actions: { [key: string]: Action };
-  readyState: Constants.ReadyState;
-  packageURL: string[];
-  opf: Epub.OPFDoc;
-  touchActive: boolean;
-  touchX: number;
-  touchY: number;
-  needResize: boolean;
-  resized: boolean;
-  needRefresh: boolean;
-  viewportSize: ViewportSize | null;
-  currentPage: Vtree.Page;
-  currentSpread: Vtree.Spread | null;
-  pagePosition: Epub.Position | null;
-  fontSize: number;
-  zoom: number;
-  fitToScreen: boolean;
-  pageViewMode: PageViewMode;
-  waitForLoading: boolean;
-  renderAllPages: boolean;
-  pref: Exprs.Preferences;
-  pageSizes: { width: number; height: number }[];
-  pixelRatio: number;
-  pixelRatioLimit: number;
+  readyState: Constants.ReadyState = Constants.ReadyState.LOADING;
+  packageURL: string[] = [];
+  opf: Epub.OPFDoc | null = null;
+  touchActive: boolean = false;
+  touchX: number = 0;
+  touchY: number = 0;
+  needResize: boolean = false;
+  resized: boolean = false;
+  needRefresh: boolean = false;
+  viewportSize: ViewportSize | null = null;
+  currentPage: Vtree.Page | null = null;
+  currentSpread: Vtree.Spread | null = null;
+  pagePosition: Epub.Position | null = null;
+  fontSize: number = 16;
+  zoom: number = 1;
+  fitToScreen: boolean = false;
+  pageViewMode: PageViewMode = PageViewMode.SINGLE_PAGE;
+  waitForLoading: boolean = false;
+  renderAllPages: boolean = true;
+  pref: Exprs.Preferences = Exprs.defaultPreferences();
+  pageSizes: { width: number; height: number }[] = [];
+
+  // Pixel ratio emulation on PDF output (PR #1079) does not work with
+  // non-Chromium browsers.
+  pixelRatioLimit: number =
+    Base.browserType === "chromium" &&
+    // Check non-legacy CSS zoom support (Chromium>=128)
+    "currentCSSZoom" in Element.prototype
+      ? 16 // max pixelRatio value on Chromium browsers
+      : 0; // disable pixelRatio emulation on non-Chromium browsers
+  pixelRatio: number = Math.min(8, this.pixelRatioLimit);
 
   // force relayout
-  viewport: Vgen.Viewport | null;
-  opfView: Epub.OPFView;
+  viewport: Vgen.Viewport | null = null;
+  opfView: Epub.OPFView | null = null;
   cmykReserveMap: CmykStore.CmykReserveMapEntry[] | undefined;
   cmykReserveMapUrl: string | undefined;
   private paginationProgressHook: Plugin.PaginationProgressHook | null = null;
@@ -151,7 +159,6 @@ export class AdaptiveViewer {
     }
     viewportElement.setAttribute(VIEWPORT_STATUS_ATTRIBUTE, "loading");
     this.fontMapper = new Font.Mapper(document.head, viewportElement);
-    this.init();
     this.kick = () => {};
     this.sendCommand = () => {};
     this.resizeListener = () => {
@@ -172,40 +179,6 @@ export class AdaptiveViewer {
       toc: this.showTOC,
     };
     this.addLogListeners();
-  }
-
-  private init(): void {
-    this.readyState = Constants.ReadyState.LOADING;
-    this.packageURL = [];
-    this.opf = null;
-    this.touchActive = false;
-    this.touchX = 0;
-    this.touchY = 0;
-    this.needResize = false;
-    this.resized = false;
-    this.needRefresh = false;
-    this.viewportSize = null;
-    this.currentPage = null;
-    this.currentSpread = null;
-    this.pagePosition = null;
-    this.fontSize = 16;
-    this.zoom = 1;
-    this.fitToScreen = false;
-    this.pageViewMode = PageViewMode.SINGLE_PAGE;
-    this.waitForLoading = false;
-    this.renderAllPages = true;
-    this.pref = Exprs.defaultPreferences();
-    this.pageSizes = [];
-
-    // Pixel ratio emulation on PDF output (PR #1079) does not work with
-    // non-Chromium browsers.
-    this.pixelRatioLimit =
-      Base.browserType === "chromium" &&
-      // Check non-legacy CSS zoom support (Chromium>=128)
-      "currentCSSZoom" in Element.prototype
-        ? 16 // max pixelRatio value on Chromium browsers
-        : 0; // disable pixelRatio emulation on non-Chromium browsers
-    this.pixelRatio = Math.min(8, this.pixelRatioLimit);
   }
 
   addLogListeners() {

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -172,7 +172,8 @@ export class CoreViewer {
   private adaptViewer_: AdaptiveViewer.AdaptiveViewer;
   private options: CoreViewerOptions;
   private eventTarget: Base.SimpleEventTarget;
-  readyState: Constants.ReadyState;
+  // installed via Object.defineProperty in the constructor
+  declare readyState: Constants.ReadyState;
 
   constructor(
     private readonly settings: CoreViewerSettings,

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3392,7 +3392,7 @@ export class CascadeInstance {
   };
   viewConditions: { [key: string]: Matchers.Matcher[] } = Object.create(null);
   dependentConditions: string[] = [];
-  elementStack: Element[];
+  elementStack: Element[] = [];
 
   constructor(
     cascade: Cascade,
@@ -3413,9 +3413,6 @@ export class CascadeInstance {
     this.currentSiblingTypeCounts = this.siblingTypeCountsStack[0];
     this.followingSiblingOrderStack = [this.currentFollowingSiblingOrder];
     this.currentFollowingSiblingTypeCounts = this.siblingTypeCountsStack[0];
-    if (VIVLIOSTYLE_DEBUG) {
-      this.elementStack = [];
-    }
   }
 
   pushConditionItem(item: ConditionItem): void {
@@ -4748,7 +4745,7 @@ export class CascadeParserHandler
   cascade: Cascade;
   state: ParseState;
   viewConditionId: string | null = null;
-  insideSelectorRule: ParseState;
+  insideSelectorRule: ParseState | undefined;
   invalid: boolean = false; // for `@supports selector()` check
 
   constructor(

--- a/packages/core/src/vivliostyle/layout-retryers.ts
+++ b/packages/core/src/vivliostyle/layout-retryers.ts
@@ -24,10 +24,11 @@ import { Layout, Vtree } from "./types";
  * @abstract
  */
 export abstract class AbstractLayoutRetryer {
-  initialBreakPositions: Layout.BreakPosition[] = null;
-  initialStateOfFormattingContext: Vtree.NodeContext = null;
-  initialPosition: Vtree.NodeContext;
-  initialFragmentLayoutConstraints: Layout.FragmentLayoutConstraint[];
+  initialBreakPositions: Layout.BreakPosition[] | null = null;
+  initialStateOfFormattingContext: Vtree.NodeContext | null = null;
+  initialPosition: Vtree.NodeContext | null = null;
+  initialFragmentLayoutConstraints: Layout.FragmentLayoutConstraint[] | null =
+    null;
 
   layout(
     nodeContext: Vtree.NodeContext,

--- a/packages/core/src/vivliostyle/print.ts
+++ b/packages/core/src/vivliostyle/print.ts
@@ -23,7 +23,7 @@ class VivliostylePrint {
   hideIframe: boolean;
   removeIframe: boolean;
   iframe: HTMLIFrameElement;
-  iframeWin: Window;
+  iframeWin: Window | null = null;
   window: Window & typeof globalThis & IFrameWindowForPrint;
 
   constructor(
@@ -42,9 +42,7 @@ class VivliostylePrint {
     this.errorCallback = errorCallback;
     this.hideIframe = hideIframe;
     this.removeIframe = removeIframe;
-  }
 
-  init() {
     this.iframe = document.createElement("iframe");
 
     if (this.hideIframe) {
@@ -142,6 +140,7 @@ class VivliostylePrint {
 }
 
 export function printHTML(htmlDoc: string, config: PrintConfig) {
-  const instance = new VivliostylePrint(htmlDoc, config);
-  instance.init();
+  // the instance registers itself as window.printInstance and starts printing
+  // eslint-disable-next-line no-new
+  new VivliostylePrint(htmlDoc, config);
 }

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -144,7 +144,7 @@ export class RepetitiveElements
     result: boolean;
   }[] = [];
   allowInsert: boolean = false;
-  allowInsertRepeatitiveElements: boolean;
+  allowInsertRepeatitiveElements: boolean = false;
 
   constructor(
     private readonly vertical: boolean,

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1040,8 +1040,8 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
   currentRowIndex: number = -1;
   currentColumnIndex: number = 0;
   originalStopAtOverflow: boolean;
-  inHeader: boolean;
-  inFooter: boolean;
+  inHeader: boolean = false;
+  inFooter: boolean = false;
   private didExtractRowSpanningCellBreakPositions: boolean = false;
 
   constructor(

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -34,7 +34,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
   head: Element;
   last: Element;
   lastOffset: number = 1;
-  idMap: { [key: string]: Element };
+  idMap: { [key: string]: Element } | null = null;
 
   constructor(
     public readonly store: XMLDocStore,


### PR DESCRIPTION
現在のVivliostyle.jsのTypeScriptはClosure Compiler由来の書き換えで、一部のTypeScriptのデフォルトオプションを無効にしています。特に「オブジェクト型は暗黙にnullable」というClosure由来の前提を移行するために導入された`strictNullChecks: false`は、現在のVivliostyle.jsのコードでは`Type | null`と混在しており、実際にnullと取り違えたことによるバグもしばしば発生しています（ #707 など）

大規模な変更になると思うのですが、もしモチベーションがあれば、`strictNullChecks`から型付けのリファクタリングをやらせていただきたいです。

このPRはその第1段です。Closure由来のコンストラクタ→`init`による二重初期化や暗黙的な初期化を、コンストラクタとフィールド初期化子に畳み込みます。