### PR TITLE
fix: Ignore invalid selectors only in a forgiving selector list

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4880,8 +4880,8 @@ export class CascadeParserHandler
 
   invalidSelector(message: string): void {
     Logging.logger.warn(message);
-    this.chain.push(new CheckConditionAction("")); // always fails
     this.setInvalid();
+    this.voidSelectorList();
   }
 
   setInvalid(): void {
@@ -5566,6 +5566,12 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
     // <complex-real-selector-list> of `:not()` and of the S of
     // `:nth-child(An+B of S)` is real, which is what "real" means.
     this.invalidSelector(`Pseudo-element ::${name} in a selector list`);
+  }
+
+  // An alternative of this list is invalid, not the selector that contains it.
+  override invalidSelector(message: string): void {
+    Logging.logger.warn(message);
+    this.setInvalid();
     this.voidAlternative();
   }
 

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4795,7 +4795,6 @@ export class CascadeParserHandler
   elementStyle: ElementStyle | null = null;
   conditionCount: number = 0;
   pseudoelement: string | null = null;
-  selectorFunctionContainsPseudoelement: boolean = false;
   footnoteContent: boolean = false;
   cascade: Cascade;
   state: ParseState;
@@ -4846,12 +4845,6 @@ export class CascadeParserHandler
     if (this.pseudoelement) {
       this.invalidSelector(
         `::${this.pseudoelement} followed by ${continuation}`,
-      );
-      return true;
-    }
-    if (this.selectorFunctionContainsPseudoelement) {
-      this.invalidSelector(
-        `Selector containing pseudo-element followed by ${continuation}`,
       );
       return true;
     }
