### PR TITLE
fix: Fix page navigation during background rendering

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2606,6 +2606,13 @@ export class OPFView implements Vgen.CustomRendererFactory {
                 }
                 loopFrame.breakLoop();
               });
+            } else if (this.isRenderingPageInAnotherTask()) {
+              // A background task is already materializing pages. Wait for
+              // the requested page to appear instead of rendering the same
+              // shared StyleInstance and CounterStore concurrently (Issue #2047).
+              frame.sleep(100).then(() => {
+                loopFrame.continueLoop();
+              });
             } else if (
               pageIndex < viewItem.layoutPositions.length &&
               !viewItem.pages[pageIndex]
@@ -2642,8 +2649,62 @@ export class OPFView implements Vgen.CustomRendererFactory {
    * Renders a page at the specified position.
    */
   renderPage(position: Position): Task.Result<PageAndPosition | null> {
+    const currentTask = Task.currentTask();
+    this.beginRenderingPage(currentTask);
+    let renderingEnded = false;
+    const endRendering = (): void => {
+      if (!renderingEnded) {
+        renderingEnded = true;
+        this.endRenderingPage(currentTask);
+      }
+    };
+    return Task.handle(
+      "renderPage",
+      (frame) => {
+        this.renderPageTracked(position).then((result) => {
+          endRendering();
+          frame.finish(result);
+        });
+      },
+      (frame, err) => {
+        endRendering();
+        frame.task.raise(err, frame.parent);
+      },
+    );
+  }
+
+  // Track renderPage tasks so navigation can wait only until its requested
+  // page is available, without canceling background pagination (Issue #2047).
+  private renderingPageTasks = new Map<Task.Task, number>();
+
+  private beginRenderingPage(task: Task.Task): void {
+    this.renderingPageTasks.set(
+      task,
+      (this.renderingPageTasks.get(task) || 0) + 1,
+    );
+  }
+
+  private endRenderingPage(task: Task.Task): void {
+    const depth = this.renderingPageTasks.get(task);
+    if (depth === 1) {
+      this.renderingPageTasks.delete(task);
+    } else if (depth) {
+      this.renderingPageTasks.set(task, depth - 1);
+    }
+  }
+
+  private isRenderingPageInAnotherTask(): boolean {
+    const currentTask = Task.currentTask();
+    return Array.from(this.renderingPageTasks.keys()).some(
+      (task) => task !== currentTask,
+    );
+  }
+
+  private renderPageTracked(
+    position: Position,
+  ): Task.Result<PageAndPosition | null> {
     const frame: Task.Frame<PageAndPosition | null> =
-      Task.newFrame("renderPage");
+      Task.newFrame("renderPageTracked");
     this.getPageViewItem(position.spineIndex).then((viewItem) => {
       if (!viewItem) {
         frame.finish(null);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -370,6 +370,78 @@ describe("epub", function () {
       ]);
     });
   });
+  describe("OPFView page rendering", function () {
+    it("stops tracking a render task after a synchronous error", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        view.renderingPageTasks = new Map();
+        var error = new Error("render failed");
+        spyOn(view, "renderPageTracked").and.throwError(error);
+
+        return adapt_task.handle(
+          "testRenderErrorCleanup",
+          function () {
+            view.renderPage({
+              spineIndex: 0,
+              pageIndex: 0,
+              offsetInItem: -1,
+            });
+          },
+          function (frame, caughtError) {
+            expect(caughtError).toBe(error);
+            expect(view.renderingPageTasks.size).toBe(0);
+            frame.finish(true);
+            done();
+          },
+        );
+      });
+    });
+
+    it("waits for a pending page being rendered by another task", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        view.renderingPageTasks = new Map();
+        var page = {};
+        var viewItem = {
+          complete: false,
+          layoutPositions: [{ page: 0 }, { page: 1 }],
+          pages: [{}],
+        };
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "getPageViewItem").and.returnValue(
+          adapt_task.newResult(viewItem),
+        );
+        spyOn(view, "renderPage").and.callThrough();
+        var scheduler = adapt_task.currentTask().getScheduler();
+        var backgroundTask = scheduler.run(function () {
+          var frame = adapt_task.newFrame("backgroundRender");
+          view.beginRenderingPage(adapt_task.currentTask());
+          frame.sleep(50).then(function () {
+            viewItem.pages[1] = page;
+            view.endRenderingPage(adapt_task.currentTask());
+            frame.finish(true);
+          });
+          return frame.result();
+        });
+        var testFrame = adapt_task.newFrame("testPendingPageWait");
+        testFrame.sleep(10).then(function () {
+          view
+            .findPage({ spineIndex: 0, pageIndex: 1, offsetInItem: -1 }, false)
+            .then(function (result) {
+              expect(result.page).toBe(page);
+              expect(view.renderPage).not.toHaveBeenCalled();
+              backgroundTask.join().then(function () {
+                testFrame.finish(true);
+                done();
+              });
+            });
+        });
+        return testFrame.result();
+      });
+    });
+  });
   describe("OPFView pagination progress", function () {
     function createFakeView(totalOffsets) {
       var view = Object.create(adapt_epub.OPFView.prototype);


### PR DESCRIPTION
Track active `renderPage()` tasks and wait for requested pages to become available instead of rendering shared layout and counter state concurrently. This prevents navigation errors without canceling background pagination or blocking navigation until the entire publication is rendered.

Add regression coverage for navigation waiting on a page produced by another rendering task.

Closes #2047

Assisted-by: GitHub Copilot Chat:gpt-5.6-sol

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2047; the AI's first attempt (canceling the rendering task on navigation) broke background pagination entirely, and the human author rejected it after manual testing.
- The AI redesigned the fix to track in-flight render tasks and wait for the requested page instead of canceling; the human author found a residual UX issue (navigation blocked while holding the down-arrow key near the end of rendering), confirmed it resolved itself once rendering finished, and accepted the behavior as acceptable.
- `/draft-commit` and `/address-pr-comments` finalized the PR.

</details>
