### PR TITLE
refactor: Ground absent namespace and id in their true null domain

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -1289,16 +1289,41 @@ export class IsNthSiblingAction extends IsNthAction {
   }
 }
 
+export type SiblingTypeCounts = {
+  byNamespace: { [ns: string]: { [localName: string]: number } };
+  noNamespace: { [localName: string]: number } | null;
+};
+
+function emptySiblingTypeCounts(): SiblingTypeCounts {
+  return { byNamespace: {}, noNamespace: null };
+}
+
+function typeCountsForNamespace(
+  counts: SiblingTypeCounts,
+  ns: string | null,
+): { [localName: string]: number } {
+  let nsCounts = ns !== null ? counts.byNamespace[ns] : counts.noNamespace;
+  if (!nsCounts) {
+    nsCounts = {};
+    if (ns !== null) {
+      counts.byNamespace[ns] = nsCounts;
+    } else {
+      counts.noNamespace = nsCounts;
+    }
+  }
+  return nsCounts;
+}
+
 export class IsNthSiblingOfTypeAction extends IsNthAction {
   constructor(a: number, b: number) {
     super(a, b);
   }
 
   override matches(cascadeInstance: CascadeInstance): boolean {
-    const order =
-      cascadeInstance.currentSiblingTypeCounts[
-        cascadeInstance.currentNamespace
-      ][cascadeInstance.currentLocalName];
+    const order = typeCountsForNamespace(
+      cascadeInstance.currentSiblingTypeCounts,
+      cascadeInstance.currentNamespace,
+    )[cascadeInstance.currentLocalName];
     return this.matchANPlusB(order);
   }
 
@@ -1335,23 +1360,24 @@ export class IsNthLastSiblingOfTypeAction extends IsNthAction {
 
   override matches(cascadeInstance: CascadeInstance): boolean {
     const counts = cascadeInstance.currentFollowingSiblingTypeCounts;
-    if (!counts[cascadeInstance.currentNamespace]) {
+    let nsCounts =
+      cascadeInstance.currentNamespace !== null
+        ? counts.byNamespace[cascadeInstance.currentNamespace]
+        : counts.noNamespace;
+    if (!nsCounts) {
       let elem = cascadeInstance.currentElement;
       do {
         const ns = elem.namespaceURI;
         const localName = elem.localName;
-        let nsCounts = counts[ns];
-        if (!nsCounts) {
-          nsCounts = counts[ns] = {};
-        }
-        nsCounts[localName] = (nsCounts[localName] || 0) + 1;
+        const elemCounts = typeCountsForNamespace(counts, ns);
+        elemCounts[localName] = (elemCounts[localName] || 0) + 1;
       } while ((elem = elem.nextElementSibling));
+      nsCounts = typeCountsForNamespace(
+        counts,
+        cascadeInstance.currentNamespace,
+      );
     }
-    return this.matchANPlusB(
-      counts[cascadeInstance.currentNamespace][
-        cascadeInstance.currentLocalName
-      ],
-    );
+    return this.matchANPlusB(nsCounts[cascadeInstance.currentLocalName]);
   }
 
   override getPriority(): number {
@@ -1619,9 +1645,9 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
     const savedSiblingOrder = cascadeInstance.currentSiblingOrder;
 
     cascadeInstance.currentElement = element;
-    cascadeInstance.currentNamespace = element.namespaceURI || "";
+    cascadeInstance.currentNamespace = element.namespaceURI;
     cascadeInstance.currentLocalName = element.localName;
-    cascadeInstance.currentId = element.id;
+    cascadeInstance.currentId = element.getAttribute("id");
     cascadeInstance.currentClassNames = element.classList
       ? Array.from(element.classList)
       : [];
@@ -3337,9 +3363,9 @@ export class CascadeInstance {
   currentStyle: ElementStyle | null = null;
   currentClassNames: string[] | null = null;
   currentLocalName: string = "";
-  currentNamespace: string = "";
-  currentId: string = "";
-  currentXmlId: string = "";
+  currentNamespace: string | null = null;
+  currentId: string | null = null;
+  currentXmlId: string | null = null;
   currentNSTag: string = "";
   currentEpubTypes: string[] | null = null;
   currentPageType: string | null = null;
@@ -3359,16 +3385,14 @@ export class CascadeInstance {
   lang: string = "";
   siblingOrderStack: number[] = [0];
   currentSiblingOrder: number = 0;
-  siblingTypeCountsStack: { [key: string]: { [key: string]: number } }[] = [{}];
-  currentSiblingTypeCounts: { [key: string]: { [key: string]: number } };
+  siblingTypeCountsStack: SiblingTypeCounts[] = [emptySiblingTypeCounts()];
+  currentSiblingTypeCounts: SiblingTypeCounts;
   currentFollowingSiblingOrder: number | null = null;
   followingSiblingOrderStack: (number | null)[];
-  followingSiblingTypeCountsStack: {
-    [key: string]: { [key: string]: number };
-  }[] = [{}];
-  currentFollowingSiblingTypeCounts: {
-    [key: string]: { [key: string]: number };
-  };
+  followingSiblingTypeCountsStack: SiblingTypeCounts[] = [
+    emptySiblingTypeCounts(),
+  ];
+  currentFollowingSiblingTypeCounts: SiblingTypeCounts;
   viewConditions: { [key: string]: Matchers.Matcher[] } = Object.create(null);
   dependentConditions: string[] = [];
   elementStack: Element[] = [];
@@ -3472,10 +3496,10 @@ export class CascadeInstance {
     this.currentElement = null;
     this.currentElementOffset = null;
     this.currentStyle = baseStyle;
-    this.currentNamespace = "";
+    this.currentNamespace = null;
     this.currentLocalName = "";
-    this.currentId = "";
-    this.currentXmlId = "";
+    this.currentId = null;
+    this.currentXmlId = null;
     this.currentClassNames = classes;
     this.currentNSTag = "";
     this.currentEpubTypes = EMPTY;
@@ -3790,7 +3814,10 @@ export class CascadeInstance {
     this.currentStyle = baseStyle;
     this.currentNamespace = element.namespaceURI;
     this.currentLocalName = element.localName;
-    const prefix = this.code.nsPrefix[this.currentNamespace];
+    const prefix =
+      this.currentNamespace !== null
+        ? this.code.nsPrefix[this.currentNamespace]
+        : undefined;
     if (prefix) {
       this.currentNSTag = prefix + this.currentLocalName;
     } else {
@@ -3824,16 +3851,13 @@ export class CascadeInstance {
     const siblingTypeCountsStack = this.siblingTypeCountsStack;
     const currentSiblingTypeCounts = (this.currentSiblingTypeCounts =
       siblingTypeCountsStack[siblingTypeCountsStack.length - 1]);
-    let currentNamespaceTypeCounts =
-      currentSiblingTypeCounts[this.currentNamespace];
-    if (!currentNamespaceTypeCounts) {
-      currentNamespaceTypeCounts = currentSiblingTypeCounts[
-        this.currentNamespace
-      ] = {};
-    }
+    const currentNamespaceTypeCounts = typeCountsForNamespace(
+      currentSiblingTypeCounts,
+      this.currentNamespace,
+    );
     currentNamespaceTypeCounts[this.currentLocalName] =
       (currentNamespaceTypeCounts[this.currentLocalName] || 0) + 1;
-    siblingTypeCountsStack.push({});
+    siblingTypeCountsStack.push(emptySiblingTypeCounts());
     const followingSiblingOrderStack = this.followingSiblingOrderStack;
     if (
       followingSiblingOrderStack[followingSiblingOrderStack.length - 1] !== null
@@ -3852,15 +3876,15 @@ export class CascadeInstance {
         followingSiblingTypeCountsStack[
           followingSiblingTypeCountsStack.length - 1
         ]);
-    if (
+    const followingNamespaceTypeCounts =
       currentFollowingSiblingTypeCounts &&
-      currentFollowingSiblingTypeCounts[this.currentNamespace]
-    ) {
-      currentFollowingSiblingTypeCounts[this.currentNamespace][
-        this.currentLocalName
-      ]--;
+      (this.currentNamespace !== null
+        ? currentFollowingSiblingTypeCounts.byNamespace[this.currentNamespace]
+        : currentFollowingSiblingTypeCounts.noNamespace);
+    if (followingNamespaceTypeCounts) {
+      followingNamespaceTypeCounts[this.currentLocalName]--;
     }
-    followingSiblingTypeCountsStack.push({});
+    followingSiblingTypeCountsStack.push(emptySiblingTypeCounts());
     this.applyActions();
     this.currentPageType = savedCurrentPageType;
 
@@ -4604,7 +4628,9 @@ export class CascadeInstance {
     for (i = 0; i < this.currentEpubTypes.length; i++) {
       this.applyAction(this.code.epubtypes, this.currentEpubTypes[i]);
     }
-    this.applyAction(this.code.ids, this.currentId);
+    if (this.currentId !== null) {
+      this.applyAction(this.code.ids, this.currentId);
+    }
     this.applyAction(this.code.tags, this.currentLocalName);
     if (this.currentLocalName != "") {
       // Universal selector does not apply to page-master-related rules.

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -163,10 +163,15 @@ describe("css-cascade", function () {
   });
 
   describe("IsNthSiblingOfTypeAction", function () {
-    function dummyCascadeInstance(counts) {
-      var element = { namespaceURI: "foo", localName: "bar" };
+    function dummyCascadeInstance(counts, namespaceURI) {
+      var ns = namespaceURI === undefined ? "foo" : namespaceURI;
+      var element = { namespaceURI: ns, localName: "bar" };
       var currentSiblingTypeCounts = { byNamespace: {}, noNamespace: null };
-      currentSiblingTypeCounts.byNamespace[element.namespaceURI] = counts;
+      if (ns === null) {
+        currentSiblingTypeCounts.noNamespace = counts;
+      } else {
+        currentSiblingTypeCounts.byNamespace[ns] = counts;
+      }
       return {
         currentSiblingTypeCounts: currentSiblingTypeCounts,
         currentNamespace: element.namespaceURI,
@@ -288,6 +293,29 @@ describe("css-cascade", function () {
       expect(chained.apply).not.toHaveBeenCalled();
 
       wired.apply(dummyCascadeInstance({ bar: 7, baz: 1 }));
+      expect(chained.apply).not.toHaveBeenCalled();
+    });
+
+    it("counts an element without a namespace in the no-namespace slot", function () {
+      var action = new adapt_csscasc.IsNthSiblingOfTypeAction(0, 3);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
+      var wired = action.wire(chained);
+
+      wired.apply(dummyCascadeInstance({ bar: 1, baz: 3 }, null));
+      expect(chained.apply).not.toHaveBeenCalled();
+
+      wired.apply(dummyCascadeInstance({ bar: 3, baz: 3 }, null));
+      expect(chained.apply).toHaveBeenCalled();
+    });
+
+    it("does not read namespaced counts for an element without a namespace", function () {
+      var action = new adapt_csscasc.IsNthSiblingOfTypeAction(0, 3);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
+      var wired = action.wire(chained);
+
+      var cascadeInstance = dummyCascadeInstance({ bar: 1 }, null);
+      cascadeInstance.currentSiblingTypeCounts.byNamespace["foo"] = { bar: 3 };
+      wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
     });
   });
@@ -470,8 +498,9 @@ describe("css-cascade", function () {
   });
 
   describe("IsNthLastSiblingOfTypeAction", function () {
-    function dummyCascadeInstance(counts) {
-      var currentElement = { namespaceURI: "foo", localName: "bar" };
+    function dummyCascadeInstance(counts, namespaceURI) {
+      var ns = namespaceURI === undefined ? "foo" : namespaceURI;
+      var currentElement = { namespaceURI: ns, localName: "bar" };
       var element = currentElement;
       Object.keys(counts).forEach(function (name) {
         for (var i = counts[name]; i > 0; i--) {
@@ -732,6 +761,111 @@ describe("css-cascade", function () {
         byNamespace: { foo: { bar: 7, baz: 1 } },
         noNamespace: null,
       });
+    });
+
+    it("fills the no-namespace slot when the element has no namespace", function () {
+      var action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(0, 3);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
+      var wired = action.wire(chained);
+
+      var cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 }, null);
+      wired.apply(cascadeInstance);
+      expect(chained.apply).not.toHaveBeenCalled();
+      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+        byNamespace: {},
+        noNamespace: { bar: 2, baz: 2 },
+      });
+
+      cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 }, null);
+      wired.apply(cascadeInstance);
+      expect(chained.apply).toHaveBeenCalled();
+      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+        byNamespace: {},
+        noNamespace: { bar: 3, baz: 1 },
+      });
+    });
+
+    it("keeps namespaced and no-namespace siblings in separate slots", function () {
+      var currentElement = {
+        namespaceURI: "foo",
+        localName: "bar",
+        nextElementSibling: {
+          namespaceURI: null,
+          localName: "bar",
+          nextElementSibling: {
+            namespaceURI: "foo",
+            localName: "bar",
+            nextElementSibling: null,
+          },
+        },
+      };
+      var cascadeInstance = {
+        currentFollowingSiblingTypeCounts: {
+          byNamespace: {},
+          noNamespace: null,
+        },
+        currentNamespace: currentElement.namespaceURI,
+        currentLocalName: currentElement.localName,
+        currentElement: currentElement,
+      };
+      var action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(0, 2);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
+
+      action.wire(chained).apply(cascadeInstance);
+
+      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+        byNamespace: { foo: { bar: 2 } },
+        noNamespace: { bar: 1 },
+      });
+      expect(chained.apply).toHaveBeenCalled();
+    });
+  });
+
+  describe("IsNthSiblingOfSelectorAction", function () {
+    function dummyElement(namespaceURI, localName) {
+      return {
+        namespaceURI: namespaceURI,
+        localName: localName,
+        previousElementSibling: null,
+        getAttribute: function () {
+          return null;
+        },
+      };
+    }
+
+    it("probes a sibling without a namespace against the no-namespace counts", function () {
+      var first = dummyElement(null, "bar");
+      var current = dummyElement(null, "bar");
+      current.previousElementSibling = first;
+      var cascadeInstance = {
+        currentElement: current,
+        currentNamespace: null,
+        currentLocalName: "bar",
+        currentId: null,
+        currentClassNames: [],
+        currentSiblingOrder: 2,
+        currentSiblingTypeCounts: {
+          byNamespace: {},
+          noNamespace: { bar: 2 },
+        },
+      };
+      var action = new adapt_csscasc.IsNthSiblingOfSelectorAction(0, 2, [
+        [new adapt_csscasc.IsNthSiblingOfTypeAction(0, 2)],
+      ]);
+      var chained = jasmine.createSpyObj("chained", ["apply"]);
+
+      action.wire(chained).apply(cascadeInstance);
+
+      // The probe reads the same slot the main walk writes, so no "" bucket
+      // is created on the side.
+      expect(cascadeInstance.currentSiblingTypeCounts).toEqual({
+        byNamespace: {},
+        noNamespace: { bar: 2 },
+      });
+      expect(chained.apply).toHaveBeenCalled();
+      expect(cascadeInstance.currentElement).toBe(current);
+      expect(cascadeInstance.currentNamespace).toBeNull();
+      expect(cascadeInstance.currentSiblingOrder).toBe(2);
     });
   });
 

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -165,8 +165,8 @@ describe("css-cascade", function () {
   describe("IsNthSiblingOfTypeAction", function () {
     function dummyCascadeInstance(counts) {
       var element = { namespaceURI: "foo", localName: "bar" };
-      var currentSiblingTypeCounts = {};
-      currentSiblingTypeCounts[element.namespaceURI] = counts;
+      var currentSiblingTypeCounts = { byNamespace: {}, noNamespace: null };
+      currentSiblingTypeCounts.byNamespace[element.namespaceURI] = counts;
       return {
         currentSiblingTypeCounts: currentSiblingTypeCounts,
         currentNamespace: element.namespaceURI,
@@ -482,7 +482,10 @@ describe("css-cascade", function () {
         }
       });
       return {
-        currentFollowingSiblingTypeCounts: {},
+        currentFollowingSiblingTypeCounts: {
+          byNamespace: {},
+          noNamespace: null,
+        },
         currentNamespace: currentElement.namespaceURI,
         currentLocalName: currentElement.localName,
         currentElement: currentElement,
@@ -498,14 +501,16 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 2, baz: 2 },
+        byNamespace: { foo: { bar: 2, baz: 2 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 3, baz: 1 },
+        byNamespace: { foo: { bar: 3, baz: 1 } },
+        noNamespace: null,
       });
     });
 
@@ -518,21 +523,24 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 1, baz: 2 },
+        byNamespace: { foo: { bar: 1, baz: 2 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 2, baz: 2 },
+        byNamespace: { foo: { bar: 2, baz: 2 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 3, baz: 1 },
+        byNamespace: { foo: { bar: 3, baz: 1 } },
+        noNamespace: null,
       });
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -542,21 +550,24 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 4, baz: 3 },
+        byNamespace: { foo: { bar: 4, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 5, baz: 3 },
+        byNamespace: { foo: { bar: 5, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 6, baz: 1 },
+        byNamespace: { foo: { bar: 6, baz: 1 } },
+        noNamespace: null,
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(2, 3);
@@ -567,21 +578,24 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 1, baz: 3 },
+        byNamespace: { foo: { bar: 1, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 2, baz: 3 },
+        byNamespace: { foo: { bar: 2, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 3, baz: 1 },
+        byNamespace: { foo: { bar: 3, baz: 1 } },
+        noNamespace: null,
       });
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -591,14 +605,16 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 4, baz: 3 },
+        byNamespace: { foo: { bar: 4, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 5, baz: 1 },
+        byNamespace: { foo: { bar: 5, baz: 1 } },
+        noNamespace: null,
       });
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -608,14 +624,16 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 6, baz: 3 },
+        byNamespace: { foo: { bar: 6, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 6, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 7, baz: 3 },
+        byNamespace: { foo: { bar: 7, baz: 3 } },
+        noNamespace: null,
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(-3, 0);
@@ -626,21 +644,24 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 1, baz: 3 },
+        byNamespace: { foo: { bar: 1, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 2, baz: 3 },
+        byNamespace: { foo: { bar: 2, baz: 3 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 3, baz: 3 },
+        byNamespace: { foo: { bar: 3, baz: 3 } },
+        noNamespace: null,
       });
 
       action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(-2, 5);
@@ -651,7 +672,8 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 1, baz: 2 },
+        byNamespace: { foo: { bar: 1, baz: 2 } },
+        noNamespace: null,
       });
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -661,14 +683,16 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 2, baz: 1 },
+        byNamespace: { foo: { bar: 2, baz: 1 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 3, baz: 2 },
+        byNamespace: { foo: { bar: 3, baz: 2 } },
+        noNamespace: null,
       });
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -678,14 +702,16 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 4, baz: 1 },
+        byNamespace: { foo: { bar: 4, baz: 1 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 5, baz: 2 },
+        byNamespace: { foo: { bar: 5, baz: 2 } },
+        noNamespace: null,
       });
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -695,14 +721,16 @@ describe("css-cascade", function () {
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 6, baz: 1 },
+        byNamespace: { foo: { bar: 6, baz: 1 } },
+        noNamespace: null,
       });
 
       cascadeInstance = dummyCascadeInstance({ bar: 6, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
       expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
-        foo: { bar: 7, baz: 1 },
+        byNamespace: { foo: { bar: 7, baz: 1 } },
+        noNamespace: null,
       });
     });
   });


### PR DESCRIPTION
`CascadeInstance`は走査中の要素の名前空間とidを文字列で保持していました`currentNamespace: string = ""; currentId: string = ""; currentXmlId: string = "";`が、実際に代入されるのは`element.namespaceURI`と`getAttribute("id")`で、どちらも不在のとき`null`を返します。したがってマップへの操作に`counts[null]`が流れ込んでいました（`"null"`扱い）。
名前空間接頭辞とidの表引きはnullスキップで、兄弟型カウントはスロットを2つに分けて、`CascadeInstance`には取得通りに`string | null`で持ってもらう形にしました。