### PR TITLE
fix: Fix the UA base stylesheet ignoring expressions and at-rules

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4699,14 +4699,6 @@ export enum ParseState {
   RULE,
 }
 
-/**
- * Cascade for base User Agent stylesheet.
- */
-export let uaBaseCascade: Cascade = null;
-export function setUABaseCascade(value: Cascade): void {
-  uaBaseCascade = value;
-}
-
 //------------- parsing ------------
 export class CascadeParserHandler
   extends CssParser.SlaveParserHandler
@@ -4735,11 +4727,7 @@ export class CascadeParserHandler
     topLevel: boolean,
   ) {
     super(scope, owner, topLevel);
-    this.cascade = parent
-      ? parent.cascade
-      : uaBaseCascade
-        ? uaBaseCascade.clone()
-        : new Cascade();
+    this.cascade = parent ? parent.cascade : new Cascade();
     this.state = ParseState.TOP;
   }
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -100,13 +100,9 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     authorStyleSheets: OPS.StyleSheetParam[] | null,
     userStyleSheets: OPS.StyleSheetParam[] | null,
   ): Task.Result<EPUBDocStore> {
-    const frame = Task.newFrame<EPUBDocStore>("EPUBDocStore.create");
-    OPS.loadUABase().then(() => {
-      const store = new EPUBDocStore(authorStyleSheets, userStyleSheets);
-      store.triggerSingleDocumentPreprocessing = true;
-      frame.finish(store);
-    });
-    return frame.result();
+    const store = new EPUBDocStore(authorStyleSheets, userStyleSheets);
+    store.triggerSingleDocumentPreprocessing = true;
+    return Task.newResult(store);
   }
 
   makeDeobfuscatorFactory():

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -64,36 +64,6 @@ import {
   UserAgentTocCss,
 } from "./assets";
 
-export const uaStylesheetBaseFetcher: TaskUtil.Fetcher<boolean> =
-  new TaskUtil.Fetcher(() => {
-    const frame: Task.Frame<boolean> = Task.newFrame("uaStylesheetBase");
-    const validatorSet = CssValidator.baseValidatorSet();
-    const url = Base.resolveURL("user-agent-base.css", Base.resourceBaseURL);
-    const handler = new CssCascade.CascadeParserHandler(
-      null,
-      null,
-      null,
-      null,
-      null,
-      validatorSet,
-      true,
-    );
-    handler.startStylesheet(CssParser.StylesheetFlavor.USER_AGENT);
-    CssCascade.setUABaseCascade(handler.cascade);
-    CssParser.parseStylesheetFromText(
-      UserAgentBaseCss,
-      handler,
-      url,
-      null,
-      null,
-    ).thenFinish(frame);
-    return frame.result();
-  }, "uaStylesheetBaseFetcher");
-
-export function loadUABase(): Task.Result<boolean> {
-  return uaStylesheetBaseFetcher.get();
-}
-
 export type FontFace = {
   properties: CssCascade.ElementStyle;
   condition: Exprs.Val;
@@ -3503,6 +3473,13 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
         }
         this.triggersByDocURL[url] = triggers;
         const sources = [] as StyleSource[];
+        sources.push({
+          url: Base.resolveURL("user-agent-base.css", Base.resourceBaseURL),
+          text: UserAgentBaseCss,
+          flavor: CssParser.StylesheetFlavor.USER_AGENT,
+          classes: null,
+          media: null,
+        });
         sources.push({
           url: Base.resolveURL("user-agent-page.css", Base.resourceBaseURL),
           text: UserAgentPageCss,


### PR DESCRIPTION
型の都合が悪いことから気づいた修正です。user-agent-base.cssは文書より先にロードされ、scopeはnullに設定されています。したがってuser-agent-base.css内の`-epubx-expr`名前・関数参照は評価できずにランタイムエラーを発生させます。また[EPUB Adaptive Layout - 2.2. Defining named values: the ‘@-epubx-define’ rule](https://idpf.org/epub/pgt/#s2.2)には「A given name can be defined at most once in all stylesheets referenced by a document.」とあるので、UAも通常のCSSと同様に処理するのが仕様準拠性は高そうです。