### PR TITLE
chore: Raise the TypeScript target to ES2019

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,8 +4,8 @@
   "version": "2.44.1",
   "author": "Vivliostyle Foundation",
   "scripts": {
-    "build": "tsc --emitDeclarationOnly && esbuild src/vivliostyle.ts --bundle --outfile=lib/vivliostyle.js --format=cjs --define:VIVLIOSTYLE_DEBUG=false --minify --sourcemap --target=es2018",
-    "build-dev": "tsc --emitDeclarationOnly && esbuild src/vivliostyle.ts --bundle --outfile=lib/vivliostyle.js --format=cjs --define:VIVLIOSTYLE_DEBUG=true --sourcemap --target=es2018",
+    "build": "tsc --emitDeclarationOnly && esbuild src/vivliostyle.ts --bundle --outfile=lib/vivliostyle.js --format=cjs --define:VIVLIOSTYLE_DEBUG=false --minify --sourcemap --target=es2019",
+    "build-dev": "tsc --emitDeclarationOnly && esbuild src/vivliostyle.ts --bundle --outfile=lib/vivliostyle.js --format=cjs --define:VIVLIOSTYLE_DEBUG=true --sourcemap --target=es2019",
     "clean": "shx rm -rf lib/* .cache",
     "dev": "yarn build-dev --watch=forever",
     "format": "prettier --write \"{*.{js,md,json},{src,types,test,resources}/**/*.{ts,js}}\"",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,11 +3,11 @@
   "exclude": ["node_modules", "examples"],
   "compilerOptions": {
     /* Basic Options */
-    "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "target": "ES2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "moduleResolution": "bundler",
     "lib": [
-      "es2018",
+      "es2019",
       "dom",
       "dom.iterable"
     ] /* Specify library files to be included in the compilation. */,

--- a/packages/viewer/tsconfig.json
+++ b/packages/viewer/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "target": "ES2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "moduleResolution": "bundler",
     "lib": [
-      "es2018",
+      "es2019",
       "dom",
       "dom.iterable"
     ] /* Specify library files to be included in the compilation. */,


### PR DESCRIPTION
refs: https://github.com/vivliostyle/vivliostyle.js/pull/2075#issuecomment-5087870986