### PR TITLE
fix: Fix rlh and lh units resolving to zero

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -6353,11 +6353,7 @@ export class CalcFilterVisitor extends Css.FilterVisitor {
       return value;
     }
     const exprText = value.toString().replace(/^calc\b/, "-epubx-expr");
-    if (
-      /\d(%|em|ex|cap|ch|ic|lh|p?v[whbi]|p?vmin|p?vmax)\W|\Wvar\(\s*--/i.test(
-        exprText,
-      )
-    ) {
+    if (this.hasUnresolvableUnit(exprText)) {
       return value;
     }
     const exprVal = CssParser.parseValue(
@@ -6369,7 +6365,7 @@ export class CalcFilterVisitor extends Css.FilterVisitor {
       try {
         const exprResult = exprVal.expr.evaluate(this.context);
         if (typeof exprResult === "number" && !isNaN(exprResult)) {
-          if (/\d(px|in|pt|pc|cm|mm|q|rem|rlh)\W/i.test(exprText)) {
+          if (this.isLengthExpr(exprText)) {
             // length value
             value = new Css.Numeric(exprResult, "px");
           } else if (!/\d[a-z]/i.test(exprText)) {
@@ -6383,6 +6379,16 @@ export class CalcFilterVisitor extends Css.FilterVisitor {
       }
     }
     return value;
+  }
+
+  protected hasUnresolvableUnit(exprText: string): boolean {
+    return /\d(%|em|ex|cap|ch|ic|lh|p?v[whbi]|p?vmin|p?vmax)\W|\Wvar\(\s*--/i.test(
+      exprText,
+    );
+  }
+
+  protected isLengthExpr(exprText: string): boolean {
+    return /\d(px|in|pt|pc|cm|mm|q|rem|rlh)\W/i.test(exprText);
   }
 
   override visitNumeric(numeric: Css.Numeric): Css.Val {
@@ -6402,6 +6408,18 @@ export class CalcFilterVisitor extends Css.FilterVisitor {
       return new Css.Numeric((numeric.num * this.percentRef) / 100, "px");
     }
     return numeric;
+  }
+}
+
+export class RootSizingCalcFilterVisitor extends CalcFilterVisitor {
+  protected override hasUnresolvableUnit(exprText: string): boolean {
+    return /\d(%|em|ex|cap|ch|ic|p?v[whbi]|p?vmin|p?vmax)\W|\Wvar\(\s*--/i.test(
+      exprText,
+    );
+  }
+
+  protected override isLengthExpr(exprText: string): boolean {
+    return /\d(px|in|pt|pc|cm|mm|q|rem|r?lh)\W/i.test(exprText);
   }
 }
 

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -635,7 +635,10 @@ export class Styler implements AbstractStyler {
     const fontSize = elemStyle["font-size"] as CssCascade.CascadeValue;
     let isRelativeFontSize = true;
     if (fontSize && !Css.isDefaultingValue(fontSize.value)) {
-      const val = fontSize.evaluate(this.context);
+      const evaluated = fontSize.evaluate(this.context);
+      const val = this.resolveRootSizingCalc(evaluated);
+      const fromRelativeCalc =
+        evaluated instanceof Css.Func && val instanceof Css.Numeric;
       if (val instanceof Css.Numeric) {
         let px = val.num;
         switch (val.unit) {
@@ -655,7 +658,7 @@ export class Styler implements AbstractStyler {
             if (unitSize) {
               px *= unitSize;
             }
-            isRelativeFontSize = false;
+            isRelativeFontSize = fromRelativeCalc;
           }
         }
         this.context.rootFontSize = px;
@@ -666,8 +669,12 @@ export class Styler implements AbstractStyler {
       this.context.rootFontSize ?? this.context.initialFontSize;
     const lineHeight = elemStyle["line-height"] as CssCascade.CascadeValue;
     let rootLineHeight: number | null = null;
+    let fromRelativeCalc = false;
     if (lineHeight && !Css.isDefaultingValue(lineHeight.value)) {
-      const val = lineHeight.evaluate(this.context);
+      const evaluated = lineHeight.evaluate(this.context);
+      const val = this.resolveRootSizingCalc(evaluated);
+      fromRelativeCalc =
+        evaluated instanceof Css.Func && val instanceof Css.Numeric;
       if (val instanceof Css.Num) {
         rootLineHeight = val.num * rootFontSize;
       } else if (val instanceof Css.Numeric) {
@@ -696,6 +703,17 @@ export class Styler implements AbstractStyler {
     }
     this.context.rootLineHeight =
       rootLineHeight ?? this.context.fontSize() * this.context.pref.lineHeight;
+    this.context.isRootLineHeightFromRelativeCalc = fromRelativeCalc;
+  }
+
+  private resolveRootSizingCalc(val: Css.Val): Css.Val {
+    if (!(val instanceof Css.Func)) {
+      return val;
+    }
+    // filtering visitors always return a value
+    return val.visit(
+      new CssCascade.RootSizingCalcFilterVisitor(this.context),
+    ) as Css.Val;
   }
 
   getTopContainerStyle(): CssCascade.ElementStyle {

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -525,6 +525,7 @@ export class Styler implements AbstractStyler {
       this.cascade.lastCounterChangeTypes,
     );
     this.postprocessTopStyle(style, false);
+    this.determineRootSizes(style);
     switch (this.root.namespaceURI) {
       case Base.NS.XHTML:
         this.bodyReached = false;
@@ -628,75 +629,73 @@ export class Styler implements AbstractStyler {
         }
       }
     }
-    if (!isBody) {
-      // root element
-      const fontSize = elemStyle["font-size"] as CssCascade.CascadeValue;
-      let isRelativeFontSize = true;
-      if (fontSize && !Css.isDefaultingValue(fontSize.value)) {
-        const val = fontSize.evaluate(this.context);
-        if (val instanceof Css.Numeric) {
-          let px = val.num;
-          switch (val.unit) {
-            case "em":
-            case "rem":
-              px *= this.context.initialFontSize;
-              break;
-            case "%":
-              px *= this.context.initialFontSize / 100;
-              break;
-            case "lh":
-            case "rlh":
-              px *=
-                (this.context.initialFontSize * Exprs.defaultUnitSizes["lh"]) /
-                Exprs.defaultUnitSizes["em"];
-              break;
-            default: {
-              const unitSize = Exprs.defaultUnitSizes[val.unit];
-              if (unitSize) {
-                px *= unitSize;
-              }
-              isRelativeFontSize = false;
+  }
+
+  private determineRootSizes(elemStyle: CssCascade.ElementStyle): void {
+    const fontSize = elemStyle["font-size"] as CssCascade.CascadeValue;
+    let isRelativeFontSize = true;
+    if (fontSize && !Css.isDefaultingValue(fontSize.value)) {
+      const val = fontSize.evaluate(this.context);
+      if (val instanceof Css.Numeric) {
+        let px = val.num;
+        switch (val.unit) {
+          case "em":
+          case "rem":
+            px *= this.context.initialFontSize;
+            break;
+          case "%":
+            px *= this.context.initialFontSize / 100;
+            break;
+          case "lh":
+          case "rlh":
+            px *= this.context.rootLineHeight;
+            break;
+          default: {
+            const unitSize = Exprs.defaultUnitSizes[val.unit];
+            if (unitSize) {
+              px *= unitSize;
             }
+            isRelativeFontSize = false;
           }
-          this.context.rootFontSize = px;
-          this.context.isRelativeRootFontSize = isRelativeFontSize;
         }
-      }
-      const rootFontSize =
-        this.context.rootFontSize ?? this.context.initialFontSize;
-      const lineHeight = elemStyle["line-height"] as CssCascade.CascadeValue;
-      if (lineHeight && !Css.isDefaultingValue(lineHeight.value)) {
-        const val = lineHeight.evaluate(this.context);
-        if (val instanceof Css.Num) {
-          this.context.rootLineHeight = val.num * rootFontSize;
-        } else if (val instanceof Css.Numeric) {
-          let px = val.num;
-          switch (val.unit) {
-            case "em":
-            case "rem":
-              px *= rootFontSize;
-              break;
-            case "%":
-              px *= rootFontSize / 100;
-              break;
-            case "lh":
-            case "rlh":
-              px *= this.context.initialFontSize * this.context.pref.lineHeight;
-              break;
-            default: {
-              const unitSize = Exprs.defaultUnitSizes[val.unit];
-              if (unitSize) {
-                px *= unitSize;
-              }
-            }
-          }
-          this.context.rootLineHeight = px;
-        }
-      } else {
-        this.context.rootLineHeight =
-          this.context.fontSize() * this.context.pref.lineHeight;
+        this.context.rootFontSize = px;
+        this.context.isRelativeRootFontSize = isRelativeFontSize;
       }
     }
+    const rootFontSize =
+      this.context.rootFontSize ?? this.context.initialFontSize;
+    const lineHeight = elemStyle["line-height"] as CssCascade.CascadeValue;
+    let rootLineHeight: number | null = null;
+    if (lineHeight && !Css.isDefaultingValue(lineHeight.value)) {
+      const val = lineHeight.evaluate(this.context);
+      if (val instanceof Css.Num) {
+        rootLineHeight = val.num * rootFontSize;
+      } else if (val instanceof Css.Numeric) {
+        let px = val.num;
+        switch (val.unit) {
+          case "em":
+          case "rem":
+            px *= rootFontSize;
+            break;
+          case "%":
+            px *= rootFontSize / 100;
+            break;
+          case "lh":
+          case "rlh":
+            px *= this.context.rootLineHeight;
+            break;
+          default: {
+            const unitSize = Exprs.defaultUnitSizes[val.unit];
+            if (unitSize) {
+              px *= unitSize;
+            }
+          }
+        }
+        rootLineHeight = px;
+      }
+    }
+    this.context.rootLineHeight =
+      rootLineHeight ?? this.context.fontSize() * this.context.pref.lineHeight;
   }
 
   getTopContainerStyle(): CssCascade.ElementStyle {

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -328,6 +328,7 @@ export class Context {
   isRelativeRootFontSize: boolean | null = null;
   fontSize: () => number;
   rootLineHeight: number;
+  isRootLineHeightFromRelativeCalc: boolean = false;
   pref: Preferences;
   scopes: { [key: string]: ScopeContext } = {};
   pageAreaWidth: number | null = null;

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -327,7 +327,7 @@ export class Context {
   rootFontSize: number | null = null;
   isRelativeRootFontSize: boolean | null = null;
   fontSize: () => number;
-  rootLineHeight: number | null = null;
+  rootLineHeight: number;
   pref: Preferences;
   scopes: { [key: string]: ScopeContext } = {};
   pageAreaWidth: number | null = null;
@@ -341,6 +341,7 @@ export class Context {
     public readonly viewportWidth: number,
     public readonly viewportHeight: number,
     fontSize: number,
+    rootLineHeight: number,
   ) {
     this.pageWidth = function () {
       if (this.actualPageWidth) {
@@ -359,6 +360,7 @@ export class Context {
       }
     };
     this.initialFontSize = fontSize;
+    this.rootLineHeight = rootLineHeight;
     this.fontSize = function () {
       if (this.rootFontSize) {
         return this.rootFontSize;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -193,6 +193,7 @@ export class Style {
         viewportWidth,
         viewportHeight,
         fontSize,
+        fontSize * Exprs.defaultPreferencesInstance.lineHeight,
       );
       const viewportProps = CssCascade.mergeAll(context, this.viewportProps);
       const width = viewportProps["width"] as CssCascade.CascadeValue;
@@ -344,7 +345,13 @@ export class StyleInstance
     pageProgression?: Constants.PageProgression,
     isVersoFirstPage?: boolean,
   ) {
-    super(style.rootScope, viewport.width, viewport.height, viewport.fontSize);
+    super(
+      style.rootScope,
+      viewport.width,
+      viewport.height,
+      viewport.fontSize,
+      viewport.fontSize * pref.lineHeight,
+    );
     this.lang = xmldoc.lang || defaultLang;
     this.faces = new Font.DocumentFaces(this.style.fontDeobfuscator);
     this.rootPageFloatLayoutContext = new PageFloats.PageFloatLayoutContext(
@@ -576,6 +583,7 @@ export class StyleInstance
         this.pageWidth(),
         this.pageHeight(),
         this.initialFontSize,
+        this.initialFontSize * Exprs.defaultPreferencesInstance.lineHeight,
       );
       const counterListener = this.counterStore.createCounterListener(
         xmldoc.url,

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1039,11 +1039,9 @@ export class ViewFactory
           } else if (
             name === "line-height" &&
             i === styles.length - 1 &&
-            this.context.rootLineHeight &&
             ((prop.value instanceof Css.Numeric &&
               (prop.value.unit === "lh" || prop.value.unit === "rlh")) ||
-              (prop.value instanceof Css.Func &&
-                this.context.isRootLineHeightFromRelativeCalc))
+              this.context.isRootLineHeightFromRelativeCalc)
           ) {
             // line-height with lh or rlh unit on root element
             prop1 = new CssCascade.CascadeValue(

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1040,8 +1040,10 @@ export class ViewFactory
             name === "line-height" &&
             i === styles.length - 1 &&
             this.context.rootLineHeight &&
-            prop.value instanceof Css.Numeric &&
-            (prop.value.unit === "lh" || prop.value.unit === "rlh")
+            ((prop.value instanceof Css.Numeric &&
+              (prop.value.unit === "lh" || prop.value.unit === "rlh")) ||
+              (prop.value instanceof Css.Func &&
+                this.context.isRootLineHeightFromRelativeCalc))
           ) {
             // line-height with lh or rlh unit on root element
             prop1 = new CssCascade.CascadeValue(

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -51,6 +51,14 @@ module.exports = [
         title: "lh/rlh on the root element itself",
       },
       {
+        file: "rlh_unit/root-calc-line-height.html",
+        title: "lh in calc() on the root line-height",
+      },
+      {
+        file: "rlh_unit/root-calc-font-size.html",
+        title: "lh in calc() on the root font-size",
+      },
+      {
         file: "root-font-var-calc.html",
         title: "rem/rlh with font shorthand var() calc() (Issue #1955)",
       },

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -39,6 +39,18 @@ module.exports = [
       },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
+        file: "rlh_unit/root-line-height-normal.html",
+        title: "rlh with root line-height: normal",
+      },
+      {
+        file: "rlh_unit/root-line-height-numeric.html",
+        title: "rlh with numeric root line-height",
+      },
+      {
+        file: "rlh_unit/root-self-reference.html",
+        title: "lh/rlh on the root element itself",
+      },
+      {
         file: "root-font-var-calc.html",
         title: "rem/rlh with font shorthand var() calc() (Issue #1955)",
       },

--- a/packages/core/test/files/rlh_unit/root-calc-font-size.html
+++ b/packages/core/test/files/rlh_unit/root-calc-font-size.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>lh in calc() on the root font-size</title>
+    <style>
+      html {
+        font-size: calc(2 * 1lh);
+      }
+      .rem-box {
+        width: 100px;
+        height: 1rem;
+        background: teal;
+      }
+      .ref-box {
+        width: 100px;
+        height: 40px;
+        background: green;
+      }
+      .marker {
+        background: orange;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      The root font-size is <code>calc(2 * 1lh)</code>. On the root element
+      <code>lh</code> refers to the initial line height, so the root font size
+      is twice that and the coefficient must not be dropped.
+    </p>
+    <div class="rem-box"></div>
+    <div class="ref-box"></div>
+    <p class="marker">
+      The teal (1rem) and green (40px) boxes above must be the same height.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/rlh_unit/root-calc-line-height.html
+++ b/packages/core/test/files/rlh_unit/root-calc-line-height.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>lh in calc() on the root line-height</title>
+    <style>
+      html {
+        line-height: calc(2 * 1lh);
+      }
+      .rlh-box {
+        width: 100px;
+        height: 1rlh;
+        background: teal;
+      }
+      .ref-box {
+        width: 100px;
+        height: 40px;
+        background: green;
+      }
+      .marker {
+        background: orange;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      The root line-height is <code>calc(2 * 1lh)</code>. On the root element
+      <code>lh</code> refers to the initial line height, so the root line
+      height is twice that and the coefficient must not be dropped.
+    </p>
+    <div class="rlh-box"></div>
+    <div class="ref-box"></div>
+    <p class="marker">
+      The teal (1rlh) and green (40px) boxes above must be the same height.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/rlh_unit/root-line-height-normal.html
+++ b/packages/core/test/files/rlh_unit/root-line-height-normal.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>rlh with root line-height: normal</title>
+    <style>
+      html {
+        line-height: normal;
+      }
+      .rlh-box {
+        width: 100px;
+        height: 3rlh;
+        background: teal;
+      }
+      .marker {
+        background: orange;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      The root element declares <code>line-height: normal</code>. Per CSS
+      Values, <code>rlh</code> must resolve against the resolved (normal) line
+      height of the root element.
+    </p>
+    <div class="rlh-box"></div>
+    <p class="marker">This paragraph must be pushed down by the box above.</p>
+  </body>
+</html>

--- a/packages/core/test/files/rlh_unit/root-line-height-numeric.html
+++ b/packages/core/test/files/rlh_unit/root-line-height-numeric.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>rlh with numeric root line-height</title>
+    <style>
+      html {
+        line-height: 2;
+      }
+      .rlh-box {
+        width: 100px;
+        height: 3rlh;
+        background: teal;
+      }
+      .marker {
+        background: orange;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      The root element declares <code>line-height: 2</code>, so
+      <code>rlh</code> resolves to twice the root font size.
+    </p>
+    <div class="rlh-box"></div>
+    <p class="marker">This paragraph must be pushed down by the box above.</p>
+  </body>
+</html>

--- a/packages/core/test/files/rlh_unit/root-self-reference.html
+++ b/packages/core/test/files/rlh_unit/root-self-reference.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>lh/rlh on the root element itself</title>
+    <style>
+      html {
+        font-size: 2rlh;
+        line-height: 2lh;
+      }
+      .rem-box {
+        width: 100px;
+        height: 1rem;
+        background: teal;
+      }
+      .rlh-box {
+        width: 100px;
+        height: 1rlh;
+        background: purple;
+      }
+      .ref-box {
+        width: 100px;
+        height: 40px;
+        background: green;
+      }
+      .marker {
+        background: orange;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      The root element sizes itself with <code>font-size: 2rlh</code> and
+      <code>line-height: 2lh</code>. Per CSS Values, lh and rlh used on the root
+      element's own font and line-height properties resolve against the initial
+      font and line-height values, so neither depends on the other and both give
+      twice the initial line height.
+    </p>
+    <div class="rem-box"></div>
+    <div class="rlh-box"></div>
+    <div class="ref-box"></div>
+    <p class="marker">
+      The teal (1rem), purple (1rlh) and green (40px) boxes above must all be
+      the same height.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
`rootLineHeight`の`| null`を外す中で気づいた不具合で、`rlh`およびルート要素内での`lh`,`calc(lh)`が不正に0になる（nullを算術に使ってしまう）経路を修正するPRです。追加したテストケースのうち「rlh with root line-height: normal」「lh in calc() on the root line-height」「lh in calc() on the root font-size」に差分が出るのが修正で、ほか2件はリグレッション確認です。