### PR TITLE
refactor: Split cascade chains into conditions and wired nodes

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -677,13 +677,9 @@ export function chainActions(
 ): CascadeAction {
   if (chain.length > 0) {
     chain.sort((a, b) => b.getPriority() - a.getPriority());
-    let chained: ChainedAction | null = null;
     for (let i = chain.length - 1; i >= 0; i--) {
-      chained = chain[i];
-      chained.chained = action;
-      action = chained;
+      action = chain[i].wire(action);
     }
-    return chained;
   }
   return action;
 }
@@ -852,24 +848,68 @@ export class ApplyRuleAction extends CascadeAction {
   }
 }
 
-export class ChainedAction extends CascadeAction {
-  chained: CascadeAction | null = null;
+export type PrimarySlot = {
+  table: ActionTable;
+  key: string;
+};
 
-  constructor() {
-    super();
-  }
-
-  override apply(cascadeInstance: CascadeInstance): void {
-    this.chained.apply(cascadeInstance);
-  }
+export abstract class ChainedAction {
+  abstract matches(cascadeInstance: CascadeInstance): boolean;
 
   getPriority(): number {
     return 0;
   }
 
-  makePrimary(cascade: Cascade): boolean {
+  primarySlot(cascade: Cascade): PrimarySlot | null {
     // cannot be made primary
+    return null;
+  }
+
+  wire(chained: CascadeAction): WiredAction {
+    return new WiredGuard(this, chained);
+  }
+}
+
+export abstract class WiredAction<
+  T extends ChainedAction = ChainedAction,
+> extends CascadeAction {
+  constructor(
+    protected readonly condition: T,
+    protected readonly chained: CascadeAction,
+  ) {
+    super();
+  }
+
+  abstract override apply(cascadeInstance: CascadeInstance): void;
+
+  makePrimary(cascade: Cascade): boolean {
+    const slot = this.condition.primarySlot(cascade);
+    if (slot) {
+      cascade.insertInTable(slot.table, slot.key, this.chained);
+      return true;
+    }
     return false;
+  }
+}
+
+export class WiredGuard extends WiredAction {
+  override apply(cascadeInstance: CascadeInstance): void {
+    if (this.condition.matches(cascadeInstance)) {
+      this.chained.apply(cascadeInstance);
+    }
+  }
+}
+
+export class WiredConditionScope extends WiredAction<CheckConditionAction> {
+  override apply(cascadeInstance: CascadeInstance): void {
+    if (this.condition.matches(cascadeInstance)) {
+      cascadeInstance.dependentConditions.push(this.condition.condition);
+      try {
+        this.chained.apply(cascadeInstance);
+      } finally {
+        cascadeInstance.dependentConditions.pop();
+      }
+    }
   }
 }
 
@@ -878,10 +918,8 @@ export class CheckClassAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (cascadeInstance.currentClassNames.includes(this.className)) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return cascadeInstance.currentClassNames.includes(this.className);
   }
 
   override getPriority(): number {
@@ -889,11 +927,8 @@ export class CheckClassAction extends ChainedAction {
   }
   // class should be checked after id
 
-  override makePrimary(cascade: Cascade): boolean {
-    if (this.chained) {
-      cascade.insertInTable(cascade.classes, this.className, this.chained);
-    }
-    return true;
+  override primarySlot(cascade: Cascade): PrimarySlot | null {
+    return { table: cascade.classes, key: this.className };
   }
 }
 
@@ -902,13 +937,11 @@ export class CheckIdAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return (
       cascadeInstance.currentId == this.id ||
       cascadeInstance.currentXmlId == this.id
-    ) {
-      this.chained.apply(cascadeInstance);
-    }
+    );
   }
 
   override getPriority(): number {
@@ -916,11 +949,8 @@ export class CheckIdAction extends ChainedAction {
   }
   // id should be checked after :root
 
-  override makePrimary(cascade: Cascade): boolean {
-    if (this.chained) {
-      cascade.insertInTable(cascade.ids, this.id, this.chained);
-    }
-    return true;
+  override primarySlot(cascade: Cascade): PrimarySlot | null {
+    return { table: cascade.ids, key: this.id };
   }
 }
 
@@ -929,10 +959,8 @@ export class CheckLocalNameAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (cascadeInstance.currentLocalName == this.localName) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return cascadeInstance.currentLocalName == this.localName;
   }
 
   override getPriority(): number {
@@ -940,11 +968,8 @@ export class CheckLocalNameAction extends ChainedAction {
   }
   // tag is a pretty good thing to check, after epub:type
 
-  override makePrimary(cascade: Cascade): boolean {
-    if (this.chained) {
-      cascade.insertInTable(cascade.tags, this.localName, this.chained);
-    }
-    return true;
+  override primarySlot(cascade: Cascade): PrimarySlot | null {
+    return { table: cascade.tags, key: this.localName };
   }
 }
 
@@ -956,13 +981,11 @@ export class CheckNSTagAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return (
       cascadeInstance.currentLocalName == this.localName &&
       cascadeInstance.currentNamespace == this.ns
-    ) {
-      this.chained.apply(cascadeInstance);
-    }
+    );
   }
 
   override getPriority(): number {
@@ -970,17 +993,13 @@ export class CheckNSTagAction extends ChainedAction {
   }
   // tag is a pretty good thing to check, after epub:type
 
-  override makePrimary(cascade: Cascade): boolean {
-    if (this.chained) {
-      let prefix = cascade.nsPrefix[this.ns];
-      if (!prefix) {
-        prefix = `ns${cascade.nsCount++}:`;
-        cascade.nsPrefix[this.ns] = prefix;
-      }
-      const nsTag = prefix + this.localName;
-      cascade.insertInTable(cascade.nstags, nsTag, this.chained);
+  override primarySlot(cascade: Cascade): PrimarySlot | null {
+    let prefix = cascade.nsPrefix[this.ns];
+    if (!prefix) {
+      prefix = `ns${cascade.nsCount++}:`;
+      cascade.nsPrefix[this.ns] = prefix;
     }
-    return true;
+    return { table: cascade.nstags, key: prefix + this.localName };
   }
 }
 
@@ -993,7 +1012,7 @@ export class CheckTargetEpubTypeAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
     if (elem instanceof HTMLAnchorElement) {
       if (
@@ -1011,11 +1030,12 @@ export class CheckTargetEpubTypeAction extends ChainedAction {
             : target.getAttributeNS(Base.NS.epub, "type") ||
               target.getAttribute("epub:type");
           if (epubType && epubType.match(this.epubTypePatt)) {
-            this.chained.apply(cascadeInstance);
+            return true;
           }
         }
       }
     }
+    return false;
   }
 }
 
