### PR TITLE
refactor: Ground expression values and parser handlers in a lexical scope

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4726,9 +4726,9 @@ export class CascadeParserHandler
     parent: CascadeParserHandler,
     public readonly regionId: string | null,
     public readonly validatorSet: CssValidator.ValidatorSet,
-    topLevel: boolean,
+    delegation: CssParser.Delegation | null,
   ) {
-    super(scope, owner, topLevel);
+    super(scope, owner, delegation);
     this.cascade = parent ? parent.cascade : new Cascade();
     this.state = ParseState.TOP;
   }
@@ -5309,43 +5309,55 @@ export class CascadeParserHandler
     funcName: string,
     params?: (number | string)[],
   ): void {
-    let parameterParserHandler: MatchesParameterParserHandler | undefined;
+    let makeParameterParserHandler:
+      | ((delegation: CssParser.Delegation) => MatchesParameterParserHandler)
+      | undefined;
     switch (funcName) {
       case "is":
-        parameterParserHandler = new MatchesParameterParserHandler(this);
+        makeParameterParserHandler = (delegation) =>
+          new MatchesParameterParserHandler(this, delegation);
         break;
       case "not":
-        parameterParserHandler = new NotParameterParserHandler(this);
+        makeParameterParserHandler = (delegation) =>
+          new NotParameterParserHandler(this, delegation);
         break;
       case "where":
-        parameterParserHandler = new WhereParameterParserHandler(this);
+        makeParameterParserHandler = (delegation) =>
+          new WhereParameterParserHandler(this, delegation);
         break;
       case "has":
-        parameterParserHandler = new HasParameterParserHandler(this);
+        makeParameterParserHandler = (delegation) =>
+          new HasParameterParserHandler(this, delegation);
         break;
       case "nth-child":
         if (params && params.length >= 2) {
-          parameterParserHandler = new NthChildOfSelectorParameterParserHandler(
-            this,
-            params[0] as number,
-            params[1] as number,
-          );
+          makeParameterParserHandler = (delegation) =>
+            new NthChildOfSelectorParameterParserHandler(
+              this,
+              delegation,
+              params[0] as number,
+              params[1] as number,
+            );
         }
         break;
       case "nth-last-child":
         if (params && params.length >= 2) {
-          parameterParserHandler =
+          makeParameterParserHandler = (delegation) =>
             new NthLastChildOfSelectorParameterParserHandler(
               this,
+              delegation,
               params[0] as number,
               params[1] as number,
             );
         }
         break;
     }
-    if (parameterParserHandler) {
-      parameterParserHandler.startSelectorRule();
-      this.owner.pushHandler(parameterParserHandler);
+    if (makeParameterParserHandler) {
+      this.owner.delegateTo((delegation) => {
+        const parameterParserHandler = makeParameterParserHandler(delegation);
+        parameterParserHandler.startSelectorRule();
+        return parameterParserHandler;
+      });
     }
   }
 }
@@ -5371,7 +5383,10 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   selectorTexts: string[] = [];
   containsPseudoelementSelector: boolean = false;
 
-  constructor(public readonly parent: CascadeParserHandler) {
+  constructor(
+    public readonly parent: CascadeParserHandler,
+    delegation: CssParser.Delegation,
+  ) {
     super(
       parent.scope,
       parent.owner,
@@ -5379,7 +5394,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
       parent,
       parent.regionId,
       parent.validatorSet,
-      false,
+      delegation,
     );
     this.parentChain = parent.chain;
   }
@@ -5421,7 +5436,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
       this.parentChain.push(new CheckConditionAction("")); // always fails
     }
 
-    this.owner.popHandler();
+    this.endDelegation();
   }
 
   override startRuleBody(): void {
@@ -5448,7 +5463,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
       }
     }
     if (!forgiving) {
-      this.owner.popHandler();
+      this.endDelegation();
     }
   }
 
@@ -5525,10 +5540,11 @@ export class HasParameterParserHandler extends MatchesParameterParserHandler {
 export class NthChildOfSelectorParameterParserHandler extends MatchesParameterParserHandler {
   constructor(
     parent: CascadeParserHandler,
+    delegation: CssParser.Delegation,
     public readonly a: number,
     public readonly b: number,
   ) {
-    super(parent);
+    super(parent, delegation);
   }
 
   override endFuncWithSelector(): void {
@@ -5547,7 +5563,7 @@ export class NthChildOfSelectorParameterParserHandler extends MatchesParameterPa
       this.parentChain.push(new CheckConditionAction("")); // always fails
     }
 
-    this.owner.popHandler();
+    this.endDelegation();
   }
 
   override forgiving(): boolean {
@@ -5575,7 +5591,7 @@ export class NthLastChildOfSelectorParameterParserHandler extends NthChildOfSele
       this.parentChain.push(new CheckConditionAction("")); // always fails
     }
 
-    this.owner.popHandler();
+    this.endDelegation();
   }
 }
 
