### PR TITLE
refactor: Declare NodeContext.parent nullable and ground ancestor walks

### DIFF
--- a/packages/core/src/vivliostyle/layout-retryers.ts
+++ b/packages/core/src/vivliostyle/layout-retryers.ts
@@ -76,7 +76,10 @@ export abstract class AbstractLayoutRetryer {
 
   clearNodes(initialPosition: Vtree.NodeContext) {
     const viewNode =
-      initialPosition.viewNode || initialPosition.parent.viewNode;
+      initialPosition.viewNode ?? initialPosition.parent?.viewNode;
+    if (!viewNode) {
+      return;
+    }
     let child: Node;
     while ((child = viewNode.lastChild)) {
       viewNode.removeChild(child);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -292,7 +292,7 @@ export function processAfterIfContinuesOfAncestors(
   const frame: Task.Frame<boolean> = Task.newFrame(
     "processAfterIfContinuesOfAncestors",
   );
-  let current: Vtree.NodeContext = nodeContext;
+  let current: Vtree.NodeContext | null = nodeContext;
   frame
     .loop(() => {
       if (current !== null) {
@@ -593,11 +593,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       .loop(() => {
         while (stepIndex >= 0) {
           const prevContext = nodeContext;
-          const step = steps[stepIndex];
-          nodeContext = VtreeImpl.makeNodeContextFromNodePositionStep(
-            step,
-            prevContext,
-          );
+          nodeContext = prevContext
+            ? VtreeImpl.makeNodeContextFromNodePositionStep(
+                steps[stepIndex],
+                prevContext,
+              )
+            : VtreeImpl.makeRootNodeContextFromNodePositionStep(
+                VtreeImpl.rootStepOfNodePosition(position),
+              );
           if (
             stepIndex === steps.length - 1 &&
             !nodeContext.formattingContext
@@ -836,7 +839,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         this.maybePeelOff(position, 0).then((position1Param) => {
           const position1 = position1Param as Vtree.NodeContext;
           if (position1 !== position) {
-            let p = position1;
+            let p: Vtree.NodeContext | null = position1;
             while (p && p.sourceNode != sourceNode) {
               p = p.parent;
             }
@@ -3019,7 +3022,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
   calculateClonedPaddingBorder(nodeContext: Vtree.NodeContext): number {
     let clonedPaddingBorder = 0;
-    for (let nc = nodeContext; nc; nc = nc.parent) {
+    for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
       if (
         !nc.inline &&
         Break.isCloneBoxDecorationBreak(nc.viewNode as Element)
@@ -3186,7 +3189,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   getAfterEdgeOfBlockContainer(nodeContext: Vtree.NodeContext): number {
-    let blockParent = nodeContext;
+    let blockParent: Vtree.NodeContext | null = nodeContext;
     do {
       blockParent = blockParent.parent;
     } while (blockParent && blockParent.inline);
@@ -3334,7 +3337,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * Determines if a page break is acceptable at this position
    */
   isBreakable(flowPosition: Vtree.NodeContext): boolean {
-    for (let nc = flowPosition; nc; nc = nc.parent) {
+    for (let nc: Vtree.NodeContext | null = flowPosition; nc; nc = nc.parent) {
       if (LayoutHelper.isOutOfFlow(nc.viewNode)) {
         return false;
       }
@@ -3450,7 +3453,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     if (!nodeContext) {
       return false;
     }
-    for (let nc = nodeContext; nc; nc = nc.parent) {
+    for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
       if (LayoutHelper.isOutOfFlow(nc.viewNode)) {
         return false;
       }
@@ -3696,7 +3699,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * as position:fixed). (Issue #1833)
    */
   hasFixedPositionAncestor(nodeContext: Vtree.NodeContext): boolean {
-    for (let nc = nodeContext; nc; nc = nc.parent) {
+    for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
       if (LayoutHelper.isFixedPositioned(nc.viewNode)) {
         return true;
       }
@@ -3747,7 +3750,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       ) {
         return;
       }
-      for (let nc = currentNodeContext; nc; nc = nc.parent) {
+      for (
+        let nc: Vtree.NodeContext | null = currentNodeContext;
+        nc;
+        nc = nc.parent
+      ) {
         if (nc.breakBefore === "column") {
           nc.breakBefore = null;
         }
@@ -3773,7 +3780,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       ) {
         return;
       }
-      for (let nc = currentNodeContext; nc; nc = nc.parent) {
+      for (
+        let nc: Vtree.NodeContext | null = currentNodeContext;
+        nc;
+        nc = nc.parent
+      ) {
         if (nc.breakBefore === "column") {
           nc.breakBefore = null;
         }
@@ -3793,7 +3804,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       if (forcedBreakValue || !Break.isPageLevelForcedBreak(breakAtTheEdge)) {
         return;
       }
-      for (let nc = currentNodeContext; nc; nc = nc.parent) {
+      for (
+        let nc: Vtree.NodeContext | null = currentNodeContext;
+        nc;
+        nc = nc.parent
+      ) {
         if (nc.breakAfter === "column") {
           nc.breakAfter = null;
         }
@@ -5277,7 +5292,7 @@ export class ColumnLayoutRetryer extends LayoutRetryers.AbstractLayoutRetryer {
 
   override clearNodes(initialPosition: Vtree.NodeContext) {
     super.clearNodes(initialPosition);
-    let nodeContext = initialPosition;
+    let nodeContext: Vtree.NodeContext | null = initialPosition;
     while (nodeContext) {
       const viewNode = nodeContext.viewNode;
       if (viewNode) {

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -74,14 +74,12 @@ export class RepetitiveElementsOwnerFormattingContext
   }
 
   getRootNodeContext(nodeContext: Vtree.NodeContext): Vtree.NodeContext | null {
+    let nc: Vtree.NodeContext | null = nodeContext;
     do {
-      if (
-        !nodeContext.belongsTo(this) &&
-        nodeContext.sourceNode === this.rootSourceNode
-      ) {
-        return nodeContext;
+      if (!nc.belongsTo(this) && nc.sourceNode === this.rootSourceNode) {
+        return nc;
       }
-    } while ((nodeContext = nodeContext.parent));
+    } while ((nc = nc.parent));
     return null;
   }
 
@@ -993,7 +991,7 @@ export class RepetitiveElementsOwnerLayoutProcessor
 }
 
 function eachAncestorNodeContext(
-  nodeContext: Vtree.NodeContext,
+  nodeContext: Vtree.NodeContext | null,
   callback: (
     p1: RepetitiveElementsOwnerFormattingContext,
     p2: Vtree.NodeContext,
@@ -1012,7 +1010,7 @@ function eachAncestorNodeContext(
 }
 
 export function appendHeaderToAncestors(
-  nodeContext: Vtree.NodeContext,
+  nodeContext: Vtree.NodeContext | null,
   column: LayoutType.Column,
 ): void {
   if (!nodeContext) {

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1196,9 +1196,10 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     rowSpanningCellBreakPositions.forEach((rowCellBreakPositions) => {
       cont = cont.thenAsync(() => {
         // Is it always correct to assume steps[1] to be the row?
+        // A table row under layout always sits below its table element context.
         const rowNodeContext = VtreeImpl.makeNodeContextFromNodePositionStep(
           rowCellBreakPositions[0].cellNodePosition.steps[1],
-          currentRow.parent,
+          (currentRow as Vtree.ChildNodeContext).parent,
         );
         return layoutContext.setCurrent(rowNodeContext, false).thenAsync(() => {
           let cont1 = Task.newResult(true);

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -457,7 +457,7 @@ class TextSpacingPolyfill {
 
     function checkIfFirstInBlock(): boolean {
       const p = checkPoints[0];
-      for (let pp = p; ; pp = pp.parent) {
+      for (let pp: Vtree.NodeContext | null = p; ; pp = pp.parent) {
         if (!pp || !pp.inline) {
           if (pp?.fragmentIndex !== 1) {
             // This block is not the first fragment
@@ -485,27 +485,41 @@ class TextSpacingPolyfill {
       return true;
     }
 
-    function checkIfAfterForcedLineBreak(): boolean {
-      let p = checkPoints[0];
-      let prevNode: Node | null | undefined;
-      while (p && p.inline) {
-        prevNode = p.viewNode?.previousSibling;
+    function findPrevNodeAtFragmentStart(): {
+      nodeContext: Vtree.NodeContext;
+      prevNode: Node;
+    } | null {
+      for (
+        let p: Vtree.NodeContext | null = checkPoints[0];
+        p && p.inline;
+        p = p.parent
+      ) {
+        const sibling = p.viewNode?.previousSibling;
+        const prevNode =
+          sibling &&
+          sibling.nodeType === Node.TEXT_NODE &&
+          /^[ \t\r\n\f]*$/.test(sibling.textContent) &&
+          p.whitespace !== Vtree.Whitespace.PRESERVE
+            ? sibling.previousSibling
+            : sibling;
         if (prevNode) {
-          if (
-            prevNode.nodeType === Node.TEXT_NODE &&
-            /^[ \t\r\n\f]*$/.test(prevNode.textContent) &&
-            p.whitespace !== Vtree.Whitespace.PRESERVE
-          ) {
-            prevNode = prevNode.previousSibling;
-          }
-          if (prevNode) {
-            break;
-          }
+          return { nodeContext: p, prevNode };
         }
-        p = p.parent;
       }
+      return null;
+    }
 
-      while (prevNode) {
+    function checkIfAfterForcedLineBreak(): boolean {
+      const found = findPrevNodeAtFragmentStart();
+      if (!found) {
+        return false;
+      }
+      const p = found.nodeContext;
+      for (
+        let prevNode: Node | null = found.prevNode;
+        prevNode;
+        prevNode = prevNode.lastChild
+      ) {
         if (prevNode.nodeType === Node.ELEMENT_NODE) {
           if ((prevNode as Element).localName === "br") {
             return true;
@@ -525,7 +539,6 @@ class TextSpacingPolyfill {
             }
           }
         }
-        prevNode = prevNode.lastChild;
       }
       return false;
     }

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1148,8 +1148,12 @@ export namespace Vtree {
     fragmentIndex: number;
   };
 
+  export type RootNodePositionStep = NodePositionStep & {
+    shadowSibling: null;
+  };
+
   export type NodePosition = {
-    steps: NodePositionStep[];
+    steps: [...NodePositionStep[], RootNodePositionStep];
     offsetInNode: number;
     after: boolean;
     preprocessedTextContent: Diff.Change[] | null;
@@ -1331,18 +1335,27 @@ export namespace Vtree {
     pageType: string | null;
 
     sourceNode: Node;
-    parent: NodeContext;
+    parent: NodeContext | null;
     boxOffset: number;
 
     resetView(): void;
-    modify(): NodeContext;
-    copy(): NodeContext;
-    clone(): NodeContext;
+    modify(): this;
+    copy(): this;
+    clone(): this;
     toNodePositionStep(): NodePositionStep;
     toNodePosition(): NodePosition;
     isInsideBFC(): boolean;
     getContainingBlockForAbsolute(): NodeContext;
     belongsTo(formattingContext: FormattingContext): boolean;
+  }
+
+  export interface ChildNodeContext extends NodeContext {
+    parent: NodeContext;
+  }
+
+  export interface RootNodeContext extends NodeContext {
+    parent: null;
+    shadowSibling: null;
   }
 
   export interface ChunkPosition {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2421,11 +2421,16 @@ export class ViewFactory
     if (this.isInsideTable(nodeContext)) {
       return null;
     }
-    for (let nc = nodeContext; nc && !nc.after; nc = nc.parent) {
+    for (
+      let nc: Vtree.NodeContext | null = nodeContext;
+      nc && !nc.after;
+      nc = nc.parent
+    ) {
       if (Break.isForcedBreakValue(nc.breakBefore)) {
         return nc.breakBefore; // forced break
       }
-      if (nc.fragmentIndex === 1 && !nc.parent) {
+      const parent = nc.parent;
+      if (nc.fragmentIndex === 1 && !parent) {
         if (nc.sourceNode === nc.sourceNode.ownerDocument?.documentElement) {
           // beginning of document
           return "page";
@@ -2434,11 +2439,14 @@ export class ViewFactory
           return null;
         }
       }
-      if (nc.parent?.floatSide) {
+      if (!parent) {
+        continue;
+      }
+      if (parent.floatSide) {
         // inside float, not break (Issue #1282)
         return null;
       }
-      const parentViewNode = nc.parent?.viewNode as Element;
+      const parentViewNode = parent.viewNode as Element;
       if (parentViewNode) {
         const style = this.viewport.window.getComputedStyle(parentViewNode);
         const paddingBlockStart = parseFloat(style.paddingBlockStart);
@@ -2450,7 +2458,7 @@ export class ViewFactory
         let node = parentViewNode?.firstChild;
         while (
           node &&
-          (Vtree.canIgnore(node, nc.parent.whitespace) ||
+          (Vtree.canIgnore(node, parent.whitespace) ||
             (!nc.floatSide && LayoutHelper.isOutOfFlow(node)))
         ) {
           node = node.nextSibling;
@@ -2476,7 +2484,11 @@ export class ViewFactory
   }
 
   private isInsideTable(nodeContext: Vtree.NodeContext): boolean {
-    for (let nc = nodeContext; nc && !nc.after; nc = nc.parent) {
+    for (
+      let nc: Vtree.NodeContext | null = nodeContext;
+      nc && !nc.after;
+      nc = nc.parent
+    ) {
       if (nc.display && nc.display.startsWith("table")) {
         return true;
       }
@@ -2825,11 +2837,17 @@ export class ViewFactory
           node?.nodeType === 1 &&
           PseudoElement.getPseudoName(node as Element) === name;
         const p = nodeContext.parent;
+        // A first-letter pseudo-element view is only generated below its
+        // originating element's context, so a context bearing one has a parent.
+        const pFirstLetter =
+          p &&
+          isPseudo(this.viewNode, "after") &&
+          isPseudo(p.viewNode, "first-letter")
+            ? (p as Vtree.ChildNodeContext)
+            : null;
         let parent = p
-          ? isPseudo(this.viewNode, "after") &&
-            isPseudo(p.viewNode, "first-letter") &&
-            p.viewNode?.hasChildNodes()
-            ? (p.parent.viewNode as Element) // Fix for issue #1175
+          ? pFirstLetter?.viewNode?.hasChildNodes()
+            ? (pFirstLetter.parent.viewNode as Element) // Fix for issue #1175
             : (p.viewNode as Element)
           : this.viewRoot;
         if (nodeContext.pluginProps["nestedFootnoteDetached"]) {
@@ -2870,7 +2888,7 @@ export class ViewFactory
     return this.createNodeView(nodeContext, firstTime, !!atUnforcedBreak);
   }
 
-  processShadowContent(pos: Vtree.NodeContext): Vtree.NodeContext {
+  processShadowContent(pos: Vtree.ChildNodeContext): Vtree.NodeContext {
     if (
       pos.shadowContext == null ||
       (pos.sourceNode as Element).localName != "content" ||
@@ -2910,7 +2928,7 @@ export class ViewFactory
       nextPos = null;
     }
     if (contentNode) {
-      const r = new Vtree.NodeContext(contentNode, parent, boxOffset);
+      const r = Vtree.NodeContext.childOf(contentNode, parent, boxOffset);
       r.shadowContext = contentShadow;
       r.shadowType = contentShadowType;
       r.shadowSibling = nextPos;
@@ -2931,39 +2949,40 @@ export class ViewFactory
     let boxOffset = pos.boxOffset + 1; // offset for the next position
     if (pos.after) {
       // root, that was the last possible position
-      if (!pos.parent) {
+      let cur = Vtree.asChildNodeContext(pos);
+      if (!cur) {
         return null;
       }
 
       // we are done with this sourceNode, see if there is a next sibling,
       // unless this is the root of the shadow tree
-      if (pos.shadowType != Vtree.ShadowType.ROOTED) {
-        const next = pos.sourceNode.nextSibling;
+      if (cur.shadowType != Vtree.ShadowType.ROOTED) {
+        const next = cur.sourceNode.nextSibling;
         if (next) {
-          pos = pos.modify();
+          cur = cur.modify();
 
           // keep shadowType
-          pos.boxOffset = boxOffset;
-          pos.sourceNode = next;
-          pos.resetView();
-          return this.processShadowContent(pos);
+          cur.boxOffset = boxOffset;
+          cur.sourceNode = next;
+          cur.resetView();
+          return this.processShadowContent(cur);
         }
       }
 
       // if no viable siblings, check if there are shadow siblings
-      if (pos.shadowSibling) {
+      if (cur.shadowSibling) {
         // our next position is the element after shadow:content in the parent
         // shadow tree
-        pos = pos.shadowSibling.modify();
-        pos.boxOffset = boxOffset;
-        return pos;
+        const sibling = cur.shadowSibling.modify();
+        sibling.boxOffset = boxOffset;
+        return sibling;
       }
 
       // if not rootless shadow, move to the "after" position for the parent
-      pos = pos.parent.modify();
-      pos.boxOffset = boxOffset;
-      pos.after = true;
-      return pos;
+      const afterParent = cur.parent.modify();
+      afterParent.boxOffset = boxOffset;
+      afterParent.after = true;
+      return afterParent;
     } else {
       // any shadow trees?
       if (pos.nodeShadow) {
@@ -2972,7 +2991,7 @@ export class ViewFactory
           shadowNode = shadowNode.firstChild;
         }
         if (shadowNode) {
-          const sr = new Vtree.NodeContext(shadowNode, pos, boxOffset);
+          const sr = Vtree.NodeContext.childOf(shadowNode, pos, boxOffset);
           sr.shadowContext = pos.nodeShadow;
           sr.shadowType = pos.nodeShadow.type;
           return this.processShadowContent(sr);
@@ -2983,7 +3002,7 @@ export class ViewFactory
       const child = pos.sourceNode.firstChild;
       if (child) {
         return this.processShadowContent(
-          new Vtree.NodeContext(child, pos, boxOffset),
+          Vtree.NodeContext.childOf(child, pos, boxOffset),
         );
       }
 
@@ -3658,9 +3677,10 @@ export class ViewFactory
     }
     const boxOffset = nodeContext.boxOffset + nodeOffset;
     const arr: Vtree.NodeContext[] = [];
-    while (nodeContext && nodeContext.firstPseudo === firstPseudo) {
-      arr.push(nodeContext);
-      nodeContext = nodeContext.parent;
+    let nc: Vtree.NodeContext | null = nodeContext;
+    while (nc && nc.firstPseudo === firstPseudo) {
+      arr.push(nc);
+      nc = nc.parent;
     }
     // the loop above runs at least once (nodeContext.firstPseudo === firstPseudo)
     let pn = arr.pop()!; // container for that pseudoelement
@@ -3669,23 +3689,19 @@ export class ViewFactory
       .loop(() => {
         while (arr.length > 0) {
           pn = arr.pop()!;
-          nodeContext = new Vtree.NodeContext(
-            pn.sourceNode,
-            nodeContext,
-            boxOffset,
-          );
+          nc = new Vtree.NodeContext(pn.sourceNode, nc, boxOffset);
           if (arr.length == 0) {
-            nodeContext.offsetInNode = offsetInNode;
-            nodeContext.after = after;
+            nc.offsetInNode = offsetInNode;
+            nc.after = after;
           }
-          nodeContext.shadowType = pn.shadowType;
-          nodeContext.shadowContext = pn.shadowContext;
-          nodeContext.nodeShadow = pn.nodeShadow;
-          nodeContext.shadowSibling = pn.shadowSibling
+          nc.shadowType = pn.shadowType;
+          nc.shadowContext = pn.shadowContext;
+          nc.nodeShadow = pn.nodeShadow;
+          nc.shadowSibling = pn.shadowSibling
             ? pn.shadowSibling
             : shadowSibling;
           shadowSibling = null;
-          const result = this.setCurrent(nodeContext, false);
+          const result = this.setCurrent(nc, false);
           if (result.isPending()) {
             return result;
           }
@@ -3693,7 +3709,7 @@ export class ViewFactory
         return Task.newResult(false);
       })
       .then(() => {
-        frame.finish(nodeContext);
+        frame.finish(nc);
       });
     return frame.result();
   }

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -387,6 +387,7 @@ export function eachAncestorFormattingContext(
 }
 
 export type NodePositionStep = Vtree.NodePositionStep;
+export type RootNodePositionStep = Vtree.RootNodePositionStep;
 
 export function isSameNodePositionStep(
   nps1: NodePositionStep,
@@ -442,7 +443,7 @@ export function isSameNodePosition(
 }
 
 export function newNodePositionFromNode(node: Node): NodePosition {
-  const step: NodePositionStep = {
+  const step: RootNodePositionStep = {
     node,
     shadowType: ShadowType.NONE,
     shadowContext: null,
@@ -463,7 +464,7 @@ export function newNodePositionFromNodeContext(
   nodeContext: Vtree.NodeContext,
   initialFragmentIndex: number | null,
 ): NodePosition {
-  const step: NodePositionStep = {
+  const step: RootNodePositionStep = {
     node: nodeContext.sourceNode,
     shadowType: ShadowType.NONE,
     shadowContext: nodeContext.shadowContext,
@@ -488,15 +489,39 @@ export function makeNodeContextFromNodePositionStep(
   parent: Vtree.NodeContext,
 ): NodeContext {
   const nodeContext = new NodeContext(step.node, parent as NodeContext, 0);
-  nodeContext.shadowType = step.shadowType;
-  nodeContext.shadowContext = step.shadowContext;
-  nodeContext.nodeShadow = step.nodeShadow;
+  applyNodePositionStep(nodeContext, step);
   nodeContext.shadowSibling = step.shadowSibling
     ? makeNodeContextFromNodePositionStep(step.shadowSibling, parent.copy())
     : null;
+  return nodeContext;
+}
+
+export function makeRootNodeContextFromNodePositionStep(
+  step: RootNodePositionStep,
+): NodeContext {
+  const nodeContext = new NodeContext(step.node, null, 0);
+  applyNodePositionStep(nodeContext, step);
+  nodeContext.shadowSibling = step.shadowSibling;
+  return nodeContext;
+}
+
+function applyNodePositionStep(
+  nodeContext: NodeContext,
+  step: NodePositionStep,
+): void {
+  nodeContext.shadowType = step.shadowType;
+  nodeContext.shadowContext = step.shadowContext;
+  nodeContext.nodeShadow = step.nodeShadow;
   nodeContext.formattingContext = step.formattingContext;
   nodeContext.fragmentIndex = step.fragmentIndex + 1;
-  return nodeContext;
+}
+
+export function rootStepOfNodePosition(
+  position: Vtree.NodePosition,
+): RootNodePositionStep {
+  // steps is [...NodePositionStep[], RootNodePositionStep]; TypeScript cannot
+  // index the trailing element of a variadic tuple, so restate its type.
+  return position.steps[position.steps.length - 1] as RootNodePositionStep;
 }
 
 export const ShadowType = Vtree.ShadowType;
@@ -613,9 +638,17 @@ export class NodeContext implements Vtree.NodeContext {
   footnotePolicy: Css.Ident | null = null;
   pageType: string | null;
 
+  static childOf(
+    sourceNode: Node,
+    parent: NodeContext,
+    boxOffset: number,
+  ): ChildNodeContext {
+    return new NodeContext(sourceNode, parent, boxOffset) as ChildNodeContext;
+  }
+
   constructor(
     public sourceNode: Node,
-    public parent: NodeContext,
+    public parent: NodeContext | null,
     public boxOffset: number,
   ) {
     this.shadowType = ShadowType.NONE;
@@ -669,8 +702,12 @@ export class NodeContext implements Vtree.NodeContext {
     this.pageType = this.parent ? this.parent.pageType : null;
   }
 
-  private cloneItem(): NodeContext {
-    const np = new NodeContext(this.sourceNode, this.parent, this.boxOffset);
+  private cloneItem(): this {
+    const np = new NodeContext(
+      this.sourceNode,
+      this.parent,
+      this.boxOffset,
+    ) as this;
     np.offsetInNode = this.offsetInNode;
     np.after = this.after;
     np.nodeShadow = this.nodeShadow;
@@ -712,15 +749,15 @@ export class NodeContext implements Vtree.NodeContext {
     return np;
   }
 
-  modify(): NodeContext {
+  modify(): this {
     if (!this.shared) {
       return this;
     }
     return this.cloneItem();
   }
 
-  copy(): NodeContext {
-    let np: NodeContext = this;
+  copy(): this {
+    let np: NodeContext | null = this;
     do {
       if (np.shared) {
         break;
@@ -731,10 +768,10 @@ export class NodeContext implements Vtree.NodeContext {
     return this;
   }
 
-  clone(): NodeContext {
+  clone(): this {
     const np = this.cloneItem();
-    let npc = np;
-    let npp: NodeContext;
+    let npc: NodeContext = np;
+    let npp: NodeContext | null;
     while ((npp = npc.parent) != null) {
       npp = npp.cloneItem();
       npc.parent = npp;
@@ -762,33 +799,30 @@ export class NodeContext implements Vtree.NodeContext {
   }
 
   toNodePosition(): NodePosition {
-    let nc: NodeContext = this;
-    const steps = [];
-
     // Fix for issue #703
-    if (
-      nc.shadowType === Vtree.ShadowType.ROOTLESS &&
-      (nc.floatReference !== PageFloats.FloatReference.INLINE ||
-        nc.floatSide === "footnote") &&
-      (nc.shadowContext?.styler as PseudoElement.PseudoelementStyler)?.style?.[
-        "_pseudos"
-      ]
-    ) {
-      nc = nc.parent;
-    }
-
-    do {
+    // A float or footnote context inside a pseudo-element shadow is always a
+    // descended one: restored heads keep the constructor's default float
+    // fields and live roots carry no shadow context.
+    const floatInPseudoContent =
+      this.shadowType === Vtree.ShadowType.ROOTLESS &&
+      (this.floatReference !== PageFloats.FloatReference.INLINE ||
+        this.floatSide === "footnote") &&
+      (this.shadowContext?.styler as PseudoElement.PseudoelementStyler)
+        ?.style?.["_pseudos"]
+        ? (this as ChildNodeContext)
+        : null;
+    const steps: NodePositionStep[] = [];
+    let nc = classifyNodeContext(
+      floatInPseudoContent ? floatInPseudoContent.parent : this,
+    );
+    while (hasParent(nc)) {
       // We need fully "peeled" path, so don't record first-XXX pseudoelement
       // containers
-      if (
-        !nc.firstPseudo ||
-        !nc.parent ||
-        nc.parent.firstPseudo === nc.firstPseudo
-      ) {
+      if (!nc.firstPseudo || nc.parent.firstPseudo === nc.firstPseudo) {
         steps.push(nc.toNodePositionStep());
       }
-      nc = nc.parent;
-    } while (nc);
+      nc = classifyNodeContext(nc.parent);
+    }
     const actualOffsetInNode = this.preprocessedTextContent
       ? Diff.resolveOriginalIndex(
           this.preprocessedTextContent,
@@ -796,7 +830,7 @@ export class NodeContext implements Vtree.NodeContext {
         )
       : this.offsetInNode;
     return {
-      steps,
+      steps: [...steps, toRootNodePositionStep(nc)],
       offsetInNode: actualOffsetInNode,
       after: this.after,
       preprocessedTextContent: this.preprocessedTextContent,
@@ -832,6 +866,38 @@ export class NodeContext implements Vtree.NodeContext {
       this.parent.formattingContext === formattingContext
     );
   }
+}
+
+export type ChildNodeContext = NodeContext & Vtree.ChildNodeContext;
+
+export function asChildNodeContext(
+  nc: Vtree.NodeContext,
+): ChildNodeContext | null {
+  return nc.parent !== null ? (nc as ChildNodeContext) : null;
+}
+
+export type RootNodeContext = NodeContext & Vtree.RootNodeContext;
+
+// Total classification by parent presence; the root refinement carries the
+// shadow-sibling correlation declared on Vtree.RootNodeContext.
+export function classifyNodeContext(
+  nc: Vtree.NodeContext,
+): ChildNodeContext | RootNodeContext {
+  return nc.parent !== null
+    ? (nc as ChildNodeContext)
+    : (nc as RootNodeContext);
+}
+
+export function hasParent(
+  nc: ChildNodeContext | RootNodeContext,
+): nc is ChildNodeContext {
+  return nc.parent !== null;
+}
+
+export function toRootNodePositionStep(
+  root: RootNodeContext,
+): RootNodePositionStep {
+  return { ...root.toNodePositionStep(), shadowSibling: root.shadowSibling };
 }
 
 export class ChunkPosition implements Vtree.ChunkPosition {


### PR DESCRIPTION
refs: #2065 

`NodeContext.parent`の`NodeContext | null`化にかかるリファクタリングです。`parent`が非nullの`ChildNodeContext`、`parent`,`shadowSibling`がnullの`RootNodeContext`など型による分類で、親が必ずある／ない前提を型として表現します。