### PR TITLE
refactor: Replace CascadeValueLike with a CascadeValue interface in types

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -35,7 +35,7 @@ import * as Matchers from "./matchers";
 import * as Plugin from "./plugin";
 import * as SemanticFootnote from "./semantic-footnote";
 import * as Vtree from "./vtree";
-import { CssStyler, Layout } from "./types";
+import { CssCascade, CssStyler, Layout } from "./types";
 import { TokenType } from "./css-tokenizer";
 import { AbstractStyler } from "./css-styler";
 
@@ -269,7 +269,7 @@ const couplingMapRightPage = buildCouplingMap(
   {},
 );
 
-export class CascadeValue {
+export class CascadeValue implements CssCascade.CascadeValue {
   constructor(
     public readonly value: Css.Val,
     public readonly priority: number,

--- a/packages/core/src/vivliostyle/semantic-footnote.ts
+++ b/packages/core/src/vivliostyle/semantic-footnote.ts
@@ -39,13 +39,6 @@ export const SEMANTIC_FOOTNOTE_FIRST_REF_ATTR =
 export const SEMANTIC_FOOTNOTE_REFERENCED_ATTR =
   "data-vivliostyle-footnote-referenced";
 
-type CascadeValueLike = {
-  value: Css.Val;
-  priority: number;
-  evaluate?: (context: Exprs.Context, propName: string) => Css.Val;
-  filterValue?: (visitor: unknown) => CascadeValueLike;
-};
-
 type ElementStyleMap = {
   [key: string]: CssCascade.ElementStyle;
 };
@@ -55,7 +48,7 @@ export type SemanticFootnoteStyleAccess = {
   getProp: (
     style: CssCascade.ElementStyle | null | undefined,
     propName: string,
-  ) => CascadeValueLike | null | undefined;
+  ) => CssCascade.CascadeValue | null | undefined;
   getStyleMap: (
     style: CssCascade.ElementStyle,
     mapName: string,
@@ -64,9 +57,12 @@ export type SemanticFootnoteStyleAccess = {
     style: CssCascade.ElementStyle,
     mapName: string,
   ) => ElementStyleMap;
-  createCascadeValue: (value: Css.Val, priority: number) => CascadeValueLike;
+  createCascadeValue: (
+    value: Css.Val,
+    priority: number,
+  ) => CssCascade.CascadeValue;
   filterFootnoteMarkerContent: (
-    content: CascadeValueLike,
+    content: CssCascade.CascadeValue,
     element: Element,
   ) => Css.Val;
 };
@@ -187,7 +183,7 @@ export function shouldGenerateSemanticFootnote(
 function getFootnoteDisplayOverride(
   style: CssCascade.ElementStyle | null,
   styleAccess: SemanticFootnoteStyleAccess,
-): CascadeValueLike | null {
+): CssCascade.CascadeValue | null {
   const footnoteDisplay = styleAccess.getProp(style, "footnote-display");
   if (footnoteDisplay) {
     return footnoteDisplay;
@@ -301,7 +297,7 @@ export function mergeSemanticFootnoteRootStyle(
   }
   if (
     footnoteMarkerContent &&
-    footnoteMarkerListStylePosition?.evaluate?.(
+    footnoteMarkerListStylePosition?.evaluate(
       context,
       "list-style-position",
     ) === Css.ident.outside
@@ -384,7 +380,7 @@ export function refreshSemanticFootnoteMarkerContent(
 ): void {
   const rawMarkerContent = sourceStyle?.[
     "_footnote-marker-content"
-  ] as CascadeValueLike;
+  ] as CssCascade.CascadeValue;
   if (rawMarkerContent) {
     computedStyle["--viv-marker-content"] = resolveMarkerContentValue(
       rawMarkerContent.value,

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -32,6 +32,21 @@ export type FragmentLayoutConstraintType =
 
 export namespace CssCascade {
   export type ElementStyle = { [key: string]: any };
+
+  export interface CascadeValue {
+    readonly value: Css.Val;
+    readonly priority: number;
+    getBaseValue(): CascadeValue;
+    filterValue(visitor: Css.Visitor): CascadeValue;
+    increaseSpecificity(specificity: number): CascadeValue;
+    evaluate(
+      context: Exprs.Context,
+      propName?: string,
+      percentRef?: number,
+      vertical?: boolean,
+    ): Css.Val;
+    isEnabled(context: Exprs.Context): boolean;
+  }
 }
 
 export namespace CssStyler {


### PR DESCRIPTION
#2063 で解消にリファクタリングが必要になった内容を分割したものです。

`CascadeValueLike`は具象クラス`CascadeValue`との結合を嫌って用意されたインターフェイスでしたが、実際にはこの定義を使っているのは`CascadeValue`だけでした。nullableを外し`CascadeValue`に忠実なインターフェイス定義を改めてtypes.tsに追加し、それを経由して型を解決することにしました。