### PR TITLE
refactor: Make nullable property contracts explicit

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -1210,10 +1210,8 @@ export class AdaptiveViewer {
         default:
           return Task.newResult(true);
       }
-      if (m) {
-        method = () =>
-          m.call(this.opfView, this.pagePosition, !this.renderAllPages);
-      }
+      method = () =>
+        m.call(this.opfView, this.pagePosition, !this.renderAllPages);
     } else if (typeof command["epage"] == "number") {
       const epage = command["epage"] as number;
       method = () =>

--- a/packages/core/src/vivliostyle/cfi.ts
+++ b/packages/core/src/vivliostyle/cfi.ts
@@ -231,7 +231,7 @@ export class OffsetStep implements Step {
 }
 
 export class Fragment {
-  steps: Step[] = null;
+  steps: Step[] | null = null;
 
   fromString(fragstr: string): void {
     let r = fragstr.match(/^#?epubcfi\((.*)\)$/);

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1091,7 +1091,7 @@ export class CounterStore {
       }
     }
     const skipIncrement: { [key: string]: boolean } = Object.create(null);
-    let resetMap: { [key: string]: number };
+    let resetMap: { [key: string]: number } | undefined;
     let resetIsNone = false;
     const reset = cascadedPageStyle["counter-reset"] as CssCascade.CascadeValue;
     if (reset) {
@@ -1106,7 +1106,7 @@ export class CounterStore {
     if (resetMap && "pages" in resetMap) {
       delete resetMap["pages"];
     }
-    let setMap: { [key: string]: number };
+    let setMap: { [key: string]: number } | undefined;
     const set = cascadedPageStyle["counter-set"] as CssCascade.CascadeValue;
     if (set) {
       const setVal = set.evaluate(context);
@@ -1128,7 +1128,7 @@ export class CounterStore {
         pageControlledNames.push(setCounterName);
       }
     }
-    let incrementMap: { [key: string]: number };
+    let incrementMap: { [key: string]: number } | undefined;
     const increment = cascadedPageStyle[
       "counter-increment"
     ] as CssCascade.CascadeValue;

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -116,7 +116,7 @@ function extractPseudoElementText(
  * @param resolved If the reference is already resolved or not
  */
 export class TargetCounterReference {
-  pageCounters: CssCascade.CounterValues = null;
+  pageCounters: CssCascade.CounterValues | null = null;
   spineIndex: number = -1;
   pageIndex: number = -1;
 
@@ -936,7 +936,7 @@ export class CounterStore {
   pageIndicesById: {
     [key: string]: { spineIndex: number; pageIndex: number };
   } = Object.create(null);
-  currentPage: Vtree.Page = null;
+  currentPage: Vtree.Page | null = null;
   newReferencesOfCurrentPage: TargetCounterReference[] = [];
   referencesToSolve: TargetCounterReference[] = [];
   referencesToSolveStack: TargetCounterReference[][] = [];

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5344,7 +5344,7 @@ export class CascadeParserHandler
     funcName: string,
     params?: (number | string)[],
   ): void {
-    let parameterParserHandler: MatchesParameterParserHandler;
+    let parameterParserHandler: MatchesParameterParserHandler | undefined;
     switch (funcName) {
       case "is":
         parameterParserHandler = new MatchesParameterParserHandler(this);

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -853,7 +853,7 @@ export class ApplyRuleAction extends CascadeAction {
 }
 
 export class ChainedAction extends CascadeAction {
-  chained: CascadeAction = null;
+  chained: CascadeAction | null = null;
 
   constructor() {
     super();
@@ -4735,9 +4735,9 @@ export class CascadeParserHandler
   extends CssParser.SlaveParserHandler
   implements CssValidator.PropertyReceiver
 {
-  chain: ChainedAction[] = null;
+  chain: ChainedAction[] | null = null;
   specificity: number = 0;
-  elementStyle: ElementStyle = null;
+  elementStyle: ElementStyle | null = null;
   conditionCount: number = 0;
   pseudoelement: string | null = null;
   selectorFunctionContainsPseudoelement: boolean = false;

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1121,7 +1121,7 @@ export class Parser {
     const isFunc = token.type === TokenType.FUNC;
     const tokenizer = this.tokenizer;
     let startPosition: number;
-    let name: string;
+    let name: string | undefined;
     if (isFunc) {
       name = token.text;
       startPosition = token.position + name.length + 1;
@@ -1149,7 +1149,8 @@ export class Parser {
       return null;
     }
     let parLevel = 0;
-    let tokenN: CssTokenizer.Token;
+    // the loop runs at least once
+    let tokenN!: CssTokenizer.Token;
     let commaCount = 0;
     while (parLevel >= 0) {
       tokenizer.consume();
@@ -1447,7 +1448,7 @@ export class Parser {
     let ns: string | null;
     let text: string | null;
     let num: number;
-    let val: Css.Val;
+    let val: Css.Val | null = null;
     let params: (number | string)[];
     let selectorStartPosition: number | null = null;
 

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -213,8 +213,8 @@ export class ParserHandler implements CssTokenizer.TokenizerHandler {
 
 export class DispatchParserHandler extends ParserHandler {
   stack: ParserHandler[] = [];
-  tokenizer: CssTokenizer.Tokenizer = null;
-  slave: ParserHandler = null;
+  tokenizer: CssTokenizer.Tokenizer | null = null;
+  slave: ParserHandler | null = null;
 
   constructor() {
     super(null);
@@ -815,10 +815,10 @@ export class Parser {
   propName: string | null = null;
   propImportant: boolean = false;
   exprContext: ExprContext;
-  result: Css.Val = null;
+  result: Css.Val | null = null;
   importReady: boolean = false;
   importURL: string | null = null;
-  importCondition: Css.Expr = null;
+  importCondition: Css.Expr | null = null;
   errorBrackets: number[] = [];
   ruleStack: string[] = [];
   regionRule: boolean = false;

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -160,8 +160,8 @@ export class Box {
   isBlockValue: boolean | null = null;
   hasBoxValue: boolean | null = null;
   styleValues = {} as { [key: string]: Css.Val };
-  beforeBox: Box = null;
-  afterBox: Box = null;
+  beforeBox: Box | null = null;
+  afterBox: Box | null = null;
   breakBefore: string | null = null;
 
   constructor(
@@ -474,7 +474,7 @@ export class Styler implements AbstractStyler {
   counterSnapshots: CounterSnapshot[] = [];
   flows = {} as { [key: string]: Vtree.Flow };
   flowChunks = [] as Vtree.FlowChunk[];
-  flowListener: FlowListener = null;
+  flowListener: FlowListener | null = null;
   flowToReach: string | null = null;
   idToReach: string | null = null;
   cascade: CssCascade.CascadeInstance;

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -38,8 +38,8 @@ export interface PropertyReceiver {
 }
 
 export class Node {
-  success: Node = null;
-  failure: Node = null;
+  success: Node | null = null;
+  failure: Node | null = null;
   code: number = 0;
 
   constructor(public validator: PropertyValidator) {}

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -837,8 +837,8 @@ export class OPFDoc {
   epageIsRenderedPage: boolean = true;
   epageCountCallback: (p1: number) => void | null = null;
   metadata: Meta = {};
-  toc: OPFItem = null;
-  cover: OPFItem = null;
+  toc: OPFItem | null = null;
+  cover: OPFItem | null = null;
   fallbackMap: { [key: string]: string } = {};
   pageProgression: Constants.PageProgression | null = null;
   documentURLTransformer: Base.DocumentURLTransformer;
@@ -1339,7 +1339,7 @@ export class OPFDoc {
 
       if (!this.toc) {
         this.toc = manifestUrl
-          ? this.items?.[0]
+          ? (this.items?.[0] ?? null)
           : this.itemMapByPath[primaryEntryPath];
       }
 

--- a/packages/core/src/vivliostyle/geometry-util.ts
+++ b/packages/core/src/vivliostyle/geometry-util.ts
@@ -545,7 +545,8 @@ export function findBottommostFullyOpenRect(
     return rect;
   }
   let bottomEdge = rect.y2;
-  let band: Band;
+  // the loop runs at least once
+  let band!: Band;
   let i: number;
   for (i = bands.length - 1; i >= 0; i--) {
     band = bands[i];

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -359,7 +359,7 @@ export class BoxBreakPosition
   implements Layout.BoxBreakPosition
 {
   private alreadyEvaluated: boolean = false;
-  breakNodeContext: Vtree.NodeContext = null;
+  breakNodeContext: Vtree.NodeContext | null = null;
 
   constructor(
     public readonly checkPoints: Vtree.NodeContext[],
@@ -426,7 +426,7 @@ export function validateCheckPoints(checkPoints: Vtree.NodeContext[]): void {
 export class Column extends VtreeImpl.Container implements Layout.Column {
   last: Node;
   viewDocument: Document;
-  flowRootFormattingContext: Vtree.FormattingContext = null;
+  flowRootFormattingContext: Vtree.FormattingContext | null = null;
   // Issue #1842: true only for columns reached after automatic column overflow.
   isNonFirstColumn: boolean = false;
   isFloat: boolean = false;
@@ -449,7 +449,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   stopAtOverflow: boolean = true;
   lastAfterPosition: Vtree.NodePosition | null = null;
   fragmentLayoutConstraints: FragmentLayoutConstraint[] = [];
-  pseudoParent: Column = null;
+  pseudoParent: Column | null = null;
   nodeContextOverflowingDueToRepetitiveElements: Vtree.NodeContext | null =
     null;
   blockDistanceToBlockEndFloats: number = NaN;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -299,9 +299,9 @@ export class StyleInstance
   rootPageBoxInstance: PageMaster.RootPageBoxInstance = null;
   styler: CssStyler.Styler = null;
   stylerMap: { [key: string]: CssStyler.Styler } = null;
-  currentLayoutPosition: Vtree.LayoutPosition = null;
-  layoutPositionAtPageStart: Vtree.LayoutPosition = null;
-  currentCascadedPageStyle: CssCascade.ElementStyle = null;
+  currentLayoutPosition: Vtree.LayoutPosition | null = null;
+  layoutPositionAtPageStart: Vtree.LayoutPosition | null = null;
+  currentCascadedPageStyle: CssCascade.ElementStyle | null = null;
   lookupOffset: number = 0;
   faces: Font.DocumentFaces;
   pageBoxInstances: { [key: string]: PageMaster.PageBoxInstance } = {};

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -43,7 +43,7 @@ export abstract class PageBox<
   // styles specified in the at-rule
   specified: CssCascade.ElementStyle = {};
   children: PageBox[] = [];
-  pageMaster: PageMaster = null;
+  pageMaster: PageMaster | null = null;
   index: number = 0;
   key: string;
 
@@ -417,7 +417,7 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
   isRightDependentOnAutoWidth: boolean = false;
   private calculatedWidth: number = 0;
   private calculatedHeight: number = 0;
-  pageMasterInstance: PageMasterInstance = null;
+  pageMasterInstance: PageMasterInstance | null = null;
   namedValues: { [key: string]: Exprs.Val } = {};
   namedFuncs: { [key: string]: Exprs.Val } = {};
   vertical: boolean = false;

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -42,7 +42,7 @@ export class RepetitiveElementsOwnerFormattingContext
 {
   formattingContextType: FormattingContextType = "RepetitiveElementsOwner";
   isRoot: boolean = false;
-  repetitiveElements: RepetitiveElement.RepetitiveElements = null;
+  repetitiveElements: RepetitiveElement.RepetitiveElements | null = null;
 
   constructor(
     public readonly parent: Vtree.FormattingContext,

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -967,7 +967,7 @@ export class RepetitiveElementsOwnerLayoutProcessor
     nodeContext: Vtree.NodeContext,
     forceRemoveSelf: boolean,
     endOfColumn: boolean,
-  ): Task.Result<boolean> | null {
+  ): Task.Result<boolean> {
     return LayoutProcessor.BlockLayoutProcessor.prototype.finishBreak.call(
       this,
       column,

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -69,7 +69,7 @@ export class TableCell {
   colSpan: number;
   rowSpan: number;
   height: number = 0;
-  anchorSlot: TableSlot = null;
+  anchorSlot: TableSlot | null = null;
 
   constructor(
     public readonly rowIndex: number,
@@ -144,7 +144,8 @@ export class BetweenTableRowBreakPosition
 {
   private formattingContext: TableFormattingContext;
 
-  acceptableCellBreakPositions: Layout.BreakPositionAndNodeContext[] = null;
+  acceptableCellBreakPositions: Layout.BreakPositionAndNodeContext[] | null =
+    null;
   private rowIndex: number | null = null;
 
   constructor(
@@ -258,7 +259,8 @@ export class BetweenTableRowBreakPosition
 export class InsideTableRowBreakPosition
   extends BreakPosition.AbstractBreakPosition
 {
-  acceptableCellBreakPositions: Layout.BreakPositionAndNodeContext[] = null;
+  acceptableCellBreakPositions: Layout.BreakPositionAndNodeContext[] | null =
+    null;
 
   constructor(
     public readonly rowIndex: number,

--- a/packages/core/src/vivliostyle/task-util.ts
+++ b/packages/core/src/vivliostyle/task-util.ts
@@ -33,8 +33,8 @@ import * as Task from "./task";
 export class Fetcher<T> {
   name: string;
   arrived: boolean = false;
-  resource: T = null;
-  task: Task.Task = null;
+  resource: T | null = null;
+  task: Task.Task | null = null;
   piggybacks: ((p1: any) => void)[] | null = [];
 
   constructor(

--- a/packages/core/src/vivliostyle/task.ts
+++ b/packages/core/src/vivliostyle/task.ts
@@ -339,7 +339,7 @@ export class Scheduler {
 export class Continuation<T> implements Base.Comparable {
   scheduledTime: number = 0;
   order: number = 0;
-  result: T = null;
+  result: T | null = null;
   canceled: boolean = false;
 
   constructor(public task: Task) {}
@@ -635,7 +635,7 @@ export class ResultImpl<T> implements Result<T> {
  * @template T
  */
 export class Frame<T> {
-  res: T = null;
+  res: T | null = null;
   state: FrameState;
   callback: ((p1: any) => void) | null = null;
   handler: ((p1: Frame<any>, p2: Error) => void) | null = null;
@@ -836,7 +836,7 @@ export class LoopBodyFrame extends Frame<boolean> {
 }
 
 export class EventItem {
-  next: EventItem = null;
+  next: EventItem | null = null;
 
   constructor(public event: Base.Event) {}
 }
@@ -846,7 +846,7 @@ export class EventItem {
  * stream to tasks.
  */
 export class EventSource {
-  continuation: Continuation<boolean> = null;
+  continuation: Continuation<boolean> | null = null;
   listeners: {
     target: Base.EventTarget;
     type: string;

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -487,7 +487,7 @@ class TextSpacingPolyfill {
 
     function checkIfAfterForcedLineBreak(): boolean {
       let p = checkPoints[0];
-      let prevNode: Node;
+      let prevNode: Node | null | undefined;
       while (p && p.inline) {
         prevNode = p.viewNode?.previousSibling;
         if (prevNode) {
@@ -851,12 +851,11 @@ class TextSpacingPolyfill {
             rect.top > nextRect.top + nextRect.height - rect.height / 10;
     }
 
-    let punctProcessing = false;
     let chromiumVoTrFallbackOnly = false;
     let hangingFirst = false;
     let hangingLast = false;
     let hangingEnd = false;
-    let tagName: "viv-ts-open" | "viv-ts-close";
+    let tagName: "viv-ts-open" | "viv-ts-close" | undefined;
     const needsChromiumVoTrFallback = isChromiumVoTrFallback(text, vertical);
 
     if (
@@ -866,7 +865,6 @@ class TextSpacingPolyfill {
     ) {
       // hanging-punctuation: first
       tagName = "viv-ts-open";
-      punctProcessing = true;
       hangingFirst = true;
     } else if (
       isLastInBlock &&
@@ -875,7 +873,6 @@ class TextSpacingPolyfill {
     ) {
       // hanging-punctuation: last
       tagName = "viv-ts-close";
-      punctProcessing = true;
       hangingLast = true;
     } else if (
       (hangingPunctuation.forceEnd || hangingPunctuation.allowEnd) &&
@@ -883,7 +880,6 @@ class TextSpacingPolyfill {
     ) {
       // hanging-punctuation: force-end | allow-end
       tagName = "viv-ts-close";
-      punctProcessing = true;
       hangingEnd = true;
     } else if (
       (spacingTrim.trimStart ||
@@ -893,7 +889,6 @@ class TextSpacingPolyfill {
     ) {
       // fullwidth opening punctuation
       tagName = "viv-ts-open";
-      punctProcessing = true;
     } else if (
       (spacingTrim.trimEnd ||
         spacingTrim.allowEnd ||
@@ -904,14 +899,12 @@ class TextSpacingPolyfill {
     ) {
       // fullwidth closing punctuation
       tagName = "viv-ts-close";
-      punctProcessing = true;
     } else if (needsChromiumVoTrFallback) {
       tagName = getChromiumVoTrFallbackTagName(text);
-      punctProcessing = true;
       chromiumVoTrFallbackOnly = true;
     }
 
-    if (punctProcessing) {
+    if (tagName !== undefined) {
       if (textNode.parentElement.localName === "viv-ts-inner") {
         // Already processed
         return 0;

--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -96,8 +96,8 @@ export function findTocAnchorElements(doc: Document): Array<Element> {
 
 export class TOCView implements Vgen.CustomRendererFactory {
   pref: Exprs.Preferences;
-  page: Vtree.Page = null;
-  instance: OPS.StyleInstance = null;
+  page: Vtree.Page | null = null;
+  instance: OPS.StyleInstance | null = null;
 
   constructor(
     public readonly store: OPS.OPSDocStore,

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -112,7 +112,7 @@ export namespace Layout {
    *    breakable block
    */
   export interface BoxBreakPosition extends AbstractBreakPosition {
-    breakNodeContext: Vtree.NodeContext;
+    breakNodeContext: Vtree.NodeContext | null;
     readonly checkPoints: Vtree.NodeContext[];
     readonly penalty: number;
   }
@@ -131,7 +131,7 @@ export namespace Layout {
   export interface Column extends Vtree.Container {
     last: Node;
     viewDocument: Document;
-    flowRootFormattingContext: Vtree.FormattingContext;
+    flowRootFormattingContext: Vtree.FormattingContext | null;
     // Issue #1842: distinguishes auto-advanced follow-up columns from the first
     // column on a page so leading-edge forced breaks can be handled differently.
     isNonFirstColumn: boolean;
@@ -164,7 +164,7 @@ export namespace Layout {
     stopAtOverflow: boolean;
     lastAfterPosition: Vtree.NodePosition | null;
     fragmentLayoutConstraints: FragmentLayoutConstraint[];
-    pseudoParent: Column;
+    pseudoParent: Column | null;
     nodeContextOverflowingDueToRepetitiveElements: Vtree.NodeContext | null;
     blockDistanceToBlockEndFloats: number;
     lastLineStride: number;
@@ -872,7 +872,7 @@ export namespace RepetitiveElement {
   export interface RepetitiveElementsOwnerFormattingContext
     extends Vtree.FormattingContext {
     isRoot: boolean;
-    repetitiveElements: RepetitiveElements;
+    repetitiveElements: RepetitiveElements | null;
     readonly parent: Vtree.FormattingContext;
     readonly rootSourceNode: Element;
     getRepetitiveElements(): RepetitiveElements;
@@ -1188,8 +1188,8 @@ export namespace Vtree {
     height: number;
     originX: number;
     originY: number;
-    exclusions: GeometryUtil.Shape[];
-    innerShape: GeometryUtil.Shape;
+    exclusions: GeometryUtil.Shape[] | null;
+    innerShape: GeometryUtil.Shape | null;
     computedBlockSize: number;
     snapWidth: number;
     snapHeight: number;
@@ -1250,7 +1250,7 @@ export namespace Vtree {
     readonly root: Element;
     readonly xmldoc: XmlDoc.XMLDocHolder;
     readonly parentShadow: ShadowContext;
-    subShadow: ShadowContext;
+    subShadow: ShadowContext | null;
     readonly type: Vtree.ShadowType;
     readonly styler: CssStyler.AbstractStyler;
 
@@ -1280,8 +1280,8 @@ export namespace Vtree {
     after: boolean;
     shadowType: ShadowType; // parent's shadow type
     shadowContext: Vtree.ShadowContext;
-    nodeShadow: Vtree.ShadowContext;
-    shadowSibling: NodeContext; // next "sibling" in the shadow tree
+    nodeShadow: Vtree.ShadowContext | null;
+    shadowSibling: NodeContext | null; // next "sibling" in the shadow tree
     // other stuff
     shared: boolean;
     inline: boolean;
@@ -1304,8 +1304,8 @@ export namespace Vtree {
     containingBlockForAbsolute: boolean;
     breakBefore: string | null;
     breakAfter: string | null;
-    viewNode: Node;
-    clearSpacer: Node;
+    viewNode: Node | null;
+    clearSpacer: Node | null;
     inheritedProps: { [key: string]: number | string | Css.Val };
     vertical: boolean;
     direction: string;
@@ -1318,7 +1318,7 @@ export namespace Vtree {
       [key: string]: string | number | undefined | null | (number | null)[];
     };
     fragmentIndex: number;
-    afterIfContinues: Selectors.AfterIfContinues;
+    afterIfContinues: Selectors.AfterIfContinues | null;
     footnotePolicy: Css.Ident | null;
     pageType: string | null;
 
@@ -1338,7 +1338,7 @@ export namespace Vtree {
   }
 
   export interface ChunkPosition {
-    floats: NodePosition[];
+    floats: NodePosition[] | null;
     primary: NodePosition;
 
     clone(): ChunkPosition;
@@ -1361,7 +1361,7 @@ export namespace XmlDoc {
     head: Element;
     last: Element;
     lastOffset: number;
-    idMap: { [key: string]: Element };
+    idMap: { [key: string]: Element } | null;
     readonly store: XMLDocStore;
     readonly url: string;
     readonly document: Document;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -785,7 +785,7 @@ export class ViewFactory
       // The percent value of inline-size on vertical-in-horizontal or
       // horizontal-in-vertical block needs to be resolved against the
       // page area height or width. (Fix for issue #1264)
-      let percentRef: number;
+      let percentRef: number | undefined;
       if (verticalChanged) {
         if (vertical) {
           if (/^(min-|max-)?(height|inline-size)$/.test(name)) {
@@ -999,8 +999,8 @@ export class ViewFactory
         }
       }
       propList.sort(Css.processingOrderFn);
-      let fontSize: Css.Val;
-      let lineHeight: Css.Val;
+      let fontSize: Css.Val | undefined;
+      let lineHeight: Css.Val | undefined;
 
       for (const name of propList) {
         if (
@@ -3233,8 +3233,8 @@ export class ViewFactory
 
     const propList = Object.keys(computedStyle);
     propList.sort(Css.processingOrderFn);
-    let fontSize: Css.Val;
-    let lineHeight: Css.Val;
+    let fontSize: Css.Val | undefined;
+    let lineHeight: Css.Val | undefined;
 
     for (const propName of propList) {
       if (propertiesNotPassedToDOM[propName]) {
@@ -3431,8 +3431,8 @@ export class ViewFactory
    */
   private getLineHeightUnitSize(
     propName: string,
-    fontSize: Css.Val,
-    lineHeight: Css.Val,
+    fontSize: Css.Val | undefined,
+    lineHeight: Css.Val | undefined,
   ): number | null {
     const parentStyle = this.getParentViewStyle();
     const parentMetrics = this.getParentComputedMetrics(parentStyle);
@@ -3521,7 +3521,10 @@ export class ViewFactory
    * Get "em" unit size in px
    * @return font-size in px, or null if cannot be determined
    */
-  private getEmUnitSize(propName: string, fontSize: Css.Val): number | null {
+  private getEmUnitSize(
+    propName: string,
+    fontSize: Css.Val | undefined,
+  ): number | null {
     const parentStyle = this.getParentViewStyle();
     const parentFontSize = this.getParentComputedMetrics(parentStyle).fontSize;
 

--- a/packages/core/src/vivliostyle/viewer-app.ts
+++ b/packages/core/src/vivliostyle/viewer-app.ts
@@ -267,7 +267,7 @@ function setViewportSize(
   orientation: string | null,
   config: { [key: string]: any },
 ): void {
-  let pageSpec: string;
+  let pageSpec: string | null | undefined;
   if (!width || !height) {
     switch (size) {
       case "A5":

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -130,7 +130,7 @@ export class Page extends Base.SimpleEventTarget {
   isAutoPageWidth: boolean = true;
   isAutoPageHeight: boolean = true;
   spineIndex: number = 0;
-  position: LayoutPosition = null;
+  position: LayoutPosition | null = null;
   offset: number = -1;
   side: Constants.PageSide | null = null;
   fetchers: TaskUtil.Fetcher<{}>[] = [];
@@ -506,7 +506,7 @@ export type ShadowType = Vtree.ShadowType; // eslint-disable-line no-redeclare
  * Data about shadow tree instance.
  */
 export class ShadowContext implements Vtree.ShadowContext {
-  subShadow: ShadowContext = null;
+  subShadow: ShadowContext | null = null;
 
   constructor(
     public readonly owner: Element,
@@ -569,8 +569,8 @@ export class NodeContext implements Vtree.NodeContext {
 
   // parent's shadow type
   shadowContext: Vtree.ShadowContext;
-  nodeShadow: Vtree.ShadowContext = null;
-  shadowSibling: NodeContext = null;
+  nodeShadow: Vtree.ShadowContext | null = null;
+  shadowSibling: NodeContext | null = null;
 
   // next "sibling" in the shadow tree
   // other stuff
@@ -595,8 +595,8 @@ export class NodeContext implements Vtree.NodeContext {
   containingBlockForAbsolute: boolean = false;
   breakBefore: string | null = null;
   breakAfter: string | null = null;
-  viewNode: Node = null;
-  clearSpacer: Node = null;
+  viewNode: Node | null = null;
+  clearSpacer: Node | null = null;
   inheritedProps: { [key: string]: number | string | Css.Val };
   vertical: boolean;
   direction: string;
@@ -609,7 +609,7 @@ export class NodeContext implements Vtree.NodeContext {
     [key: string]: string | number | undefined | null | (number | null)[];
   } = {};
   fragmentIndex: number = 1;
-  afterIfContinues: Selectors.AfterIfContinues = null;
+  afterIfContinues: Selectors.AfterIfContinues | null = null;
   footnotePolicy: Css.Ident | null = null;
   pageType: string | null;
 
@@ -835,7 +835,7 @@ export class NodeContext implements Vtree.NodeContext {
 }
 
 export class ChunkPosition implements Vtree.ChunkPosition {
-  floats: NodePosition[] = null;
+  floats: NodePosition[] | null = null;
 
   constructor(public primary: NodePosition) {}
 
@@ -949,8 +949,8 @@ export class LayoutPosition {
   highestSeenOffset: number = 0;
 
   // FIXME: This properties seem to be not used
-  highestSeenNode: Node;
-  lookupPositionOffset: number;
+  highestSeenNode: Node | null = null;
+  lookupPositionOffset: number | null = null;
 
   clone(): LayoutPosition {
     const newcp = new LayoutPosition();
@@ -1046,8 +1046,8 @@ export class Container implements Vtree.Container {
   height: number = 0;
   originX: number = 0;
   originY: number = 0;
-  exclusions: GeometryUtil.Shape[] = null;
-  innerShape: GeometryUtil.Shape = null;
+  exclusions: GeometryUtil.Shape[] | null = null;
+  innerShape: GeometryUtil.Shape | null = null;
   computedBlockSize: number = 0;
   snapWidth: number = 0;
   snapHeight: number = 0;

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -296,7 +296,7 @@ export function parseAndReturnNullIfError(
   opt_parser?: DOMParser,
 ): Document | null {
   const parser = opt_parser || new DOMParser();
-  let doc: Document;
+  let doc: Document | undefined;
   try {
     doc = parser.parseFromString(str, type as DOMParserSupportedType);
   } catch (e) {}


### PR DESCRIPTION
refs: #2049

明示的なnull代入や一時的な未代入のうち、非nullアサーションなしで対応可能な箇所について`| null / undefined`を付与します。