@@ -5259,7 +5252,6 @@ export class CascadeParserHandler
   override nextSelector(): void {
     this.finishChain();
     this.pseudoelement = null;
-    this.selectorFunctionContainsPseudoelement = false;
     this.footnoteContent = false;
     this.specificity = 0;
     if (!this.selectorListVoided) {
@@ -5274,7 +5266,6 @@ export class CascadeParserHandler
     this.state = ParseState.SELECTOR;
     this.elementStyle = {} as ElementStyle;
     this.pseudoelement = null;
-    this.selectorFunctionContainsPseudoelement = false;
     this.specificity = 0;
     this.footnoteContent = false;
     this.selectorListVoided = false;
@@ -5334,7 +5325,6 @@ export class CascadeParserHandler
     this.processChain(this.makeApplyRuleAction(this.specificity));
     this.chain = new NoSelectorChain();
     this.pseudoelement = null;
-    this.selectorFunctionContainsPseudoelement = false;
     this.viewConditionId = null;
     this.footnoteContent = false;
     this.specificity = 0;
@@ -5501,7 +5491,6 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   chains: ChainedAction[][] = [];
   maxSpecificity: number = 0;
   selectorTexts: string[] = [];
-  containsPseudoelementSelector: boolean = false;
 
   constructor(
     public readonly parent: CascadeParserHandler,
@@ -5525,7 +5514,6 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   }
 
   takeAlternative(actions: ChainedAction[]): void {
-    this.containsPseudoelementSelector ||= !!this.pseudoelement;
     this.chains.push(actions);
     this.maxSpecificity = Math.max(this.maxSpecificity, this.specificity);
   }
@@ -5552,8 +5540,6 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
       if (this.increasingSpecificity()) {
         this.parent.specificity += this.maxSpecificity;
       }
-      this.parent.selectorFunctionContainsPseudoelement ||=
-        this.containsPseudoelementSelector;
     } else {
       // func argument is empty or all invalid
       this.parentChain.push(new CheckConditionAction("")); // always fails
@@ -5568,6 +5554,22 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
 
   override error(mnemonics: string, token: CssTokenizer.Token): void {
     super.error(mnemonics, token);
+    this.voidAlternative();
+  }
+
+  override pseudoelementSelector(
+    name: string,
+    params: (number | string)[] | null,
+  ): void {
+    // Selectors Level 4 keeps pseudo-elements out of every selector list a
+    // pseudo-class takes: `:is()` and `:where()` exclude them outright, and the
+    // <complex-real-selector-list> of `:not()` and of the S of
+    // `:nth-child(An+B of S)` is real, which is what "real" means.
+    this.invalidSelector(`Pseudo-element ::${name} in a selector list`);
+    this.voidAlternative();
+  }
+
+  private voidAlternative(): void {
     this.voidSelector();
     this.pseudoelement = null;
     this.viewConditionId = null;
@@ -5575,10 +5577,10 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
     this.specificity = 0;
 
     // A list that is not forgiving is invalid as a whole once one alternative
-    // fails to parse, and so is the selector that contains it. The walk stops
-    // at the first forgiving list, which drops that selector as one of its own
-    // alternatives; reaching the top instead voids the rule and hands the
-    // parse back.
+    // is voided, and so is the selector that contains it. The walk stops at the
+    // first forgiving list, which drops that selector as one of its own
+    // alternatives; reaching the top instead voids the rule and hands the parse
+    // back.
     let handler: CascadeParserHandler = this;
     while (
       handler instanceof MatchesParameterParserHandler &&

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5297,6 +5297,10 @@ export class CascadeParserHandler
     this.chain.finishIn(this);
   }
 
+  voidSelector(): void {
+    this.chain = new NoSelectorChain();
+  }
+
   applyRuleForSelector(): void {
     this.processChain(this.makeApplyRuleAction(this.specificity));
     this.chain = new NoSelectorChain();
@@ -5530,24 +5534,25 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
 
   override error(mnemonics: string, token: CssTokenizer.Token): void {
     super.error(mnemonics, token);
-    this.chain = new NoSelectorChain();
+    this.voidSelector();
     this.pseudoelement = null;
     this.viewConditionId = null;
     this.footnoteContent = false;
     this.specificity = 0;
 
-    let forgiving = false;
-    for (
-      let handler: CascadeParserHandler = this;
-      handler instanceof MatchesParameterParserHandler;
-      handler = handler.parent
+    // A list that is not forgiving is invalid as a whole once one alternative
+    // fails to parse, and so is the selector that contains it. The walk stops
+    // at the first forgiving list, which drops that selector as one of its own
+    // alternatives; reaching the top instead hands the parse back.
+    let handler: CascadeParserHandler = this;
+    while (
+      handler instanceof MatchesParameterParserHandler &&
+      !handler.forgiving()
     ) {
-      if (handler.forgiving()) {
-        forgiving = true;
-        break;
-      }
+      handler.parent.voidSelector();
+      handler = handler.parent;
     }
-    if (!forgiving) {
+    if (!(handler instanceof MatchesParameterParserHandler)) {
       this.endDelegation();
     }
   }
@@ -5574,7 +5579,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   }
 
   /**
-   * @returns true if this takes a forgiving selector list (:is/where/has)
+   * @returns true if this takes a forgiving selector list (:is/where)
    */
   forgiving(): boolean {
     return true;
@@ -5617,6 +5622,12 @@ export class HasParameterParserHandler extends MatchesParameterParserHandler {
   override relational(): boolean {
     return true;
   }
+
+  // `:has()` took a <forgiving-relative-selector-list> in an earlier draft.
+  // Selectors Level 4 gives it a <relative-selector-list>.
+  override forgiving(): boolean {
+    return false;
+  }
 }
 
 /**
@@ -5648,8 +5659,9 @@ export class NthChildOfSelectorParameterParserHandler extends MatchesParameterPa
     this.endDelegation();
   }
 
+  // Selectors Level 4 gives S a <complex-real-selector-list>.
   override forgiving(): boolean {
-    return true;
+    return false;
   }
 }
 

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5311,6 +5311,12 @@ export class CascadeParserHandler
 
   voidSelector(): void {
     this.chain = new NoSelectorChain();
+    this.pseudoelement = null;
+    // Neither `nextSelector` nor `startSelectorRule` resets this, so a voided
+    // selector would leave it for the next rule to read.
+    this.viewConditionId = null;
+    this.footnoteContent = false;
+    this.specificity = 0;
   }
 
   // A style rule takes a selector list that is not forgiving, so one invalid
@@ -5323,11 +5329,7 @@ export class CascadeParserHandler
 
   applyRuleForSelector(): void {
     this.processChain(this.makeApplyRuleAction(this.specificity));
-    this.chain = new NoSelectorChain();
-    this.pseudoelement = null;
-    this.viewConditionId = null;
-    this.footnoteContent = false;
-    this.specificity = 0;
+    this.voidSelector();
   }
 
   protected makeApplyRuleAction(specificity: number): ApplyRuleAction {
@@ -5577,10 +5579,6 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
 
   private voidAlternative(): void {
     this.voidSelector();
-    this.pseudoelement = null;
-    this.viewConditionId = null;
-    this.footnoteContent = false;
-    this.specificity = 0;
 
     // A list that is not forgiving is invalid as a whole once one alternative
     // is voided, and so is the selector that contains it. The walk stops at the

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4789,6 +4789,8 @@ export class CascadeParserHandler
   implements CssValidator.PropertyReceiver
 {
   chain: SelectorChain = new NoSelectorChain();
+  selectorListVoided: boolean = false;
+  private pendingChained: CascadeAction[] = [];
   specificity: number = 0;
   elementStyle: ElementStyle | null = null;
   conditionCount: number = 0;
@@ -4823,11 +4825,21 @@ export class CascadeParserHandler
     this.chain.emit(action, this);
   }
 
+  // Nothing enters the cascade until the whole selector list of the rule has
+  // been read, so that an invalid selector takes with it the selectors that
+  // precede it as well as those that follow.
   insertChained(chained: CascadeAction): void {
-    if (chained instanceof WiredAction && chained.makePrimary(this.cascade)) {
-      return;
+    this.pendingChained.push(chained);
+  }
+
+  private takePendingChained(): void {
+    for (const chained of this.pendingChained) {
+      if (chained instanceof WiredAction && chained.makePrimary(this.cascade)) {
+        continue;
+      }
+      this.insertNonPrimary(chained);
     }
-    this.insertNonPrimary(chained);
+    this.pendingChained.splice(0);
   }
 
   private invalidContinuationAfterPseudoelement(continuation: string): boolean {
@@ -5250,7 +5262,9 @@ export class CascadeParserHandler
     this.selectorFunctionContainsPseudoelement = false;
     this.footnoteContent = false;
     this.specificity = 0;
-    this.chain = new AccumulatedSelectorChain();
+    if (!this.selectorListVoided) {
+      this.chain = new AccumulatedSelectorChain();
+    }
   }
 
   override startSelectorRule(): void {
@@ -5263,6 +5277,8 @@ export class CascadeParserHandler
     this.selectorFunctionContainsPseudoelement = false;
     this.specificity = 0;
     this.footnoteContent = false;
+    this.selectorListVoided = false;
+    this.pendingChained.splice(0);
     this.chain = new AccumulatedSelectorChain();
     this.invalid = false;
   }
@@ -5282,6 +5298,11 @@ export class CascadeParserHandler
 
   override startRuleBody(): void {
     this.finishChain();
+    if (this.selectorListVoided) {
+      this.pendingChained.splice(0);
+    } else {
+      this.takePendingChained();
+    }
     super.startRuleBody();
     if (this.state == ParseState.SELECTOR) {
       this.state = ParseState.TOP;
@@ -5299,6 +5320,14 @@ export class CascadeParserHandler
 
   voidSelector(): void {
     this.chain = new NoSelectorChain();
+  }
+
+  // A style rule takes a selector list that is not forgiving, so one invalid
+  // selector takes the whole rule with it, including the selectors that follow
+  // the comma.
+  voidSelectorList(): void {
+    this.voidSelector();
+    this.selectorListVoided = true;
   }
 
   applyRuleForSelector(): void {
@@ -5490,6 +5519,11 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
     this.parentChain = parent.chain;
   }
 
+  // The rule being parsed belongs to the handler this list is nested in.
+  override insertChained(chained: CascadeAction): void {
+    this.parent.insertChained(chained);
+  }
+
   takeAlternative(actions: ChainedAction[]): void {
     this.containsPseudoelementSelector ||= !!this.pseudoelement;
     this.chains.push(actions);
@@ -5543,16 +5577,18 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
     // A list that is not forgiving is invalid as a whole once one alternative
     // fails to parse, and so is the selector that contains it. The walk stops
     // at the first forgiving list, which drops that selector as one of its own
-    // alternatives; reaching the top instead hands the parse back.
+    // alternatives; reaching the top instead voids the rule and hands the
+    // parse back.
     let handler: CascadeParserHandler = this;
     while (
       handler instanceof MatchesParameterParserHandler &&
       !handler.forgiving()
     ) {
-      handler.parent.voidSelector();
       handler = handler.parent;
+      handler.voidSelector();
     }
     if (!(handler instanceof MatchesParameterParserHandler)) {
+      handler.voidSelectorList();
       this.endDelegation();
     }
   }

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4729,11 +4729,66 @@ export enum ParseState {
 }
 
 //------------- parsing ------------
+export interface SelectorChain {
+  push(action: ChainedAction): void;
+  restartWith(action: ChainedAction): SelectorChain;
+  emit(action: CascadeAction, handler: CascadeParserHandler): void;
+  contributeTo(list: MatchesParameterParserHandler): void;
+  recordTextIn(texts: string[], text: string): void;
+  finishIn(handler: CascadeParserHandler): void;
+}
+
+class AccumulatedSelectorChain implements SelectorChain {
+  readonly actions: ChainedAction[] = [];
+
+  push(action: ChainedAction): void {
+    this.actions.push(action);
+  }
+
+  restartWith(action: ChainedAction): SelectorChain {
+    const restarted = new AccumulatedSelectorChain();
+    restarted.push(action);
+    return restarted;
+  }
+
+  emit(action: CascadeAction, handler: CascadeParserHandler): void {
+    handler.insertChained(chainActions(this.actions, action));
+  }
+
+  contributeTo(list: MatchesParameterParserHandler): void {
+    list.takeAlternative(this.actions);
+  }
+
+  recordTextIn(texts: string[], text: string): void {
+    texts.push(text);
+  }
+
+  finishIn(handler: CascadeParserHandler): void {
+    handler.applyRuleForSelector();
+  }
+}
+
+class NoSelectorChain implements SelectorChain {
+  push(): void {}
+
+  restartWith(): SelectorChain {
+    return this;
+  }
+
+  emit(): void {}
+
+  contributeTo(): void {}
+
+  recordTextIn(): void {}
+
+  finishIn(): void {}
+}
+
 export class CascadeParserHandler
   extends CssParser.SlaveParserHandler
   implements CssValidator.PropertyReceiver
 {
-  chain: ChainedAction[] | null = null;
+  chain: SelectorChain = new NoSelectorChain();
   specificity: number = 0;
   elementStyle: ElementStyle | null = null;
   conditionCount: number = 0;
@@ -4765,7 +4820,10 @@ export class CascadeParserHandler
   }
 
   processChain(action: CascadeAction): void {
-    const chained = chainActions(this.chain, action);
+    this.chain.emit(action, this);
+  }
+
+  insertChained(chained: CascadeAction): void {
     if (chained instanceof WiredAction && chained.makePrimary(this.cascade)) {
       return;
     }
@@ -5132,7 +5190,7 @@ export class CascadeParserHandler
         new DescendantConditionItem(condition, this.viewConditionId, null),
       ),
     );
-    this.chain = [new CheckConditionAction(condition)];
+    this.chain = this.chain.restartWith(new CheckConditionAction(condition));
     this.viewConditionId = null;
   }
 
@@ -5146,7 +5204,7 @@ export class CascadeParserHandler
         new ChildConditionItem(condition, this.viewConditionId, null),
       ),
     );
-    this.chain = [new CheckConditionAction(condition)];
+    this.chain = this.chain.restartWith(new CheckConditionAction(condition));
     this.viewConditionId = null;
   }
 
@@ -5162,7 +5220,7 @@ export class CascadeParserHandler
         new AdjacentSiblingConditionItem(condition, this.viewConditionId, null),
       ),
     );
-    this.chain = [new CheckConditionAction(condition)];
+    this.chain = this.chain.restartWith(new CheckConditionAction(condition));
     this.viewConditionId = null;
   }
 
@@ -5182,7 +5240,7 @@ export class CascadeParserHandler
         ),
       ),
     );
-    this.chain = [new CheckConditionAction(condition)];
+    this.chain = this.chain.restartWith(new CheckConditionAction(condition));
     this.viewConditionId = null;
   }
 
@@ -5192,7 +5250,7 @@ export class CascadeParserHandler
     this.selectorFunctionContainsPseudoelement = false;
     this.footnoteContent = false;
     this.specificity = 0;
-    this.chain = [];
+    this.chain = new AccumulatedSelectorChain();
   }
 
   override startSelectorRule(): void {
@@ -5205,7 +5263,7 @@ export class CascadeParserHandler
     this.selectorFunctionContainsPseudoelement = false;
     this.specificity = 0;
     this.footnoteContent = false;
-    this.chain = [];
+    this.chain = new AccumulatedSelectorChain();
     this.invalid = false;
   }
 
@@ -5236,15 +5294,17 @@ export class CascadeParserHandler
   }
 
   finishChain(): void {
-    if (this.chain) {
-      this.processChain(this.makeApplyRuleAction(this.specificity));
-      this.chain = null;
-      this.pseudoelement = null;
-      this.selectorFunctionContainsPseudoelement = false;
-      this.viewConditionId = null;
-      this.footnoteContent = false;
-      this.specificity = 0;
-    }
+    this.chain.finishIn(this);
+  }
+
+  applyRuleForSelector(): void {
+    this.processChain(this.makeApplyRuleAction(this.specificity));
+    this.chain = new NoSelectorChain();
+    this.pseudoelement = null;
+    this.selectorFunctionContainsPseudoelement = false;
+    this.viewConditionId = null;
+    this.footnoteContent = false;
+    this.specificity = 0;
   }
 
   protected makeApplyRuleAction(specificity: number): ApplyRuleAction {
@@ -5404,7 +5464,7 @@ export let conditionCount: number = 0;
  * Cascade Parser Handler for :is() and similar pseudo-classes parameter
  */
 export class MatchesParameterParserHandler extends CascadeParserHandler {
-  parentChain: ChainedAction[];
+  parentChain: SelectorChain;
   chains: ChainedAction[][] = [];
   maxSpecificity: number = 0;
   selectorTexts: string[] = [];
@@ -5426,13 +5486,15 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
     this.parentChain = parent.chain;
   }
 
-  override nextSelector(): void {
+  takeAlternative(actions: ChainedAction[]): void {
     this.containsPseudoelementSelector ||= !!this.pseudoelement;
-    if (this.chain) {
-      this.chains.push(this.chain);
-    }
+    this.chains.push(actions);
     this.maxSpecificity = Math.max(this.maxSpecificity, this.specificity);
-    this.chain = [];
+  }
+
+  override nextSelector(): void {
+    this.chain.contributeTo(this);
+    this.chain = new AccumulatedSelectorChain();
     this.pseudoelement = null;
     this.viewConditionId = null;
     this.footnoteContent = false;
@@ -5440,12 +5502,8 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
   }
 
   override endFuncWithSelector(): void {
-    this.containsPseudoelementSelector ||= !!this.pseudoelement;
-    if (this.chain) {
-      this.chains.push(this.chain);
-    }
+    this.chain.contributeTo(this);
     if (this.chains.length > 0) {
-      this.maxSpecificity = Math.max(this.maxSpecificity, this.specificity);
       this.parentChain.push(
         this.relational()
           ? new MatchesRelationalAction(this.selectorTexts)
@@ -5472,7 +5530,7 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
 
   override error(mnemonics: string, token: CssTokenizer.Token): void {
     super.error(mnemonics, token);
-    this.chain = null;
+    this.chain = new NoSelectorChain();
     this.pseudoelement = null;
     this.viewConditionId = null;
     this.footnoteContent = false;
@@ -5496,8 +5554,8 @@ export class MatchesParameterParserHandler extends CascadeParserHandler {
 
   override pushSelectorText(selectorText: string): void {
     // selectorText is used only for relational pseudo-class `:has()`
-    if (this.chain && this.relational()) {
-      this.selectorTexts.push(selectorText);
+    if (this.relational()) {
+      this.chain.recordTextIn(this.selectorTexts, selectorText);
     }
   }
 
@@ -5575,11 +5633,8 @@ export class NthChildOfSelectorParameterParserHandler extends MatchesParameterPa
   }
 
   override endFuncWithSelector(): void {
-    if (this.chain) {
-      this.chains.push(this.chain);
-    }
+    this.chain.contributeTo(this);
     if (this.chains.length > 0) {
-      this.maxSpecificity = Math.max(this.maxSpecificity, this.specificity);
       this.parentChain.push(
         new IsNthSiblingOfSelectorAction(this.a, this.b, this.chains),
       );
@@ -5603,11 +5658,8 @@ export class NthChildOfSelectorParameterParserHandler extends MatchesParameterPa
  */
 export class NthLastChildOfSelectorParameterParserHandler extends NthChildOfSelectorParameterParserHandler {
   override endFuncWithSelector(): void {
-    if (this.chain) {
-      this.chains.push(this.chain);
-    }
+    this.chain.contributeTo(this);
     if (this.chains.length > 0) {
-      this.maxSpecificity = Math.max(this.maxSpecificity, this.specificity);
       this.parentChain.push(
         new IsNthLastSiblingOfSelectorAction(this.a, this.b, this.chains),
       );

--- a/packages/core/test/files/css-parse-error/forgiving-selector-list.html
+++ b/packages/core/test/files/css-parse-error/forgiving-selector-list.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Syntax error in a forgiving selector list</title>
+    <style>
+      div:is(# p) {
+        color: red;
+      }
+      p {
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <p>This paragraph should be green.</p>
+  </body>
+</html>

--- a/packages/core/test/files/css-parse-error/invalid-selector-in-a-rule.html
+++ b/packages/core/test/files/css-parse-error/invalid-selector-in-a-rule.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Invalid selector in a rule</title>
+    <style>
+      x:not(# p), .after {
+        color: red;
+      }
+      .before, y:not(# q) {
+        color: red;
+      }
+      d,
+      e {
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <d class="after">This text should be green.</d>
+      <e class="before">This text should be green too.</e>
+    </div>
+  </body>
+</html>

--- a/packages/core/test/files/css-parse-error/pseudo-element-in-a-selector-list.html
+++ b/packages/core/test/files/css-parse-error/pseudo-element-in-a-selector-list.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Pseudo-element in a selector list</title>
+    <style>
+      div:is(.x, ::before) span {
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="x"><span>This text should be green.</span></div>
+  </body>
+</html>

--- a/packages/core/test/files/css-parse-error/unforgiving-selector-list.html
+++ b/packages/core/test/files/css-parse-error/unforgiving-selector-list.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Syntax error in an unforgiving selector list</title>
+    <style>
+      div:has(.x, # p) span {
+        color: red;
+      }
+      li:nth-child(2n of .y, # q) {
+        color: red;
+      }
+      span,
+      li {
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div><span class="x">This text should be green.</span></div>
+    <ol>
+      <li class="y">This item should be green.</li>
+      <li class="y">This item should be green too.</li>
+    </ol>
+  </body>
+</html>

--- a/packages/core/test/files/css-parse-error/unknown-pseudo-class.html
+++ b/packages/core/test/files/css-parse-error/unknown-pseudo-class.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Unknown pseudo-class in a selector list</title>
+    <style>
+      p:unknown-pseudo, .c {
+        color: red;
+      }
+      div {
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="c">This text should be green.</div>
+  </body>
+</html>

--- a/packages/core/test/files/css-parse-error/voided-alternative-pseudo-element.html
+++ b/packages/core/test/files/css-parse-error/voided-alternative-pseudo-element.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Pseudo-element in a voided alternative</title>
+    <style>
+      div:is(.x, # ::before) span {
+        color: green;
+      }
+      p:is(*, # ::before) {
+        color: red;
+      }
+      p {
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="x"><span>This text should be green.</span></div>
+    <p>This paragraph should be green.</p>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -53,6 +53,10 @@ module.exports = [
         file: "css-parse-error/unforgiving-selector-list.html",
         title: "Syntax error in an unforgiving selector list",
       },
+      {
+        file: "css-parse-error/invalid-selector-in-a-rule.html",
+        title: "Invalid selector in a rule",
+      },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
         file: "rlh_unit/root-line-height-normal.html",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -61,6 +61,10 @@ module.exports = [
         file: "css-parse-error/pseudo-element-in-a-selector-list.html",
         title: "Pseudo-element in a selector list",
       },
+      {
+        file: "css-parse-error/unknown-pseudo-class.html",
+        title: "Unknown pseudo-class in a selector list",
+      },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
         file: "rlh_unit/root-line-height-normal.html",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -41,6 +41,14 @@ module.exports = [
         file: "css-parse-error/gradient-background-image.html",
         title: "Gradient background-image",
       },
+      {
+        file: "css-parse-error/forgiving-selector-list.html",
+        title: "Syntax error in a forgiving selector list",
+      },
+      {
+        file: "css-parse-error/voided-alternative-pseudo-element.html",
+        title: "Pseudo-element in a voided alternative",
+      },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
         file: "rlh_unit/root-line-height-normal.html",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -57,6 +57,10 @@ module.exports = [
         file: "css-parse-error/invalid-selector-in-a-rule.html",
         title: "Invalid selector in a rule",
       },
+      {
+        file: "css-parse-error/pseudo-element-in-a-selector-list.html",
+        title: "Pseudo-element in a selector list",
+      },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
         file: "rlh_unit/root-line-height-normal.html",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -49,6 +49,10 @@ module.exports = [
         file: "css-parse-error/voided-alternative-pseudo-element.html",
         title: "Pseudo-element in a voided alternative",
       },
+      {
+        file: "css-parse-error/unforgiving-selector-list.html",
+        title: "Syntax error in an unforgiving selector list",
+      },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
         file: "rlh_unit/root-line-height-normal.html",

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1163,6 +1163,16 @@ describe("css-cascade", function () {
         );
       });
 
+      it("keeps the view condition of the voided selector out of the next rule", function (done) {
+        parseCascade(
+          "p::nth-fragment(2n+1):not(# a) { color: red } q { color: blue }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["q"].viewConditionId).toBeNull();
+          },
+        );
+      });
+
       it("drops a rule whose selector never finished", function (done) {
         // The rule never reaches its body, so nothing it built is taken.
         parseCascade(
@@ -1238,6 +1248,16 @@ describe("css-cascade", function () {
           done,
           function (cascade) {
             expect(Object.keys(cascade.tags)).toEqual(["div"]);
+          },
+        );
+      });
+
+      it("keeps the view condition of the voided selector out of the next rule", function (done) {
+        parseCascade(
+          "p::nth-fragment(2n+1):unknown-pseudo { color: red } q { color: blue }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["q"].viewConditionId).toBeNull();
           },
         );
       });

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1047,16 +1047,34 @@ describe("css-cascade", function () {
         );
       });
 
-      it("drops a voided alternative of :nth-child(An+B of S)", function (done) {
+      it("voids :nth-child(An+B of S) whose alternative was voided", function (done) {
+        // Selectors Level 4 gives S a <complex-real-selector-list>.
         parseCascade(
           "div:nth-child(2n of !!!, .x) { color: red }",
           done,
           function (cascade) {
-            var action = cascade.tags["div"].condition;
-            expect(action).toEqual(
-              jasmine.any(adapt_csscasc.IsNthSiblingOfSelectorAction),
-            );
-            expect(action.firstActions.length).toBe(1);
+            expect(Object.keys(cascade.tags)).toEqual([]);
+          },
+        );
+      });
+
+      it("voids :has() whose alternative was voided", function (done) {
+        // Selectors Level 4 gives `:has()` a <relative-selector-list>.
+        parseCascade(
+          "div:has(# p, q) { color: red }",
+          done,
+          function (cascade) {
+            expect(Object.keys(cascade.tags)).toEqual([]);
+          },
+        );
+      });
+
+      it("drops a voided unforgiving list from the forgiving list around it", function (done) {
+        parseCascade(
+          "div:is(:has(.x, # p), .z) span { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["*"].condition.firstActions.length).toBe(1);
           },
         );
       });
@@ -1071,16 +1089,14 @@ describe("css-cascade", function () {
         );
       });
 
-      it("keeps building the enclosing selector after a voided list", function (done) {
-        // `:not()` is not forgiving, so the error hands the parse back to the
-        // selector that contains it.
+      it("voids the enclosing selector when an unforgiving list is voided", function (done) {
+        // The error hands the parse back to the selector that contains the
+        // list, so what follows is read as a selector of its own.
         parseCascade(
           "x:not(u|y, .c d, z) { color: red }",
           done,
           function (cascade) {
-            expect(cascade.tags["x"]).toEqual(
-              jasmine.any(adapt_csscasc.ApplyRuleAction),
-            );
+            expect(cascade.tags["x"]).toBeUndefined();
             expect(cascade.classes["c"]).toEqual(
               jasmine.any(adapt_csscasc.ConditionItemAction),
             );
@@ -1142,20 +1158,6 @@ describe("css-cascade", function () {
         );
       });
 
-      it("keeps the source text of the alternatives :has() kept", function (done) {
-        parseCascade(
-          "div:has(# p, q) { color: red }",
-          done,
-          function (cascade) {
-            var action = cascade.tags["div"].condition;
-            expect(action).toEqual(
-              jasmine.any(adapt_csscasc.MatchesRelationalAction),
-            );
-            expect(action.selectorTexts).toEqual([" q"]);
-          },
-        );
-      });
-
       it("drops a rule whose selector never finished", function (done) {
         parseCascade(
           "div:is(!!!}p>{}) span { color: red }",
@@ -1205,6 +1207,16 @@ describe("css-cascade", function () {
           expect(cascade.tags["div"]).toEqual(
             jasmine.any(adapt_csscasc.ConditionItemAction),
           );
+        });
+      });
+
+      it("keeps the source text of the alternatives :has() takes", function (done) {
+        parseCascade("div:has(p, q) { color: red }", done, function (cascade) {
+          var action = cascade.tags["div"].condition;
+          expect(action).toEqual(
+            jasmine.any(adapt_csscasc.MatchesRelationalAction),
+          );
+          expect(action.selectorTexts).toEqual(["p", " q"]);
         });
       });
 

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -22,6 +22,7 @@ import * as adapt_cssvalid from "../../../src/vivliostyle/css-validator";
 import * as adapt_exprs from "../../../src/vivliostyle/exprs";
 import * as adapt_cssparse from "../../../src/vivliostyle/css-parser";
 import * as adapt_csstok from "../../../src/vivliostyle/css-tokenizer";
+import * as adapt_task from "../../../src/vivliostyle/task";
 import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
 import * as vivliostyle_test_util_mock_plugin from "../../util/mock/vivliostyle/plugin-mock";
 
@@ -1005,6 +1006,263 @@ describe("css-cascade", function () {
     });
   });
 
+  describe("the selector under parse", function () {
+    describe("a syntax error inside the argument", function () {
+      function parseCascade(cssText, done, callback) {
+        var handler = cascadeParserHandler(
+          new adapt_exprs.LexicalScope(null),
+          adapt_cssvalid.baseValidatorSet(),
+        );
+        handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
+        adapt_task.start(function () {
+          adapt_cssparse
+            .parseStylesheetFromText(cssText, handler.owner, null, null, null)
+            .then(function (parsed) {
+              expect(parsed).toBe(true);
+              callback(handler.finish());
+              done();
+            });
+          return adapt_task.newResult(true);
+        });
+      }
+
+      it("fails a list whose only alternative was voided", function (done) {
+        parseCascade("div:is(!!!) { color: red }", done, function (cascade) {
+          var action = cascade.tags["div"];
+          expect(action).toEqual(
+            jasmine.any(adapt_csscasc.WiredConditionScope),
+          );
+          expect(action.condition.condition).toBe("");
+        });
+      });
+
+      it("drops the voided alternative and keeps the rest", function (done) {
+        parseCascade(
+          "div:is(!!!, .x) { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["div"]).toBeUndefined();
+            expect(cascade.tags["*"].condition.firstActions.length).toBe(1);
+          },
+        );
+      });
+
+      it("drops a voided alternative of :nth-child(An+B of S)", function (done) {
+        parseCascade(
+          "div:nth-child(2n of !!!, .x) { color: red }",
+          done,
+          function (cascade) {
+            var action = cascade.tags["div"].condition;
+            expect(action).toEqual(
+              jasmine.any(adapt_csscasc.IsNthSiblingOfSelectorAction),
+            );
+            expect(action.firstActions.length).toBe(1);
+          },
+        );
+      });
+
+      it("takes the alternative the parser rebuilds after recovering", function (done) {
+        parseCascade(
+          "div:is(!!!}p, .x) { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["*"].condition.firstActions.length).toBe(2);
+          },
+        );
+      });
+
+      it("keeps building the enclosing selector after a voided list", function (done) {
+        // `:not()` is not forgiving, so the error hands the parse back to the
+        // selector that contains it.
+        parseCascade(
+          "x:not(u|y, .c d, z) { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["x"]).toEqual(
+              jasmine.any(adapt_csscasc.ApplyRuleAction),
+            );
+            expect(cascade.classes["c"]).toEqual(
+              jasmine.any(adapt_csscasc.ConditionItemAction),
+            );
+            expect(cascade.tags["d"]).toEqual(
+              jasmine.any(adapt_csscasc.WiredConditionScope),
+            );
+          },
+        );
+      });
+
+      it("emits nothing for a combinator in a voided alternative", function (done) {
+        // The condition a combinator registers is read by the rest of that
+        // alternative, which is dropped.
+        parseCascade(
+          "div:is(# p q, .x) { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["*"].condition.firstActions.length).toBe(1);
+          },
+        );
+      });
+
+      it("leaves the specificity of a voided alternative out of the list", function (done) {
+        // Selectors 4 computes the specificity of a forgiving list from the
+        // alternatives it keeps.
+        parseCascade(
+          "div:is(# #i, .x) { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["*"].chained.chained.specificity).toBe(257);
+          },
+        );
+      });
+
+      it("keeps a pseudo-element of a voided alternative out of the enclosing selector", function (done) {
+        // Recording a pseudo-element does not touch the selector under parse,
+        // so the parser reaches `::before` with the alternative already voided.
+        parseCascade(
+          "div:is(.x, # ::before) span { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["span"]).toEqual(
+              jasmine.any(adapt_csscasc.WiredConditionScope),
+            );
+            expect(cascade.tags["span"].chained).toEqual(
+              jasmine.any(adapt_csscasc.ApplyRuleAction),
+            );
+          },
+        );
+      });
+
+      it("leaves the specificity of a pseudo-element in a voided alternative out of the list", function (done) {
+        parseCascade(
+          "div:is(*, # ::before) { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["div"].chained.specificity).toBe(1);
+          },
+        );
+      });
+
+      it("keeps the source text of the alternatives :has() kept", function (done) {
+        parseCascade(
+          "div:has(# p, q) { color: red }",
+          done,
+          function (cascade) {
+            var action = cascade.tags["div"].condition;
+            expect(action).toEqual(
+              jasmine.any(adapt_csscasc.MatchesRelationalAction),
+            );
+            expect(action.selectorTexts).toEqual([" q"]);
+          },
+        );
+      });
+
+      it("drops a rule whose selector never finished", function (done) {
+        parseCascade(
+          "div:is(!!!}p>{}) span { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["div"]).toBeUndefined();
+            expect(cascade.tags["span"]).toBeUndefined();
+            expect(cascade.tags["p"]).toEqual(
+              jasmine.any(adapt_csscasc.ConditionItemAction),
+            );
+          },
+        );
+      });
+    });
+
+    describe("without a syntax error", function () {
+      function parseCascade(cssText, done, callback) {
+        var handler = cascadeParserHandler(
+          new adapt_exprs.LexicalScope(null),
+          adapt_cssvalid.baseValidatorSet(),
+        );
+        handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
+        adapt_task.start(function () {
+          adapt_cssparse
+            .parseStylesheetFromText(cssText, handler.owner, null, null, null)
+            .then(function (parsed) {
+              expect(parsed).toBe(true);
+              callback(handler.finish());
+              done();
+            });
+          return adapt_task.newResult(true);
+        });
+      }
+
+      it("registers a sibling condition before the chain restarts", function (done) {
+        // The condition item is read by the rest of the selector, so it must
+        // not be guarded by the condition it sets.
+        parseCascade("div + p { color: red }", done, function (cascade) {
+          expect(cascade.tags["div"]).toEqual(
+            jasmine.any(adapt_csscasc.ConditionItemAction),
+          );
+        });
+      });
+
+      it("registers a following sibling condition before the chain restarts", function (done) {
+        parseCascade("div ~ p { color: red }", done, function (cascade) {
+          expect(cascade.tags["div"]).toEqual(
+            jasmine.any(adapt_csscasc.ConditionItemAction),
+          );
+        });
+      });
+
+      it("takes the alternatives of :nth-last-child(An+B of S)", function (done) {
+        parseCascade(
+          "div:nth-last-child(2n of .x) { color: red }",
+          done,
+          function (cascade) {
+            var action = cascade.tags["div"].condition;
+            expect(action).toEqual(
+              jasmine.any(adapt_csscasc.IsNthLastSiblingOfSelectorAction),
+            );
+            expect(action.firstActions.length).toBe(1);
+          },
+        );
+      });
+
+      it("takes the selector in the order the parser reports it", function (done) {
+        // The first action decides which table the rule is indexed under, and
+        // the id table is looked up by `currentId` while CheckIdAction also
+        // accepts `currentXmlId`.
+        parseCascade("#a#b { color: red }", done, function (cascade) {
+          expect(Object.keys(cascade.ids)).toEqual(["a"]);
+        });
+      });
+
+      it("leaves no selector behind once the rule is applied", function () {
+        // A handler that answers an at-rule itself, as ops does for
+        // `@-epubx-page-template`, receives a second rule body with no
+        // selector rule in between.
+        var handler = cascadeParserHandler(
+          new adapt_exprs.LexicalScope(null),
+          adapt_cssvalid.baseValidatorSet(),
+        );
+        handler.startSelectorRule();
+        handler.tagSelector(null, "div");
+        handler.startRuleBody();
+        handler.startRuleBody();
+
+        var cascade = handler.finish();
+        expect(Object.keys(cascade.tags)).toEqual(["div"]);
+        expect(cascade.tags["div"]).toEqual(
+          jasmine.any(adapt_csscasc.ApplyRuleAction),
+        );
+      });
+
+      it("keeps the view condition of a selector out of the next rule", function (done) {
+        parseCascade(
+          "p::nth-fragment(2n+1) { color: red } q { color: blue }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["q"].viewConditionId).toBeNull();
+          },
+        );
+      });
+    });
+  });
+
   describe("CascadeParserHandler", function () {
     describe("simpleProperty", function () {
       vivliostyle_test_util_mock_plugin.setup();
@@ -1072,8 +1330,8 @@ describe("css-cascade", function () {
             null,
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributePresentAction),
           );
@@ -1091,8 +1349,8 @@ describe("css-cascade", function () {
             "bar",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeEqAction),
           );
@@ -1111,8 +1369,8 @@ describe("css-cascade", function () {
             "i",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeEqAction),
           );
@@ -1129,8 +1387,8 @@ describe("css-cascade", function () {
             "bar",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1150,8 +1408,8 @@ describe("css-cascade", function () {
             "b c",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckConditionAction),
           );
@@ -1166,8 +1424,8 @@ describe("css-cascade", function () {
             "",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckConditionAction),
           );
@@ -1184,8 +1442,8 @@ describe("css-cascade", function () {
             "bar",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1206,8 +1464,8 @@ describe("css-cascade", function () {
             "",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1229,8 +1487,8 @@ describe("css-cascade", function () {
             "bar",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1252,8 +1510,8 @@ describe("css-cascade", function () {
             "i",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1270,8 +1528,8 @@ describe("css-cascade", function () {
             "i",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1287,8 +1545,8 @@ describe("css-cascade", function () {
             "",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckConditionAction),
           );
@@ -1305,8 +1563,8 @@ describe("css-cascade", function () {
             "bar",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1327,8 +1585,8 @@ describe("css-cascade", function () {
             "",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckConditionAction),
           );
@@ -1345,8 +1603,8 @@ describe("css-cascade", function () {
             "bar",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckAttributeRegExpAction),
           );
@@ -1367,8 +1625,8 @@ describe("css-cascade", function () {
             "",
           );
 
-          expect(handler.chain.length).toBe(1);
-          var action = handler.chain[0];
+          expect(handler.chain.actions.length).toBe(1);
+          var action = handler.chain.actions[0];
           expect(action).toEqual(
             jasmine.any(adapt_csscasc.CheckConditionAction),
           );
@@ -1379,8 +1637,8 @@ describe("css-cascade", function () {
       it("represents nothing when an unsupported operator is passed", function () {
         handler.attributeSelector("ns", "foo", null, "bar");
 
-        expect(handler.chain.length).toBe(1);
-        var action = handler.chain[0];
+        expect(handler.chain.actions.length).toBe(1);
+        var action = handler.chain.actions[0];
         expect(action).toEqual(jasmine.any(adapt_csscasc.CheckConditionAction));
         expect(action.condition).toBe("");
       });

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1221,6 +1221,41 @@ describe("css-cascade", function () {
       });
     });
 
+    describe("an unknown pseudo-class", function () {
+      it("voids the rule", function (done) {
+        parseCascade(
+          "p:unknown-pseudo, div { color: red }",
+          done,
+          function (cascade) {
+            expect(Object.keys(cascade.tags)).toEqual([]);
+          },
+        );
+      });
+
+      it("keeps the rules that follow", function (done) {
+        parseCascade(
+          "p:unknown-pseudo { color: red } div { color: blue }",
+          done,
+          function (cascade) {
+            expect(Object.keys(cascade.tags)).toEqual(["div"]);
+          },
+        );
+      });
+
+      it("drops only the alternative inside a forgiving list", function (done) {
+        parseCascade(
+          "div:is(.x, :unknown-pseudo) span { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["*"].condition.firstActions.length).toBe(1);
+            expect(cascade.tags["span"]).toEqual(
+              jasmine.any(adapt_csscasc.WiredConditionScope),
+            );
+          },
+        );
+      });
+    });
+
     describe("without a syntax error", function () {
       it("registers a sibling condition before the chain restarts", function (done) {
         // The condition item is read by the rest of the selector, so it must
@@ -1676,13 +1711,11 @@ describe("css-cascade", function () {
         });
       });
 
-      it("represents nothing when an unsupported operator is passed", function () {
+      it("voids the selector when an unsupported operator is passed", function () {
         handler.attributeSelector("ns", "foo", null, "bar");
 
-        expect(handler.chain.actions.length).toBe(1);
-        var action = handler.chain.actions[0];
-        expect(action).toEqual(jasmine.any(adapt_csscasc.CheckConditionAction));
-        expect(action.condition).toBe("");
+        expect(handler.chain.actions).toBeUndefined();
+        expect(handler.selectorListVoided).toBe(true);
       });
     });
   });

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1007,25 +1007,25 @@ describe("css-cascade", function () {
   });
 
   describe("the selector under parse", function () {
-    describe("a syntax error inside the argument", function () {
-      function parseCascade(cssText, done, callback) {
-        var handler = cascadeParserHandler(
-          new adapt_exprs.LexicalScope(null),
-          adapt_cssvalid.baseValidatorSet(),
-        );
-        handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
-        adapt_task.start(function () {
-          adapt_cssparse
-            .parseStylesheetFromText(cssText, handler.owner, null, null, null)
-            .then(function (parsed) {
-              expect(parsed).toBe(true);
-              callback(handler.finish());
-              done();
-            });
-          return adapt_task.newResult(true);
-        });
-      }
+    function parseCascade(cssText, done, callback) {
+      var handler = cascadeParserHandler(
+        new adapt_exprs.LexicalScope(null),
+        adapt_cssvalid.baseValidatorSet(),
+      );
+      handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
+      adapt_task.start(function () {
+        adapt_cssparse
+          .parseStylesheetFromText(cssText, handler.owner, null, null, null)
+          .then(function (parsed) {
+            expect(parsed).toBe(true);
+            callback(handler.finish());
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    }
 
+    describe("a syntax error inside the argument", function () {
       it("fails a list whose only alternative was voided", function (done) {
         parseCascade("div:is(!!!) { color: red }", done, function (cascade) {
           var action = cascade.tags["div"];
@@ -1175,25 +1175,53 @@ describe("css-cascade", function () {
       });
     });
 
-    describe("without a syntax error", function () {
-      function parseCascade(cssText, done, callback) {
-        var handler = cascadeParserHandler(
-          new adapt_exprs.LexicalScope(null),
-          adapt_cssvalid.baseValidatorSet(),
+    describe("a pseudo-element inside the argument", function () {
+      it("drops the alternative from a forgiving list", function (done) {
+        parseCascade(
+          "div:is(.x, ::before) span { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["*"].condition.firstActions.length).toBe(1);
+            expect(cascade.tags["span"]).toEqual(
+              jasmine.any(adapt_csscasc.WiredConditionScope),
+            );
+          },
         );
-        handler.owner.startStylesheet(adapt_cssparse.StylesheetFlavor.AUTHOR);
-        adapt_task.start(function () {
-          adapt_cssparse
-            .parseStylesheetFromText(cssText, handler.owner, null, null, null)
-            .then(function (parsed) {
-              expect(parsed).toBe(true);
-              callback(handler.finish());
-              done();
-            });
-          return adapt_task.newResult(true);
-        });
-      }
+      });
 
+      it("voids the rule when the list is not forgiving", function (done) {
+        parseCascade(
+          "div:not(.x, ::before) span { color: red }",
+          done,
+          function (cascade) {
+            expect(Object.keys(cascade.tags)).toEqual([]);
+          },
+        );
+      });
+
+      it("matches nothing when it was the only alternative", function (done) {
+        parseCascade(
+          "div:is(::before) span { color: red }",
+          done,
+          function (cascade) {
+            expect(cascade.tags["div"].condition.condition).toBe("");
+          },
+        );
+      });
+
+      it("keeps a pseudo-element outside such a list", function (done) {
+        parseCascade(
+          "div:is(.x) ::before { color: red }",
+          done,
+          function (cascade) {
+            var applied = cascade.tags["*"].list[1].chained;
+            expect(applied.pseudoelement).toBe("before");
+          },
+        );
+      });
+    });
+
+    describe("without a syntax error", function () {
       it("registers a sibling condition before the chain restarts", function (done) {
         // The condition item is read by the rest of the selector, so it must
         // not be guarded by the condition it sets.

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1089,20 +1089,25 @@ describe("css-cascade", function () {
         );
       });
 
-      it("voids the enclosing selector when an unforgiving list is voided", function (done) {
-        // The error hands the parse back to the selector that contains the
-        // list, so what follows is read as a selector of its own.
+      it("voids the rule when an unforgiving list is voided", function (done) {
+        // A style rule takes a selector list that is not forgiving either, so
+        // the selectors after the comma go with it.
         parseCascade(
           "x:not(u|y, .c d, z) { color: red }",
           done,
           function (cascade) {
-            expect(cascade.tags["x"]).toBeUndefined();
-            expect(cascade.classes["c"]).toEqual(
-              jasmine.any(adapt_csscasc.ConditionItemAction),
-            );
-            expect(cascade.tags["d"]).toEqual(
-              jasmine.any(adapt_csscasc.WiredConditionScope),
-            );
+            expect(Object.keys(cascade.tags)).toEqual([]);
+            expect(Object.keys(cascade.classes)).toEqual([]);
+          },
+        );
+      });
+
+      it("voids the selectors that precede the invalid one", function (done) {
+        parseCascade(
+          "a, b:has(# p), c { color: red } e { color: blue }",
+          done,
+          function (cascade) {
+            expect(Object.keys(cascade.tags)).toEqual(["e"]);
           },
         );
       });
@@ -1159,15 +1164,12 @@ describe("css-cascade", function () {
       });
 
       it("drops a rule whose selector never finished", function (done) {
+        // The rule never reaches its body, so nothing it built is taken.
         parseCascade(
           "div:is(!!!}p>{}) span { color: red }",
           done,
           function (cascade) {
-            expect(cascade.tags["div"]).toBeUndefined();
-            expect(cascade.tags["span"]).toBeUndefined();
-            expect(cascade.tags["p"]).toEqual(
-              jasmine.any(adapt_csscasc.ConditionItemAction),
-            );
+            expect(Object.keys(cascade.tags)).toEqual([]);
           },
         );
       });


### PR DESCRIPTION
[`<forgiving-selector-list>`](https://drafts.csswg.org/selectors/#typedef-forgiving-selector-list)にかかる不具合を解消します。`CascadeParserHandler.chain: ChainedAction[] | null`のnullはセレクタルールが開いていないことと、選択肢が構文エラーで無くなったことを兼ねていました。nullチェックがない`tagSelector`の`this.chain.push(…)`によって`<forgiving-selector-list>`で許容される`div:is(# p)`がTypeErrorになり、逆に`nextSelector`と`endFuncWithSelector`の`if (this.chain)`は無くなった選択肢だけを捨てて残りを`chains`に採るため`MatchesParameterParserHandler`の派生がすべて寛容になり、`:not()`と`:has()`、`:nth-child(An+B of S)`の`S`まで寛容に振る舞っていました（`:has()`は後からforgivingを外されています w3c/csswg-drafts#7676 ）。

追加した6つのVRTケースのうち5ケースで差分が出ます。invalid-selector-in-a-rule.htmlは描画差は出ないが処理が変わったので今後のリグレッション確認のためのケースです。