@@ -5583,8 +5599,9 @@ export class DefineParserHandler extends CssParser.SlaveParserHandler {
   constructor(
     scope: Exprs.LexicalScope,
     owner: CssParser.DispatchParserHandler,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, false);
+    super(scope, owner, delegation);
   }
 
   override property(name: string, value: Css.Val, important: boolean): void {
@@ -5610,9 +5627,10 @@ export class PropSetParserHandler
     public readonly condition: Exprs.Val,
     public readonly elementStyle: ElementStyle,
     public readonly validatorSet: CssValidator.ValidatorSet,
+    delegation: CssParser.Delegation,
     public readonly ruleType?: string,
   ) {
-    super(scope, owner, false);
+    super(scope, owner, delegation);
     this.order = 0;
   }
 

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2020,6 +2020,9 @@ export interface CounterListener {
 }
 
 export interface CounterResolver {
+  readonly rootScope: Exprs.LexicalScope;
+  readonly pageScope: Exprs.LexicalScope;
+
   setStyler(styler: CssStyler.AbstractStyler): void;
 
   /**
@@ -2264,14 +2267,6 @@ export class ContentPropVisitor extends Css.FilterVisitor {
         expr: Exprs.Val,
       ) => void;
     } | null;
-  }
-
-  private getPageScope(): Exprs.LexicalScope | null {
-    return (
-      this.cascade.context as {
-        style?: { pageScope?: Exprs.LexicalScope | null };
-      }
-    )?.style?.pageScope;
   }
 
   private hasLocalCounterResetOrSet(counterName: string): boolean {
@@ -2528,7 +2523,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
       const isPageCounter =
         counterName === "pages" ||
         counterStore?.isPageControlledCounter?.(counterName);
-      const pageScope = this.getPageScope();
+      const pageScope = this.counterResolver.pageScope;
       const nativeExpr = new Exprs.Native(
         pageScope,
         () =>
@@ -2585,7 +2580,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
       const isPageCounter =
         counterName === "pages" ||
         counterStore?.isPageControlledCounter?.(counterName);
-      const pageScope = this.getPageScope();
+      const pageScope = this.counterResolver.pageScope;
       const nativeExpr = new Exprs.Native(
         pageScope,
         () =>
@@ -2840,7 +2835,13 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     if (leader.length == 0) {
       return new Css.Str("");
     }
-    return new Css.Expr(new Exprs.Native(null, () => leader, "viv-leader"));
+    return new Css.Expr(
+      new Exprs.Native(
+        this.counterResolver.rootScope,
+        () => leader,
+        "viv-leader",
+      ),
+    );
   }
 
   override visitFunc(func: Css.Func): Css.Val {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4437,7 +4437,8 @@ export class CascadeInstance {
         // all variables substituted
         const validatorSet = (styler as any)
           .validatorSet as CssValidator.ValidatorSet;
-        const shorthand = validatorSet?.getShorthand(name, value)?.clone();
+        const scope = (styler as any).scope as Exprs.LexicalScope;
+        const shorthand = validatorSet?.getShorthand(name, value)?.clone(scope);
         if (shorthand) {
           if (Css.isDefaultingValue(value)) {
             for (const nameLH of shorthand.propList) {
@@ -4452,7 +4453,7 @@ export class CascadeInstance {
             // cannot handle directly, so normalize it through parseValue
             // before expanding the shorthand to longhands.
             const valueSH = CssParser.parseValue(
-              (styler as any).scope,
+              scope,
               new CssTokenizer.Tokenizer(value.toString(), null),
               "",
             );
@@ -5253,6 +5254,7 @@ export class CascadeParserHandler
       name,
       value,
       important,
+      this.scope,
       this,
     );
   }
@@ -5622,6 +5624,7 @@ export class PropSetParserHandler
         name,
         value,
         important,
+        this.scope,
         this,
       );
     }
@@ -5674,6 +5677,7 @@ export class PropertyParserHandler
       name,
       value,
       important,
+      this.scope,
       this,
     );
   }

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -3416,6 +3416,7 @@ export class PageMarginBoxParserHandler
       name,
       value,
       important,
+      this.scope,
       this,
     );
   }
@@ -3461,6 +3462,7 @@ export class PageFootnoteAreaParserHandler
       name,
       value,
       important,
+      this.scope,
       this,
     );
   }

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -3151,8 +3151,17 @@ export class PageParserHandler
     parent: CssCascade.CascadeParserHandler,
     validatorSet: CssValidator.ValidatorSet,
     private readonly pageProps: { [key: string]: CssCascade.ElementStyle },
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, parent?.condition, parent, null, validatorSet, false);
+    super(
+      scope,
+      owner,
+      parent?.condition,
+      parent,
+      null,
+      validatorSet,
+      delegation,
+    );
   }
 
   override startPageRule(): void {
@@ -3366,13 +3375,16 @@ export class PageParserHandler
       style = pseudoStyle;
     }
 
-    const handler = new PageFootnoteAreaParserHandler(
-      this.scope,
-      this.owner,
-      this.validatorSet,
-      style,
+    this.owner.delegateTo(
+      (delegation) =>
+        new PageFootnoteAreaParserHandler(
+          this.scope,
+          this.owner,
+          this.validatorSet,
+          style,
+          delegation,
+        ),
     );
-    this.owner.pushHandler(handler);
   }
 
   override startPageMarginBoxRule(name: string): void {
@@ -3385,13 +3397,16 @@ export class PageParserHandler
       boxStyle = {} as CssCascade.ElementStyle;
       marginBoxMap[name] = boxStyle;
     }
-    const handler = new PageMarginBoxParserHandler(
-      this.scope,
-      this.owner,
-      this.validatorSet,
-      boxStyle,
+    this.owner.delegateTo(
+      (delegation) =>
+        new PageMarginBoxParserHandler(
+          this.scope,
+          this.owner,
+          this.validatorSet,
+          boxStyle,
+          delegation,
+        ),
     );
-    this.owner.pushHandler(handler);
   }
 }
 
@@ -3407,8 +3422,9 @@ export class PageMarginBoxParserHandler
     owner: CssParser.DispatchParserHandler,
     public readonly validatorSet: CssValidator.ValidatorSet,
     public readonly boxStyle: CssCascade.ElementStyle,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, false);
+    super(scope, owner, delegation);
   }
 
   override property(name: string, value: Css.Val, important: boolean): void {
@@ -3453,8 +3469,9 @@ export class PageFootnoteAreaParserHandler
     owner: CssParser.DispatchParserHandler,
     public readonly validatorSet: CssValidator.ValidatorSet,
     public readonly areaStyle: CssCascade.ElementStyle,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, false);
+    super(scope, owner, delegation);
   }
 
   override property(name: string, value: Css.Val, important: boolean): void {

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -430,17 +430,15 @@ export class SkippingParserHandler extends ParserHandler {
     public readonly topLevel,
   ) {
     super(scope);
-    if (owner) {
-      this.flavor = owner.flavor;
-    }
+    this.flavor = owner.flavor;
   }
 
   override getCurrentToken(): CssTokenizer.Token {
-    return this.owner?.getCurrentToken();
+    return this.owner.getCurrentToken();
   }
 
   override error(mnemonics: string, token: CssTokenizer.Token): void {
-    this.owner?.errorMsg(mnemonics, token);
+    this.owner.errorMsg(mnemonics, token);
   }
 
   override startRuleBody(): void {
@@ -2917,24 +2915,17 @@ export function parseStylesheet(
   classes: string | null,
   media: string | null,
 ): Task.Result<boolean> {
-  const parserHandler = normalizeParserHandler(handler);
   const expandedText = expandNesting(tokenizer.input);
   if (expandedText !== tokenizer.input) {
     return parseStylesheetInternal(
-      new CssTokenizer.Tokenizer(expandedText, parserHandler),
-      parserHandler,
+      new CssTokenizer.Tokenizer(expandedText, handler),
+      handler,
       baseURL,
       classes,
       media,
     );
   }
-  return parseStylesheetInternal(
-    tokenizer,
-    parserHandler,
-    baseURL,
-    classes,
-    media,
-  );
+  return parseStylesheetInternal(tokenizer, handler, baseURL, classes, media);
 }
 
 function parseStylesheetInternal(
@@ -3008,40 +2999,17 @@ export function parseStylesheetFromText(
   classes: string | null,
   media: string | null,
 ): Task.Result<boolean> {
-  const parserHandler = normalizeParserHandler(handler);
   return Task.handle(
     "parseStylesheetFromText",
     (frame) => {
-      const tok = new CssTokenizer.Tokenizer(text, parserHandler);
-      parseStylesheet(tok, parserHandler, baseURL, classes, media).thenFinish(
-        frame,
-      );
+      const tok = new CssTokenizer.Tokenizer(text, handler);
+      parseStylesheet(tok, handler, baseURL, classes, media).thenFinish(frame);
     },
     (frame, err) => {
       Logging.logger.warn(err, `Failed to parse stylesheet text: ${text}`);
       frame.finish(false);
     },
   );
-}
-
-function normalizeParserHandler(handler: ParserHandler): ParserHandler {
-  if (handler instanceof DispatchParserHandler) {
-    return handler;
-  }
-  if (handler instanceof SlaveParserHandler) {
-    if (handler.owner) {
-      return handler.owner;
-    }
-    // Some parser entry points are passed a top-level slave handler. Wrap it in
-    // a dispatch handler once so selector functions parse through the normal
-    // dispatch path and the slave retains a stable owner reference.
-    const dispatchHandler = new DispatchParserHandler();
-    dispatchHandler.flavor = handler.flavor;
-    dispatchHandler.slave = handler;
-    handler.owner = dispatchHandler;
-    return dispatchHandler;
-  }
-  return handler;
 }
 
 export function parseStylesheetFromURL(

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -2901,9 +2901,13 @@ export class ErrorHandler extends ParserHandler {
   }
 }
 
+/**
+ * Parses a stylesheet. Sub-handlers for selector functions and at-rules take
+ * over the parse by pushing themselves onto the dispatch handler's stack.
+ */
 export function parseStylesheet(
   tokenizer: CssTokenizer.Tokenizer,
-  handler: ParserHandler,
+  handler: DispatchParserHandler,
   baseURL: string,
   classes: string | null,
   media: string | null,
@@ -2923,7 +2927,7 @@ export function parseStylesheet(
 
 function parseStylesheetInternal(
   tokenizer: CssTokenizer.Tokenizer,
-  handler: ParserHandler,
+  handler: DispatchParserHandler,
   baseURL: string,
   classes: string | null,
   media: string | null,
@@ -2987,7 +2991,7 @@ function parseStylesheetInternal(
 
 export function parseStylesheetFromText(
   text: string,
-  handler: ParserHandler,
+  handler: DispatchParserHandler,
   baseURL: string,
   classes: string | null,
   media: string | null,
@@ -3007,7 +3011,7 @@ export function parseStylesheetFromText(
 
 export function parseStylesheetFromURL(
   url: string,
-  handler: ParserHandler,
+  handler: DispatchParserHandler,
   classes: string | null,
   media: string | null,
 ): Task.Result<boolean> {

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -2921,7 +2921,7 @@ export class ErrorHandler extends ParserHandler {
 
 /**
  * Parses a stylesheet. Sub-handlers for selector functions and at-rules take
- * over the parse by pushing themselves onto the dispatch handler's stack.
+ * over the parse by delegating from the dispatch handler (see `delegateTo()`).
  */
 export function parseStylesheet(
   tokenizer: CssTokenizer.Tokenizer,

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -77,7 +77,7 @@ export type AttributeSelectorCaseSensitivity = "i" | "s" | null;
 export class ParserHandler implements CssTokenizer.TokenizerHandler {
   flavor: StylesheetFlavor;
 
-  constructor(public scope: Exprs.LexicalScope) {
+  constructor(public readonly scope: Exprs.LexicalScope) {
     this.flavor = StylesheetFlavor.AUTHOR;
   }
 
@@ -216,8 +216,8 @@ export class DispatchParserHandler extends ParserHandler {
   tokenizer: CssTokenizer.Tokenizer | null = null;
   slave: ParserHandler | null = null;
 
-  constructor() {
-    super(null);
+  constructor(scope: Exprs.LexicalScope) {
+    super(scope);
   }
 
   pushHandler(slave: ParserHandler): void {
@@ -1368,9 +1368,6 @@ export class Parser {
 
   makeCondition(classes: string | null, condition: Exprs.Val): Css.Expr {
     const scope = this.handler.getScope();
-    if (!scope) {
-      return null;
-    }
     condition = condition || scope._true;
     if (classes) {
       const classList = classes.split(/\s+/);
@@ -2894,17 +2891,13 @@ export class Parser {
 }
 
 export class ErrorHandler extends ParserHandler {
-  constructor(public readonly scope: Exprs.LexicalScope) {
-    super(null);
+  constructor(scope: Exprs.LexicalScope) {
+    super(scope);
   }
 
   override error(mnemonics: string, token: CssTokenizer.Token): void {
     // throw new Error(mnemonics + " " + token);
     Logging.logger.warn(mnemonics, token.toString());
-  }
-
-  override getScope(): Exprs.LexicalScope {
-    return this.scope;
   }
 }
 

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -211,22 +211,36 @@ export class ParserHandler implements CssTokenizer.TokenizerHandler {
   }
 }
 
-export class DispatchParserHandler extends ParserHandler {
-  stack: ParserHandler[] = [];
+export class Delegation {
+  constructor(readonly outer: ParserHandler) {}
+}
+
+export class DispatchParserHandler<
+  T extends ParserHandler = ParserHandler,
+> extends ParserHandler {
   tokenizer: CssTokenizer.Tokenizer | null = null;
-  slave: ParserHandler | null = null;
 
-  constructor(scope: Exprs.LexicalScope) {
+  readonly initialSlave: T;
+  slave: ParserHandler;
+
+  constructor(
+    scope: Exprs.LexicalScope,
+    makeSlave: (owner: DispatchParserHandler) => T,
+  ) {
     super(scope);
+    this.initialSlave = this.slave = makeSlave(this);
   }
 
-  pushHandler(slave: ParserHandler): void {
-    this.stack.push(this.slave);
+  delegateTo<S extends ParserHandler>(
+    makeSlave: (delegation: Delegation) => S,
+  ): S {
+    const slave = makeSlave(new Delegation(this.slave));
     this.slave = slave;
+    return slave;
   }
 
-  popHandler(): void {
-    this.slave = this.stack.pop();
+  takeBack(delegation: Delegation): void {
+    this.slave = delegation.outer;
   }
 
   override getCurrentToken(): CssTokenizer.Token {
@@ -257,11 +271,8 @@ export class DispatchParserHandler extends ParserHandler {
 
   override startStylesheet(flavor: StylesheetFlavor): void {
     super.startStylesheet(flavor);
-    if (this.stack.length > 0) {
-      // This can occur as a result of an error
-      this.slave = this.stack[0];
-      this.stack = [];
-    }
+    // Handlers left delegation by an error are dropped here.
+    this.slave = this.initialSlave;
     this.slave.startStylesheet(flavor);
   }
 
@@ -427,7 +438,7 @@ export class SkippingParserHandler extends ParserHandler {
   constructor(
     scope: Exprs.LexicalScope,
     public owner: DispatchParserHandler,
-    public readonly topLevel,
+    public readonly delegation: Delegation | null,
   ) {
     super(scope);
     this.flavor = owner.flavor;
@@ -445,9 +456,15 @@ export class SkippingParserHandler extends ParserHandler {
     this.depth++;
   }
 
+  protected endDelegation(): void {
+    if (this.delegation) {
+      this.owner.takeBack(this.delegation);
+    }
+  }
+
   override endRule(): void {
-    if (--this.depth == 0 && !this.topLevel) {
-      this.owner.popHandler();
+    if (--this.depth == 0) {
+      this.endDelegation();
     }
   }
 }
@@ -456,9 +473,9 @@ export class SlaveParserHandler extends SkippingParserHandler {
   constructor(
     scope: Exprs.LexicalScope,
     owner: DispatchParserHandler,
-    topLevel: boolean,
+    delegation: Delegation | null,
   ) {
-    super(scope, owner, topLevel);
+    super(scope, owner, delegation);
   }
 
   report(message: string): void {
@@ -467,8 +484,9 @@ export class SlaveParserHandler extends SkippingParserHandler {
 
   reportAndSkip(message: string): void {
     this.report(message);
-    this.owner.pushHandler(
-      new SkippingParserHandler(this.scope, this.owner, false),
+    this.owner.delegateTo(
+      (delegation) =>
+        new SkippingParserHandler(this.scope, this.owner, delegation),
     );
   }
 

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -1347,7 +1347,7 @@ export class ShorthandValidator extends Css.Visitor {
     return new this(validatorSet, syntax, propList);
   }
 
-  clone(): this {
+  clone(scope: Exprs.LexicalScope): ShorthandValidator {
     return new (this.constructor as any)(
       this.validatorSet,
       this.syntax,
@@ -1719,10 +1719,24 @@ export class BrowserShorthandValidator extends ShorthandValidator {
     super(validatorSet, [], propList);
   }
 
-  override clone(): this {
-    return new (this.constructor as any)(this.validatorSet, this.name, [
-      ...this.propList,
-    ]);
+  override clone(scope: Exprs.LexicalScope): ShorthandValidator {
+    return new ScopedBrowserShorthandValidator(
+      this.validatorSet,
+      this.name,
+      [...this.propList],
+      scope,
+    );
+  }
+}
+
+export class ScopedBrowserShorthandValidator extends BrowserShorthandValidator {
+  constructor(
+    validatorSet: ValidatorSet,
+    name: string,
+    propList: string[],
+    public readonly scope: Exprs.LexicalScope,
+  ) {
+    super(validatorSet, name, propList);
   }
 
   private validateValueText(valueText: string): boolean {
@@ -1743,7 +1757,7 @@ export class BrowserShorthandValidator extends ShorthandValidator {
         continue;
       }
       const parsed = CssParser.parseValue(
-        this.validatorSet.scope,
+        this.scope,
         new CssTokenizer.Tokenizer(valueText, null),
         "",
       );
@@ -1893,7 +1907,6 @@ export class ValidatorSet {
   shorthands: { [key: string]: ShorthandValidator } = {};
   layoutProps: ValueMap = {};
   backgroundProps: ValueMap = {};
-  readonly scope = new Exprs.LexicalScope(null);
   private browserShorthandStyle: CSSStyleDeclaration | null = null;
   private browserShorthandMisses: { [key: string]: true } = {};
   private browserPropertyNamesForAll: string[] | null = null;
@@ -2606,6 +2619,7 @@ export class ValidatorSet {
     name: string,
     value: Css.Val,
     important: boolean,
+    scope: Exprs.LexicalScope,
     receiver: PropertyReceiver,
   ): void {
     const ruleType = (receiver as PropertyReceiver & { ruleType?: string })
@@ -2645,7 +2659,7 @@ export class ValidatorSet {
     const px = this.prefixes[name];
     if (!px || !px[prefix]) {
       if (CSS.supports(origName, value.toString())) {
-        const shorthand = this.getShorthand(shorthandName, value)?.clone();
+        const shorthand = this.getShorthand(shorthandName, value)?.clone(scope);
         if (shorthand) {
           if (Css.isDefaultingValue(value)) {
             shorthand.propagateDefaultingValue(value, important, receiver);
@@ -2691,7 +2705,7 @@ export class ValidatorSet {
         receiver.invalidPropertyValue(origName, value);
       }
     } else {
-      const shorthand = this.getShorthand(name, value)?.clone();
+      const shorthand = this.getShorthand(name, value)?.clone(scope);
       if (!shorthand) {
         receiver.unknownProperty(origName, value);
         return;

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -3267,7 +3267,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         viewport.height,
       );
       const cssMatrix = CssParser.parseValue(
-        null,
+        viewItem.instance.style.rootScope,
         new CssTokenizer.Tokenizer(matrix, null),
         "",
       );

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -549,7 +549,7 @@ export class Context {
   }
 
   queryVal(scope: LexicalScope, key: string): Result | undefined {
-    const s = scope && this.scopes[scope.scopeKey];
+    const s = this.scopes[scope.scopeKey];
     return s ? s[key] : undefined;
   }
 
@@ -566,8 +566,7 @@ export type DependencyCache = {
 export class Val {
   key: string;
 
-  constructor(public scope: LexicalScope) {
-    this.scope = scope;
+  constructor(public readonly scope: LexicalScope) {
     this.key = `_${nextKeyIndex++}`;
   }
 
@@ -627,9 +626,7 @@ export class Val {
       return result;
     }
     result = this.evaluateCore(context);
-    if (this.scope) {
-      context.storeVal(this.scope, this.key, result);
-    }
+    context.storeVal(this.scope, this.key, result);
     return result;
   }
 

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -563,27 +563,22 @@ export type DependencyCache = {
   [key: string]: boolean | Special;
 };
 
-export class Val {
+export abstract class Val {
   key: string;
 
   constructor(public readonly scope: LexicalScope) {
     this.key = `_${nextKeyIndex++}`;
   }
 
-  /** @override */
   toString(): string {
     const buf = new Base.StringBuffer();
     this.appendTo(buf, 0);
     return buf.toString();
   }
 
-  appendTo(buf: Base.StringBuffer, priority: number): void {
-    throw new Error("F_ABSTRACT");
-  }
+  abstract appendTo(buf: Base.StringBuffer, priority: number): void;
 
-  protected evaluateCore(context: Context): Result {
-    throw new Error("F_ABSTRACT");
-  }
+  protected abstract evaluateCore(context: Context): Result;
 
   expand(context: Context, params: Val[]): Val {
     return this;
@@ -635,7 +630,7 @@ export class Val {
   }
 }
 
-export class Prefix extends Val {
+export abstract class Prefix extends Val {
   constructor(
     scope: LexicalScope,
     public val: Val,
@@ -643,13 +638,9 @@ export class Prefix extends Val {
     super(scope);
   }
 
-  protected getOp(): string {
-    throw new Error("F_ABSTRACT");
-  }
+  protected abstract getOp(): string;
 
-  evalPrefix(val: Result): Result {
-    throw new Error("F_ABSTRACT");
-  }
+  abstract evalPrefix(val: Result): Result;
 
   override evaluateCore(context: Context): Result {
     const val = this.val.evaluate(context);
@@ -687,7 +678,7 @@ export class Prefix extends Val {
   }
 }
 
-export class Infix extends Val {
+export abstract class Infix extends Val {
   constructor(
     scope: LexicalScope,
     public lhs: Val,
@@ -696,23 +687,9 @@ export class Infix extends Val {
     super(scope);
   }
 
-  getPriority(): number {
-    throw new Error("F_ABSTRACT");
-  }
+  abstract getPriority(): number;
 
-  getOp(): string {
-    throw new Error("F_ABSTRACT");
-  }
-
-  evalInfix(lhs: Result, rhs: Result): Result {
-    throw new Error("F_ABSTRACT");
-  }
-
-  override evaluateCore(context: Context): Result {
-    const lhs = this.lhs.evaluate(context);
-    const rhs = this.rhs.evaluate(context);
-    return this.evalInfix(lhs, rhs);
-  }
+  abstract getOp(): string;
 
   override dependCore(
     other: Val,
@@ -750,7 +727,17 @@ export class Infix extends Val {
   }
 }
 
-export class Logical extends Infix {
+export abstract class EagerInfix extends Infix {
+  abstract evalInfix(lhs: Result, rhs: Result): Result;
+
+  override evaluateCore(context: Context): Result {
+    const lhs = this.lhs.evaluate(context);
+    const rhs = this.rhs.evaluate(context);
+    return this.evalInfix(lhs, rhs);
+  }
+}
+
+export abstract class Logical extends Infix {
   constructor(scope: LexicalScope, lhs: Val, rhs: Val) {
     super(scope, lhs, rhs);
   }
@@ -760,7 +747,7 @@ export class Logical extends Infix {
   }
 }
 
-export class Comparison extends Infix {
+export abstract class Comparison extends EagerInfix {
   constructor(scope: LexicalScope, lhs: Val, rhs: Val) {
     super(scope, lhs, rhs);
   }
@@ -770,7 +757,7 @@ export class Comparison extends Infix {
   }
 }
 
-export class Additive extends Infix {
+export abstract class Additive extends EagerInfix {
   constructor(scope: LexicalScope, lhs: Val, rhs: Val) {
     super(scope, lhs, rhs);
   }
@@ -780,7 +767,7 @@ export class Additive extends Infix {
   }
 }
 
-export class Multiplicative extends Infix {
+export abstract class Multiplicative extends EagerInfix {
   constructor(scope: LexicalScope, lhs: Val, rhs: Val) {
     super(scope, lhs, rhs);
   }
@@ -1419,6 +1406,10 @@ export class Param extends Val {
   override appendTo(buf: Base.StringBuffer, priority: number): void {
     buf.append("$");
     buf.append(this.index.toString());
+  }
+
+  override evaluateCore(context: Context): Result {
+    throw new Error(`Parameter not expanded: ${this.index}`);
   }
 
   override expand(context: Context, params: Val[]): Val {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -3324,8 +3324,9 @@ export class StyleParserHandler extends CssParser.DispatchParserHandler {
   pageProps = {} as { [key: string]: CssCascade.ElementStyle };
 
   constructor(public readonly validatorSet: CssValidator.ValidatorSet) {
-    super();
-    this.rootScope = new Exprs.LexicalScope(null);
+    const rootScope = new Exprs.LexicalScope(null);
+    super(rootScope);
+    this.rootScope = rootScope;
     this.pageScope = new Exprs.LexicalScope(this.rootScope);
     this.rootBox = new PageMaster.RootPageBox(this.rootScope);
     this.cascadeParserHandler = new BaseParserHandler(this, null, null, null);

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -660,6 +660,7 @@ export class StyleInstance
       name,
       val,
       false,
+      this.style.rootScope,
       supportsReceiver,
     );
     return supported;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -77,8 +77,17 @@ class CounterStyleParserHandler extends CssCascade.PropSetParserHandler {
     validatorSet: CssValidator.ValidatorSet,
     private readonly counterStyleName: string,
     private readonly counterStyles: CounterStyle.CounterStyleStore,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, null, elementStyle, validatorSet, "counter-style");
+    super(
+      scope,
+      owner,
+      null,
+      elementStyle,
+      validatorSet,
+      delegation,
+      "counter-style",
+    );
   }
 
   override endRule(): void {
@@ -3136,19 +3145,15 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
 
   constructor(
     public masterHandler: StyleParserHandler,
+    owner: CssParser.DispatchParserHandler,
+    scope: Exprs.LexicalScope,
+    validatorSet: CssValidator.ValidatorSet,
     condition: Exprs.Val,
     parent: BaseParserHandler,
     regionId: string | null,
+    delegation: CssParser.Delegation | null,
   ) {
-    super(
-      masterHandler.rootScope,
-      masterHandler,
-      condition,
-      parent,
-      regionId,
-      masterHandler.validatorSet,
-      !parent,
-    );
+    super(scope, owner, condition, parent, regionId, validatorSet, delegation);
   }
 
   override startPageTemplateRule(): void {}
@@ -3167,13 +3172,15 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       this.condition,
       this.owner.getBaseSpecificity(),
     );
-    this.masterHandler.pushHandler(
-      new PageMaster.PageMasterParserHandler(
-        pageMaster.scope,
-        this.masterHandler,
-        pageMaster,
-        this.validatorSet,
-      ),
+    this.owner.delegateTo(
+      (delegation) =>
+        new PageMaster.PageMasterParserHandler(
+          pageMaster.scope,
+          this.owner,
+          pageMaster,
+          this.validatorSet,
+          delegation,
+        ),
     );
   }
 
@@ -3182,14 +3189,25 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
     if (this.condition != null) {
       condition = Exprs.and(this.scope, this.condition, condition);
     }
-    this.masterHandler.pushHandler(
-      new BaseParserHandler(this.masterHandler, condition, this, this.regionId),
+    this.owner.delegateTo(
+      (delegation) =>
+        new BaseParserHandler(
+          this.masterHandler,
+          this.owner,
+          this.scope,
+          this.validatorSet,
+          condition,
+          this,
+          this.regionId,
+          delegation,
+        ),
     );
   }
 
   override startDefineRule(): void {
-    this.masterHandler.pushHandler(
-      new CssCascade.DefineParserHandler(this.scope, this.owner),
+    this.owner.delegateTo(
+      (delegation) =>
+        new CssCascade.DefineParserHandler(this.scope, this.owner, delegation),
     );
   }
 
@@ -3199,28 +3217,32 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       properties,
       condition: this.condition,
     });
-    this.masterHandler.pushHandler(
-      new CssCascade.PropSetParserHandler(
-        this.scope,
-        this.owner,
-        null,
-        properties,
-        this.masterHandler.validatorSet,
-        "font-face",
-      ),
+    this.owner.delegateTo(
+      (delegation) =>
+        new CssCascade.PropSetParserHandler(
+          this.scope,
+          this.owner,
+          null,
+          properties,
+          this.masterHandler.validatorSet,
+          delegation,
+          "font-face",
+        ),
     );
   }
 
   override startCounterStyleRule(name: string): void {
-    this.masterHandler.pushHandler(
-      new CounterStyleParserHandler(
-        this.scope,
-        this.owner,
-        {} as CssCascade.ElementStyle,
-        this.masterHandler.validatorSet,
-        name,
-        this.masterHandler.counterStyles,
-      ),
+    this.owner.delegateTo(
+      (delegation) =>
+        new CounterStyleParserHandler(
+          this.scope,
+          this.owner,
+          {} as CssCascade.ElementStyle,
+          this.masterHandler.validatorSet,
+          name,
+          this.masterHandler.counterStyles,
+          delegation,
+        ),
     );
   }
 
@@ -3230,28 +3252,32 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       style = {} as CssCascade.ElementStyle;
       this.masterHandler.flowProps[flowName] = style;
     }
-    this.masterHandler.pushHandler(
-      new CssCascade.PropSetParserHandler(
-        this.scope,
-        this.owner,
-        null,
-        style,
-        this.masterHandler.validatorSet,
-      ),
+    this.owner.delegateTo(
+      (delegation) =>
+        new CssCascade.PropSetParserHandler(
+          this.scope,
+          this.owner,
+          null,
+          style,
+          this.masterHandler.validatorSet,
+          delegation,
+        ),
     );
   }
 
   override startViewportRule(): void {
     const viewportProps = {} as CssCascade.ElementStyle;
     this.masterHandler.viewportProps.push(viewportProps);
-    this.masterHandler.pushHandler(
-      new CssCascade.PropSetParserHandler(
-        this.scope,
-        this.owner,
-        this.condition,
-        viewportProps,
-        this.masterHandler.validatorSet,
-      ),
+    this.owner.delegateTo(
+      (delegation) =>
+        new CssCascade.PropSetParserHandler(
+          this.scope,
+          this.owner,
+          this.condition,
+          viewportProps,
+          this.masterHandler.validatorSet,
+          delegation,
+        ),
     );
   }
 
@@ -3265,13 +3291,15 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
         pseudos[pseudoelem] = style;
       }
     }
-    this.masterHandler.pushHandler(
-      new CssPage.PageFootnoteAreaParserHandler(
-        this.scope,
-        this.owner,
-        this.masterHandler.validatorSet,
-        style,
-      ),
+    this.owner.delegateTo(
+      (delegation) =>
+        new CssPage.PageFootnoteAreaParserHandler(
+          this.scope,
+          this.owner,
+          this.masterHandler.validatorSet,
+          style,
+          delegation,
+        ),
     );
   }
 
@@ -3281,14 +3309,17 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
   }
 
   override startPageRule(): void {
-    const pageHandler = new CssPage.PageParserHandler(
-      this.masterHandler.pageScope,
-      this.masterHandler,
-      this,
-      this.validatorSet,
-      this.masterHandler.pageProps,
+    const pageHandler = this.owner.delegateTo(
+      (delegation) =>
+        new CssPage.PageParserHandler(
+          this.masterHandler.pageScope,
+          this.owner,
+          this,
+          this.validatorSet,
+          this.masterHandler.pageProps,
+          delegation,
+        ),
     );
-    this.masterHandler.pushHandler(pageHandler);
     pageHandler.startPageRule();
   }
 
@@ -3299,23 +3330,29 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       const regionId = `R${this.masterHandler.regionCount++}`;
       this.special("region-id", Css.getName(regionId));
       this.endRule();
-      const regionHandler = new BaseParserHandler(
-        this.masterHandler,
-        this.condition,
-        this,
-        regionId,
+      const regionHandler = this.owner.delegateTo(
+        (delegation) =>
+          new BaseParserHandler(
+            this.masterHandler,
+            this.owner,
+            this.scope,
+            this.validatorSet,
+            this.condition,
+            this,
+            regionId,
+            delegation,
+          ),
       );
-      this.masterHandler.pushHandler(regionHandler);
       regionHandler.startRuleBody();
     }
   }
 }
 
-export class StyleParserHandler extends CssParser.DispatchParserHandler {
-  rootScope: Exprs.LexicalScope;
-  pageScope: Exprs.LexicalScope;
-  rootBox: PageMaster.RootPageBox;
-  cascadeParserHandler: BaseParserHandler;
+export class StyleParserHandler extends CssParser.DispatchParserHandler<BaseParserHandler> {
+  readonly rootScope: Exprs.LexicalScope;
+  readonly pageScope: Exprs.LexicalScope;
+  readonly rootBox: PageMaster.RootPageBox;
+  readonly cascadeParserHandler: BaseParserHandler;
   regionCount: number = 0;
   fontFaces = [] as FontFace[];
   counterStyles = new CounterStyle.CounterStyleStore();
@@ -3326,12 +3363,26 @@ export class StyleParserHandler extends CssParser.DispatchParserHandler {
 
   constructor(public readonly validatorSet: CssValidator.ValidatorSet) {
     const rootScope = new Exprs.LexicalScope(null);
-    super(rootScope);
+    super(
+      rootScope,
+      // The owner is this handler itself, still inside its own super() call,
+      // so the cascade handler takes its scope and validator set directly.
+      (owner) =>
+        new BaseParserHandler(
+          owner as StyleParserHandler,
+          owner,
+          rootScope,
+          validatorSet,
+          null,
+          null,
+          null,
+          null,
+        ),
+    );
     this.rootScope = rootScope;
     this.pageScope = new Exprs.LexicalScope(this.rootScope);
     this.rootBox = new PageMaster.RootPageBox(this.rootScope);
-    this.cascadeParserHandler = new BaseParserHandler(this, null, null, null);
-    this.slave = this.cascadeParserHandler;
+    this.cascadeParserHandler = this.initialSlave;
   }
 }
 

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -2069,8 +2069,9 @@ export class PageBoxParserHandler
     owner: CssParser.DispatchParserHandler,
     public readonly target: PageBox,
     public readonly validatorSet: CssValidator.ValidatorSet,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, false);
+    super(scope, owner, delegation);
   }
 
   override property(name: string, value: Css.Val, important: boolean): void {
@@ -2110,8 +2111,9 @@ export class PartitionParserHandler extends PageBoxParserHandler {
     owner: CssParser.DispatchParserHandler,
     target: Partition,
     validatorSet: CssValidator.ValidatorSet,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, target, validatorSet);
+    super(scope, owner, target, validatorSet, delegation);
   }
 }
 
@@ -2121,8 +2123,9 @@ export class PartitionGroupParserHandler extends PageBoxParserHandler {
     owner: CssParser.DispatchParserHandler,
     target: PartitionGroup,
     validatorSet: CssValidator.ValidatorSet,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, target, validatorSet);
+    super(scope, owner, target, validatorSet, delegation);
     target.specified["width"] = new CssCascade.CascadeValue(
       Css.hundredPercent,
       0,
@@ -2145,13 +2148,16 @@ export class PartitionGroupParserHandler extends PageBoxParserHandler {
       classes,
       this.target,
     );
-    const handler = new PartitionParserHandler(
-      this.scope,
-      this.owner,
-      partition,
-      this.validatorSet,
+    this.owner.delegateTo(
+      (delegation) =>
+        new PartitionParserHandler(
+          this.scope,
+          this.owner,
+          partition,
+          this.validatorSet,
+          delegation,
+        ),
     );
-    this.owner.pushHandler(handler);
   }
 
   override startPartitionGroupRule(
@@ -2166,13 +2172,16 @@ export class PartitionGroupParserHandler extends PageBoxParserHandler {
       classes,
       this.target,
     );
-    const handler = new PartitionGroupParserHandler(
-      this.scope,
-      this.owner,
-      partitionGroup,
-      this.validatorSet,
+    this.owner.delegateTo(
+      (delegation) =>
+        new PartitionGroupParserHandler(
+          this.scope,
+          this.owner,
+          partitionGroup,
+          this.validatorSet,
+          delegation,
+        ),
     );
-    this.owner.pushHandler(handler);
   }
 }
 
@@ -2182,8 +2191,9 @@ export class PageMasterParserHandler extends PageBoxParserHandler {
     owner: CssParser.DispatchParserHandler,
     target: PageMaster,
     validatorSet: CssValidator.ValidatorSet,
+    delegation: CssParser.Delegation,
   ) {
-    super(scope, owner, target, validatorSet);
+    super(scope, owner, target, validatorSet, delegation);
   }
 
   override startPartitionRule(
@@ -2198,13 +2208,16 @@ export class PageMasterParserHandler extends PageBoxParserHandler {
       classes,
       this.target,
     );
-    const handler = new PartitionParserHandler(
-      this.scope,
-      this.owner,
-      partition,
-      this.validatorSet,
+    this.owner.delegateTo(
+      (delegation) =>
+        new PartitionParserHandler(
+          this.scope,
+          this.owner,
+          partition,
+          this.validatorSet,
+          delegation,
+        ),
     );
-    this.owner.pushHandler(handler);
   }
 
   override startPartitionGroupRule(
@@ -2219,12 +2232,15 @@ export class PageMasterParserHandler extends PageBoxParserHandler {
       classes,
       this.target,
     );
-    const handler = new PartitionGroupParserHandler(
-      this.scope,
-      this.owner,
-      partitionGroup,
-      this.validatorSet,
+    this.owner.delegateTo(
+      (delegation) =>
+        new PartitionGroupParserHandler(
+          this.scope,
+          this.owner,
+          partitionGroup,
+          this.validatorSet,
+          delegation,
+        ),
     );
-    this.owner.pushHandler(handler);
   }
 }

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -2078,6 +2078,7 @@ export class PageBoxParserHandler
       name,
       value,
       important,
+      this.scope,
       this,
     );
   }

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -26,6 +26,21 @@ import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
 import * as vivliostyle_test_util_mock_plugin from "../../util/mock/vivliostyle/plugin-mock";
 
 describe("css-cascade", function () {
+  function cascadeParserHandler(scope, validatorSet) {
+    const dispatchHandler = new adapt_cssparse.DispatchParserHandler();
+    const handler = new adapt_csscasc.CascadeParserHandler(
+      scope,
+      dispatchHandler,
+      null,
+      null,
+      null,
+      validatorSet,
+      true,
+    );
+    dispatchHandler.slave = handler;
+    return handler;
+  }
+
   describe("IsNthSiblingAction", function () {
     it("when a=0, matches if currentSiblingOrder=b", function () {
       var action = new adapt_csscasc.IsNthSiblingAction(0, 3);
@@ -847,7 +862,10 @@ describe("css-cascade", function () {
           };
         }
 
-        var handler = new adapt_csscasc.CascadeParserHandler();
+        var handler = cascadeParserHandler(
+          new adapt_exprs.LexicalScope(null),
+          adapt_cssvalid.baseValidatorSet(),
+        );
         var style = (handler.elementStyle = {});
         handler.simpleProperty("foo", adapt_css.getName("bar"), false);
         var originalPriority = style["foo"].priority;
@@ -874,7 +892,10 @@ describe("css-cascade", function () {
       var handler;
 
       beforeEach(function () {
-        handler = new adapt_csscasc.CascadeParserHandler();
+        handler = cascadeParserHandler(
+          new adapt_exprs.LexicalScope(null),
+          adapt_cssvalid.baseValidatorSet(),
+        );
         handler.startSelectorRule();
       });
 

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1368,7 +1368,7 @@ describe("css-cascade", function () {
       var styler = {
         root: element,
         validatorSet: validatorSet,
-        scope: validatorSet.scope,
+        scope: new adapt_exprs.LexicalScope(null),
         getStyle: function (currentElement) {
           return styleMap.get(currentElement) || null;
         },
@@ -1621,7 +1621,7 @@ describe("css-cascade", function () {
       var styler = {
         root: element,
         validatorSet: validatorSet,
-        scope: validatorSet.scope,
+        scope: new adapt_exprs.LexicalScope(null),
         getStyle: function () {
           return style;
         },

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -27,18 +27,20 @@ import * as vivliostyle_test_util_mock_plugin from "../../util/mock/vivliostyle/
 
 describe("css-cascade", function () {
   function cascadeParserHandler(scope, validatorSet) {
-    const dispatchHandler = new adapt_cssparse.DispatchParserHandler(scope);
-    const handler = new adapt_csscasc.CascadeParserHandler(
+    const dispatchHandler = new adapt_cssparse.DispatchParserHandler(
       scope,
-      dispatchHandler,
-      null,
-      null,
-      null,
-      validatorSet,
-      true,
+      (owner) =>
+        new adapt_csscasc.CascadeParserHandler(
+          scope,
+          owner,
+          null,
+          null,
+          null,
+          validatorSet,
+          null,
+        ),
     );
-    dispatchHandler.slave = handler;
-    return handler;
+    return dispatchHandler.initialSlave;
   }
 
   describe("IsNthSiblingAction", function () {

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -27,7 +27,7 @@ import * as vivliostyle_test_util_mock_plugin from "../../util/mock/vivliostyle/
 
 describe("css-cascade", function () {
   function cascadeParserHandler(scope, validatorSet) {
-    const dispatchHandler = new adapt_cssparse.DispatchParserHandler();
+    const dispatchHandler = new adapt_cssparse.DispatchParserHandler(scope);
     const handler = new adapt_csscasc.CascadeParserHandler(
       scope,
       dispatchHandler,

--- a/packages/core/test/spec/vivliostyle/css-page-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-page-spec.js
@@ -198,16 +198,21 @@ describe("css-page", function () {
 
     function createHandler() {
       const scope = new adapt_exprs.LexicalScope(null);
-      const dispatchHandler = new adapt_cssparse.DispatchParserHandler(scope);
-      const handler = new vivliostyle_css_page.PageParserHandler(
+      const dispatchHandler = new adapt_cssparse.DispatchParserHandler(
         scope,
-        dispatchHandler,
-        null,
-        null,
-        pageProps,
+        () => new adapt_cssparse.ParserHandler(scope),
       );
-      dispatchHandler.slave = handler;
-      return handler;
+      return dispatchHandler.delegateTo(
+        (delegation) =>
+          new vivliostyle_css_page.PageParserHandler(
+            scope,
+            dispatchHandler,
+            null,
+            null,
+            pageProps,
+            delegation,
+          ),
+      );
     }
 
     beforeEach(function () {

--- a/packages/core/test/spec/vivliostyle/css-page-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-page-spec.js
@@ -197,15 +197,17 @@ describe("css-page", function () {
     var pageProps, handler;
 
     function createHandler() {
-      return new vivliostyle_css_page.PageParserHandler(
-        null,
-        new adapt_cssparse.DispatchParserHandler(
-          new adapt_exprs.LexicalScope(null),
-        ),
+      const scope = new adapt_exprs.LexicalScope(null);
+      const dispatchHandler = new adapt_cssparse.DispatchParserHandler(scope);
+      const handler = new vivliostyle_css_page.PageParserHandler(
+        scope,
+        dispatchHandler,
         null,
         null,
         pageProps,
       );
+      dispatchHandler.slave = handler;
+      return handler;
     }
 
     beforeEach(function () {

--- a/packages/core/test/spec/vivliostyle/css-page-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-page-spec.js
@@ -19,6 +19,7 @@
 import * as adapt_css from "../../../src/vivliostyle/css";
 import * as adapt_csscasc from "../../../src/vivliostyle/css-cascade";
 import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
+import * as adapt_exprs from "../../../src/vivliostyle/exprs";
 import * as vivliostyle_css_page from "../../../src/vivliostyle/css-page";
 
 describe("css-page", function () {
@@ -198,7 +199,9 @@ describe("css-page", function () {
     function createHandler() {
       return new vivliostyle_css_page.PageParserHandler(
         null,
-        new adapt_cssparse.DispatchParserHandler(),
+        new adapt_cssparse.DispatchParserHandler(
+          new adapt_exprs.LexicalScope(null),
+        ),
         null,
         null,
         pageProps,

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -24,9 +24,9 @@ import * as adapt_task from "../../../src/vivliostyle/task";
 
 describe("css-parser", function () {
   describe("Parser", function () {
-    var handler = new adapt_cssparse.ParserHandler(
-      new adapt_exprs.LexicalScope(null),
-    );
+    var scope = new adapt_exprs.LexicalScope(null);
+    var handler = new adapt_cssparse.DispatchParserHandler(scope);
+    handler.slave = new adapt_cssparse.ParserHandler(scope);
 
     beforeEach(function () {
       spyOn(handler, "error");

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -19,11 +19,14 @@
 import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
 import * as adapt_cssnesting from "../../../src/vivliostyle/css-nesting";
 import * as adapt_csstok from "../../../src/vivliostyle/css-tokenizer";
+import * as adapt_exprs from "../../../src/vivliostyle/exprs";
 import * as adapt_task from "../../../src/vivliostyle/task";
 
 describe("css-parser", function () {
   describe("Parser", function () {
-    var handler = new adapt_cssparse.ParserHandler(null);
+    var handler = new adapt_cssparse.ParserHandler(
+      new adapt_exprs.LexicalScope(null),
+    );
 
     beforeEach(function () {
       spyOn(handler, "error");

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -25,8 +25,10 @@ import * as adapt_task from "../../../src/vivliostyle/task";
 describe("css-parser", function () {
   describe("Parser", function () {
     var scope = new adapt_exprs.LexicalScope(null);
-    var handler = new adapt_cssparse.DispatchParserHandler(scope);
-    handler.slave = new adapt_cssparse.ParserHandler(scope);
+    var handler = new adapt_cssparse.DispatchParserHandler(
+      scope,
+      () => new adapt_cssparse.ParserHandler(scope),
+    );
 
     beforeEach(function () {
       spyOn(handler, "error");

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -26,7 +26,7 @@ import * as vivliostyle_logging from "../../../src/vivliostyle/logging";
 
 describe("css-validator", function () {
   function cascadeParserHandler(scope, validatorSet) {
-    const dispatchHandler = new adapt_cssparse.DispatchParserHandler();
+    const dispatchHandler = new adapt_cssparse.DispatchParserHandler(scope);
     const handler = new adapt_csscasc.CascadeParserHandler(
       scope,
       dispatchHandler,

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -465,7 +465,7 @@ describe("css-validator", function () {
       });
     });
 
-    it("should parse selector functions with a top-level cascade handler", function (done) {
+    it("should parse selector functions through the dispatch owner", function (done) {
       var validatorSet = adapt_cssvalid.baseValidatorSet();
       var handler = cascadeParserHandler(validatorSet);
       handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -25,7 +25,8 @@ import * as adapt_task from "../../../src/vivliostyle/task";
 import * as vivliostyle_logging from "../../../src/vivliostyle/logging";
 
 describe("css-validator", function () {
-  function cascadeParserHandler(scope, validatorSet) {
+  function cascadeParserHandler(validatorSet) {
+    const scope = new adapt_exprs.LexicalScope(null);
     const dispatchHandler = new adapt_cssparse.DispatchParserHandler(scope);
     const handler = new adapt_csscasc.CascadeParserHandler(
       scope,
@@ -41,11 +42,8 @@ describe("css-validator", function () {
   }
 
   function parseCascade(cssText, done, callback) {
-    var handler = cascadeParserHandler(
-      new adapt_exprs.LexicalScope(null),
-      adapt_cssvalid.baseValidatorSet(),
-    );
-    handler.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
+    var handler = cascadeParserHandler(adapt_cssvalid.baseValidatorSet());
+    handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
     adapt_task.start(function () {
       adapt_cssparse
         .parseStylesheetFromText(cssText, handler.owner, null, null, null)
@@ -384,7 +382,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo-or = bar | [ baz || biz ];");
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -436,7 +434,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = bAr | Baz | bIZ ;");
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -469,8 +467,8 @@ describe("css-validator", function () {
 
     it("should parse selector functions with a top-level cascade handler", function (done) {
       var validatorSet = adapt_cssvalid.baseValidatorSet();
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
-      handler.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
+      var handler = cascadeParserHandler(validatorSet);
+      handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -495,8 +493,8 @@ describe("css-validator", function () {
     });
     it("should parse semantic footnote noteref default selectors", function (done) {
       var validatorSet = adapt_cssvalid.baseValidatorSet();
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
-      handler.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
+      var handler = cascadeParserHandler(validatorSet);
+      handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -523,7 +521,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = SPACE(IDENT+);");
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -551,7 +549,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = COMMA( IDENT+ );");
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -579,7 +577,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo-comma = none | COMMA( [ bar | baz ]+ );");
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -607,7 +605,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("spacefoo = none | SPACE( [ bar | baz ]+ );");
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -641,7 +639,7 @@ describe("css-validator", function () {
         "accept-function = COMMA(AC_VALUES+);";
 
       validatorSet.parse(validation_txt);
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -671,7 +669,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = bar( SPACE( POS_NUM [ SLASH POS_NUM ]? ) );");
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -720,7 +718,7 @@ describe("css-validator", function () {
           "SHORTHANDS\n\n" +
           "font = FONT font-style font-variant font-weight font-stretch ;",
       );
-      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
+      var handler = cascadeParserHandler(validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -25,20 +25,30 @@ import * as adapt_task from "../../../src/vivliostyle/task";
 import * as vivliostyle_logging from "../../../src/vivliostyle/logging";
 
 describe("css-validator", function () {
-  function parseCascade(cssText, done, callback) {
-    var handler = new adapt_csscasc.CascadeParserHandler(
+  function cascadeParserHandler(scope, validatorSet) {
+    const dispatchHandler = new adapt_cssparse.DispatchParserHandler();
+    const handler = new adapt_csscasc.CascadeParserHandler(
+      scope,
+      dispatchHandler,
       null,
       null,
       null,
-      null,
-      null,
-      adapt_cssvalid.baseValidatorSet(),
+      validatorSet,
       true,
+    );
+    dispatchHandler.slave = handler;
+    return handler;
+  }
+
+  function parseCascade(cssText, done, callback) {
+    var handler = cascadeParserHandler(
+      new adapt_exprs.LexicalScope(null),
+      adapt_cssvalid.baseValidatorSet(),
     );
     handler.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
     adapt_task.start(function () {
       adapt_cssparse
-        .parseStylesheetFromText(cssText, handler, null, null, null)
+        .parseStylesheetFromText(cssText, handler.owner, null, null, null)
         .then(function (result) {
           expect(result).toBe(true);
           callback(handler.finish(), handler);
@@ -374,15 +384,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo-or = bar | [ baz || biz ];");
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -392,7 +394,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             ".test { foo-or: bar; }\n.test2 { foo-or: baz biz; }",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -434,15 +436,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = bAr | Baz | bIZ ;");
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -459,7 +453,7 @@ describe("css-validator", function () {
               ".test6 { foo: BAZ; }" +
               ".test6 { foo: biz; }" +
               "",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -475,15 +469,7 @@ describe("css-validator", function () {
 
     it("should parse selector functions with a top-level cascade handler", function (done) {
       var validatorSet = adapt_cssvalid.baseValidatorSet();
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       handler.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
@@ -494,7 +480,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             '@namespace epub "http://www.idpf.org/2007/ops";\n:not(a[epub|type~="noteref"], a[epub\\:type~="noteref"], a[role~="doc-noteref"])::footnote-call { content: counter(footnote); }',
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -509,15 +495,7 @@ describe("css-validator", function () {
     });
     it("should parse semantic footnote noteref default selectors", function (done) {
       var validatorSet = adapt_cssvalid.baseValidatorSet();
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       handler.startStylesheet(adapt_cssparse.StylesheetFlavor.USER_AGENT);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
@@ -528,7 +506,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             '@namespace epub "http://www.idpf.org/2007/ops";\na[epub|type="noteref"]:not(sup > *, :has(> sup)),\na[epub\\:type="noteref"]:not(sup > *, :has(> sup)),\na[role="doc-noteref"]:not(sup > *, :has(> sup)) { font-size: 0.75em; vertical-align: super; line-height: 0; }',
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -545,15 +523,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = SPACE(IDENT+);");
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -563,7 +533,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             ".test { foo: bar; }\n.test2 { foo: bar baz boo; }",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -581,15 +551,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = COMMA( IDENT+ );");
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -599,7 +561,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             ".test { foo: bar,baz; }\n .test2{ foo: bar; }",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -617,15 +579,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo-comma = none | COMMA( [ bar | baz ]+ );");
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -635,7 +589,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             ".test { foo-comma: none; }\n.test2 { foo-comma: bar,baz; }\n .test3 { foo-comma: bar; }",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -653,15 +607,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("spacefoo = none | SPACE( [ bar | baz ]+ );");
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -671,7 +617,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             ".test { spacefoo: none; }\n.test2 { spacefoo: bar baz; }\n .test3 { spacefoo: bar; }",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -695,15 +641,7 @@ describe("css-validator", function () {
         "accept-function = COMMA(AC_VALUES+);";
 
       validatorSet.parse(validation_txt);
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -716,7 +654,7 @@ describe("css-validator", function () {
               ".test2 { accept-function: the-function(foo bar, bar baz); }\n" +
               ".test3 { accept-function: the-function(fff, foo bar, bar baz); }\n" +
               ".test4 { accept-function: the-function(bb bz, foo bar, bar baz); }",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -733,15 +671,7 @@ describe("css-validator", function () {
       var validatorSet = new adapt_cssvalid.ValidatorSet();
       validatorSet.initBuiltInValidators();
       validatorSet.parse("foo = bar( SPACE( POS_NUM [ SLASH POS_NUM ]? ) );");
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -751,7 +681,7 @@ describe("css-validator", function () {
         adapt_cssparse
           .parseStylesheetFromText(
             ".test { foo: bar( 10 / 10 ) ; }\n" + ".test2 { foo: bar( 10 ) ; }",
-            handler,
+            handler.owner,
             null,
             null,
             null,
@@ -790,15 +720,7 @@ describe("css-validator", function () {
           "SHORTHANDS\n\n" +
           "font = FONT font-style font-variant font-weight font-stretch ;",
       );
-      var handler = new adapt_csscasc.CascadeParserHandler(
-        null,
-        null,
-        null,
-        null,
-        null,
-        validatorSet,
-        true,
-      );
+      var handler = cascadeParserHandler(validatorSet.scope, validatorSet);
       var warnListener = jasmine.createSpy("warn listener");
       vivliostyle_logging.logger.addListener(
         vivliostyle_logging.LogLevel.WARN,
@@ -814,7 +736,7 @@ describe("css-validator", function () {
               '.test5 { font: oblique small-caps bold ultra-condensed 12px/14px "Times" ; }\n' +
               '.test6 { font: small-caps wider oblique 12px "Times" ; }\n' +
               ".test7 { font: status-bar ; }",
-            handler,
+            handler.owner,
             null,
             null,
             null,

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -27,18 +27,20 @@ import * as vivliostyle_logging from "../../../src/vivliostyle/logging";
 describe("css-validator", function () {
   function cascadeParserHandler(validatorSet) {
     const scope = new adapt_exprs.LexicalScope(null);
-    const dispatchHandler = new adapt_cssparse.DispatchParserHandler(scope);
-    const handler = new adapt_csscasc.CascadeParserHandler(
+    const dispatchHandler = new adapt_cssparse.DispatchParserHandler(
       scope,
-      dispatchHandler,
-      null,
-      null,
-      null,
-      validatorSet,
-      true,
+      (owner) =>
+        new adapt_csscasc.CascadeParserHandler(
+          scope,
+          owner,
+          null,
+          null,
+          null,
+          validatorSet,
+          null,
+        ),
     );
-    dispatchHandler.slave = handler;
-    return handler;
+    return dispatchHandler.initialSlave;
   }
 
   function parseCascade(cssText, done, callback) {


### PR DESCRIPTION
`Val.scope`のnullableを外すことから波及する範囲のPRです。唯一nullを渡していたリーダーの`Native`に`CounterResolver`経由で`rootScope`を供給し、`ContentPropVisitor`がキャストで`pageScope`を掘り出していた箇所も同じ経路に寄せます。入口で`owner`を後付け配線していた`normalizeParserHandler`を削除し、`owner`と`scope`をコンストラクタで受け取ってnullが入る経路を塞ぎます。

あわせて`F_ABSTRACT`ランタイムエラーで表現されている抽象クラスをTypeScriptの`abstract`で表現し直します。`evalInfix`をabstractにしたことから短絡評価する`Logical`と両辺を評価する`EagerInfix`を分け継承関係を整理します。