@@ -1024,10 +1044,8 @@ export class CheckNamespaceAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (cascadeInstance.currentNamespace == this.ns) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return cascadeInstance.currentNamespace == this.ns;
   }
 }
 
@@ -1111,17 +1129,13 @@ export class CheckAttributePresentAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (
-      checkAttribute(
-        cascadeInstance.currentElement,
-        this.ns,
-        this.name,
-        () => true,
-      )
-    ) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return checkAttribute(
+      cascadeInstance.currentElement,
+      this.ns,
+      this.name,
+      () => true,
+    );
   }
 }
 
@@ -1135,22 +1149,14 @@ export class CheckAttributeEqAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (
-      checkAttribute(
-        cascadeInstance.currentElement,
-        this.ns,
-        this.name,
-        (attribute) =>
-          attributeValueEquals(
-            attribute.value,
-            this.value,
-            this.caseSensitivity,
-          ),
-      )
-    ) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return checkAttribute(
+      cascadeInstance.currentElement,
+      this.ns,
+      this.name,
+      (attribute) =>
+        attributeValueEquals(attribute.value, this.value, this.caseSensitivity),
+    );
   }
 
   override getPriority(): number {
@@ -1160,14 +1166,11 @@ export class CheckAttributeEqAction extends ChainedAction {
     return 0;
   }
 
-  override makePrimary(cascade: Cascade): boolean {
+  override primarySlot(cascade: Cascade): PrimarySlot | null {
     if (this.name == "type" && this.ns == Base.NS.epub) {
-      if (this.chained) {
-        cascade.insertInTable(cascade.epubtypes, this.value, this.chained);
-      }
-      return true;
+      return { table: cascade.epubtypes, key: this.value };
     }
-    return false;
+    return null;
   }
 }
 
@@ -1179,25 +1182,21 @@ export class CheckNamespaceSupportedAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (
-      checkAttribute(
-        cascadeInstance.currentElement,
-        this.ns,
-        this.name,
-        (attribute) => !!supportedNamespaces[attribute.value],
-      )
-    ) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return checkAttribute(
+      cascadeInstance.currentElement,
+      this.ns,
+      this.name,
+      (attribute) => !!supportedNamespaces[attribute.value],
+    );
   }
 
   override getPriority(): number {
     return 0;
   }
 
-  override makePrimary(cascade: Cascade): boolean {
-    return false;
+  override primarySlot(cascade: Cascade): PrimarySlot | null {
+    return null;
   }
 }
 
@@ -1211,17 +1210,13 @@ export class CheckAttributeRegExpAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (
-      checkAttribute(
-        cascadeInstance.currentElement,
-        this.ns,
-        this.name,
-        (attribute) => !!attribute.value.match(this.regexp),
-      )
-    ) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return checkAttribute(
+      cascadeInstance.currentElement,
+      this.ns,
+      this.name,
+      (attribute) => !!attribute.value.match(this.regexp),
+    );
   }
 }
 
@@ -1230,10 +1225,8 @@ export class CheckLangAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (cascadeInstance.lang.match(this.langRegExp)) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return !!cascadeInstance.lang.match(this.langRegExp);
   }
 }
 
@@ -1242,10 +1235,8 @@ export class IsFirstAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (cascadeInstance.isFirst) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return cascadeInstance.isFirst;
   }
 
   override getPriority(): number {
@@ -1258,10 +1249,8 @@ export class IsRootAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (cascadeInstance.isRoot) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return cascadeInstance.isRoot;
   }
 
   override getPriority(): number {
@@ -1269,7 +1258,7 @@ export class IsRootAction extends ChainedAction {
   }
 }
 
