### PR TITLE
fix: Load documents with reserved characters in filenames

### DIFF
--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -72,6 +72,10 @@ function shouldSkipHeadForWebPub(url: string): boolean {
   );
 }
 
+function encodeURLPath(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
 export type Position = {
   spineIndex: number;
   pageIndex: number;
@@ -1321,7 +1325,7 @@ export class OPFDoc {
     const primaryEntryPath = getPathFromURL(primaryEntryURL, pubURL);
     const primaryEntryReadingOrderURL =
       primaryEntryPath !== null
-        ? encodeURI(primaryEntryPath)
+        ? encodeURLPath(primaryEntryPath)
         : /^(?:about:|blob:)/i.test(primaryEntryURL)
           ? primaryEntryURL
           : null;
@@ -1347,7 +1351,7 @@ export class OPFDoc {
           Base.resolveURL(href, pubURL),
         );
         const path = getPathFromURL(hrefNoFragment, pubURL);
-        const url = path !== null ? encodeURI(path) : hrefNoFragment;
+        const url = path !== null ? encodeURLPath(path) : hrefNoFragment;
         if (manifestObj["readingOrder"].indexOf(url) == -1) {
           manifestObj["readingOrder"].push(url);
         }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -7,6 +7,10 @@ module.exports = [
     category: "General",
     files: [
       { file: "counter_in_running.html", title: "Counter in running element" },
+      {
+        file: "filename%23hash.html",
+        title: "Reserved character in filename (Issue #2076)",
+      },
       { file: "print_media/index.html", title: "Print media" },
       {
         file: "vivliostyle_media/index.html",

--- a/packages/core/test/files/filename#hash.html
+++ b/packages/core/test/files/filename#hash.html
@@ -1,0 +1,16 @@
+<!-- Test case for Issue #2076: load a document whose filename contains # -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Reserved character in filename</title>
+    <style>
+      @page {
+        size: 200mm 150mm;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Pass if this document is loaded.</p>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -128,6 +128,32 @@ describe("epub", function () {
           return adapt_task.newResult(true);
         });
       });
+
+      ["%23", "%3F", "%3A"].forEach(function (encodedCharacter) {
+        it(
+          "preserves " + encodedCharacter + " in the primary entry filename",
+          function (done) {
+            var store = new adapt_epub.EPUBDocStore();
+            var doc = new DOMParser().parseFromString(
+              "<html xmlns='http://www.w3.org/1999/xhtml'><head><title>Reserved character</title></head><body></body></html>",
+              "text/html",
+            );
+            var url =
+              "https://example.com/book/file" + encodedCharacter + "name.html";
+
+            adapt_task.start(function () {
+              adapt_epub.OPFDoc.fromWebPubManifest(store, url, {}, doc).then(
+                function (opf) {
+                  expect(opf.spine.length).toBe(1);
+                  expect(opf.spine[0].src).toBe(url);
+                  done();
+                },
+              );
+              return adapt_task.newResult(true);
+            });
+          },
+        );
+      });
     });
 
     describe("OPFDocumentURLTransformer", function () {


### PR DESCRIPTION
Encode Web Publication path segments with `encodeURIComponent()` so that `#`, `?`, and `:` in filenames are not interpreted as URL syntax.

Add unit and visual regression coverage for percent-encoded reserved characters.

Closes #2076

Assisted-by: GitHub Copilot Chat:gpt-5.6-sol

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2076; the AI implemented the `encodeURIComponent()`-based path encoding and added unit and visual regression coverage.
- `/draft-commit` finalized the PR after human review.

</details>
