### PR TITLE
refactor: Require a non-root position to peel off

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2483,14 +2483,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           linePositions[count - 1],
           true,
         );
-        if (lineBreak == null) {
+        const childLineBreak =
+          lineBreak && VtreeImpl.asChildNodeContext(lineBreak);
+        if (!childLineBreak) {
           loopFrame.breakLoop();
           return;
         }
-        this.finishBreak(lineBreak, false, false).then(() => {
+        this.finishBreak(childLineBreak, false, false).then(() => {
           totalLineCount += count;
           this.layoutContext
-            .peelOff(lineBreak, 0)
+            .peelOff(childLineBreak, 0)
             .then((resNodeContextParam) => {
               nodeContext = resNodeContextParam;
               firstPseudo = nodeContext.firstPseudo;

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -658,8 +658,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       position.firstPseudo.count == 0
     ) {
       // first char
-      if (position.viewNode.nodeType != 1) {
-        const text = position.viewNode.textContent;
+      const textPosition = VtreeImpl.asTextNodeContext(position);
+      if (textPosition) {
+        const viewNode = textPosition.viewNode;
+        const text = viewNode.textContent;
         const r = text.match(Base.firstLetterPattern);
         let firstLetterLength = r ? r[0].length : 0;
         if (
@@ -675,12 +677,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             const firstLetterText = r2[0];
             firstLetterLength = firstLetterText.length;
             position.sourceNode.textContent = firstLetterText;
-            position.viewNode.textContent = firstLetterText;
+            viewNode.textContent = firstLetterText;
             position.sourceNode.nextSibling.textContent =
               text2.substr(firstLetterLength);
           }
         }
-        return this.layoutContext.peelOff(position, firstLetterLength);
+        if (firstLetterLength > 0) {
+          const viewText = viewNode.textContent ?? "";
+          viewNode.textContent = viewText.substr(0, firstLetterLength);
+        }
+        return this.layoutContext.peelOff(textPosition, firstLetterLength);
       }
     }
     return Task.newResult(position) as Task.Result<Vtree.NodeContext>;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1094,7 +1094,7 @@ export namespace Vtree {
      * after the end of that pseudoelement.
      */
     peelOff(
-      nodeContext: NodeContext,
+      nodeContext: ChildNodeContext,
       nodeOffset: number,
     ): Task.Result<NodeContext>;
     /**

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1358,6 +1358,11 @@ export namespace Vtree {
     shadowSibling: null;
   }
 
+  export interface TextNodeContext extends NodeContext {
+    parent: NodeContext;
+    viewNode: Text;
+  }
+
   export interface ChunkPosition {
     floats: NodePosition[] | null;
     primary: NodePosition;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -3665,9 +3665,6 @@ export class ViewFactory
     let offsetInNode = nodeContext.offsetInNode;
     const after = nodeContext.after;
     if (nodeOffset > 0) {
-      const viewNode = nodeContext.viewNode;
-      const text = viewNode.textContent ?? "";
-      viewNode.textContent = text.substr(0, nodeOffset);
       offsetInNode += nodeOffset;
     } else if (!after && nodeContext.viewNode && offsetInNode == 0) {
       const parent = nodeContext.viewNode.parentNode;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -3657,7 +3657,7 @@ export class ViewFactory
 
   /** @override */
   peelOff(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.ChildNodeContext,
     nodeOffset: number,
   ): Task.Result<Vtree.NodeContext> {
     const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("peelOff");
@@ -3673,32 +3673,44 @@ export class ViewFactory
       }
     }
     const boxOffset = nodeContext.boxOffset + nodeOffset;
+
+    // arr collects the chain strictly below its container, innermost first
     const arr: Vtree.NodeContext[] = [];
-    let nc: Vtree.NodeContext | null = nodeContext;
-    while (nc && nc.firstPseudo === firstPseudo) {
-      arr.push(nc);
-      nc = nc.parent;
+    let container: Vtree.NodeContext = nodeContext;
+    for (
+      let parent: Vtree.NodeContext | null = nodeContext.parent;
+      parent && parent.firstPseudo === firstPseudo;
+      parent = container.parent
+    ) {
+      arr.push(container);
+      container = parent;
     }
-    // the loop above runs at least once (nodeContext.firstPseudo === firstPseudo)
-    let pn = arr.pop()!; // container for that pseudoelement
-    let shadowSibling = pn.shadowSibling;
+    let shadowSibling = container.shadowSibling;
+    let i = arr.length - 1;
+    let rebuilt: Vtree.NodeContext | null = null;
     frame
       .loop(() => {
-        while (arr.length > 0) {
-          pn = arr.pop()!;
-          nc = new Vtree.NodeContext(pn.sourceNode, nc, boxOffset);
-          if (arr.length == 0) {
-            nc.offsetInNode = offsetInNode;
-            nc.after = after;
+        while (i >= 0) {
+          const pn = arr[i];
+          const child = new Vtree.NodeContext(
+            pn.sourceNode,
+            rebuilt ?? container.parent,
+            boxOffset,
+          );
+          if (i == 0) {
+            child.offsetInNode = offsetInNode;
+            child.after = after;
           }
-          nc.shadowType = pn.shadowType;
-          nc.shadowContext = pn.shadowContext;
-          nc.nodeShadow = pn.nodeShadow;
-          nc.shadowSibling = pn.shadowSibling
+          child.shadowType = pn.shadowType;
+          child.shadowContext = pn.shadowContext;
+          child.nodeShadow = pn.nodeShadow;
+          child.shadowSibling = pn.shadowSibling
             ? pn.shadowSibling
             : shadowSibling;
           shadowSibling = null;
-          const result = this.setCurrent(nc, false);
+          rebuilt = child;
+          i--;
+          const result = this.setCurrent(child, false);
           if (result.isPending()) {
             return result;
           }
@@ -3706,7 +3718,7 @@ export class ViewFactory
         return Task.newResult(false);
       })
       .then(() => {
-        frame.finish(nc);
+        frame.finish(rebuilt ?? nodeContext.parent);
       });
     return frame.result();
   }

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -519,8 +519,6 @@ function applyNodePositionStep(
 export function rootStepOfNodePosition(
   position: Vtree.NodePosition,
 ): RootNodePositionStep {
-  // steps is [...NodePositionStep[], RootNodePositionStep]; TypeScript cannot
-  // index the trailing element of a variadic tuple, so restate its type.
   return position.steps[position.steps.length - 1] as RootNodePositionStep;
 }
 
@@ -878,8 +876,6 @@ export function asChildNodeContext(
 
 export type RootNodeContext = NodeContext & Vtree.RootNodeContext;
 
-// Total classification by parent presence; the root refinement carries the
-// shadow-sibling correlation declared on Vtree.RootNodeContext.
 export function classifyNodeContext(
   nc: Vtree.NodeContext,
 ): ChildNodeContext | RootNodeContext {
@@ -898,6 +894,16 @@ export function toRootNodePositionStep(
   root: RootNodeContext,
 ): RootNodePositionStep {
   return { ...root.toNodePositionStep(), shadowSibling: root.shadowSibling };
+}
+
+export type TextNodeContext = NodeContext & Vtree.TextNodeContext;
+
+export function asTextNodeContext(
+  nc: Vtree.NodeContext,
+): TextNodeContext | null {
+  return nc.viewNode !== null && nc.viewNode.nodeType !== 1
+    ? (nc as TextNodeContext)
+    : null;
 }
 
 export class ChunkPosition implements Vtree.ChunkPosition {

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -901,7 +901,7 @@ export type TextNodeContext = NodeContext & Vtree.TextNodeContext;
 export function asTextNodeContext(
   nc: Vtree.NodeContext,
 ): TextNodeContext | null {
-  return nc.viewNode !== null && nc.viewNode.nodeType !== 1
+  return nc.parent !== null && nc.viewNode?.nodeType === 3
     ? (nc as TextNodeContext)
     : null;
 }


### PR DESCRIPTION
refs: #2067 

first-letterテキストの切り詰めを`maybePeelOff`側へ移動し`viewNode`の非null前提を`peelOff`から外したうえで、`peelOff`の引数を`ChildNodeContext`（親が必ずある）へ狭めます。非nullアサーションが必要な`frame.finish(nc);`を解消するためにループのロジックを書き換えて`frame.finish(rebuilt ?? nodeContext.parent);`とします。