### PR TITLE
refactor: Read a leader's block container from its node context

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2931,6 +2931,20 @@ function getContentWidth(
   return totalWidth;
 }
 
+function asLeaderNodeContext(
+  c: Vtree.RenderedNodeContext,
+): Vtree.ContainedElementNodeContext | null {
+  const element = Vtree.asElementNodeContext(c);
+  return element !== null &&
+    element.after &&
+    element.viewNode.hasAttribute("data-viv-leader") &&
+    // a leader is generated as the content of a pseudo element, so it is
+    // always built under a parent
+    element.blockContainer !== null
+    ? (element as Vtree.ContainedElementNodeContext)
+    : null;
+}
+
 /**
  * POST_LAYOUT_BLOCK hook function for CSS leader()
  * @param nodeContext
@@ -2942,28 +2956,17 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
   checkPoints: Vtree.RenderedNodeContext[],
   column: Layout.Column,
 ) => {
-  const leaders: {
-    leaderContext: Vtree.RenderedNodeContext;
-    pseudoElem: HTMLElement;
-    pseudoParent: HTMLElement;
-  }[] = [];
-  for (const c of checkPoints) {
-    const leaderElem =
-      c.after && c.viewNode.nodeType === 1 ? (c.viewNode as Element) : null;
-    const pseudoElem = leaderElem?.getAttribute("data-viv-leader")
-      ? leaderElem.parentElement
-      : null;
+  const leaders = checkPoints.flatMap((c) => {
+    const leaderContext = asLeaderNodeContext(c);
+    const pseudoElem = leaderContext?.viewNode.parentElement;
     const pseudoParent = pseudoElem?.parentElement;
-    if (leaderElem && pseudoElem && pseudoParent) {
-      leaders.push({ leaderContext: c, pseudoElem, pseudoParent });
-    }
-  }
+    return leaderContext && pseudoElem && pseudoParent
+      ? [{ leaderContext, pseudoElem, pseudoParent }]
+      : [];
+  });
   for (const { leaderContext: c, pseudoElem, pseudoParent } of leaders) {
-    // we want to access the bottom block element, which contains single leader().
-    let container = c.parent;
-    while (container && container.inline) {
-      container = container.parent;
-    }
+    // the bottom block element, which contains single leader()
+    const container = c.blockContainer;
     const leaderElem = c.viewNode as HTMLElement;
     const pseudoName = pseudoElem.getAttribute("data-adapt-pseudo");
     const leader = leaderElem.getAttribute("data-viv-leader-value");
@@ -3009,9 +3012,7 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
       columnContainer.style.columnFill = "auto";
     }
 
-    const box = column.clientLayout.getElementClientRect(
-      container.viewNode as Element,
-    );
+    const box = column.clientLayout.getElementClientRect(container.viewNode);
     const innerInit = column.clientLayout.getElementClientRect(pseudoElem);
     const innerMarginInlineEnd = column.parseComputedLength(marginInlineEnd);
 
@@ -3022,7 +3023,7 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
     let topmostInlineAncestor: Element = pseudoParent;
     while (
       topmostInlineAncestor.parentElement &&
-      topmostInlineAncestor.parentElement !== (container.viewNode as Element)
+      topmostInlineAncestor.parentElement !== container.viewNode
     ) {
       topmostInlineAncestor = topmostInlineAncestor.parentElement;
     }

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1347,6 +1347,7 @@ export namespace Vtree {
 
     sourceNode: Node;
     parent: NodeContext | null;
+    blockContainer: ElementNodeContext | null;
     boxOffset: number;
 
     resetView(): void;
@@ -1378,6 +1379,10 @@ export namespace Vtree {
   }
 
   export type RenderedNodeContext = ElementNodeContext | TextNodeContext;
+
+  export interface ContainedElementNodeContext extends ElementNodeContext {
+    blockContainer: ElementNodeContext;
+  }
 
   export interface FloatNodeContext extends ElementNodeContext {
     floatSide: string;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2470,13 +2470,11 @@ export class ViewFactory
       }
     }
 
-    const startBreakType =
-      (
-        this.context as Exprs.Context & {
-          pageLayout: { position: Vtree.LayoutPosition } | null;
-        }
-      )?.pageLayout?.position.flowPositions[this.flowName]?.startBreakType ??
-      null;
+    const startBreakType = (
+      this.context as Exprs.Context & {
+        currentLayoutPosition: Vtree.LayoutPosition;
+      }
+    )?.currentLayoutPosition?.flowPositions[this.flowName]?.startBreakType;
 
     if (Break.isForcedBreakValue(startBreakType)) {
       return startBreakType; // forced break

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2927,7 +2927,7 @@ export class ViewFactory
       nextPos = null;
     }
     if (contentNode) {
-      const r = Vtree.NodeContext.siblingOf(contentNode, pos, boxOffset);
+      const r = Vtree.NodeContext.childOf(contentNode, pos.parent, boxOffset);
       r.shadowContext = contentShadow;
       r.shadowType = contentShadowType;
       r.shadowSibling = nextPos;
@@ -3093,7 +3093,7 @@ export class ViewFactory
     // Create NodeContext for footnote-call with the same parent as footnote
     const footnoteCallContext = Vtree.NodeContext.siblingOf(
       footnoteCallSourceNode,
-      footnoteNodeContext as Vtree.ChildNodeContext,
+      footnoteNodeContext,
       footnoteNodeContext.boxOffset,
     );
 

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2470,11 +2470,13 @@ export class ViewFactory
       }
     }
 
-    const startBreakType = (
-      this.context as Exprs.Context & {
-        currentLayoutPosition: Vtree.LayoutPosition;
-      }
-    )?.currentLayoutPosition?.flowPositions[this.flowName]?.startBreakType;
+    const startBreakType =
+      (
+        this.context as Exprs.Context & {
+          pageLayout: { position: Vtree.LayoutPosition } | null;
+        }
+      )?.pageLayout?.position.flowPositions[this.flowName]?.startBreakType ??
+      null;
 
     if (Break.isForcedBreakValue(startBreakType)) {
       return startBreakType; // forced break
@@ -2898,7 +2900,6 @@ export class ViewFactory
     }
     const boxOffset = pos.boxOffset;
     const shadow = pos.shadowContext;
-    const parent = pos.parent;
 
     // content that will be inserted
     let contentNode: Node | null;
@@ -2928,7 +2929,7 @@ export class ViewFactory
       nextPos = null;
     }
     if (contentNode) {
-      const r = Vtree.NodeContext.childOf(contentNode, parent, boxOffset);
+      const r = Vtree.NodeContext.siblingOf(contentNode, pos, boxOffset);
       r.shadowContext = contentShadow;
       r.shadowType = contentShadowType;
       r.shadowSibling = nextPos;
@@ -3092,9 +3093,9 @@ export class ViewFactory
     );
 
     // Create NodeContext for footnote-call with the same parent as footnote
-    const footnoteCallContext = new Vtree.NodeContext(
+    const footnoteCallContext = Vtree.NodeContext.siblingOf(
       footnoteCallSourceNode,
-      footnoteNodeContext.parent as Vtree.NodeContext,
+      footnoteNodeContext as Vtree.ChildNodeContext,
       footnoteNodeContext.boxOffset,
     );
 
@@ -3693,11 +3694,14 @@ export class ViewFactory
       .loop(() => {
         while (i >= 0) {
           const pn = arr[i];
+          const parentContext = rebuilt ?? container.parent;
           const child = new Vtree.NodeContext(
             pn.sourceNode,
-            rebuilt ?? container.parent,
+            parentContext,
             boxOffset,
           );
+          child.blockContainer =
+            parentContext && Vtree.blockContainerForChildrenOf(parentContext);
           if (i == 0) {
             child.offsetInNode = offsetInNode;
             child.after = after;

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -488,7 +488,9 @@ export function makeNodeContextFromNodePositionStep(
   step: NodePositionStep,
   parent: Vtree.NodeContext,
 ): NodeContext {
-  const nodeContext = new NodeContext(step.node, parent as NodeContext, 0);
+  const parentContext = parent as NodeContext;
+  const nodeContext = new NodeContext(step.node, parentContext, 0);
+  nodeContext.blockContainer = blockContainerForChildrenOf(parentContext);
   applyNodePositionStep(nodeContext, step);
   nodeContext.shadowSibling = step.shadowSibling
     ? makeNodeContextFromNodePositionStep(step.shadowSibling, parent.copy())
@@ -635,13 +637,26 @@ export class NodeContext implements Vtree.NodeContext {
   afterIfContinues: Selectors.AfterIfContinues | null = null;
   footnotePolicy: Css.Ident | null = null;
   pageType: string | null;
+  blockContainer: ElementNodeContext | null = null;
 
   static childOf(
     sourceNode: Node,
     parent: NodeContext,
     boxOffset: number,
   ): ChildNodeContext {
-    return new NodeContext(sourceNode, parent, boxOffset) as ChildNodeContext;
+    const nodeContext = new NodeContext(sourceNode, parent, boxOffset);
+    nodeContext.blockContainer = blockContainerForChildrenOf(parent);
+    return nodeContext as ChildNodeContext;
+  }
+
+  static siblingOf(
+    sourceNode: Node,
+    sibling: ChildNodeContext,
+    boxOffset: number,
+  ): ChildNodeContext {
+    const nodeContext = new NodeContext(sourceNode, sibling.parent, boxOffset);
+    nodeContext.blockContainer = sibling.blockContainer;
+    return nodeContext as ChildNodeContext;
   }
 
   constructor(
@@ -744,6 +759,7 @@ export class NodeContext implements Vtree.NodeContext {
     np.afterIfContinues = this.afterIfContinues;
     np.footnotePolicy = this.footnotePolicy;
     np.pageType = this.pageType;
+    np.blockContainer = this.blockContainer;
     return np;
   }
 
@@ -768,12 +784,17 @@ export class NodeContext implements Vtree.NodeContext {
 
   clone(): this {
     const np = this.cloneItem();
+    const chain: NodeContext[] = [np];
     let npc: NodeContext = np;
     let npp: NodeContext | null;
     while ((npp = npc.parent) != null) {
       npp = npp.cloneItem();
       npc.parent = npp;
       npc = npp;
+      chain.push(npp);
+    }
+    for (let i = chain.length - 2; i >= 0; i--) {
+      chain[i].blockContainer = blockContainerForChildrenOf(chain[i + 1]);
     }
     return np;
   }
@@ -940,6 +961,18 @@ export function asRenderedNodeContext(
   nc: Vtree.NodeContext,
 ): RenderedNodeContext | null {
   return asElementNodeContext(nc) ?? asTextNodeContext(nc);
+}
+
+export type ContainedElementNodeContext = NodeContext &
+  Vtree.ContainedElementNodeContext;
+
+export function blockContainerForChildrenOf(
+  parent: NodeContext,
+): ElementNodeContext | null {
+  const element = asElementNodeContext(parent);
+  return element && !(parent.inline && parent.blockContainer)
+    ? element
+    : parent.blockContainer;
 }
 
 export class ChunkPosition implements Vtree.ChunkPosition {

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -651,12 +651,12 @@ export class NodeContext implements Vtree.NodeContext {
 
   static siblingOf(
     sourceNode: Node,
-    sibling: ChildNodeContext,
+    sibling: NodeContext,
     boxOffset: number,
-  ): ChildNodeContext {
+  ): NodeContext {
     const nodeContext = new NodeContext(sourceNode, sibling.parent, boxOffset);
     nodeContext.blockContainer = sibling.blockContainer;
-    return nodeContext as ChildNodeContext;
+    return nodeContext;
   }
 
   constructor(


### PR DESCRIPTION
リーダーの`POST_LAYOUT_BLOCK`フックでは、`getAttribute("data-viv-leader")`の判定でブロックコンテナを必ず持つことを暗黙に表現していました。`blockContainer`をNodeContextに持たせ、`ContainedElementNodeContext`にブロックコンテナを必ず持つNodeContextを分離し、`asLeaderNodeContext`でガードします。ここで`blockContainer !== null`は恒真です。本来的にはフック＋対応する生成の間で要素の型の絞り込みが行なわれるとよいのだと思いますが、全体への影響が大きいと考えています。些細なこととして、`checkPoints.flatMap`とすれば`leaders`の型は推論で決められます。