### PR TITLE
refactor: Complete null contracts in view generation

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5826,7 +5826,7 @@ export function flattenCascadedStyle(
   context: Exprs.Context,
   regionIds: string[],
   isFootnote: boolean,
-  nodeContext: Vtree.NodeContext,
+  nodeContext: Vtree.NodeContext | null,
 ): { [key: string]: CascadeValue } {
   const cascMap = {} as { [key: string]: CascadeValue };
   for (const n in style) {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5826,7 +5826,6 @@ export function flattenCascadedStyle(
   context: Exprs.Context,
   regionIds: string[],
   isFootnote: boolean,
-  nodeContext: Vtree.NodeContext | null,
 ): { [key: string]: CascadeValue } {
   const cascMap = {} as { [key: string]: CascadeValue };
   for (const n in style) {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -763,7 +763,7 @@ export function convertFontRelativeLengthToPx(
 
 export function convertFontSizeToPx(
   numeric: Css.Numeric,
-  parentFontSize: number,
+  parentFontSize: number | null,
   context: Exprs.Context,
 ): Css.Numeric {
   numeric = convertFontRelativeLengthToPx(numeric, parentFontSize, context);

--- a/packages/core/src/vivliostyle/display.ts
+++ b/packages/core/src/vivliostyle/display.ts
@@ -128,7 +128,9 @@ function isDisplayType(
   );
 }
 
-export function isInlineLevel(display: Css.Val | string | undefined): boolean {
+export function isInlineLevel(
+  display: Css.Val | string | null | undefined,
+): boolean {
   if (!isDisplayType(display)) {
     return false;
   }
@@ -150,7 +152,9 @@ export function isInlineLevel(display: Css.Val | string | undefined): boolean {
 /**
  * Check if the display value includes "list-item", like "inline list-item".
  */
-export function isListItem(display: Css.Val | string | undefined): boolean {
+export function isListItem(
+  display: Css.Val | string | null | undefined,
+): boolean {
   if (!isDisplayType(display)) {
     return false;
   }
@@ -176,7 +180,7 @@ export function isBlockLevel(display: Css.Val | string | undefined): boolean {
 }
 
 export function isRubyInternalDisplay(
-  display: Css.Val | string | undefined,
+  display: Css.Val | string | null | undefined,
 ): boolean {
   if (!isDisplayType(display)) {
     return false;
@@ -196,10 +200,10 @@ export function isRubyInternalDisplay(
  * Judges if the generated box establishes a new block formatting context.
  */
 export function establishesBFC(
-  display: Css.Val,
-  position: Css.Ident,
-  float: Css.Val,
-  overflow: Css.Ident,
+  display: Css.Val | null | undefined,
+  position: Css.Ident | null | undefined,
+  float: Css.Val | null | undefined,
+  overflow: Css.Ident | null | undefined,
   writingMode?: Css.Ident,
   parentWritingMode?: Css.Ident,
   isFlowRoot?: boolean,

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -796,7 +796,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   nextInTree(
     position: Vtree.NodeContext,
     atUnforcedBreak?: boolean,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const cont = this.layoutContext.nextInTree(position, atUnforcedBreak);
     return processAfterIfContinues(cont, this);
   }

--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -304,7 +304,7 @@ export function newJSONStore(): JSONStore {
 export function loadElement(
   elem: Element,
   src?: string,
-  alt?: string,
+  alt?: string | null,
 ): TaskUtil.Fetcher<string> {
   const fetcher = new TaskUtil.Fetcher(
     () => {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -318,8 +318,7 @@ export class StyleInstance
   private invalidPageAreaOnCurrentPage: boolean = false;
   private repeatedInvalidPageAreaLayoutPosition: Vtree.LayoutPosition | null =
     null;
-  private semanticFootnoteFirstRefOffsets: Map<string, number | null> =
-    new Map();
+  private semanticFootnoteFirstRefOffsets: Map<string, number> = new Map();
   private semanticFootnoteFirstRefOffsetsInitialized = { value: false };
   pageGroupPageCounts: {
     [pageType: string]: Map<Element, number>;

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -964,7 +964,6 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
       context,
       regionIds,
       false,
-      null,
     );
     this.vertical = CssCascade.isVertical(
       cascMap,

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -175,9 +175,9 @@ export type ResolveTextNodeBreakerHook = (
 export type ResolveFormattingContextHook = (
   p1: Vtree.NodeContext,
   p2: boolean,
-  p3: Css.Val,
-  p4: Css.Ident,
-  p5: Css.Val,
+  p3: Css.Val | null | undefined,
+  p4: Css.Ident | null | undefined,
+  p5: Css.Val | null | undefined,
   p6: boolean,
 ) => Vtree.FormattingContext;
 

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -204,7 +204,7 @@ export namespace Layout {
     nextInTree(
       position: Vtree.NodeContext,
       atUnforcedBreak?: boolean,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     /**
      * Builds the view for a single unbreakable element.
      * @param position start source position.
@@ -1054,7 +1054,7 @@ export namespace Vtree {
     nextInTree(
       nodeContext: NodeContext,
       atUnforcedBreak?: boolean,
-    ): Task.Result<NodeContext>;
+    ): Task.Result<NodeContext | null>;
     /**
      * Apply pseudo-element styles (if any).
      * @param target element to apply styles to
@@ -1272,7 +1272,7 @@ export namespace Vtree {
     offsetInNode: number;
     after: boolean;
     shadowType: ShadowType; // parent's shadow type
-    shadowContext: Vtree.ShadowContext;
+    shadowContext: Vtree.ShadowContext | null;
     nodeShadow: Vtree.ShadowContext | null;
     shadowSibling: NodeContext | null; // next "sibling" in the shadow tree
     // other stuff

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1241,8 +1241,8 @@ export namespace Vtree {
   export interface ShadowContext {
     readonly owner: Element;
     readonly root: Element;
-    readonly xmldoc: XmlDoc.XMLDocHolder;
-    readonly parentShadow: ShadowContext;
+    readonly xmldoc: XmlDoc.XMLDocHolder | null;
+    readonly parentShadow: ShadowContext | null;
     subShadow: ShadowContext | null;
     readonly type: Vtree.ShadowType;
     readonly styler: CssStyler.AbstractStyler;
@@ -1255,7 +1255,7 @@ export namespace Vtree {
    * @param count 0 - first-letter, 1 or more - first line(s)
    */
   export interface FirstPseudo {
-    readonly outer: FirstPseudo;
+    readonly outer: FirstPseudo | null;
     readonly count: number;
   }
 
@@ -1299,7 +1299,7 @@ export namespace Vtree {
     breakAfter: string | null;
     viewNode: Node | null;
     clearSpacer: Node | null;
-    inheritedProps: { [key: string]: number | string | Css.Val };
+    inheritedProps: { [key: string]: number | string | Css.Val | undefined };
     vertical: boolean;
     direction: string;
     firstPseudo: FirstPseudo;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -146,7 +146,8 @@ export function initIFrame(iframe: HTMLIFrameElement): void {
   iframe.addEventListener(
     "load",
     () => {
-      iframe.contentWindow.navigator["epubReadingSystem"] = {
+      // the load event fires only when the iframe has a browsing context
+      iframe.contentWindow!.navigator["epubReadingSystem"] = {
         name: "adapt",
         version: "0.1",
         layoutStyle: "paginated",
@@ -219,7 +220,7 @@ export class ViewFactory
     public readonly cascadedPageStyle?: CssCascade.ElementStyle,
     private readonly semanticFootnoteFirstRefOffsets: Map<
       string,
-      number | null
+      number
     > = new Map(),
     private readonly semanticFootnoteFirstRefOffsetsInitialized: {
       value: boolean;
@@ -412,20 +413,21 @@ export class ViewFactory
   }
 
   createPseudoelementShadow(
+    nodeContext: Vtree.NodeContext,
     element: Element,
     isRoot: boolean,
     cascStyle: CssCascade.ElementStyle,
     computedStyle: { [key: string]: Css.Val },
     styler: CssStyler.AbstractStyler,
     context: Exprs.Context,
-    parentShadow: Vtree.ShadowContext,
-    subShadow: Vtree.ShadowContext,
-  ): Vtree.ShadowContext {
+    parentShadow: Vtree.ShadowContext | null,
+    subShadow: Vtree.ShadowContext | null,
+  ): Vtree.ShadowContext | null {
     const pseudoMap = this.getPseudoMap(
       cascStyle,
       this.regionIds,
       this.isFootnote,
-      this.nodeContext,
+      nodeContext,
       context,
     );
     if (!pseudoMap) {
@@ -555,7 +557,7 @@ export class ViewFactory
     isFootnote: boolean,
     nodeContext: Vtree.NodeContext,
     context: Exprs.Context,
-  ): CssCascade.ElementStyleMap {
+  ): CssCascade.ElementStyleMap | null {
     const pseudoMap = CssCascade.getStyleMap(cascStyle, "_pseudos");
     if (!pseudoMap) {
       return null;
@@ -596,10 +598,10 @@ export class ViewFactory
     href: string,
     type: Vtree.ShadowType,
     element: Element,
-    parentShadow: Vtree.ShadowContext,
-    subShadow: Vtree.ShadowContext,
-  ): Task.Result<Vtree.ShadowContext> {
-    const frame: Task.Frame<Vtree.ShadowContext> =
+    parentShadow: Vtree.ShadowContext | null,
+    subShadow: Vtree.ShadowContext | null,
+  ): Task.Result<Vtree.ShadowContext | null> {
+    const frame: Task.Frame<Vtree.ShadowContext | null> =
       Task.newFrame("createRefShadow");
     this.xmldoc.store.load(href).then((refDocParam) => {
       const refDoc = refDocParam;
@@ -624,19 +626,20 @@ export class ViewFactory
   }
 
   createShadows(
+    nodeContext: Vtree.NodeContext,
     element: Element,
     isRoot,
     cascStyle: CssCascade.ElementStyle,
     computedStyle: { [key: string]: Css.Val },
     styler: CssStyler.AbstractStyler,
     context: Exprs.Context,
-    shadowContext: Vtree.ShadowContext,
-  ): Task.Result<Vtree.ShadowContext> {
-    const frame: Task.Frame<Vtree.ShadowContext> =
+    shadowContext: Vtree.ShadowContext | null,
+  ): Task.Result<Vtree.ShadowContext | null> {
+    const frame: Task.Frame<Vtree.ShadowContext | null> =
       Task.newFrame("createShadows");
-    const shadow: Vtree.ShadowContext = null;
+    const shadow: Vtree.ShadowContext | null = null;
     const templateURLVal = computedStyle["template"];
-    let cont: Task.Result<Vtree.ShadowContext>;
+    let cont: Task.Result<Vtree.ShadowContext | null>;
     if (
       templateURLVal instanceof Css.URL ||
       templateURLVal === Css.ident.footnote
@@ -669,22 +672,20 @@ export class ViewFactory
       cont = Task.newResult(shadow);
     }
     cont.then((shadow) => {
-      let cont1: Task.Result<Vtree.ShadowContext> = null;
+      let cont1: Task.Result<Vtree.ShadowContext | null> | null = null;
       if (element.namespaceURI == Base.NS.SHADOW) {
         if (element.localName == "include") {
           let href = element.getAttribute("href");
-          let xmldoc: XmlDoc.XMLDocHolder = null;
+          let xmldoc: XmlDoc.XMLDocHolder = this.xmldoc;
           if (href) {
-            xmldoc = shadowContext ? shadowContext.xmldoc : this.xmldoc;
+            xmldoc = shadowContext?.xmldoc ?? this.xmldoc;
           } else if (shadowContext) {
             if (shadowContext.owner.namespaceURI == Base.NS.XHTML) {
               href = shadowContext.owner.getAttribute("href");
             } else {
               href = shadowContext.owner.getAttributeNS(Base.NS.XLINK, "href");
             }
-            xmldoc = shadowContext.parentShadow
-              ? shadowContext.parentShadow.xmldoc
-              : this.xmldoc;
+            xmldoc = shadowContext.parentShadow?.xmldoc ?? this.xmldoc;
           }
           if (href) {
             href = Base.resolveReferenceURL(href, xmldoc.url);
@@ -701,7 +702,7 @@ export class ViewFactory
       if (cont1 == null) {
         cont1 = Task.newResult(shadow);
       }
-      let cont2: Task.Result<Vtree.ShadowContext> = null;
+      let cont2: Task.Result<Vtree.ShadowContext | null> | null = null;
       cont1.then((shadow) => {
         if (computedStyle["display"] === Css.ident.table_cell) {
           const url = Base.resolveURL(
@@ -720,6 +721,7 @@ export class ViewFactory
         }
         cont2.then((shadow) => {
           shadow = this.createPseudoelementShadow(
+            nodeContext,
             element,
             isRoot,
             cascStyle,
@@ -789,11 +791,11 @@ export class ViewFactory
       if (verticalChanged) {
         if (vertical) {
           if (/^(min-|max-)?(height|inline-size)$/.test(name)) {
-            percentRef = context.pageAreaHeight;
+            percentRef = context.pageAreaHeight ?? undefined;
           }
         } else {
           if (/^(min-|max-)?(width|inline-size)$/.test(name)) {
-            percentRef = context.pageAreaWidth;
+            percentRef = context.pageAreaWidth ?? undefined;
           }
         }
       }
@@ -865,8 +867,8 @@ export class ViewFactory
     lang: string | null;
     elementStyle: CssCascade.ElementStyle;
   } {
-    let node = nodeContext.sourceNode;
-    const styles = [];
+    let node: Node | null = nodeContext.sourceNode;
+    const styles: CssCascade.ElementStyle[] = [];
     let lang: string | null = null;
     const isFootnoteContentInclude =
       node instanceof Element &&
@@ -994,7 +996,7 @@ export class ViewFactory
     );
     for (let i = styles.length - 1; i >= 0; --i) {
       const style = styles[i];
-      const propList = [];
+      const propList: string[] = [];
       for (const propName in style) {
         if (CssCascade.isInherited(propName)) {
           propList.push(propName);
@@ -1320,7 +1322,7 @@ export class ViewFactory
       return frame.result();
     }
 
-    let display = computedStyle["display"];
+    let display: Css.Val | null | undefined = computedStyle["display"];
 
     if (
       SemanticFootnote.isSemanticFootnoteElement(element) &&
@@ -1334,9 +1336,9 @@ export class ViewFactory
       if (display === Css.ident.initial || display === Css.ident.unset) {
         display = Css.ident.inline;
       } else if (display === Css.ident.inherit) {
-        display =
-          nodeContext.parent?.display &&
-          Css.getName(nodeContext.parent?.display);
+        display = nodeContext.parent?.display
+          ? Css.getName(nodeContext.parent.display)
+          : null;
       } else {
         display = null;
       }
@@ -1358,18 +1360,19 @@ export class ViewFactory
     nodeContext.flexContainer =
       display === Css.ident.flex || isFixedSizeGridContainer;
     this.createShadows(
+      nodeContext,
       element,
       isRoot,
       elementStyle,
       computedStyle,
       styler,
       this.context,
-      nodeContext.shadowContext as Vtree.ShadowContext,
+      nodeContext.shadowContext,
     ).then((shadowParam) => {
       nodeContext.nodeShadow = shadowParam;
       const position = computedStyle["position"] as Css.Ident;
-      let floatSide = computedStyle["float"];
-      let clearSide = computedStyle["clear"] as Css.Ident;
+      let floatSide: Css.Val | null = computedStyle["float"];
+      let clearSide: Css.Ident | null = computedStyle["clear"] as Css.Ident;
       const writingMode = nodeContext.vertical
         ? Css.ident.vertical_rl
         : Css.ident.horizontal_tb;
@@ -1776,8 +1779,8 @@ export class ViewFactory
 
       // Create the view element
       let custom = false;
-      let inner: Element = null;
-      const fetchers = [];
+      let inner: Element | null = null;
+      const fetchers: TaskUtil.Fetcher<string>[] = [];
       let ns = element.namespaceURI;
       let tag = element.localName;
       let originalTag = tag;
@@ -1836,7 +1839,7 @@ export class ViewFactory
       }
       if (computedStyle["behavior"]) {
         const behavior = computedStyle["behavior"].toString();
-        if (behavior != "none" && this.customRenderer) {
+        if (behavior != "none") {
           custom = true;
         }
       }
@@ -1846,7 +1849,7 @@ export class ViewFactory
       ) {
         custom = true;
       }
-      let elemResult: Task.Result<Element>;
+      let elemResult: Task.Result<Element | null>;
       if (custom) {
         const parentNode = nodeContext.parent
           ? nodeContext.parent.viewNode
@@ -1938,21 +1941,21 @@ export class ViewFactory
         // Workaround for issue #1439
         // `<tr><a id="…"></a><td>…` causes table layout issue, so change to
         // `<tr><td><a id="…"></a>…`
+        const parentLastElementChild = (
+          nodeContext.parent?.viewNode as Element | null
+        )?.lastElementChild;
         if (
           display === Css.ident.table_cell &&
-          (nodeContext.parent?.viewNode as Element)?.lastElementChild
-            ?.localName === "a"
+          parentLastElementChild?.localName === "a"
         ) {
-          result.appendChild(
-            (nodeContext.parent.viewNode as Element).lastElementChild,
-          );
+          result.appendChild(parentLastElementChild);
         }
 
         for (let i = 0; i < attributeCount; i++) {
           const attribute = attributes[i];
           const attributeNS = attribute.namespaceURI;
           let attributeName = attribute.localName;
-          let attributeValue = attribute.nodeValue;
+          let attributeValue = attribute.value;
           if (!attributeNS) {
             if (!Scripts.allowScripts && attributeName.match(/^on/)) {
               continue; // don't propagate JavaScript code
@@ -2175,7 +2178,7 @@ export class ViewFactory
               return true;
             }
             for (
-              let p = nodeContext.parent?.viewNode as HTMLElement;
+              let p = nodeContext.parent?.viewNode as HTMLElement | null;
               p && p !== this.viewRoot;
               p = p.parentElement
             ) {
@@ -2282,7 +2285,7 @@ export class ViewFactory
           this.page.fetchers.push(Net.loadElement(result));
         }
 
-        this.preprocessElementStyle(computedStyle);
+        this.preprocessElementStyle(nodeContext, computedStyle);
         this.applyComputedStyles(result, computedStyle);
 
         if (nodeContext.inline) {
@@ -2346,7 +2349,7 @@ export class ViewFactory
         this.viewNode = result;
         if (fetchers.length) {
           TaskUtil.waitForFetchers(fetchers).then(() => {
-            if (imageResolution > 0) {
+            if (imageResolution !== undefined && imageResolution > 0) {
               this.modifyElemDimensionWithImageResolution(
                 images,
                 imageResolution,
@@ -2421,7 +2424,7 @@ export class ViewFactory
         return nc.breakBefore; // forced break
       }
       if (nc.fragmentIndex === 1 && !nc.parent) {
-        if (nc.sourceNode === nc.sourceNode.ownerDocument.documentElement) {
+        if (nc.sourceNode === nc.sourceNode.ownerDocument?.documentElement) {
           // beginning of document
           return "page";
         } else {
@@ -2661,12 +2664,15 @@ export class ViewFactory
     });
   }
 
-  private preprocessElementStyle(computedStyle: { [key: string]: Css.Val }) {
+  private preprocessElementStyle(
+    nodeContext: Vtree.NodeContext,
+    computedStyle: { [key: string]: Css.Val },
+  ) {
     const hooks: Plugin.PreProcessElementStyleHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
     );
     hooks.forEach((hook) => {
-      hook(this.nodeContext, computedStyle);
+      hook(nodeContext, computedStyle);
     });
   }
 
@@ -2676,7 +2682,7 @@ export class ViewFactory
     styler: CssStyler.AbstractStyler,
   ) {
     for (
-      let child: Node = element.firstChild;
+      let child: Node | null = element.firstChild;
       child;
       child = child.nextSibling
     ) {
@@ -2760,7 +2766,7 @@ export class ViewFactory
       return Task.newResult(true);
     }
     let originl: string;
-    let textContent = (originl = this.sourceNode.textContent);
+    let textContent = (originl = nodeContext.sourceNode.textContent ?? "");
     const frame: Task.Frame<boolean> = Task.newFrame("preprocessTextContent");
     const hooks: Plugin.PreProcessTextContentHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.PREPROCESS_TEXT_CONTENT,
@@ -2799,10 +2805,10 @@ export class ViewFactory
     const frame: Task.Frame<boolean> = Task.newFrame("createNodeView");
     let result: Task.Result<boolean>;
     let needToProcessChildren = true;
-    if (this.sourceNode.nodeType == 1) {
+    if (nodeContext.sourceNode.nodeType == 1) {
       result = this.createElementView(nodeContext, firstTime, atUnforcedBreak);
     } else {
-      if (this.sourceNode.nodeType == 8) {
+      if (nodeContext.sourceNode.nodeType == 8) {
         this.viewNode = null; // comment node
         result = Task.newResult(true);
       } else {
@@ -2813,7 +2819,7 @@ export class ViewFactory
       needToProcessChildren = processChildren;
       nodeContext.viewNode = this.viewNode;
       if (this.viewNode) {
-        const isPseudo = (node: Node, name: string): boolean =>
+        const isPseudo = (node: Node | null, name: string): boolean =>
           node?.nodeType === 1 &&
           PseudoElement.getPseudoName(node as Element) === name;
         const p = nodeContext.parent;
@@ -3666,7 +3672,7 @@ export class ViewFactory
     return frame.result();
   }
 
-  createElement(ns: string, tag: string): Element {
+  createElement(ns: string | null, tag: string): Element {
     if (ns == Base.NS.XHTML) {
       return this.document.createElement(tag);
     }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1270,7 +1270,7 @@ export class ViewFactory
     elementStyle = SemanticFootnote.mergeSemanticFootnoteIncludeStyle(
       element,
       elementStyle,
-      nodeContext.shadowContext as Vtree.ShadowContext,
+      nodeContext.shadowContext,
       this.xmldoc.url,
       (reference) => this.xmldoc.getElement(reference),
       CssCascade.FOOTNOTE_COUNTER_ATTR,
@@ -1279,7 +1279,7 @@ export class ViewFactory
     elementStyle = SemanticFootnote.mergeSemanticFootnoteRootStyle(
       element,
       elementStyle,
-      nodeContext.shadowContext as Vtree.ShadowContext,
+      nodeContext.shadowContext,
       this.context,
       semanticFootnoteStyleAccess,
     );
@@ -1424,7 +1424,7 @@ export class ViewFactory
       const semanticFootnoteStyle =
         SemanticFootnote.getSemanticFootnoteStyleState(
           element,
-          nodeContext.shadowContext as Vtree.ShadowContext,
+          nodeContext.shadowContext,
           semanticFootnoteStyleAccess,
         );
       SemanticFootnote.refreshSemanticFootnoteMarkerContent(

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -858,11 +858,14 @@ export class ViewFactory
     return vertical;
   }
 
-  private inheritFromSourceParent(elementStyle: CssCascade.ElementStyle): {
+  private inheritFromSourceParent(
+    nodeContext: Vtree.NodeContext,
+    elementStyle: CssCascade.ElementStyle,
+  ): {
     lang: string | null;
     elementStyle: CssCascade.ElementStyle;
   } {
-    let node = this.nodeContext.sourceNode;
+    let node = nodeContext.sourceNode;
     const styles = [];
     let lang: string | null = null;
     const isFootnoteContentInclude =
@@ -871,14 +874,13 @@ export class ViewFactory
       node.localName === "include" &&
       node.classList.contains("-vivliostyle-footnote-content");
     const shouldSkipAncestorMarkerProps =
-      this.isFootnote &&
-      (!this.nodeContext?.parent || isFootnoteContentInclude);
+      this.isFootnote && (!nodeContext?.parent || isFootnoteContentInclude);
 
     // TODO: this is hacky. We need to recover the path through the shadow
     // trees, but we do not have the full shadow tree structure at this point.
     // This code handles coming out of the shadow trees, but does not go back in
     // (through shadow:content element).
-    let shadowContext = this.nodeContext.shadowContext;
+    let shadowContext = nodeContext.shadowContext;
 
     // For semantic footnotes, the wrapper generated from
     // <s:include class="-vivliostyle-footnote-content"> should inherit from
@@ -953,7 +955,7 @@ export class ViewFactory
         this.context,
         this.regionIds,
         this.isFootnote,
-        this.nodeContext,
+        nodeContext,
       );
       for (const name in flattenedCurrentStyle) {
         if (!CssCascade.isInherited(name)) {
@@ -1089,24 +1091,27 @@ export class ViewFactory
     return this.fallbackMap[url] || url;
   }
 
-  inheritLangAttribute() {
-    this.nodeContext.lang =
-      Base.getLangAttribute(this.nodeContext.sourceNode as Element) ||
-      (this.nodeContext.parent && this.nodeContext.parent.lang) ||
-      this.nodeContext.lang;
+  inheritLangAttribute(nodeContext: Vtree.NodeContext) {
+    nodeContext.lang =
+      Base.getLangAttribute(nodeContext.sourceNode as Element) ||
+      (nodeContext.parent && nodeContext.parent.lang) ||
+      nodeContext.lang;
   }
 
-  transferPolyfilledInheritedProps(computedStyle: { [key: string]: Css.Val }) {
+  transferPolyfilledInheritedProps(
+    nodeContext: Vtree.NodeContext,
+    computedStyle: { [key: string]: Css.Val },
+  ) {
     const polyfilledInheritedProps =
       CssCascade.getPolyfilledInheritedProps().filter(
         (name) => computedStyle[name],
       );
     if (polyfilledInheritedProps.length) {
-      let props = this.nodeContext.inheritedProps;
-      if (this.nodeContext.parent) {
-        props = this.nodeContext.inheritedProps = {};
-        for (const n in this.nodeContext.parent.inheritedProps) {
-          props[n] = this.nodeContext.parent.inheritedProps[n];
+      let props = nodeContext.inheritedProps;
+      if (nodeContext.parent) {
+        props = nodeContext.inheritedProps = {};
+        for (const n in nodeContext.parent.inheritedProps) {
+          props[n] = nodeContext.parent.inheritedProps[n];
         }
       }
       polyfilledInheritedProps.forEach((name) => {
@@ -1177,6 +1182,7 @@ export class ViewFactory
    * @return holding true if children should be processed
    */
   private createElementView(
+    nodeContext: Vtree.NodeContext,
     firstTime: boolean,
     atUnforcedBreak: boolean,
   ): Task.Result<boolean> {
@@ -1185,16 +1191,16 @@ export class ViewFactory
 
     // Figure out element's styles
     let element = this.sourceNode as Element;
-    const styler = this.nodeContext.shadowContext
-      ? this.nodeContext.shadowContext.styler
+    const styler = nodeContext.shadowContext
+      ? nodeContext.shadowContext.styler
       : this.styler;
     let elementStyle = styler.getStyle(element, false);
     this.syncSemanticFootnoteCounterToTarget(element);
-    if (!this.nodeContext.shadowContext) {
+    if (!nodeContext.shadowContext) {
       const offset = this.xmldoc.getElementOffset(element);
       Matchers.NthFragmentMatcher.registerFragmentIndex(
         offset,
-        this.nodeContext.fragmentIndex,
+        nodeContext.fragmentIndex,
         0,
       );
     }
@@ -1219,10 +1225,13 @@ export class ViewFactory
             ),
           ).value,
       };
-    if (!this.nodeContext.parent) {
-      const inheritedValues = this.inheritFromSourceParent(elementStyle);
+    if (!nodeContext.parent) {
+      const inheritedValues = this.inheritFromSourceParent(
+        nodeContext,
+        elementStyle,
+      );
       elementStyle = inheritedValues.elementStyle;
-      this.nodeContext.lang = inheritedValues.lang;
+      nodeContext.lang = inheritedValues.lang;
     }
     const positionCV: CssCascade.CascadeValue = elementStyle["position"];
     const floatCV: CssCascade.CascadeValue = elementStyle["float"];
@@ -1237,25 +1246,28 @@ export class ViewFactory
         ? PageFloats.floatReferenceOf(floatReferenceCV.value.toString())
         : null;
     const isSemanticFootnoteInRootedShadow =
-      !!this.nodeContext.shadowContext &&
-      this.nodeContext.shadowContext.type === Vtree.ShadowType.ROOTED &&
+      !!nodeContext.shadowContext &&
+      nodeContext.shadowContext.type === Vtree.ShadowType.ROOTED &&
       SemanticFootnote.isSemanticFootnoteElement(element);
     if (
-      this.nodeContext.parent &&
+      nodeContext.parent &&
       (Display.isRunning(positionCV?.value) ||
         (floatReference && PageFloats.isPageFloat(floatReference)) ||
         isSemanticFootnoteInRootedShadow)
     ) {
       // Detached or transcluded content should inherit from the source tree,
       // not from the synthetic view parent.
-      const inheritedValues = this.inheritFromSourceParent(elementStyle);
+      const inheritedValues = this.inheritFromSourceParent(
+        nodeContext,
+        elementStyle,
+      );
       elementStyle = inheritedValues.elementStyle;
-      this.nodeContext.lang = inheritedValues.lang;
+      nodeContext.lang = inheritedValues.lang;
     }
     elementStyle = SemanticFootnote.mergeSemanticFootnoteIncludeStyle(
       element,
       elementStyle,
-      this.nodeContext.shadowContext as Vtree.ShadowContext,
+      nodeContext.shadowContext as Vtree.ShadowContext,
       this.xmldoc.url,
       (reference) => this.xmldoc.getElement(reference),
       CssCascade.FOOTNOTE_COUNTER_ATTR,
@@ -1264,13 +1276,13 @@ export class ViewFactory
     elementStyle = SemanticFootnote.mergeSemanticFootnoteRootStyle(
       element,
       elementStyle,
-      this.nodeContext.shadowContext as Vtree.ShadowContext,
+      nodeContext.shadowContext as Vtree.ShadowContext,
       this.context,
       semanticFootnoteStyleAccess,
     );
-    this.nodeContext.vertical = this.computeStyle(
-      this.nodeContext.vertical,
-      this.nodeContext.direction === "rtl",
+    nodeContext.vertical = this.computeStyle(
+      nodeContext.vertical,
+      nodeContext.direction === "rtl",
       elementStyle,
       computedStyle,
     );
@@ -1282,11 +1294,11 @@ export class ViewFactory
       // Fix page float margin collapsing issue (Issue #1282)
       computedStyle["display"] = Css.ident.flow_root;
     }
-    styler.processContent(element, computedStyle, this.nodeContext);
-    this.transferPolyfilledInheritedProps(computedStyle);
-    this.inheritLangAttribute();
+    styler.processContent(element, computedStyle, nodeContext);
+    this.transferPolyfilledInheritedProps(nodeContext, computedStyle);
+    this.inheritLangAttribute(nodeContext);
     if (computedStyle["direction"]) {
-      this.nodeContext.direction = computedStyle["direction"].toString();
+      nodeContext.direction = computedStyle["direction"].toString();
     }
 
     // Sort out the properties
@@ -1323,8 +1335,8 @@ export class ViewFactory
         display = Css.ident.inline;
       } else if (display === Css.ident.inherit) {
         display =
-          this.nodeContext.parent?.display &&
-          Css.getName(this.nodeContext.parent?.display);
+          nodeContext.parent?.display &&
+          Css.getName(nodeContext.parent?.display);
       } else {
         display = null;
       }
@@ -1334,9 +1346,8 @@ export class ViewFactory
       frame.finish(false);
       return frame.result();
     }
-    const isRoot = this.nodeContext.parent == null;
-    const blockSize =
-      computedStyle[this.nodeContext.vertical ? "width" : "height"];
+    const isRoot = nodeContext.parent == null;
+    const blockSize = computedStyle[nodeContext.vertical ? "width" : "height"];
     // Issue #1999: fixed-size grid boxes used as synthetic page references
     // must stay whole. Once fragmented, continuation fragments lose the block
     // size and later reference pages collapse.
@@ -1344,7 +1355,7 @@ export class ViewFactory
       (display === Css.ident.grid || display === Css.ident.inline_grid) &&
       !!blockSize &&
       !(blockSize === Css.ident.auto || Css.isDefaultingValue(blockSize));
-    this.nodeContext.flexContainer =
+    nodeContext.flexContainer =
       display === Css.ident.flex || isFixedSizeGridContainer;
     this.createShadows(
       element,
@@ -1353,17 +1364,17 @@ export class ViewFactory
       computedStyle,
       styler,
       this.context,
-      this.nodeContext.shadowContext as Vtree.ShadowContext,
+      nodeContext.shadowContext as Vtree.ShadowContext,
     ).then((shadowParam) => {
-      this.nodeContext.nodeShadow = shadowParam;
+      nodeContext.nodeShadow = shadowParam;
       const position = computedStyle["position"] as Css.Ident;
       let floatSide = computedStyle["float"];
       let clearSide = computedStyle["clear"] as Css.Ident;
-      const writingMode = this.nodeContext.vertical
+      const writingMode = nodeContext.vertical
         ? Css.ident.vertical_rl
         : Css.ident.horizontal_tb;
-      const parentWritingMode = this.nodeContext.parent
-        ? this.nodeContext.parent.vertical
+      const parentWritingMode = nodeContext.parent
+        ? nodeContext.parent.vertical
           ? Css.ident.vertical_rl
           : Css.ident.horizontal_tb
         : writingMode;
@@ -1377,7 +1388,7 @@ export class ViewFactory
         (columnWidth &&
           columnWidth !== Css.ident.auto &&
           !Css.isDefaultingValue(columnWidth));
-      this.nodeContext.establishesBFC = Display.establishesBFC(
+      nodeContext.establishesBFC = Display.establishesBFC(
         display,
         position,
         floatSide,
@@ -1386,10 +1397,10 @@ export class ViewFactory
         parentWritingMode,
         isMultiColumn || isFlowRoot,
       );
-      this.nodeContext.containingBlockForAbsolute =
+      nodeContext.containingBlockForAbsolute =
         Display.establishesCBForAbsolute(position);
       if (
-        this.nodeContext.isInsideBFC() &&
+        nodeContext.isInsideBFC() &&
         floatSide !== Css.ident.footnote &&
         !(floatReference && PageFloats.isPageFloat(floatReference))
       ) {
@@ -1403,13 +1414,13 @@ export class ViewFactory
       let usesOutsideFootnoteMarker = false;
       const isFootnoteBodyInFootnoteArea =
         this.isFootnote &&
-        (!this.nodeContext?.parent ||
-          this.nodeContext.pluginProps["nestedFootnoteDetached"] ||
+        (!nodeContext?.parent ||
+          nodeContext.pluginProps["nestedFootnoteDetached"] ||
           isSemanticFootnoteInRootedShadow);
       const semanticFootnoteStyle =
         SemanticFootnote.getSemanticFootnoteStyleState(
           element,
-          this.nodeContext.shadowContext as Vtree.ShadowContext,
+          nodeContext.shadowContext as Vtree.ShadowContext,
           semanticFootnoteStyleAccess,
         );
       SemanticFootnote.refreshSemanticFootnoteMarkerContent(
@@ -1491,8 +1502,8 @@ export class ViewFactory
       }
       if (clearSide) {
         if (clearSide === Css.ident.inherit) {
-          if (this.nodeContext.parent && this.nodeContext.parent.clearSide) {
-            clearSide = Css.getName(this.nodeContext.parent.clearSide);
+          if (nodeContext.parent && nodeContext.parent.clearSide) {
+            clearSide = Css.getName(nodeContext.parent.clearSide);
           }
         }
         if (
@@ -1519,7 +1530,7 @@ export class ViewFactory
             (computedStyle["display"] &&
               computedStyle["display"] != Css.ident.inline)
           ) {
-            this.nodeContext.clearSide = clearSide.toString();
+            nodeContext.clearSide = clearSide.toString();
           }
         }
       }
@@ -1536,7 +1547,7 @@ export class ViewFactory
           !Css.isDefaultingValue(breakInside) &&
           breakInside !== Css.ident.auto)
       ) {
-        this.nodeContext.breakPenalty++;
+        nodeContext.breakPenalty++;
       }
       if (
         display &&
@@ -1544,41 +1555,42 @@ export class ViewFactory
         Display.isInlineLevel(display)
       ) {
         // Don't break inside ruby, inline-block, etc.
-        this.nodeContext.breakPenalty++;
+        nodeContext.breakPenalty++;
       }
-      this.nodeContext.inline =
+      nodeContext.inline =
         (!floating && !display) ||
         Display.isInlineLevel(display) ||
         Display.isRubyInternalDisplay(display);
-      this.nodeContext.display = display ? display.toString() : "inline";
-      this.nodeContext.floatSide = floating ? floatSide.toString() : null;
-      this.nodeContext.floatReference =
+      nodeContext.display = display ? display.toString() : "inline";
+      nodeContext.floatSide = floating ? floatSide.toString() : null;
+      nodeContext.floatReference =
         floatReference || PageFloats.FloatReference.INLINE;
       const floatMinWrapBlock = computedStyle["float-min-wrap-block"];
-      this.nodeContext.floatMinWrapBlock =
+      nodeContext.floatMinWrapBlock =
         floatMinWrapBlock && !Css.isDefaultingValue(floatMinWrapBlock)
           ? (floatMinWrapBlock as Css.Numeric)
           : null;
 
       // Leaves handling of multicol specified on non-root/body elements to the browser
-      const insideNonRootMultiColumn = this.isInsideNonRootMultiColumn();
+      const insideNonRootMultiColumn =
+        this.isInsideNonRootMultiColumn(nodeContext);
 
       const columnSpan = computedStyle["column-span"];
-      this.nodeContext.columnSpan =
+      nodeContext.columnSpan =
         !insideNonRootMultiColumn &&
         columnSpan &&
         !Css.isDefaultingValue(columnSpan)
           ? columnSpan
           : null;
-      if (!this.nodeContext.inline) {
+      if (!nodeContext.inline) {
         const breakAfter = computedStyle["break-after"];
         if (
           breakAfter &&
           !Css.isDefaultingValue(breakAfter) &&
           !(insideNonRootMultiColumn && breakAfter === Css.ident.column)
         ) {
-          this.nodeContext.breakAfter = breakAfter.toString();
-          if (Break.forcedBreakValues[this.nodeContext.breakAfter]) {
+          nodeContext.breakAfter = breakAfter.toString();
+          if (Break.forcedBreakValues[nodeContext.breakAfter]) {
             // delete computedStyle["break-after"];
 
             // Instead of deleting, set to "column" so that the browser can handle it.
@@ -1591,8 +1603,8 @@ export class ViewFactory
           !Css.isDefaultingValue(breakBefore) &&
           !(insideNonRootMultiColumn && breakBefore === Css.ident.column)
         ) {
-          this.nodeContext.breakBefore = breakBefore.toString();
-          if (Break.forcedBreakValues[this.nodeContext.breakBefore]) {
+          nodeContext.breakBefore = breakBefore.toString();
+          if (Break.forcedBreakValues[nodeContext.breakBefore]) {
             if (this.isAtStartOfPage()) {
               delete computedStyle["break-before"];
             } else {
@@ -1600,8 +1612,8 @@ export class ViewFactory
               computedStyle["break-before"] = Css.ident.column;
             }
           }
-          if (this.nodeContext.fragmentIndex !== 1) {
-            this.nodeContext.breakBefore = null;
+          if (nodeContext.fragmentIndex !== 1) {
+            nodeContext.breakBefore = null;
           }
         }
         // Named page type
@@ -1613,8 +1625,8 @@ export class ViewFactory
         let pageType = specifiedPageType;
         if (
           !pageType &&
-          !this.nodeContext.parent &&
-          (this.nodeContext.shadowContext ||
+          !nodeContext.parent &&
+          (nodeContext.shadowContext ||
             display === Css.ident.table_header_group ||
             display === Css.ident.table_footer_group)
         ) {
@@ -1622,15 +1634,15 @@ export class ViewFactory
           pageType = this.styler.cascade.currentPageType;
         }
         if (!pageType || pageType.toLowerCase() === "auto") {
-          pageType = this.nodeContext.pageType;
+          pageType = nodeContext.pageType;
         } else {
-          this.nodeContext.pageType = pageType;
+          nodeContext.pageType = pageType;
         }
         const hasExplicitPageType =
           specifiedPageType != null &&
           specifiedPageType.toLowerCase() !== "auto";
         const effectivePageType = hasExplicitPageType
-          ? this.nodeContext.fragmentIndex === 1
+          ? nodeContext.fragmentIndex === 1
             ? this.getEffectiveStartPageType(element, pageType)
             : (this.styler.cascade.currentPageType ?? pageType)
           : pageType;
@@ -1644,10 +1656,10 @@ export class ViewFactory
           )
         ) {
           if (
-            this.nodeContext.fragmentIndex === 1 &&
-            !Break.isSpreadBreakValue(this.nodeContext.breakBefore)
+            nodeContext.fragmentIndex === 1 &&
+            !Break.isSpreadBreakValue(nodeContext.breakBefore)
           ) {
-            this.nodeContext.breakBefore = "page";
+            nodeContext.breakBefore = "page";
           }
           // Fix for issue #1309
           if (effectivePageType !== this.styler.cascade.previousPageType) {
@@ -1657,7 +1669,7 @@ export class ViewFactory
           this.styler.cascade.currentPageType = effectivePageType;
         }
       }
-      this.nodeContext.captionSide =
+      nodeContext.captionSide =
         (computedStyle["caption-side"] &&
           computedStyle["caption-side"].toString()) ||
         "top";
@@ -1674,13 +1686,13 @@ export class ViewFactory
             inlineBorderSpacing = blockBorderSpacing = borderSpacing;
           }
           if (inlineBorderSpacing.isNumeric()) {
-            this.nodeContext.inlineBorderSpacing = Css.toNumber(
+            nodeContext.inlineBorderSpacing = Css.toNumber(
               inlineBorderSpacing,
               this.context,
             );
           }
           if (blockBorderSpacing.isNumeric()) {
-            this.nodeContext.blockBorderSpacing = Css.toNumber(
+            nodeContext.blockBorderSpacing = Css.toNumber(
               blockBorderSpacing,
               this.context,
             );
@@ -1693,23 +1705,24 @@ export class ViewFactory
       if (footnotePolicy && !Css.isDefaultingValue(footnotePolicy)) {
         computedStyle["--viv-footnote-policy"] = footnotePolicy;
       }
-      this.nodeContext.footnotePolicy =
+      nodeContext.footnotePolicy =
         footnotePolicy && !Css.isDefaultingValue(footnotePolicy)
           ? footnotePolicy
           : null;
       const firstPseudo = computedStyle["x-first-pseudo"] as Css.Int;
       if (firstPseudo) {
-        const outerPseudo = this.nodeContext.parent
-          ? this.nodeContext.parent.firstPseudo
+        const outerPseudo = nodeContext.parent
+          ? nodeContext.parent.firstPseudo
           : null;
-        this.nodeContext.firstPseudo = new Vtree.FirstPseudo(
+        nodeContext.firstPseudo = new Vtree.FirstPseudo(
           outerPseudo,
           /** Css.Int */
           firstPseudo.num,
         );
       }
-      if (!this.nodeContext.inline) {
+      if (!nodeContext.inline) {
         this.processAfterIfcontinues(
+          nodeContext,
           element,
           elementStyle,
           styler,
@@ -1722,12 +1735,12 @@ export class ViewFactory
           whitespace.toString(),
         );
         if (whitespaceValue !== null) {
-          this.nodeContext.whitespace = whitespaceValue;
+          nodeContext.whitespace = whitespaceValue;
         }
       }
       const hyphenateCharacter = computedStyle["hyphenate-character"];
       if (hyphenateCharacter && hyphenateCharacter instanceof Css.Str) {
-        this.nodeContext.hyphenateCharacter = hyphenateCharacter.str;
+        nodeContext.hyphenateCharacter = hyphenateCharacter.str;
       }
       const wordBreak = computedStyle["word-break"];
       const lineBreak = computedStyle["line-break"];
@@ -1738,31 +1751,27 @@ export class ViewFactory
         overflowWrap === Css.ident.break_word ||
         overflowWrap === Css.ident.anywhere
       ) {
-        this.nodeContext.breakWord = true;
+        nodeContext.breakWord = true;
       }
 
       // Resolve formatting context
       this.resolveFormattingContext(
-        this.nodeContext,
+        nodeContext,
         firstTime,
         display,
         position,
         floatSide,
         isRoot,
       );
-      if (
-        this.nodeContext.parent &&
-        this.nodeContext.parent.formattingContext
-      ) {
-        firstTime = this.nodeContext.parent.formattingContext.isFirstTime(
-          this.nodeContext,
+      if (nodeContext.parent && nodeContext.parent.formattingContext) {
+        firstTime = nodeContext.parent.formattingContext.isFirstTime(
+          nodeContext,
           firstTime,
         );
       }
-      if (!this.nodeContext.inline) {
-        this.nodeContext.repeatOnBreak =
-          this.processRepeatOnBreak(computedStyle);
-        this.findAndProcessRepeatingElements(element, styler);
+      if (!nodeContext.inline) {
+        nodeContext.repeatOnBreak = this.processRepeatOnBreak(computedStyle);
+        this.findAndProcessRepeatingElements(nodeContext, element, styler);
       }
 
       // Create the view element
@@ -1794,7 +1803,7 @@ export class ViewFactory
         ns = Base.NS.XHTML;
       } else if (ns == Base.NS.SHADOW) {
         ns = Base.NS.XHTML;
-        tag = this.nodeContext.inline ? "span" : "div";
+        tag = nodeContext.inline ? "span" : "div";
       } else {
         custom = !!this.customRenderer;
       }
@@ -1839,8 +1848,8 @@ export class ViewFactory
       }
       let elemResult: Task.Result<Element>;
       if (custom) {
-        const parentNode = this.nodeContext.parent
-          ? this.nodeContext.parent.viewNode
+        const parentNode = nodeContext.parent
+          ? nodeContext.parent.viewNode
           : null;
         elemResult = this.customRenderer(
           element,
@@ -1870,7 +1879,7 @@ export class ViewFactory
           isMultiColumn &&
           computedStyle["column-fill"] === Css.ident.auto
         ) {
-          const blockSize = this.nodeContext.vertical
+          const blockSize = nodeContext.vertical
             ? computedStyle["width"]
             : computedStyle["height"];
           if (
@@ -1896,7 +1905,7 @@ export class ViewFactory
           result.addEventListener("click", this.page.hrefHandler, false);
         }
         if (inner) {
-          this.applyPseudoelementStyle(this.nodeContext, "inner", inner);
+          this.applyPseudoelementStyle(nodeContext, "inner", inner);
           result.appendChild(inner);
         }
         if (
@@ -1905,7 +1914,7 @@ export class ViewFactory
         ) {
           initIFrame(result as HTMLIFrameElement);
         }
-        const imageResolution = this.nodeContext.inheritedProps[
+        const imageResolution = nodeContext.inheritedProps[
           "image-resolution"
         ] as number | undefined;
         const images: {
@@ -1931,11 +1940,11 @@ export class ViewFactory
         // `<tr><td><a id="…"></a>…`
         if (
           display === Css.ident.table_cell &&
-          (this.nodeContext.parent?.viewNode as Element)?.lastElementChild
+          (nodeContext.parent?.viewNode as Element)?.lastElementChild
             ?.localName === "a"
         ) {
           result.appendChild(
-            (this.nodeContext.parent.viewNode as Element).lastElementChild,
+            (nodeContext.parent.viewNode as Element).lastElementChild,
           );
         }
 
@@ -2166,7 +2175,7 @@ export class ViewFactory
               return true;
             }
             for (
-              let p = this.nodeContext.parent?.viewNode as HTMLElement;
+              let p = nodeContext.parent?.viewNode as HTMLElement;
               p && p !== this.viewRoot;
               p = p.parentElement
             ) {
@@ -2179,7 +2188,7 @@ export class ViewFactory
           const hasPercentBlockSize = (): boolean => {
             // Check if the image has percentage block size, which is usually same as auto,
             // which means the size is not determined until the image is loaded.
-            const blockSize = this.nodeContext.vertical ? cssWidth : cssHeight;
+            const blockSize = nodeContext.vertical ? cssWidth : cssHeight;
             return blockSize instanceof Css.Numeric && blockSize.unit === "%";
           };
           if (
@@ -2276,7 +2285,7 @@ export class ViewFactory
         this.preprocessElementStyle(computedStyle);
         this.applyComputedStyles(result, computedStyle);
 
-        if (this.nodeContext.inline) {
+        if (nodeContext.inline) {
           if (!firstTime) {
             Break.setBoxBreakFlag(result, "inline-start");
             if (Break.isCloneBoxDecorationBreak(result)) {
@@ -2285,7 +2294,7 @@ export class ViewFactory
           }
         } else {
           if (!firstTime) {
-            const blockSizeP = this.nodeContext.vertical ? "width" : "height";
+            const blockSizeP = nodeContext.vertical ? "width" : "height";
             if (Base.getCSSProperty(result, blockSizeP)) {
               // When a box with a specified block size is fragmented,
               // the fragmented box should not have the block size.
@@ -2296,7 +2305,7 @@ export class ViewFactory
               Base.setCSSProperty(
                 result,
                 blockSizeP,
-                this.nodeContext.display === "table-row" ? "0.01px" : "",
+                nodeContext.display === "table-row" ? "0.01px" : "",
               );
             }
             Break.setBoxBreakFlag(result, "block-start");
@@ -2312,14 +2321,14 @@ export class ViewFactory
             // Detect forced or unforced break at this point
             // to handle margin-break properly.
             // Note: Do not use `atUnforcedBreak` which may be inaccurate.
-            const breakType = this.getBreakTypeAt(this.nodeContext);
+            const breakType = this.getBreakTypeAt(nodeContext);
             const anyBreak = breakType !== null;
             const unforcedBreak = breakType === "auto";
             if (
               (marginBreak === Css.ident.discard && anyBreak) ||
               (marginBreak !== Css.ident.keep &&
                 unforcedBreak &&
-                !this.nodeContext.floatSide)
+                !nodeContext.floatSide)
             ) {
               Break.setMarginDiscardFlag(result, "block-start");
             }
@@ -2342,7 +2351,7 @@ export class ViewFactory
                 images,
                 imageResolution,
                 computedStyle,
-                this.nodeContext.vertical,
+                nodeContext.vertical,
               );
             }
             frame.finish(needToProcessChildren);
@@ -2390,8 +2399,8 @@ export class ViewFactory
    * but leaves it to the browser to handle other multi-column.
    * This check is for such non-root/body multi-column.
    */
-  private isInsideNonRootMultiColumn(): boolean {
-    const element = this.nodeContext.parent?.viewNode as Element;
+  private isInsideNonRootMultiColumn(nodeContext: Vtree.NodeContext): boolean {
+    const element = nodeContext.parent?.viewNode as Element;
     return !!(element && LayoutHelper.findAncestorNonRootMultiColumn(element));
   }
 
@@ -2471,6 +2480,7 @@ export class ViewFactory
   }
 
   private processAfterIfcontinues(
+    nodeContext: Vtree.NodeContext,
     element: Element,
     cascStyle: CssCascade.ElementStyle,
     styler: CssStyler.AbstractStyler,
@@ -2480,7 +2490,7 @@ export class ViewFactory
       cascStyle,
       this.regionIds,
       this.isFootnote,
-      this.nodeContext,
+      nodeContext,
       context,
     );
     if (!pseudoMap) {
@@ -2497,7 +2507,7 @@ export class ViewFactory
         context,
         this.exprContentListener,
       );
-      this.nodeContext.afterIfContinues = new Layout.AfterIfContinues(
+      nodeContext.afterIfContinues = new Layout.AfterIfContinues(
         element,
         shadowStyler,
       );
@@ -2661,6 +2671,7 @@ export class ViewFactory
   }
 
   private findAndProcessRepeatingElements(
+    nodeContext: Vtree.NodeContext,
     element: Element,
     styler: CssStyler.AbstractStyler,
   ) {
@@ -2675,8 +2686,8 @@ export class ViewFactory
       const computedStyle: { [key: string]: Css.Val } = {};
       const elementStyle = styler.getStyle(child as Element, false);
       this.computeStyle(
-        this.nodeContext.vertical,
-        this.nodeContext.direction === "rtl",
+        nodeContext.vertical,
+        nodeContext.direction === "rtl",
         elementStyle,
         computedStyle,
       );
@@ -2685,23 +2696,22 @@ export class ViewFactory
         continue;
       }
       if (
-        this.nodeContext.formattingContext instanceof
+        nodeContext.formattingContext instanceof
           RepetitiveElement.RepetitiveElementsOwnerFormattingContext &&
-        !this.nodeContext.belongsTo(this.nodeContext.formattingContext)
+        !nodeContext.belongsTo(nodeContext.formattingContext)
       ) {
         return;
       }
-      const parent = this.nodeContext.parent;
+      const parent = nodeContext.parent;
       const parentFormattingContext = parent && parent.formattingContext;
-      this.nodeContext.formattingContext =
+      nodeContext.formattingContext =
         new RepetitiveElement.RepetitiveElementsOwnerFormattingContext(
           parentFormattingContext,
-          this.nodeContext.sourceNode as Element,
+          nodeContext.sourceNode as Element,
         );
       (
-        this.nodeContext
-          .formattingContext as RepetitiveElement.RepetitiveElementsOwnerFormattingContext
-      ).initializeRepetitiveElements(this.nodeContext.vertical);
+        nodeContext.formattingContext as RepetitiveElement.RepetitiveElementsOwnerFormattingContext
+      ).initializeRepetitiveElements(nodeContext.vertical);
       return;
     }
   }
@@ -2728,12 +2738,14 @@ export class ViewFactory
     return null;
   }
 
-  private createTextNodeView(): Task.Result<boolean> {
+  private createTextNodeView(
+    nodeContext: Vtree.NodeContext,
+  ): Task.Result<boolean> {
     const frame: Task.Frame<boolean> = Task.newFrame("createTextNodeView");
-    this.preprocessTextContent().then(() => {
+    this.preprocessTextContent(nodeContext).then(() => {
       const offsetInNode = this.offsetInNode || 0;
       const textContent = Diff.restoreNewText(
-        this.nodeContext.preprocessedTextContent,
+        nodeContext.preprocessedTextContent,
       ).substr(offsetInNode);
       this.viewNode = document.createTextNode(textContent);
       frame.finish(true);
@@ -2741,8 +2753,10 @@ export class ViewFactory
     return frame.result();
   }
 
-  private preprocessTextContent(): Task.Result<boolean> {
-    if (this.nodeContext.preprocessedTextContent != null) {
+  private preprocessTextContent(
+    nodeContext: Vtree.NodeContext,
+  ): Task.Result<boolean> {
+    if (nodeContext.preprocessedTextContent != null) {
       return Task.newResult(true);
     }
     let originl: string;
@@ -2757,7 +2771,7 @@ export class ViewFactory
         if (index >= hooks.length) {
           return Task.newResult(false);
         }
-        return hooks[index++](this.nodeContext, textContent).thenAsync(
+        return hooks[index++](nodeContext, textContent).thenAsync(
           (processedText) => {
             textContent = processedText;
             return Task.newResult(true);
@@ -2765,7 +2779,7 @@ export class ViewFactory
         );
       })
       .then(() => {
-        this.nodeContext.preprocessedTextContent = Diff.diffChars(
+        nodeContext.preprocessedTextContent = Diff.diffChars(
           originl,
           textContent,
         );
@@ -2778,6 +2792,7 @@ export class ViewFactory
    * @return holding true if children should be processed
    */
   createNodeView(
+    nodeContext: Vtree.NodeContext,
     firstTime: boolean,
     atUnforcedBreak: boolean,
   ): Task.Result<boolean> {
@@ -2785,23 +2800,23 @@ export class ViewFactory
     let result: Task.Result<boolean>;
     let needToProcessChildren = true;
     if (this.sourceNode.nodeType == 1) {
-      result = this.createElementView(firstTime, atUnforcedBreak);
+      result = this.createElementView(nodeContext, firstTime, atUnforcedBreak);
     } else {
       if (this.sourceNode.nodeType == 8) {
         this.viewNode = null; // comment node
         result = Task.newResult(true);
       } else {
-        result = this.createTextNodeView();
+        result = this.createTextNodeView(nodeContext);
       }
     }
     result.then((processChildren) => {
       needToProcessChildren = processChildren;
-      this.nodeContext.viewNode = this.viewNode;
+      nodeContext.viewNode = this.viewNode;
       if (this.viewNode) {
         const isPseudo = (node: Node, name: string): boolean =>
           node?.nodeType === 1 &&
           PseudoElement.getPseudoName(node as Element) === name;
-        const p = this.nodeContext.parent;
+        const p = nodeContext.parent;
         let parent = p
           ? isPseudo(this.viewNode, "after") &&
             isPseudo(p.viewNode, "first-letter") &&
@@ -2809,13 +2824,13 @@ export class ViewFactory
             ? (p.parent.viewNode as Element) // Fix for issue #1175
             : (p.viewNode as Element)
           : this.viewRoot;
-        if (this.nodeContext.pluginProps["nestedFootnoteDetached"]) {
+        if (nodeContext.pluginProps["nestedFootnoteDetached"]) {
           // Nested footnote, attach to the root (Issue #1352)
           parent = this.viewRoot;
         }
         if (parent) {
           if (
-            this.nodeContext.inline &&
+            nodeContext.inline &&
             // ignore whitespace text node
             !(this.viewNode.nodeType === 3 && Vtree.canIgnore(this.viewNode)) &&
             !parent.hasChildNodes() &&
@@ -2850,7 +2865,7 @@ export class ViewFactory
     }
     this.viewNode = null;
     if (this.nodeContext) {
-      return this.createNodeView(firstTime, !!atUnforcedBreak);
+      return this.createNodeView(nodeContext, firstTime, !!atUnforcedBreak);
     }
     return Task.newResult(true);
   }
@@ -3833,7 +3848,7 @@ export class ViewFactory
           }
         }
       } else {
-        const blockSizeP = this.nodeContext.vertical ? "width" : "height";
+        const blockSizeP = nodeContext.vertical ? "width" : "height";
         if (Base.getCSSProperty(elem, blockSizeP)) {
           // When a box with a specified block size is fragmented,
           // the fragmented box should not have the block size.

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -628,7 +628,7 @@ export class ViewFactory
   createShadows(
     nodeContext: Vtree.NodeContext,
     element: Element,
-    isRoot,
+    isRoot: boolean,
     cascStyle: CssCascade.ElementStyle,
     computedStyle: { [key: string]: Css.Val },
     styler: CssStyler.AbstractStyler,
@@ -875,7 +875,7 @@ export class ViewFactory
       node.localName === "include" &&
       node.classList.contains("-vivliostyle-footnote-content");
     const shouldSkipAncestorMarkerProps =
-      this.isFootnote && (!nodeContext?.parent || isFootnoteContentInclude);
+      this.isFootnote && (!nodeContext.parent || isFootnoteContentInclude);
 
     // TODO: this is hacky. We need to recover the path through the shadow
     // trees, but we do not have the full shadow tree structure at this point.
@@ -1416,7 +1416,7 @@ export class ViewFactory
       let usesOutsideFootnoteMarker = false;
       const isFootnoteBodyInFootnoteArea =
         this.isFootnote &&
-        (!nodeContext?.parent ||
+        (!nodeContext.parent ||
           nodeContext.pluginProps["nestedFootnoteDetached"] ||
           isSemanticFootnoteInRootedShadow);
       const semanticFootnoteStyle =
@@ -1794,7 +1794,7 @@ export class ViewFactory
         } else if (tag == "audi_") {
           tag = "audio";
         } else if (tag == "object") {
-          custom = !!this.customRenderer;
+          custom = true;
         }
         if (
           element.hasAttribute(PseudoElement.PSEUDO_ATTR) &&
@@ -1810,7 +1810,7 @@ export class ViewFactory
         ns = Base.NS.XHTML;
         tag = nodeContext.inline ? "span" : "div";
       } else {
-        custom = !!this.customRenderer;
+        custom = true;
       }
       if (isListItem) {
         // Keep display: list-item so the browser's native ::marker is used.
@@ -2864,18 +2864,10 @@ export class ViewFactory
     atUnforcedBreak?: boolean,
   ): Task.Result<boolean> {
     this.nodeContext = nodeContext;
-    if (nodeContext) {
-      this.sourceNode = nodeContext.sourceNode;
-      this.offsetInNode = nodeContext.offsetInNode;
-    } else {
-      this.sourceNode = null;
-      this.offsetInNode = -1;
-    }
+    this.sourceNode = nodeContext.sourceNode;
+    this.offsetInNode = nodeContext.offsetInNode;
     this.viewNode = null;
-    if (this.nodeContext) {
-      return this.createNodeView(nodeContext, firstTime, !!atUnforcedBreak);
-    }
-    return Task.newResult(true);
+    return this.createNodeView(nodeContext, firstTime, !!atUnforcedBreak);
   }
 
   processShadowContent(pos: Vtree.NodeContext): Vtree.NodeContext {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -759,7 +759,6 @@ export class ViewFactory
       context,
       this.regionIds,
       this.isFootnote,
-      this.nodeContext,
     );
     const isRoot = !this.nodeContext?.parent;
     if (isRoot) {
@@ -958,7 +957,6 @@ export class ViewFactory
         this.context,
         this.regionIds,
         this.isFootnote,
-        nodeContext,
       );
       for (const name in flattenedCurrentStyle) {
         if (!CssCascade.isInherited(name)) {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -919,26 +919,27 @@ export class ViewFactory
 
     let steps = -1;
     while (node && node.nodeType == 1) {
-      const shadowRoot = shadowContext && shadowContext.root == node;
+      const shadow = shadowContext;
+      const shadowRoot = shadow !== null && shadow.root == node;
       const semanticFootnoteRootInRootedShadow =
-        !!shadowRoot &&
-        shadowContext.type == Vtree.ShadowType.ROOTED &&
+        shadowRoot &&
+        shadow.type == Vtree.ShadowType.ROOTED &&
         SemanticFootnote.isSemanticFootnoteElement(node as Element);
       if (
         !shadowRoot ||
-        shadowContext.type == Vtree.ShadowType.ROOTLESS ||
+        shadow.type == Vtree.ShadowType.ROOTLESS ||
         semanticFootnoteRootInRootedShadow
       ) {
-        const styler = shadowContext
-          ? (shadowContext.styler as CssStyler.AbstractStyler)
+        const styler = shadow
+          ? (shadow.styler as CssStyler.AbstractStyler)
           : this.styler;
         const nodeStyle = styler.getStyle(node as Element, false);
         styles.push(nodeStyle);
         lang = lang || Base.getLangAttribute(node as Element);
       }
       if (shadowRoot && !semanticFootnoteRootInRootedShadow) {
-        node = shadowContext.owner;
-        shadowContext = shadowContext.parentShadow;
+        node = shadow.owner;
+        shadowContext = shadow.parentShadow;
       } else {
         node = node.parentNode;
         steps++;
@@ -1156,9 +1157,9 @@ export class ViewFactory
   resolveFormattingContext(
     nodeContext: Vtree.NodeContext,
     firstTime: boolean,
-    display: Css.Val,
-    position: Css.Ident,
-    float: Css.Val,
+    display: Css.Val | null | undefined,
+    position: Css.Ident | null | undefined,
+    float: Css.Val | null | undefined,
     isRoot: boolean,
   ) {
     const hooks: Plugin.ResolveFormattingContextHook[] = Plugin.getHooksForName(
@@ -1433,7 +1434,7 @@ export class ViewFactory
       );
       footnoteDisplay = semanticFootnoteStyle.footnoteDisplay;
 
-      let floating =
+      const floatSideName =
         floatSide instanceof Css.SpaceList ||
         floatSide === Css.ident.left ||
         floatSide === Css.ident.right ||
@@ -1447,7 +1448,10 @@ export class ViewFactory
         floatSide === Css.ident.snap_inline ||
         floatSide === Css.ident.inside ||
         floatSide === Css.ident.outside ||
-        floatSide === Css.ident.footnote;
+        floatSide === Css.ident.footnote
+          ? floatSide.toString()
+          : null;
+      let floating = floatSideName !== null;
       if (floatSide) {
         // Don't want to set it in view DOM CSS.
         delete computedStyle["float"];
@@ -1565,7 +1569,7 @@ export class ViewFactory
         Display.isInlineLevel(display) ||
         Display.isRubyInternalDisplay(display);
       nodeContext.display = display ? display.toString() : "inline";
-      nodeContext.floatSide = floating ? floatSide.toString() : null;
+      nodeContext.floatSide = floating ? floatSideName : null;
       nodeContext.floatReference =
         floatReference || PageFloats.FloatReference.INLINE;
       const floatMinWrapBlock = computedStyle["float-min-wrap-block"];
@@ -2889,7 +2893,7 @@ export class ViewFactory
     const parent = pos.parent;
 
     // content that will be inserted
-    let contentNode: Node;
+    let contentNode: Node | null;
     let contentShadowType: Vtree.ShadowType;
     const contentShadow = shadow.subShadow || shadow.parentShadow;
     if (shadow.subShadow) {
@@ -2905,29 +2909,32 @@ export class ViewFactory
       contentShadowType = Vtree.ShadowType.ROOTLESS;
     }
     const nextSibling = pos.sourceNode.nextSibling;
+    let nextPos: Vtree.NodeContext | null;
     if (nextSibling) {
       pos.sourceNode = nextSibling;
       pos.resetView();
+      nextPos = pos;
     } else if (pos.shadowSibling) {
-      pos = pos.shadowSibling;
-    } else if (contentNode) {
-      pos = null;
+      nextPos = pos.shadowSibling;
     } else {
-      pos = pos.parent.modify();
-      pos.after = true;
+      nextPos = null;
     }
     if (contentNode) {
       const r = new Vtree.NodeContext(contentNode, parent, boxOffset);
       r.shadowContext = contentShadow;
       r.shadowType = contentShadowType;
-      r.shadowSibling = pos;
+      r.shadowSibling = nextPos;
       return this.processShadowContent(r);
     }
-    pos.boxOffset = boxOffset;
-    return pos;
+    if (nextPos === null) {
+      nextPos = pos.parent.modify();
+      nextPos.after = true;
+    }
+    nextPos.boxOffset = boxOffset;
+    return nextPos;
   }
 
-  private nextPositionInTree(pos: Vtree.NodeContext): Vtree.NodeContext {
+  private nextPositionInTree(pos: Vtree.NodeContext): Vtree.NodeContext | null {
     let boxOffset = pos.boxOffset + 1; // offset for the next position
     if (pos.after) {
       // root, that was the last possible position
@@ -3015,7 +3022,7 @@ export class ViewFactory
     let prev: Node | null = viewNode.previousSibling;
     while (prev) {
       if (prev.nodeType === Node.TEXT_NODE) {
-        if (prev.textContent.trim().length === 0) {
+        if ((prev.textContent ?? "").trim().length === 0) {
           prev = prev.previousSibling;
           continue;
         }
@@ -3144,13 +3151,15 @@ export class ViewFactory
   nextInTree(
     position: Vtree.NodeContext,
     atUnforcedBreak?: boolean,
-  ): Task.Result<Vtree.NodeContext> {
-    let nodeContext = this.nextPositionInTree(position);
-    if (!nodeContext || nodeContext.after) {
-      return Task.newResult(nodeContext);
+  ): Task.Result<Vtree.NodeContext | null> {
+    const nextPosition = this.nextPositionInTree(position);
+    if (!nextPosition || nextPosition.after) {
+      return Task.newResult<Vtree.NodeContext | null>(nextPosition);
     }
-    this.syncTextNodePageTypeBoundary(nodeContext);
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("nextInTree");
+    this.syncTextNodePageTypeBoundary(nextPosition);
+    let nodeContext = nextPosition;
+    const frame: Task.Frame<Vtree.NodeContext | null> =
+      Task.newFrame("nextInTree");
     this.setCurrent(nodeContext, true, atUnforcedBreak).then(
       (processChildren) => {
         if (!nodeContext.viewNode || !processChildren) {
@@ -3339,7 +3348,8 @@ export class ViewFactory
       ) {
         // Fix for Issue #568
         Base.setCSSProperty(
-          this.page.pageAreaElement.parentElement.parentElement,
+          // the page area element is always nested in bleed box and container
+          this.page.pageAreaElement.parentElement!.parentElement!,
           propName,
           value.toString(),
         );
@@ -3622,8 +3632,9 @@ export class ViewFactory
     let offsetInNode = nodeContext.offsetInNode;
     const after = nodeContext.after;
     if (nodeOffset > 0) {
-      const text = nodeContext.viewNode.textContent;
-      nodeContext.viewNode.textContent = text.substr(0, nodeOffset);
+      const viewNode = nodeContext.viewNode;
+      const text = viewNode.textContent ?? "";
+      viewNode.textContent = text.substr(0, nodeOffset);
       offsetInNode += nodeOffset;
     } else if (!after && nodeContext.viewNode && offsetInNode == 0) {
       const parent = nodeContext.viewNode.parentNode;
@@ -3632,17 +3643,18 @@ export class ViewFactory
       }
     }
     const boxOffset = nodeContext.boxOffset + nodeOffset;
-    const arr = [];
+    const arr: Vtree.NodeContext[] = [];
     while (nodeContext && nodeContext.firstPseudo === firstPseudo) {
       arr.push(nodeContext);
       nodeContext = nodeContext.parent;
     }
-    let pn = arr.pop(); // container for that pseudoelement
+    // the loop above runs at least once (nodeContext.firstPseudo === firstPseudo)
+    let pn = arr.pop()!; // container for that pseudoelement
     let shadowSibling = pn.shadowSibling;
     frame
       .loop(() => {
         while (arr.length > 0) {
-          pn = arr.pop();
+          pn = arr.pop()!;
           nodeContext = new Vtree.NodeContext(
             pn.sourceNode,
             nodeContext,
@@ -4013,7 +4025,8 @@ export class ViewFactory
     anonymousBlock.className = "viv-anonymous-block";
 
     for (
-      let node = forcedBreakElem.nextSibling, nextNode = null;
+      let node: Node | null = forcedBreakElem.nextSibling,
+        nextNode: Node | null = null;
       node;
       node = nextNode
     ) {
@@ -4033,7 +4046,7 @@ export class ViewFactory
     const num = numeric.num;
     const unit = numeric.unit;
     if (Exprs.isFontRelativeLengthUnit(unit)) {
-      let elem = viewNode;
+      let elem: Node | null = viewNode;
       while (elem && elem.nodeType !== 1) {
         elem = elem.parentNode;
       }

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -281,7 +281,7 @@ export function whitespaceFromPropertyValue(
   }
 }
 
-export function canIgnore(node: Node, whitespace?: Whitespace): boolean {
+export function canIgnore(node: Node | null, whitespace?: Whitespace): boolean {
   if (!node) {
     return true;
   }
@@ -511,9 +511,9 @@ export class ShadowContext implements Vtree.ShadowContext {
   constructor(
     public readonly owner: Element,
     public readonly root: Element,
-    public readonly xmldoc: XmlDoc.XMLDocHolder,
-    public readonly parentShadow: ShadowContext,
-    superShadow: ShadowContext,
+    public readonly xmldoc: XmlDoc.XMLDocHolder | null,
+    public readonly parentShadow: ShadowContext | null,
+    superShadow: ShadowContext | null,
     public readonly type: ShadowType,
     public readonly styler: CssStyler.AbstractStyler,
   ) {
@@ -548,7 +548,7 @@ export function isSameShadowContext(
  */
 export class FirstPseudo implements Vtree.FirstPseudo {
   constructor(
-    public readonly outer: FirstPseudo,
+    public readonly outer: FirstPseudo | null,
     public readonly count: number,
   ) {}
 }
@@ -568,7 +568,7 @@ export class NodeContext implements Vtree.NodeContext {
   shadowType: ShadowType;
 
   // parent's shadow type
-  shadowContext: Vtree.ShadowContext;
+  shadowContext: Vtree.ShadowContext | null;
   nodeShadow: Vtree.ShadowContext | null = null;
   shadowSibling: NodeContext | null = null;
 
@@ -597,7 +597,7 @@ export class NodeContext implements Vtree.NodeContext {
   breakAfter: string | null = null;
   viewNode: Node | null = null;
   clearSpacer: Node | null = null;
-  inheritedProps: { [key: string]: number | string | Css.Val };
+  inheritedProps: { [key: string]: number | string | Css.Val | undefined };
   vertical: boolean;
   direction: string;
   firstPseudo: FirstPseudo;


### PR DESCRIPTION
refs #2062 

vgen.tsと連鎖する`|null`を埋めるPRです。ミュータブルなプロパティ`this.nodeContext`はnarrowingが失われないよう、引数で引き回す構造に改めています。