-export class IsNthAction extends ChainedAction {
+export abstract class IsNthAction extends ChainedAction {
   constructor(
     public readonly a: number,
     public readonly b: number,
@@ -1291,10 +1280,8 @@ export class IsNthSiblingAction extends IsNthAction {
     super(a, b);
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (this.matchANPlusB(cascadeInstance.currentSiblingOrder)) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return this.matchANPlusB(cascadeInstance.currentSiblingOrder);
   }
 
   override getPriority(): number {
@@ -1307,14 +1294,12 @@ export class IsNthSiblingOfTypeAction extends IsNthAction {
     super(a, b);
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     const order =
       cascadeInstance.currentSiblingTypeCounts[
         cascadeInstance.currentNamespace
       ][cascadeInstance.currentLocalName];
-    if (this.matchANPlusB(order)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return this.matchANPlusB(order);
   }
 
   override getPriority(): number {
@@ -1327,7 +1312,7 @@ export class IsNthLastSiblingAction extends IsNthAction {
     super(a, b);
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     let order = cascadeInstance.currentFollowingSiblingOrder;
     if (order === null) {
       order = cascadeInstance.currentFollowingSiblingOrder =
@@ -1335,9 +1320,7 @@ export class IsNthLastSiblingAction extends IsNthAction {
         cascadeInstance.currentSiblingOrder +
         1;
     }
-    if (this.matchANPlusB(order)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return this.matchANPlusB(order);
   }
 
   override getPriority(): number {
@@ -1350,7 +1333,7 @@ export class IsNthLastSiblingOfTypeAction extends IsNthAction {
     super(a, b);
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     const counts = cascadeInstance.currentFollowingSiblingTypeCounts;
     if (!counts[cascadeInstance.currentNamespace]) {
       let elem = cascadeInstance.currentElement;
@@ -1364,15 +1347,11 @@ export class IsNthLastSiblingOfTypeAction extends IsNthAction {
         nsCounts[localName] = (nsCounts[localName] || 0) + 1;
       } while ((elem = elem.nextElementSibling));
     }
-    if (
-      this.matchANPlusB(
-        counts[cascadeInstance.currentNamespace][
-          cascadeInstance.currentLocalName
-        ],
-      )
-    ) {
-      this.chained.apply(cascadeInstance);
-    }
+    return this.matchANPlusB(
+      counts[cascadeInstance.currentNamespace][
+        cascadeInstance.currentLocalName
+      ],
+    );
   }
 
   override getPriority(): number {
@@ -1385,20 +1364,20 @@ export class IsEmptyAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     let node: Node | null = cascadeInstance.currentElement.firstChild;
     while (node) {
       switch (node.nodeType) {
         case Node.ELEMENT_NODE:
-          return;
+          return false;
         case Node.TEXT_NODE:
           if ((node as Text).length > 0) {
-            return;
+            return false;
           }
       }
       node = node.nextSibling;
     }
-    this.chained.apply(cascadeInstance);
+    return true;
   }
 
   override getPriority(): number {
@@ -1411,11 +1390,9 @@ export class IsEnabledAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
-    if ((elem as any).disabled === false) {
-      this.chained.apply(cascadeInstance);
-    }
+    return (elem as any).disabled === false;
   }
 
   override getPriority(): number {
@@ -1428,11 +1405,9 @@ export class IsDisabledAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
-    if ((elem as any).disabled === true) {
-      this.chained.apply(cascadeInstance);
-    }
+    return (elem as any).disabled === true;
   }
 
   override getPriority(): number {
@@ -1445,11 +1420,9 @@ export class IsCheckedAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
-    if ((elem as any).selected === true || (elem as any).checked === true) {
-      this.chained.apply(cascadeInstance);
-    }
+    return (elem as any).selected === true || (elem as any).checked === true;
   }
 
   override getPriority(): number {
@@ -1462,15 +1435,12 @@ export class CheckConditionAction extends ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    if (cascadeInstance.conditions[this.condition]) {
-      try {
-        cascadeInstance.dependentConditions.push(this.condition);
-        this.chained.apply(cascadeInstance);
-      } finally {
-        cascadeInstance.dependentConditions.pop();
-      }
-    }
+  override matches(cascadeInstance: CascadeInstance): boolean {
+    return !!cascadeInstance.conditions[this.condition];
+  }
+
+  override wire(chained: CascadeAction): WiredAction {
+    return new WiredConditionScope(this, chained);
   }
 
   override getPriority(): number {
@@ -1502,34 +1472,37 @@ export class CheckAppliedAction extends CascadeAction {
 export class MatchesAction extends ChainedAction {
   checkAppliedAction: CheckAppliedAction;
   firstActions: CascadeAction[] = [];
+  readonly priority: number;
 
   constructor(chains: ChainedAction[][]) {
     super();
     this.checkAppliedAction = new CheckAppliedAction();
+    this.priority = Math.max(
+      ...chains.map((chain) =>
+        chain.length > 0
+          ? Math.max(...chain.map((action) => action.getPriority()))
+          : 0,
+      ),
+    );
     for (const chain of chains) {
       this.firstActions.push(chainActions(chain, this.checkAppliedAction));
     }
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     for (const firstAction of this.firstActions) {
       firstAction.apply(cascadeInstance);
       if (this.checkAppliedAction.applied) {
         break;
       }
     }
-    if (this.checkAppliedAction.applied === this.positive()) {
-      this.chained.apply(cascadeInstance);
-    }
+    const applied = this.checkAppliedAction.applied;
     this.checkAppliedAction.applied = false;
+    return applied === this.positive();
   }
 
   override getPriority(): number {
-    return Math.max(
-      ...this.firstActions.map((firstAction) =>
-        firstAction instanceof ChainedAction ? firstAction.getPriority() : 0,
-      ),
-    );
+    return this.priority;
   }
 
   positive(): boolean {
@@ -1558,7 +1531,7 @@ export class MatchesRelationalAction extends MatchesAction {
     super([]);
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     for (const selectorText of this.selectorTexts) {
       let selectorWithScope: string;
       let scopingRoot: ParentNode;
@@ -1581,10 +1554,9 @@ export class MatchesRelationalAction extends MatchesAction {
         }
       } catch (e) {}
     }
-    if (this.checkAppliedAction.applied) {
-      this.chained.apply(cascadeInstance);
-    }
+    const applied = this.checkAppliedAction.applied;
     this.checkAppliedAction.applied = false;
+    return applied;
   }
 
   override relational(): boolean {
@@ -1607,7 +1579,7 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
     }
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     // Check if current element matches the selector
     for (const firstAction of this.firstActions) {
       firstAction.apply(cascadeInstance);
@@ -1616,7 +1588,7 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
       }
     }
     if (!this.checkAppliedAction.applied) {
-      return; // Element doesn't match selector, so :nth-child(of S) doesn't match
+      return false; // Element doesn't match selector, so :nth-child(of S) doesn't match
     }
     this.checkAppliedAction.applied = false;
 
@@ -1631,9 +1603,7 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
       sibling = sibling.previousElementSibling;
     }
 
-    if (this.matchANPlusB(order)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return this.matchANPlusB(order);
   }
 
   protected matchesSelector(
@@ -1698,7 +1668,7 @@ export class IsNthLastSiblingOfSelectorAction extends IsNthSiblingOfSelectorActi
     super(a, b, chains);
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override matches(cascadeInstance: CascadeInstance): boolean {
     // Check if current element matches the selector
     for (const firstAction of this.firstActions) {
       firstAction.apply(cascadeInstance);
@@ -1707,7 +1677,7 @@ export class IsNthLastSiblingOfSelectorAction extends IsNthSiblingOfSelectorActi
       }
     }
     if (!this.checkAppliedAction.applied) {
-      return; // Element doesn't match selector, so :nth-last-child(of S) doesn't match
+      return false; // Element doesn't match selector, so :nth-last-child(of S) doesn't match
     }
     this.checkAppliedAction.applied = false;
 
@@ -1722,9 +1692,7 @@ export class IsNthLastSiblingOfSelectorAction extends IsNthSiblingOfSelectorActi
       sibling = sibling.nextElementSibling;
     }
 
-    if (this.matchANPlusB(order)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return this.matchANPlusB(order);
   }
 
   override getPriority(): number {
@@ -4781,10 +4749,7 @@ export class CascadeParserHandler
 
   processChain(action: CascadeAction): void {
     const chained = chainActions(this.chain, action);
-    if (
-      chained !== action &&
-      (chained as ChainedAction).makePrimary(this.cascade)
-    ) {
+    if (chained instanceof WiredAction && chained.makePrimary(this.cascade)) {
       return;
     }
     this.insertNonPrimary(chained);
@@ -5394,7 +5359,9 @@ export class CascadeParserHandler
   }
 }
 
-export const nthSelectorActionClasses: { [key: string]: typeof IsNthAction } = {
+export const nthSelectorActionClasses: {
+  [key: string]: new (a: number, b: number) => IsNthAction;
+} = {
   "nth-child": IsNthSiblingAction,
   "nth-of-type": IsNthSiblingOfTypeAction,
   "nth-last-child": IsNthLastSiblingAction,

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -2858,21 +2858,18 @@ export class CheckPageTypeAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
-    if (cascadeInstance.currentPageType === this.pageType) {
-      this.chained.apply(cascadeInstance);
-    }
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
+    return cascadeInstance.currentPageType === this.pageType;
   }
 
   override getPriority(): number {
     return 3;
   }
 
-  override makePrimary(cascade: CssCascade.Cascade): boolean {
-    if (this.chained) {
-      cascade.insertInTable(cascade.pagetypes, this.pageType, this.chained);
-    }
-    return true;
+  override primarySlot(
+    cascade: CssCascade.Cascade,
+  ): CssCascade.PrimarySlot | null {
+    return { table: cascade.pagetypes, key: this.pageType };
   }
 }
 
@@ -2881,11 +2878,9 @@ export class IsFirstPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const pageNumber = new Exprs.Named(this.scope, "page-number");
-    if (pageNumber.evaluate(cascadeInstance.context) === 1) {
-      this.chained.apply(cascadeInstance);
-    }
+    return pageNumber.evaluate(cascadeInstance.context) === 1;
   }
 
   override getPriority(): number {
@@ -2898,11 +2893,9 @@ export class IsBlankPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const blankPage = new Exprs.Named(this.scope, "blank-page");
-    if (blankPage.evaluate(cascadeInstance.context)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return !!blankPage.evaluate(cascadeInstance.context);
   }
 
   override getPriority(): number {
@@ -2915,11 +2908,9 @@ export class IsLeftPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const leftPage = new Exprs.Named(this.scope, "left-page");
-    if (leftPage.evaluate(cascadeInstance.context)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return !!leftPage.evaluate(cascadeInstance.context);
   }
 
   override getPriority(): number {
@@ -2932,11 +2923,9 @@ export class IsRightPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const rightPage = new Exprs.Named(this.scope, "right-page");
-    if (rightPage.evaluate(cascadeInstance.context)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return !!rightPage.evaluate(cascadeInstance.context);
   }
 
   override getPriority(): number {
@@ -2949,11 +2938,9 @@ export class IsRectoPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const rectoPage = new Exprs.Named(this.scope, "recto-page");
-    if (rectoPage.evaluate(cascadeInstance.context)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return !!rectoPage.evaluate(cascadeInstance.context);
   }
 
   override getPriority(): number {
@@ -2966,11 +2953,9 @@ export class IsVersoPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const versoPage = new Exprs.Named(this.scope, "verso-page");
-    if (versoPage.evaluate(cascadeInstance.context)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return !!versoPage.evaluate(cascadeInstance.context);
   }
 
   override getPriority(): number {
@@ -2987,15 +2972,13 @@ export class IsNthPageAction extends CssCascade.IsNthAction {
     super(a, b);
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const styleInstance: any /* Ops.StyleInstance */ = cascadeInstance.context;
     let pageNumber = styleInstance.layoutPositionAtPageStart.page;
     if (styleInstance.blankPageAtStart) {
       pageNumber--;
     }
-    if (pageNumber && this.matchANPlusB(pageNumber)) {
-      this.chained.apply(cascadeInstance);
-    }
+    return !!pageNumber && this.matchANPlusB(pageNumber);
   }
 
   override getPriority(): number {
@@ -3013,17 +2996,17 @@ export class IsNthOfPageTypeAction extends CssCascade.IsNthAction {
     super(a, b);
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
     const pageTypeIndices = cascadeInstance.pageTypePageIndices[this.pageType];
     if (!pageTypeIndices) {
-      return;
+      return false;
     }
     for (const pageTypeIndex of pageTypeIndices) {
       if (this.matchANPlusB(pageTypeIndex)) {
-        this.chained.apply(cascadeInstance);
-        return;
+        return true;
       }
     }
+    return false;
   }
 
   override getPriority(): number {

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -29,7 +29,7 @@ describe("css-cascade", function () {
   describe("IsNthSiblingAction", function () {
     it("when a=0, matches if currentSiblingOrder=b", function () {
       var action = new adapt_csscasc.IsNthSiblingAction(0, 3);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 1 });
@@ -41,7 +41,7 @@ describe("css-cascade", function () {
 
     it("when a is non-zero, matches if non-negative n which satisfies currentSiblingOrder=an+b exists", function () {
       var action = new adapt_csscasc.IsNthSiblingAction(3, 0);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 1 });
@@ -53,7 +53,7 @@ describe("css-cascade", function () {
       wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 4 });
@@ -66,7 +66,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(2, 3);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 1 });
@@ -78,7 +78,7 @@ describe("css-cascade", function () {
       wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 4 });
@@ -87,7 +87,7 @@ describe("css-cascade", function () {
       wired.apply({ currentSiblingOrder: 5 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 6 });
@@ -97,7 +97,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(-3, 0);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 1 });
@@ -110,13 +110,13 @@ describe("css-cascade", function () {
       expect(chained.apply).not.toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(-2, 5);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 1 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 2 });
@@ -125,7 +125,7 @@ describe("css-cascade", function () {
       wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 4 });
@@ -134,7 +134,7 @@ describe("css-cascade", function () {
       wired.apply({ currentSiblingOrder: 5 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply({ currentSiblingOrder: 6 });
@@ -159,7 +159,7 @@ describe("css-cascade", function () {
 
     it("when a=0, matches if currentSiblingTypeCounts[namespace][locaName]=b", function () {
       var action = new adapt_csscasc.IsNthSiblingOfTypeAction(0, 3);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
@@ -171,7 +171,7 @@ describe("css-cascade", function () {
 
     it("when a is non-zero, matches if non-negative n which satisfies currentSiblingTypeCounts[namespace][locaName]=an+b exists", function () {
       var action = new adapt_csscasc.IsNthSiblingOfTypeAction(3, 0);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
@@ -183,7 +183,7 @@ describe("css-cascade", function () {
       wired.apply(dummyCascadeInstance({ bar: 3, baz: 1 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 4, baz: 3 }));
@@ -196,7 +196,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingOfTypeAction(2, 3);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
@@ -208,7 +208,7 @@ describe("css-cascade", function () {
       wired.apply(dummyCascadeInstance({ bar: 3, baz: 1 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 4, baz: 3 }));
@@ -217,7 +217,7 @@ describe("css-cascade", function () {
       wired.apply(dummyCascadeInstance({ bar: 5, baz: 1 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 6, baz: 3 }));
@@ -227,7 +227,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingOfTypeAction(-3, 0);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
@@ -240,13 +240,13 @@ describe("css-cascade", function () {
       expect(chained.apply).not.toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingOfTypeAction(-2, 5);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 1, baz: 2 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 2, baz: 1 }));
@@ -255,7 +255,7 @@ describe("css-cascade", function () {
       wired.apply(dummyCascadeInstance({ bar: 3, baz: 2 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 4, baz: 1 }));
@@ -264,7 +264,7 @@ describe("css-cascade", function () {
       wired.apply(dummyCascadeInstance({ bar: 5, baz: 2 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       wired.apply(dummyCascadeInstance({ bar: 6, baz: 1 }));
@@ -286,7 +286,7 @@ describe("css-cascade", function () {
 
     it("when a=0, matches if currentFollowingSiblingOrder=b", function () {
       var action = new adapt_csscasc.IsNthLastSiblingAction(0, 3);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance(4);
@@ -302,7 +302,7 @@ describe("css-cascade", function () {
 
     it("when a is non-zero, matches if non-negative n which satisfies currentFollowingSiblingOrder=an+b exists", function () {
       var action = new adapt_csscasc.IsNthLastSiblingAction(3, 0);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance(3);
@@ -320,7 +320,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(6);
@@ -339,7 +339,7 @@ describe("css-cascade", function () {
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(2, 3);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(3);
@@ -357,7 +357,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(6);
@@ -370,7 +370,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(8);
@@ -384,7 +384,7 @@ describe("css-cascade", function () {
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(7);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(-3, 0);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(3);
@@ -403,7 +403,7 @@ describe("css-cascade", function () {
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(-2, 5);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(3);
@@ -411,7 +411,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(4);
@@ -423,7 +423,7 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
@@ -437,7 +437,7 @@ describe("css-cascade", function () {
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(8);
@@ -474,7 +474,7 @@ describe("css-cascade", function () {
 
     it("when a=0, matches if currentFollowingSiblingTypeCounts[namespace][locaName]=b", function () {
       var action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(0, 3);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 });
@@ -494,7 +494,7 @@ describe("css-cascade", function () {
 
     it("when a is non-zero, matches if non-negative n which satisfies currentFollowingSiblingTypeCounts[namespace][locaName]=an+b exists", function () {
       var action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(3, 0);
-      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 2 });
@@ -518,7 +518,7 @@ describe("css-cascade", function () {
         foo: { bar: 3, baz: 1 },
       });
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 3 });
@@ -543,7 +543,7 @@ describe("css-cascade", function () {
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(2, 3);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 3 });
@@ -567,7 +567,7 @@ describe("css-cascade", function () {
         foo: { bar: 3, baz: 1 },
       });
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 3 });
@@ -584,7 +584,7 @@ describe("css-cascade", function () {
         foo: { bar: 5, baz: 1 },
       });
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 3 });
@@ -602,7 +602,7 @@ describe("css-cascade", function () {
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(-3, 0);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 3 });
@@ -627,7 +627,7 @@ describe("css-cascade", function () {
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(-2, 5);
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 2 });
@@ -637,7 +637,7 @@ describe("css-cascade", function () {
         foo: { bar: 1, baz: 2 },
       });
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 1 });
@@ -654,7 +654,7 @@ describe("css-cascade", function () {
         foo: { bar: 3, baz: 2 },
       });
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 1 });
@@ -671,7 +671,7 @@ describe("css-cascade", function () {
         foo: { bar: 5, baz: 2 },
       });
 
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 1 });
@@ -706,7 +706,7 @@ describe("css-cascade", function () {
     var wired;
 
     beforeEach(function () {
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
     });
 
@@ -744,7 +744,7 @@ describe("css-cascade", function () {
     var wired;
 
     beforeEach(function () {
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
     });
 
@@ -758,7 +758,7 @@ describe("css-cascade", function () {
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
-    it("applies if the element does not have 'disabled' property", function () {
+    it("not applies if the element does not have 'disabled' property", function () {
       wired.apply({ currentElement: {} });
       expect(chained.apply).not.toHaveBeenCalled();
     });
@@ -770,7 +770,7 @@ describe("css-cascade", function () {
     var wired;
 
     beforeEach(function () {
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
     });
 
@@ -784,7 +784,7 @@ describe("css-cascade", function () {
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
-    it("applies if the element does not have 'disabled' property", function () {
+    it("not applies if the element does not have 'disabled' property", function () {
       wired.apply({ currentElement: {} });
       expect(chained.apply).not.toHaveBeenCalled();
     });
@@ -796,7 +796,7 @@ describe("css-cascade", function () {
     var wired;
 
     beforeEach(function () {
-      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
     });
 
@@ -820,7 +820,7 @@ describe("css-cascade", function () {
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
-    it("applies if the element does not have 'selected' nor 'checked' property", function () {
+    it("not applies if the element does not have 'selected' nor 'checked' property", function () {
       wired.apply({ currentElement: {} });
       expect(chained.apply).not.toHaveBeenCalled();
     });

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -29,111 +29,118 @@ describe("css-cascade", function () {
   describe("IsNthSiblingAction", function () {
     it("when a=0, matches if currentSiblingOrder=b", function () {
       var action = new adapt_csscasc.IsNthSiblingAction(0, 3);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 1 });
+      wired.apply({ currentSiblingOrder: 1 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 3 });
+      wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).toHaveBeenCalled();
     });
 
     it("when a is non-zero, matches if non-negative n which satisfies currentSiblingOrder=an+b exists", function () {
       var action = new adapt_csscasc.IsNthSiblingAction(3, 0);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 1 });
+      wired.apply({ currentSiblingOrder: 1 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 2 });
+      wired.apply({ currentSiblingOrder: 2 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 3 });
+      wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 4 });
+      wired.apply({ currentSiblingOrder: 4 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 5 });
+      wired.apply({ currentSiblingOrder: 5 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 6 });
+      wired.apply({ currentSiblingOrder: 6 });
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(2, 3);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 1 });
+      wired.apply({ currentSiblingOrder: 1 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 2 });
+      wired.apply({ currentSiblingOrder: 2 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 3 });
+      wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 4 });
+      wired.apply({ currentSiblingOrder: 4 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 5 });
+      wired.apply({ currentSiblingOrder: 5 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 6 });
+      wired.apply({ currentSiblingOrder: 6 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 7 });
+      wired.apply({ currentSiblingOrder: 7 });
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(-3, 0);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 1 });
+      wired.apply({ currentSiblingOrder: 1 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 2 });
+      wired.apply({ currentSiblingOrder: 2 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 3 });
+      wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).not.toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(-2, 5);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 1 });
+      wired.apply({ currentSiblingOrder: 1 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 2 });
+      wired.apply({ currentSiblingOrder: 2 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 3 });
+      wired.apply({ currentSiblingOrder: 3 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 4 });
+      wired.apply({ currentSiblingOrder: 4 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 5 });
+      wired.apply({ currentSiblingOrder: 5 });
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply({ currentSiblingOrder: 6 });
+      wired.apply({ currentSiblingOrder: 6 });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply({ currentSiblingOrder: 7 });
+      wired.apply({ currentSiblingOrder: 7 });
       expect(chained.apply).not.toHaveBeenCalled();
     });
   });
@@ -152,111 +159,118 @@ describe("css-cascade", function () {
 
     it("when a=0, matches if currentSiblingTypeCounts[namespace][locaName]=b", function () {
       var action = new adapt_csscasc.IsNthSiblingOfTypeAction(0, 3);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 3, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 3, baz: 3 }));
       expect(chained.apply).toHaveBeenCalled();
     });
 
     it("when a is non-zero, matches if non-negative n which satisfies currentSiblingTypeCounts[namespace][locaName]=an+b exists", function () {
       var action = new adapt_csscasc.IsNthSiblingOfTypeAction(3, 0);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 2, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 2, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 3, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 3, baz: 1 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 4, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 4, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 5, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 5, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 6, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 6, baz: 1 }));
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingOfTypeAction(2, 3);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 2, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 2, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 3, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 3, baz: 1 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 4, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 4, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 5, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 5, baz: 1 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 6, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 6, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 7, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 7, baz: 3 }));
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingOfTypeAction(-3, 0);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 2, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 2, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 3, baz: 3 }));
+      wired.apply(dummyCascadeInstance({ bar: 3, baz: 3 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingOfTypeAction(-2, 5);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 1, baz: 2 }));
+      wired.apply(dummyCascadeInstance({ bar: 1, baz: 2 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 2, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 2, baz: 1 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 3, baz: 2 }));
+      wired.apply(dummyCascadeInstance({ bar: 3, baz: 2 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 4, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 4, baz: 1 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 5, baz: 2 }));
+      wired.apply(dummyCascadeInstance({ bar: 5, baz: 2 }));
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
-      action.apply(dummyCascadeInstance({ bar: 6, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 6, baz: 1 }));
       expect(chained.apply).not.toHaveBeenCalled();
 
-      action.apply(dummyCascadeInstance({ bar: 7, baz: 1 }));
+      wired.apply(dummyCascadeInstance({ bar: 7, baz: 1 }));
       expect(chained.apply).not.toHaveBeenCalled();
     });
   });
@@ -272,160 +286,167 @@ describe("css-cascade", function () {
 
     it("when a=0, matches if currentFollowingSiblingOrder=b", function () {
       var action = new adapt_csscasc.IsNthLastSiblingAction(0, 3);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance(4);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
     });
 
     it("when a is non-zero, matches if non-negative n which satisfies currentFollowingSiblingOrder=an+b exists", function () {
       var action = new adapt_csscasc.IsNthLastSiblingAction(3, 0);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance(3);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
 
       cascadeInstance = dummyCascadeInstance(4);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(6);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
 
       cascadeInstance = dummyCascadeInstance(7);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
 
       cascadeInstance = dummyCascadeInstance(8);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(2, 3);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(3);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
 
       cascadeInstance = dummyCascadeInstance(4);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(6);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
 
       cascadeInstance = dummyCascadeInstance(7);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(8);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
 
       cascadeInstance = dummyCascadeInstance(9);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(7);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(-3, 0);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(3);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
 
       cascadeInstance = dummyCascadeInstance(4);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(-2, 5);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(3);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(4);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
 
       cascadeInstance = dummyCascadeInstance(6);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
 
       cascadeInstance = dummyCascadeInstance(7);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance(8);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
 
       cascadeInstance = dummyCascadeInstance(9);
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingOrder).toBe(7);
     });
@@ -453,19 +474,18 @@ describe("css-cascade", function () {
 
     it("when a=0, matches if currentFollowingSiblingTypeCounts[namespace][locaName]=b", function () {
       var action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(0, 3);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 2, baz: 2 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 3, baz: 1 },
@@ -474,187 +494,195 @@ describe("css-cascade", function () {
 
     it("when a is non-zero, matches if non-negative n which satisfies currentFollowingSiblingTypeCounts[namespace][locaName]=an+b exists", function () {
       var action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(3, 0);
-      var chained = (action.chained = jasmine.createSpyObj("chianed", [
-        "apply",
-      ]));
+      var chained = jasmine.createSpyObj("chianed", ["apply"]);
+      var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 2 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 1, baz: 2 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 2, baz: 2 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 3, baz: 1 },
       });
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 4, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 5, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 6, baz: 1 },
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(2, 3);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 1, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 2, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 3, baz: 1 },
       });
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 4, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 5, baz: 1 },
       });
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 6, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 6, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 7, baz: 3 },
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(-3, 0);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 1, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 2, baz: 3 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 3 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 3, baz: 3 },
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(-2, 5);
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 2 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 1, baz: 2 },
       });
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 2, baz: 1 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 2 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 3, baz: 2 },
       });
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 4, baz: 1 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 2 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 5, baz: 2 },
       });
 
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
 
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 6, baz: 1 },
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 6, baz: 1 });
-      action.apply(cascadeInstance);
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
         foo: { bar: 7, baz: 1 },
@@ -675,18 +703,20 @@ describe("css-cascade", function () {
 
     var action = new adapt_csscasc.IsEmptyAction();
     var chained;
+    var wired;
 
     beforeEach(function () {
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
     });
 
     it("applies if the element has no children", function () {
-      action.apply(dummyCascadeInstance(null));
+      wired.apply(dummyCascadeInstance(null));
       expect(chained.apply).toHaveBeenCalled();
     });
 
     it("applies if the element has only comment nodes or empty text nodes (length=0) as its children", function () {
-      action.apply(
+      wired.apply(
         dummyCascadeInstance([
           { nodeType: Node.COMMENT_NODE, length: 10 },
           { nodeType: Node.TEXT_NODE, length: 0 },
@@ -696,12 +726,12 @@ describe("css-cascade", function () {
     });
 
     it("not applies if the element has an element child", function () {
-      action.apply(dummyCascadeInstance([{ nodeType: Node.ELEMENT_NODE }]));
+      wired.apply(dummyCascadeInstance([{ nodeType: Node.ELEMENT_NODE }]));
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
     it("not applies if the element has a non-empty text node as a child", function () {
-      action.apply(
+      wired.apply(
         dummyCascadeInstance([{ nodeType: Node.TEXT_NODE, length: 1 }]),
       );
       expect(chained.apply).not.toHaveBeenCalled();
@@ -711,23 +741,25 @@ describe("css-cascade", function () {
   describe("IsEnabledAction", function () {
     var action = new adapt_csscasc.IsEnabledAction();
     var chained;
+    var wired;
 
     beforeEach(function () {
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
     });
 
     it("applies if the element's 'disabled' property is false (not undefined)", function () {
-      action.apply({ currentElement: { disabled: false } });
+      wired.apply({ currentElement: { disabled: false } });
       expect(chained.apply).toHaveBeenCalled();
     });
 
     it("not applies if the element's 'disabled' property is true", function () {
-      action.apply({ currentElement: { disabled: true } });
+      wired.apply({ currentElement: { disabled: true } });
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
     it("applies if the element does not have 'disabled' property", function () {
-      action.apply({ currentElement: {} });
+      wired.apply({ currentElement: {} });
       expect(chained.apply).not.toHaveBeenCalled();
     });
   });
@@ -735,23 +767,25 @@ describe("css-cascade", function () {
   describe("IsDisabledAction", function () {
     var action = new adapt_csscasc.IsDisabledAction();
     var chained;
+    var wired;
 
     beforeEach(function () {
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
     });
 
     it("applies if the element's 'disabled' property is true", function () {
-      action.apply({ currentElement: { disabled: true } });
+      wired.apply({ currentElement: { disabled: true } });
       expect(chained.apply).toHaveBeenCalled();
     });
 
     it("not applies if the element's 'disabled' property is false (not undefined)", function () {
-      action.apply({ currentElement: { disabled: false } });
+      wired.apply({ currentElement: { disabled: false } });
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
     it("applies if the element does not have 'disabled' property", function () {
-      action.apply({ currentElement: {} });
+      wired.apply({ currentElement: {} });
       expect(chained.apply).not.toHaveBeenCalled();
     });
   });
@@ -759,33 +793,35 @@ describe("css-cascade", function () {
   describe("IsCheckedAction", function () {
     var action = new adapt_csscasc.IsCheckedAction();
     var chained;
+    var wired;
 
     beforeEach(function () {
-      chained = action.chained = jasmine.createSpyObj("chianed", ["apply"]);
+      chained = jasmine.createSpyObj("chianed", ["apply"]);
+      wired = action.wire(chained);
     });
 
     it("applies if the element's 'selected' property is true", function () {
-      action.apply({ currentElement: { selected: true } });
+      wired.apply({ currentElement: { selected: true } });
       expect(chained.apply).toHaveBeenCalled();
     });
 
     it("applies if the element's 'checked' property is true", function () {
-      action.apply({ currentElement: { checked: true } });
+      wired.apply({ currentElement: { checked: true } });
       expect(chained.apply).toHaveBeenCalled();
     });
 
     it("not applies if the element's 'selected' property is false (not undefined)", function () {
-      action.apply({ currentElement: { selected: false } });
+      wired.apply({ currentElement: { selected: false } });
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
     it("not applies if the element's 'checked' property is false (not undefined)", function () {
-      action.apply({ currentElement: { checked: false } });
+      wired.apply({ currentElement: { checked: false } });
       expect(chained.apply).not.toHaveBeenCalled();
     });
 
     it("applies if the element does not have 'selected' nor 'checked' property", function () {
-      action.apply({ currentElement: {} });
+      wired.apply({ currentElement: {} });
       expect(chained.apply).not.toHaveBeenCalled();
     });
   });
@@ -1178,17 +1214,17 @@ describe("css-cascade", function () {
           "",
           "data-Case",
         );
-        var chained = (action.chained = jasmine.createSpyObj("chained", [
-          "apply",
-        ]));
+        var chained = jasmine.createSpyObj("chained", ["apply"]);
+        var wired = action.wire(chained);
 
-        action.apply({ currentElement: element });
+        wired.apply({ currentElement: element });
         expect(chained.apply).toHaveBeenCalled();
 
         action = new adapt_csscasc.CheckAttributePresentAction("", "data-case");
-        chained = action.chained = jasmine.createSpyObj("chained", ["apply"]);
+        chained = jasmine.createSpyObj("chained", ["apply"]);
+        wired = action.wire(chained);
 
-        action.apply({ currentElement: element });
+        wired.apply({ currentElement: element });
         expect(chained.apply).not.toHaveBeenCalled();
       });
 
@@ -1204,11 +1240,10 @@ describe("css-cascade", function () {
           "open",
           "i",
         );
-        var chained = (action.chained = jasmine.createSpyObj("chained", [
-          "apply",
-        ]));
+        var chained = jasmine.createSpyObj("chained", ["apply"]);
+        var wired = action.wire(chained);
 
-        action.apply({ currentElement: element });
+        wired.apply({ currentElement: element });
         expect(chained.apply).toHaveBeenCalled();
       });
 
@@ -1224,11 +1259,10 @@ describe("css-cascade", function () {
           "ä",
           "i",
         );
-        var chained = (action.chained = jasmine.createSpyObj("chained", [
-          "apply",
-        ]));
+        var chained = jasmine.createSpyObj("chained", ["apply"]);
+        var wired = action.wire(chained);
 
-        action.apply({ currentElement: element });
+        wired.apply({ currentElement: element });
         expect(chained.apply).not.toHaveBeenCalled();
       });
 
@@ -1244,11 +1278,10 @@ describe("css-cascade", function () {
           "open",
           "s",
         );
-        var chained = (action.chained = jasmine.createSpyObj("chained", [
-          "apply",
-        ]));
+        var chained = jasmine.createSpyObj("chained", ["apply"]);
+        var wired = action.wire(chained);
 
-        action.apply({ currentElement: element });
+        wired.apply({ currentElement: element });
         expect(chained.apply).not.toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
refs: #2069

`ChainedAction`はnullableな`chained`フィールドを後付けで配線するしくみで、非nullアサーションを構造的に避ける方法を改めて考える必要がありました。このPRでは`ChainedAction.wire(chained): WiredAction`で配線を、`WiredAction`を継承する`WiredGuard`（条件が成立したら継続）・`WiredConditionScope`（動的範囲を注釈しつつ継続）で既存のサブクラスを表現することで、`chained`がnullである経路を型から排除します。