### PR TITLE
fix: Apply `::after` pseudo-element props with the style of its own element

### DIFF
--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -539,6 +539,78 @@ export function getCSSProperty(
   return opt_value || "";
 }
 
+/**
+ * A node reached from another one, which therefore has a parent. lib.dom
+ * declares `parentNode` only on `Node`, where it is nullable. The name avoids
+ * lib.dom's `ChildNode`, a mixin that says nothing about the parent.
+ */
+export interface ChildDomNode extends Node {
+  readonly parentNode: ParentNode;
+}
+
+export interface ChildElement extends Element {
+  readonly parentNode: ParentNode;
+}
+
+export function documentElementOf(doc: Document): ChildElement {
+  // the document element is the element child of the document
+  return doc.documentElement as ChildElement;
+}
+
+export function nextElementSiblingOf(element: Element): ChildElement | null {
+  // a sibling exists only under a parent the two share
+  return element.nextElementSibling as ChildElement | null;
+}
+
+export function previousElementSiblingOf(
+  element: Element,
+): ChildElement | null {
+  // a sibling exists only under a parent the two share
+  return element.previousElementSibling as ChildElement | null;
+}
+
+/**
+ * A position reached from the root the cursor was opened at. Moving never goes
+ * above the root's own parent, which is what makes every position the cursor
+ * yields a node with a parent.
+ */
+export class RootBoundCursor {
+  private constructor(
+    private readonly root: ChildElement,
+    readonly node: ChildDomNode,
+  ) {}
+
+  static atRoot(root: ChildElement): RootBoundCursor {
+    return new RootBoundCursor(root, root);
+  }
+
+  private moveTo(node: Node | null): RootBoundCursor | null {
+    return node === null
+      ? null
+      : new RootBoundCursor(this.root, node as ChildDomNode);
+  }
+
+  get firstChild(): RootBoundCursor | null {
+    return this.moveTo(this.node.firstChild);
+  }
+
+  get nextSibling(): RootBoundCursor | null {
+    return this.moveTo(this.node.nextSibling);
+  }
+
+  get parent(): RootBoundCursor | null {
+    if (this.node === this.root) {
+      return null;
+    }
+    const parent = this.node.parentNode;
+    // the root alone does not bound the walk: a sibling move can leave its
+    // subtree
+    return parent === this.root || parent === this.root.parentNode
+      ? null
+      : this.moveTo(parent);
+  }
+}
+
 export function getLangAttribute(element: Element): string {
   let lang = element.getAttributeNS(NS.XML, "lang");
   if (!lang && element.namespaceURI == NS.XHTML) {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -793,7 +793,7 @@ export class ElementCascadeInstance extends StyledCascadeInstance {
     currentStyle: ElementStyle,
     currentClassNames: string[],
     currentEpubTypes: string[],
-    public readonly currentElement: Element,
+    public readonly currentElement: Base.ChildElement,
   ) {
     super(instance, currentStyle, currentClassNames, currentEpubTypes);
   }
@@ -1364,9 +1364,7 @@ export class IsNthLastSiblingAction extends IsNthAction {
     let order = cascadeInstance.instance.currentFollowingSiblingOrder;
     if (order === null) {
       order = cascadeInstance.instance.currentFollowingSiblingOrder =
-        // the cascade walks connected elements, whose parentNode is an
-        // element or the document
-        cascadeInstance.currentElement.parentNode!.childElementCount -
+        cascadeInstance.currentElement.parentNode.childElementCount -
         cascadeInstance.instance.currentSiblingOrder +
         1;
     }
@@ -1390,13 +1388,13 @@ export class IsNthLastSiblingOfTypeAction extends IsNthAction {
         ? counts.byNamespace[cascadeInstance.instance.currentNamespace]
         : counts.noNamespace;
     if (!nsCounts) {
-      let elem = cascadeInstance.currentElement;
+      let elem: Base.ChildElement | null = cascadeInstance.currentElement;
       do {
         const ns = elem.namespaceURI;
         const localName = elem.localName;
         const elemCounts = typeCountsForNamespace(counts, ns);
         elemCounts[localName] = (elemCounts[localName] || 0) + 1;
-      } while ((elem = elem.nextElementSibling));
+      } while ((elem = Base.nextElementSiblingOf(elem)));
       nsCounts = typeCountsForNamespace(
         counts,
         cascadeInstance.instance.currentNamespace,
@@ -1590,9 +1588,7 @@ export class MatchesRelationalAction extends MatchesAction {
       let scopingRoot: ParentNode;
       if (/^\s*[+~]/.test(selectorText)) {
         // :has(+ F) or :has(~ F)
-        // the cascade walks connected elements, whose parentNode is an
-        // element or the document
-        scopingRoot = cascadeInstance.currentElement.parentNode!;
+        scopingRoot = cascadeInstance.currentElement.parentNode;
         const index = Array.from(scopingRoot.children).indexOf(
           cascadeInstance.currentElement,
         );
@@ -1650,19 +1646,19 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
     // Count siblings that match the selector
     const elem = cascadeInstance.currentElement;
     let order = 1;
-    let sibling = elem.previousElementSibling;
+    let sibling = Base.previousElementSiblingOf(elem);
     while (sibling) {
       if (this.matchesSelector(sibling, cascadeInstance)) {
         order++;
       }
-      sibling = sibling.previousElementSibling;
+      sibling = Base.previousElementSiblingOf(sibling);
     }
 
     return this.matchANPlusB(order);
   }
 
   protected matchesSelector(
-    element: Element,
+    element: Base.ChildElement,
     cascadeInstance: ElementCascadeInstance,
   ): boolean {
     const instance = cascadeInstance.instance;
@@ -1739,12 +1735,12 @@ export class IsNthLastSiblingOfSelectorAction extends IsNthSiblingOfSelectorActi
     // Count siblings (from end) that match the selector
     const elem = cascadeInstance.currentElement;
     let order = 1;
-    let sibling = elem.nextElementSibling;
+    let sibling = Base.nextElementSiblingOf(elem);
     while (sibling) {
       if (this.matchesSelector(sibling, cascadeInstance)) {
         order++;
       }
-      sibling = sibling.nextElementSibling;
+      sibling = Base.nextElementSiblingOf(sibling);
     }
 
     return this.matchANPlusB(order);
@@ -3836,7 +3832,7 @@ export class CascadeInstance {
 
   pushElement(
     styler: CssStyler.AbstractStyler,
-    element: Element,
+    element: Base.ChildElement,
     baseStyle: ElementStyle,
     elementOffset: number,
   ): ElementCascadeInstance {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -778,8 +778,29 @@ export type ActionTable = {
   [key: string]: CascadeAction;
 };
 
+export class StyledCascadeInstance {
+  constructor(
+    public readonly instance: CascadeInstance,
+    public readonly currentStyle: ElementStyle,
+    public readonly currentClassNames: string[],
+    public readonly currentEpubTypes: string[],
+  ) {}
+}
+
+export class ElementCascadeInstance extends StyledCascadeInstance {
+  constructor(
+    instance: CascadeInstance,
+    currentStyle: ElementStyle,
+    currentClassNames: string[],
+    currentEpubTypes: string[],
+    public readonly currentElement: Element,
+  ) {
+    super(instance, currentStyle, currentClassNames, currentEpubTypes);
+  }
+}
+
 export class CascadeAction {
-  apply(cascadeInstance: CascadeInstance): void {}
+  apply(cascadeInstance: StyledCascadeInstance): void {}
 
   mergeWith(other: CascadeAction): CascadeAction {
     return new CompoundAction([this, other]);
@@ -796,9 +817,9 @@ export class ConditionItemAction extends CascadeAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
-    cascadeInstance.pushConditionItem(
-      this.conditionItem.fresh(cascadeInstance),
+  override apply(cascadeInstance: StyledCascadeInstance): void {
+    cascadeInstance.instance.pushConditionItem(
+      this.conditionItem.fresh(cascadeInstance.instance),
     );
   }
 }
@@ -808,7 +829,7 @@ export class CompoundAction extends CascadeAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override apply(cascadeInstance: StyledCascadeInstance): void {
     for (let i = 0; i < this.list.length; i++) {
       this.list[i].apply(cascadeInstance);
     }
@@ -835,15 +856,15 @@ export class ApplyRuleAction extends CascadeAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override apply(cascadeInstance: StyledCascadeInstance): void {
     mergeIn(
-      cascadeInstance.context,
+      cascadeInstance.instance.context,
       cascadeInstance.currentStyle,
       this.style,
       this.specificity,
       this.pseudoelement,
       this.regionId,
-      cascadeInstance.buildViewConditionMatcher(this.viewConditionId),
+      cascadeInstance.instance.buildViewConditionMatcher(this.viewConditionId),
     );
   }
 }
@@ -854,7 +875,7 @@ export type PrimarySlot = {
 };
 
 export abstract class ChainedAction {
-  abstract matches(cascadeInstance: CascadeInstance): boolean;
+  abstract matches(cascadeInstance: StyledCascadeInstance): boolean;
 
   getPriority(): number {
     return 0;
@@ -880,7 +901,7 @@ export abstract class WiredAction<
     super();
   }
 
-  abstract override apply(cascadeInstance: CascadeInstance): void;
+  abstract override apply(cascadeInstance: StyledCascadeInstance): void;
 
   makePrimary(cascade: Cascade): boolean {
     const slot = this.condition.primarySlot(cascade);
@@ -893,7 +914,7 @@ export abstract class WiredAction<
 }
 
 export class WiredGuard extends WiredAction {
-  override apply(cascadeInstance: CascadeInstance): void {
+  override apply(cascadeInstance: StyledCascadeInstance): void {
     if (this.condition.matches(cascadeInstance)) {
       this.chained.apply(cascadeInstance);
     }
@@ -901,13 +922,15 @@ export class WiredGuard extends WiredAction {
 }
 
 export class WiredConditionScope extends WiredAction<CheckConditionAction> {
-  override apply(cascadeInstance: CascadeInstance): void {
+  override apply(cascadeInstance: StyledCascadeInstance): void {
     if (this.condition.matches(cascadeInstance)) {
-      cascadeInstance.dependentConditions.push(this.condition.condition);
+      cascadeInstance.instance.dependentConditions.push(
+        this.condition.condition,
+      );
       try {
         this.chained.apply(cascadeInstance);
       } finally {
-        cascadeInstance.dependentConditions.pop();
+        cascadeInstance.instance.dependentConditions.pop();
       }
     }
   }
@@ -918,7 +941,7 @@ export class CheckClassAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
     return cascadeInstance.currentClassNames.includes(this.className);
   }
 
@@ -937,10 +960,10 @@ export class CheckIdAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
     return (
-      cascadeInstance.currentId == this.id ||
-      cascadeInstance.currentXmlId == this.id
+      cascadeInstance.instance.currentId == this.id ||
+      cascadeInstance.instance.currentXmlId == this.id
     );
   }
 
@@ -959,8 +982,8 @@ export class CheckLocalNameAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    return cascadeInstance.currentLocalName == this.localName;
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
+    return cascadeInstance.instance.currentLocalName == this.localName;
   }
 
   override getPriority(): number {
@@ -981,10 +1004,10 @@ export class CheckNSTagAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
     return (
-      cascadeInstance.currentLocalName == this.localName &&
-      cascadeInstance.currentNamespace == this.ns
+      cascadeInstance.instance.currentLocalName == this.localName &&
+      cascadeInstance.instance.currentNamespace == this.ns
     );
   }
 
@@ -1012,7 +1035,7 @@ export class CheckTargetEpubTypeAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
     if (elem instanceof HTMLAnchorElement) {
       if (
@@ -1044,8 +1067,8 @@ export class CheckNamespaceAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    return cascadeInstance.currentNamespace == this.ns;
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
+    return cascadeInstance.instance.currentNamespace == this.ns;
   }
 }
 
@@ -1129,7 +1152,7 @@ export class CheckAttributePresentAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     return checkAttribute(
       cascadeInstance.currentElement,
       this.ns,
@@ -1149,7 +1172,7 @@ export class CheckAttributeEqAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     return checkAttribute(
       cascadeInstance.currentElement,
       this.ns,
@@ -1182,7 +1205,7 @@ export class CheckNamespaceSupportedAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     return checkAttribute(
       cascadeInstance.currentElement,
       this.ns,
@@ -1210,7 +1233,7 @@ export class CheckAttributeRegExpAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     return checkAttribute(
       cascadeInstance.currentElement,
       this.ns,
@@ -1225,8 +1248,8 @@ export class CheckLangAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    return !!cascadeInstance.lang.match(this.langRegExp);
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
+    return !!cascadeInstance.instance.lang.match(this.langRegExp);
   }
 }
 
@@ -1235,8 +1258,8 @@ export class IsFirstAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    return cascadeInstance.isFirst;
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
+    return cascadeInstance.instance.isFirst;
   }
 
   override getPriority(): number {
@@ -1249,8 +1272,8 @@ export class IsRootAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    return cascadeInstance.isRoot;
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
+    return cascadeInstance.instance.isRoot;
   }
 
   override getPriority(): number {
@@ -1280,8 +1303,8 @@ export class IsNthSiblingAction extends IsNthAction {
     super(a, b);
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    return this.matchANPlusB(cascadeInstance.currentSiblingOrder);
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
+    return this.matchANPlusB(cascadeInstance.instance.currentSiblingOrder);
   }
 
   override getPriority(): number {
@@ -1319,11 +1342,11 @@ export class IsNthSiblingOfTypeAction extends IsNthAction {
     super(a, b);
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
     const order = typeCountsForNamespace(
-      cascadeInstance.currentSiblingTypeCounts,
-      cascadeInstance.currentNamespace,
-    )[cascadeInstance.currentLocalName];
+      cascadeInstance.instance.currentSiblingTypeCounts,
+      cascadeInstance.instance.currentNamespace,
+    )[cascadeInstance.instance.currentLocalName];
     return this.matchANPlusB(order);
   }
 
@@ -1337,12 +1360,14 @@ export class IsNthLastSiblingAction extends IsNthAction {
     super(a, b);
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    let order = cascadeInstance.currentFollowingSiblingOrder;
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
+    let order = cascadeInstance.instance.currentFollowingSiblingOrder;
     if (order === null) {
-      order = cascadeInstance.currentFollowingSiblingOrder =
-        cascadeInstance.currentElement.parentNode.childElementCount -
-        cascadeInstance.currentSiblingOrder +
+      order = cascadeInstance.instance.currentFollowingSiblingOrder =
+        // the cascade walks connected elements, whose parentNode is an
+        // element or the document
+        cascadeInstance.currentElement.parentNode!.childElementCount -
+        cascadeInstance.instance.currentSiblingOrder +
         1;
     }
     return this.matchANPlusB(order);
@@ -1358,11 +1383,11 @@ export class IsNthLastSiblingOfTypeAction extends IsNthAction {
     super(a, b);
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    const counts = cascadeInstance.currentFollowingSiblingTypeCounts;
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
+    const counts = cascadeInstance.instance.currentFollowingSiblingTypeCounts;
     let nsCounts =
-      cascadeInstance.currentNamespace !== null
-        ? counts.byNamespace[cascadeInstance.currentNamespace]
+      cascadeInstance.instance.currentNamespace !== null
+        ? counts.byNamespace[cascadeInstance.instance.currentNamespace]
         : counts.noNamespace;
     if (!nsCounts) {
       let elem = cascadeInstance.currentElement;
@@ -1374,10 +1399,12 @@ export class IsNthLastSiblingOfTypeAction extends IsNthAction {
       } while ((elem = elem.nextElementSibling));
       nsCounts = typeCountsForNamespace(
         counts,
-        cascadeInstance.currentNamespace,
+        cascadeInstance.instance.currentNamespace,
       );
     }
-    return this.matchANPlusB(nsCounts[cascadeInstance.currentLocalName]);
+    return this.matchANPlusB(
+      nsCounts[cascadeInstance.instance.currentLocalName],
+    );
   }
 
   override getPriority(): number {
@@ -1390,7 +1417,7 @@ export class IsEmptyAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     let node: Node | null = cascadeInstance.currentElement.firstChild;
     while (node) {
       switch (node.nodeType) {
@@ -1416,7 +1443,7 @@ export class IsEnabledAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
     return (elem as any).disabled === false;
   }
@@ -1431,7 +1458,7 @@ export class IsDisabledAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
     return (elem as any).disabled === true;
   }
@@ -1446,7 +1473,7 @@ export class IsCheckedAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     const elem = cascadeInstance.currentElement;
     return (elem as any).selected === true || (elem as any).checked === true;
   }
@@ -1461,8 +1488,8 @@ export class CheckConditionAction extends ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
-    return !!cascadeInstance.conditions[this.condition];
+  override matches(cascadeInstance: StyledCascadeInstance): boolean {
+    return !!cascadeInstance.instance.conditions[this.condition];
   }
 
   override wire(chained: CascadeAction): WiredAction {
@@ -1481,7 +1508,7 @@ export class CheckAppliedAction extends CascadeAction {
     super();
   }
 
-  override apply(cascadeInstance: CascadeInstance): void {
+  override apply(cascadeInstance: StyledCascadeInstance): void {
     this.applied = true;
   }
 
@@ -1515,7 +1542,7 @@ export class MatchesAction extends ChainedAction {
     }
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     for (const firstAction of this.firstActions) {
       firstAction.apply(cascadeInstance);
       if (this.checkAppliedAction.applied) {
@@ -1557,13 +1584,15 @@ export class MatchesRelationalAction extends MatchesAction {
     super([]);
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     for (const selectorText of this.selectorTexts) {
       let selectorWithScope: string;
       let scopingRoot: ParentNode;
       if (/^\s*[+~]/.test(selectorText)) {
         // :has(+ F) or :has(~ F)
-        scopingRoot = cascadeInstance.currentElement.parentNode;
+        // the cascade walks connected elements, whose parentNode is an
+        // element or the document
+        scopingRoot = cascadeInstance.currentElement.parentNode!;
         const index = Array.from(scopingRoot.children).indexOf(
           cascadeInstance.currentElement,
         );
@@ -1605,7 +1634,7 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
     }
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     // Check if current element matches the selector
     for (const firstAction of this.firstActions) {
       firstAction.apply(cascadeInstance);
@@ -1634,23 +1663,18 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
 
   protected matchesSelector(
     element: Element,
-    cascadeInstance: CascadeInstance,
+    cascadeInstance: ElementCascadeInstance,
   ): boolean {
+    const instance = cascadeInstance.instance;
     // Temporarily save and restore cascade state to test against sibling
-    const savedElement = cascadeInstance.currentElement;
-    const savedNS = cascadeInstance.currentNamespace;
-    const savedLocalName = cascadeInstance.currentLocalName;
-    const savedId = cascadeInstance.currentId;
-    const savedClassNames = cascadeInstance.currentClassNames;
-    const savedSiblingOrder = cascadeInstance.currentSiblingOrder;
+    const savedNS = instance.currentNamespace;
+    const savedLocalName = instance.currentLocalName;
+    const savedId = instance.currentId;
+    const savedSiblingOrder = instance.currentSiblingOrder;
 
-    cascadeInstance.currentElement = element;
-    cascadeInstance.currentNamespace = element.namespaceURI;
-    cascadeInstance.currentLocalName = element.localName;
-    cascadeInstance.currentId = element.getAttribute("id");
-    cascadeInstance.currentClassNames = element.classList
-      ? Array.from(element.classList)
-      : [];
+    instance.currentNamespace = element.namespaceURI;
+    instance.currentLocalName = element.localName;
+    instance.currentId = element.getAttribute("id");
 
     // Calculate sibling order for the element
     let siblingOrder = 1;
@@ -1659,10 +1683,17 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
       siblingOrder++;
       sib = sib.previousElementSibling;
     }
-    cascadeInstance.currentSiblingOrder = siblingOrder;
+    instance.currentSiblingOrder = siblingOrder;
 
+    const siblingCascadeInstance = new ElementCascadeInstance(
+      instance,
+      cascadeInstance.currentStyle,
+      element.classList ? Array.from(element.classList) : [],
+      cascadeInstance.currentEpubTypes,
+      element,
+    );
     for (const firstAction of this.firstActions) {
-      firstAction.apply(cascadeInstance);
+      firstAction.apply(siblingCascadeInstance);
       if (this.checkAppliedAction.applied) {
         break;
       }
@@ -1671,12 +1702,10 @@ export class IsNthSiblingOfSelectorAction extends IsNthAction {
     this.checkAppliedAction.applied = false;
 
     // Restore cascade state
-    cascadeInstance.currentElement = savedElement;
-    cascadeInstance.currentNamespace = savedNS;
-    cascadeInstance.currentLocalName = savedLocalName;
-    cascadeInstance.currentId = savedId;
-    cascadeInstance.currentClassNames = savedClassNames;
-    cascadeInstance.currentSiblingOrder = savedSiblingOrder;
+    instance.currentNamespace = savedNS;
+    instance.currentLocalName = savedLocalName;
+    instance.currentId = savedId;
+    instance.currentSiblingOrder = savedSiblingOrder;
 
     return matched;
   }
@@ -1694,7 +1723,7 @@ export class IsNthLastSiblingOfSelectorAction extends IsNthSiblingOfSelectorActi
     super(a, b, chains);
   }
 
-  override matches(cascadeInstance: CascadeInstance): boolean {
+  override matches(cascadeInstance: ElementCascadeInstance): boolean {
     // Check if current element matches the selector
     for (const firstAction of this.firstActions) {
       firstAction.apply(cascadeInstance);
@@ -1962,6 +1991,7 @@ export class AfterPseudoelementItem implements ConditionItem {
   constructor(
     public readonly afterprop: ElementStyle,
     public readonly element: Element,
+    public readonly elementStyle: ElementStyle,
   ) {}
 
   /** @override */
@@ -1977,7 +2007,11 @@ export class AfterPseudoelementItem implements ConditionItem {
   /** @override */
   pop(cascadeInstance: CascadeInstance, depth: number): boolean {
     if (depth == 0) {
-      cascadeInstance.processPseudoelementProps(this.afterprop, this.element);
+      cascadeInstance.processPseudoelementProps(
+        this.afterprop,
+        this.element,
+        this.elementStyle,
+      );
       return true;
     }
     return false;
@@ -2267,6 +2301,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     public cascade: CascadeInstance,
     public element: Element,
     public readonly counterResolver: CounterResolver,
+    private readonly elementStyle: ElementStyle | null,
     private readonly pseudoName?: string,
   ) {
     super();
@@ -2797,7 +2832,9 @@ export class ContentPropVisitor extends Css.FilterVisitor {
             stringValue = pseudoElem.textContent || "";
           } else {
             // Fallback: get from stored styles and evaluate counter() functions
-            const pseudos = getStyleMap(this.cascade.currentStyle, "_pseudos");
+            const pseudos = this.elementStyle
+              ? getStyleMap(this.elementStyle, "_pseudos")
+              : undefined;
             const val = (pseudos?.[pseudoName]?.["content"] as CascadeValue)
               ?.value;
             if (val) {
@@ -2805,9 +2842,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
             } else if (pseudoName === "marker") {
               // Native ::marker: content was extracted to --viv-marker-content
               const markerVal = (
-                this.cascade.currentStyle[
-                  "--viv-marker-content"
-                ] as CascadeValue
+                this.elementStyle?.["--viv-marker-content"] as CascadeValue
               )?.value;
               stringValue = getStringValueFromCssContentVal(
                 markerVal,
@@ -2820,7 +2855,9 @@ export class ContentPropVisitor extends Css.FilterVisitor {
       case "first-letter":
         {
           // Respect ::before/after pseudo-elements (Issue #1174)
-          const pseudos = getStyleMap(this.cascade.currentStyle, "_pseudos");
+          const pseudos = this.elementStyle
+            ? getStyleMap(this.elementStyle, "_pseudos")
+            : undefined;
           const beforeVal = (pseudos?.["before"]?.["content"] as CascadeValue)
             ?.value;
           const afterVal = (pseudos?.["after"]?.["content"] as CascadeValue)
@@ -3481,10 +3518,14 @@ export class CascadeInstance {
     );
   }
 
-  applyAction(table: ActionTable, key: string): void {
+  applyAction(
+    cascadeInstance: StyledCascadeInstance,
+    table: ActionTable,
+    key: string,
+  ): void {
     const action = table[key];
     if (action) {
-      action.apply(this);
+      action.apply(cascadeInstance);
     }
   }
 
@@ -3504,7 +3545,9 @@ export class CascadeInstance {
     this.currentNSTag = "";
     this.currentEpubTypes = EMPTY;
     this.currentPageType = pageType;
-    this.applyActions();
+    this.applyActions(
+      new StyledCascadeInstance(this, baseStyle, classes, EMPTY),
+    );
   }
 
   defineCounter(counterName: string, value: number) {
@@ -3524,7 +3567,7 @@ export class CascadeInstance {
     scoping[counterName] = true;
   }
 
-  pushCounters(props: ElementStyle): void {
+  pushCounters(props: ElementStyle, elementStyle: ElementStyle | null): void {
     const counterChanges = new Set<string>();
     const counterChangeTypes: {
       [key: string]: "reset" | "set" | "increment";
@@ -3610,7 +3653,7 @@ export class CascadeInstance {
     }
     if (
       floatVal === Css.ident.footnote &&
-      !this.currentStyle["--viv-semantic-footnote-content"]
+      !elementStyle?.["--viv-semantic-footnote-content"]
     ) {
       if (!incrementMap) {
         incrementMap = Object.create(null);
@@ -3621,7 +3664,7 @@ export class CascadeInstance {
       // on the element (parent element of the pseudo element).
       if (incrementMap["footnote"] === undefined) {
         const incrPropValue = (
-          this.currentStyle["counter-increment"] as CascadeValue
+          elementStyle?.["counter-increment"] as CascadeValue
         )?.value;
         if (
           !incrPropValue ||
@@ -3718,13 +3761,17 @@ export class CascadeInstance {
    * Process CSS string-set property
    * https://drafts.csswg.org/css-gcpm-3/#setting-named-strings-the-string-set-pro
    */
-  setNamedStrings(props: ElementStyle): void {
+  setNamedStrings(
+    props: ElementStyle,
+    element: Element,
+    elementOffset: number,
+  ): void {
     let stringSet = props["string-set"] as CascadeValue;
     if (!stringSet) {
       return;
     }
     stringSet = stringSet.filterValue(
-      new ContentPropVisitor(this, this.currentElement, this.counterResolver),
+      new ContentPropVisitor(this, element, this.counterResolver, props),
     );
     const sets =
       stringSet.value instanceof Css.CommaList
@@ -3748,17 +3795,13 @@ export class CascadeInstance {
               new Css.SpaceList(valueParts),
               this.context,
             ),
-            this.currentElementOffset,
+            elementOffset,
           );
         } else {
           const stringValue = valueParts
             .map((v) => getStringValueFromCssContentVal(v, this.context))
             .join("");
-          this.counterResolver.setNamedString(
-            name,
-            stringValue,
-            this.currentElementOffset,
-          );
+          this.counterResolver.setNamedString(name, stringValue, elementOffset);
         }
       }
     }
@@ -3769,27 +3812,34 @@ export class CascadeInstance {
    * Process CSS running elements
    * https://drafts.csswg.org/css-gcpm-3/#running-elements
    */
-  setRunningElement(props: ElementStyle): void {
+  setRunningElement(props: ElementStyle, elementOffset: number): void {
     const position = props["position"] as CascadeValue;
     if (
       position?.value instanceof Css.Func &&
       position.value.name === "running"
     ) {
       const name = position.value.values[0].stringValue();
-      this.counterResolver.setRunningElement(name, this.currentElementOffset);
+      this.counterResolver.setRunningElement(name, elementOffset);
     }
   }
 
   processPseudoelementProps(
     pseudoprops: ElementStyle,
     element: Element,
+    elementStyle: ElementStyle,
     pseudoName?: string,
   ): void {
-    this.pushCounters(pseudoprops);
+    this.pushCounters(pseudoprops, elementStyle);
     const content = pseudoprops["content"] as CascadeValue;
     if (content) {
       pseudoprops["content"] = content.filterValue(
-        new ContentPropVisitor(this, element, this.counterResolver, pseudoName),
+        new ContentPropVisitor(
+          this,
+          element,
+          this.counterResolver,
+          elementStyle,
+          pseudoName,
+        ),
       );
     }
     this.popCounters();
@@ -3826,17 +3876,11 @@ export class CascadeInstance {
     this.currentId = element.getAttribute("id");
     this.currentXmlId = element.getAttributeNS(Base.NS.XML, "id");
     const classes = element.getAttribute("class");
-    if (classes) {
-      this.currentClassNames = classes.split(/\s+/);
-    } else {
-      this.currentClassNames = EMPTY;
-    }
+    const classNames = classes ? classes.split(/\s+/) : EMPTY;
+    this.currentClassNames = classNames;
     const types = element.getAttributeNS(Base.NS.epub, "type");
-    if (types) {
-      this.currentEpubTypes = types.split(/\s+/);
-    } else {
-      this.currentEpubTypes = EMPTY;
-    }
+    const epubTypes = types ? types.split(/\s+/) : EMPTY;
+    this.currentEpubTypes = epubTypes;
     const lang = Base.getLangAttribute(element);
     if (lang) {
       this.stack[this.stack.length - 1].push(new RestoreLangItem(this.lang));
@@ -3885,19 +3929,27 @@ export class CascadeInstance {
       followingNamespaceTypeCounts[this.currentLocalName]--;
     }
     followingSiblingTypeCountsStack.push(emptySiblingTypeCounts());
-    this.applyActions();
+    this.applyActions(
+      new ElementCascadeInstance(
+        this,
+        baseStyle,
+        classNames,
+        epubTypes,
+        element,
+      ),
+    );
     this.currentPageType = savedCurrentPageType;
 
     // Substitute var()
-    this.applyVarFilter([this.currentStyle], styler, element);
+    this.applyVarFilter([baseStyle], styler, element);
 
     // Calculate calc()
-    this.applyCalcFilter(this.currentStyle, this.context);
+    this.applyCalcFilter(baseStyle, this.context);
 
     // Convert device-cmyk() to color(srgb ...)
-    this.applyCmykFilter(this.currentStyle, this.currentElement);
+    this.applyCmykFilter(baseStyle, element);
 
-    this.applyAttrFilter(element, styler);
+    this.applyAttrFilter(element, styler, baseStyle);
     const quotesCasc = baseStyle["quotes"] as CascadeValue;
     let itemToPushLast: QuotesScopeItem | null = null;
     if (quotesCasc) {
@@ -3922,7 +3974,7 @@ export class CascadeInstance {
         }
       }
     }
-    this.pushCounters(this.currentStyle);
+    this.pushCounters(baseStyle, baseStyle);
     const id =
       this.currentId || this.currentXmlId || element.getAttribute("name") || "";
     if (isRoot || id) {
@@ -3982,9 +4034,7 @@ export class CascadeInstance {
                 this.hasNonTrivialViewConditionalPseudoContent(pseudoProps)
               )) ||
             (pseudoName === "marker" &&
-              !Display.isListItem(
-                getProp(this.currentStyle, "display")?.value,
-              )) ||
+              !Display.isListItem(getProp(baseStyle, "display")?.value)) ||
             ((pseudoName === "footnote-call" ||
               pseudoName === "footnote-marker") &&
               floatValue !== Css.ident.footnote &&
@@ -3997,7 +4047,12 @@ export class CascadeInstance {
           ) {
             delete pseudos[pseudoName];
           } else if (before) {
-            this.processPseudoelementProps(pseudoProps, element, pseudoName);
+            this.processPseudoelementProps(
+              pseudoProps,
+              element,
+              baseStyle,
+              pseudoName,
+            );
 
             if (pseudoName === "marker") {
               // Extract ::marker properties into CSS custom properties on the
@@ -4007,6 +4062,7 @@ export class CascadeInstance {
                 pseudoProps,
                 element,
                 styler,
+                baseStyle,
               );
               // Delete the pseudo to prevent fake element generation
               delete pseudos[pseudoName];
@@ -4028,6 +4084,7 @@ export class CascadeInstance {
                   pseudoProps,
                   element,
                   styler,
+                  baseStyle,
                 );
                 // Preserve the original footnote-marker content for semantic
                 // footnotes so vgen can re-evaluate it with the final counter.
@@ -4039,11 +4096,11 @@ export class CascadeInstance {
                     footnoteMarkerContent;
                 }
                 // Set display: list-item for native ::marker to work
-                this.currentStyle["display"] = new CascadeValue(
+                baseStyle["display"] = new CascadeValue(
                   Css.getName("list-item"),
                   0,
                 );
-                this.currentStyle["list-style-position"] = new CascadeValue(
+                baseStyle["list-style-position"] = new CascadeValue(
                   Css.ident.outside,
                   0,
                 );
@@ -4081,7 +4138,7 @@ export class CascadeInstance {
             }
           } else {
             this.stack[this.stack.length - 2].push(
-              new AfterPseudoelementItem(pseudoProps, element),
+              new AfterPseudoelementItem(pseudoProps, element, baseStyle),
             );
           }
         }
@@ -4089,10 +4146,10 @@ export class CascadeInstance {
     }
 
     // process CSS string-set property
-    this.setNamedStrings(this.currentStyle);
+    this.setNamedStrings(baseStyle, element, elementOffset);
 
     // process CSS running elements
-    this.setRunningElement(this.currentStyle);
+    this.setRunningElement(baseStyle, elementOffset);
 
     if (itemToPushLast) {
       this.stack[this.stack.length - 2].push(itemToPushLast);
@@ -4151,9 +4208,10 @@ export class CascadeInstance {
     pseudoProps: ElementStyle,
     element: Element,
     styler: CssStyler.AbstractStyler,
+    elementStyle: ElementStyle,
   ): void {
     const isListItem = Display.isListItem(
-      (this.currentStyle["display"] as CascadeValue)?.value,
+      (elementStyle["display"] as CascadeValue)?.value,
     );
 
     // Resolve marker content from list-style-* if no explicit content
@@ -4188,8 +4246,7 @@ export class CascadeInstance {
       ) {
         // list-style-type: <counter-style>
         const listItemCount = (
-          (this.currentStyle["ua-list-item-count"] as CascadeValue)
-            ?.value as Css.Num
+          (elementStyle["ua-list-item-count"] as CascadeValue)?.value as Css.Num
         )?.num;
         if (listItemCount != null) {
           const lowerName = listStyleType.name.toLowerCase();
@@ -4224,7 +4281,7 @@ export class CascadeInstance {
       if (Vtree.nonTrivialContent(contentVal)) {
         // Resolve any Css.Expr nodes (e.g., from counter()) to strings
         const resolvedContent = this.resolveMarkerContentVal(contentVal);
-        this.currentStyle["--viv-marker-content"] = new CascadeValue(
+        elementStyle["--viv-marker-content"] = new CascadeValue(
           resolvedContent,
           0,
         );
@@ -4237,16 +4294,13 @@ export class CascadeInstance {
       if (prop) {
         const val = prop.evaluate(this.context, propName);
         if (val && !Css.isDefaultingValue(val)) {
-          this.currentStyle[`--viv-marker-${propName}`] = new CascadeValue(
-            val,
-            0,
-          );
+          elementStyle[`--viv-marker-${propName}`] = new CascadeValue(val, 0);
         }
       }
     }
 
     // list-style-position
-    if (!Display.isInlineLevel(getProp(this.currentStyle, "display")?.value)) {
+    if (!Display.isInlineLevel(getProp(elementStyle, "display")?.value)) {
       const listStylePosition = this.getInheritedPropertyValue(
         "list-style-position",
         styler,
@@ -4257,7 +4311,7 @@ export class CascadeInstance {
         listStylePosition !== Css.ident.outside &&
         !Css.isDefaultingValue(listStylePosition)
       ) {
-        this.currentStyle["list-style-position"] = new CascadeValue(
+        elementStyle["list-style-position"] = new CascadeValue(
           listStylePosition,
           0,
         );
@@ -4391,8 +4445,9 @@ export class CascadeInstance {
   private applyAttrFilter(
     element: Element,
     styler: CssStyler.AbstractStyler,
+    elementStyle: ElementStyle,
   ): void {
-    const currentStyle = this.currentStyle;
+    const currentStyle = elementStyle;
     const pseudoMap = getStyleMap(currentStyle, "_pseudos");
     for (const pseudoName in pseudoMap) {
       this.applyAttrFilterInner(styler, element, pseudoMap[pseudoName]);
@@ -4620,31 +4675,37 @@ export class CascadeInstance {
     }
   }
 
-  private applyActions(): void {
+  private applyActions(cascadeInstance: StyledCascadeInstance): void {
     let i: number;
-    for (i = 0; i < this.currentClassNames.length; i++) {
-      this.applyAction(this.code.classes, this.currentClassNames[i]);
+    const classNames = cascadeInstance.currentClassNames;
+    for (i = 0; i < classNames.length; i++) {
+      this.applyAction(cascadeInstance, this.code.classes, classNames[i]);
     }
-    for (i = 0; i < this.currentEpubTypes.length; i++) {
-      this.applyAction(this.code.epubtypes, this.currentEpubTypes[i]);
+    const epubTypes = cascadeInstance.currentEpubTypes;
+    for (i = 0; i < epubTypes.length; i++) {
+      this.applyAction(cascadeInstance, this.code.epubtypes, epubTypes[i]);
     }
     if (this.currentId !== null) {
-      this.applyAction(this.code.ids, this.currentId);
+      this.applyAction(cascadeInstance, this.code.ids, this.currentId);
     }
-    this.applyAction(this.code.tags, this.currentLocalName);
+    this.applyAction(cascadeInstance, this.code.tags, this.currentLocalName);
     if (this.currentLocalName != "") {
       // Universal selector does not apply to page-master-related rules.
-      this.applyAction(this.code.tags, "*");
+      this.applyAction(cascadeInstance, this.code.tags, "*");
     }
-    this.applyAction(this.code.nstags, this.currentNSTag);
+    this.applyAction(cascadeInstance, this.code.nstags, this.currentNSTag);
 
     // Apply page rules only when currentPageType is not null
     if (this.currentPageType !== null) {
-      this.applyAction(this.code.pagetypes, this.currentPageType);
+      this.applyAction(
+        cascadeInstance,
+        this.code.pagetypes,
+        this.currentPageType,
+      );
 
       // We represent page rules without selectors by *, though it is illegal in
       // CSS
-      this.applyAction(this.code.pagetypes, "*");
+      this.applyAction(cascadeInstance, this.code.pagetypes, "*");
     }
 
     this.stack.push([]);

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2301,7 +2301,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     public cascade: CascadeInstance,
     public element: Element,
     public readonly counterResolver: CounterResolver,
-    private readonly elementStyle: ElementStyle | null,
+    private readonly elementStyle: ElementStyle,
     private readonly pseudoName?: string,
   ) {
     super();
@@ -2346,8 +2346,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
     propName: "counter-reset" | "counter-set" | "counter-increment",
     options: { reset?: boolean; defaultValue?: number },
   ): boolean {
-    const currentStyle = this.cascade.currentStyle;
-    const cascVal = currentStyle?.[propName] as CascadeValue;
+    const cascVal = this.elementStyle[propName] as CascadeValue;
     if (!cascVal) {
       return false;
     }
@@ -2832,9 +2831,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
             stringValue = pseudoElem.textContent || "";
           } else {
             // Fallback: get from stored styles and evaluate counter() functions
-            const pseudos = this.elementStyle
-              ? getStyleMap(this.elementStyle, "_pseudos")
-              : undefined;
+            const pseudos = getStyleMap(this.elementStyle, "_pseudos");
             const val = (pseudos?.[pseudoName]?.["content"] as CascadeValue)
               ?.value;
             if (val) {
@@ -2842,7 +2839,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
             } else if (pseudoName === "marker") {
               // Native ::marker: content was extracted to --viv-marker-content
               const markerVal = (
-                this.elementStyle?.["--viv-marker-content"] as CascadeValue
+                this.elementStyle["--viv-marker-content"] as CascadeValue
               )?.value;
               stringValue = getStringValueFromCssContentVal(
                 markerVal,
@@ -2855,9 +2852,7 @@ export class ContentPropVisitor extends Css.FilterVisitor {
       case "first-letter":
         {
           // Respect ::before/after pseudo-elements (Issue #1174)
-          const pseudos = this.elementStyle
-            ? getStyleMap(this.elementStyle, "_pseudos")
-            : undefined;
+          const pseudos = getStyleMap(this.elementStyle, "_pseudos");
           const beforeVal = (pseudos?.["before"]?.["content"] as CascadeValue)
             ?.value;
           const afterVal = (pseudos?.["after"]?.["content"] as CascadeValue)
@@ -3397,14 +3392,11 @@ export class CascadeInstance {
   conditions = Object.create(null) as { [key: string]: number };
   currentElement: Element | null = null;
   currentElementOffset: number | null = null;
-  currentStyle: ElementStyle | null = null;
-  currentClassNames: string[] | null = null;
   currentLocalName: string = "";
   currentNamespace: string | null = null;
   currentId: string | null = null;
   currentXmlId: string | null = null;
   currentNSTag: string = "";
-  currentEpubTypes: string[] | null = null;
   currentPageType: string | null = null;
   previousPageType: string | null = null;
   firstPageType: string | null = null;
@@ -3536,14 +3528,11 @@ export class CascadeInstance {
   ): void {
     this.currentElement = null;
     this.currentElementOffset = null;
-    this.currentStyle = baseStyle;
     this.currentNamespace = null;
     this.currentLocalName = "";
     this.currentId = null;
     this.currentXmlId = null;
-    this.currentClassNames = classes;
     this.currentNSTag = "";
-    this.currentEpubTypes = EMPTY;
     this.currentPageType = pageType;
     this.applyActions(
       new StyledCascadeInstance(this, baseStyle, classes, EMPTY),
@@ -3567,7 +3556,7 @@ export class CascadeInstance {
     scoping[counterName] = true;
   }
 
-  pushCounters(props: ElementStyle, elementStyle: ElementStyle | null): void {
+  pushCounters(props: ElementStyle, elementStyle: ElementStyle): void {
     const counterChanges = new Set<string>();
     const counterChangeTypes: {
       [key: string]: "reset" | "set" | "increment";
@@ -3653,7 +3642,7 @@ export class CascadeInstance {
     }
     if (
       floatVal === Css.ident.footnote &&
-      !elementStyle?.["--viv-semantic-footnote-content"]
+      !elementStyle["--viv-semantic-footnote-content"]
     ) {
       if (!incrementMap) {
         incrementMap = Object.create(null);
@@ -3664,7 +3653,7 @@ export class CascadeInstance {
       // on the element (parent element of the pseudo element).
       if (incrementMap["footnote"] === undefined) {
         const incrPropValue = (
-          elementStyle?.["counter-increment"] as CascadeValue
+          elementStyle["counter-increment"] as CascadeValue
         )?.value;
         if (
           !incrPropValue ||
@@ -3850,7 +3839,7 @@ export class CascadeInstance {
     element: Element,
     baseStyle: ElementStyle,
     elementOffset: number,
-  ): void {
+  ): ElementCascadeInstance {
     if (VIVLIOSTYLE_DEBUG) {
       this.elementStack.push(element);
     }
@@ -3861,7 +3850,6 @@ export class CascadeInstance {
     this.currentPageType = null;
     this.currentElement = element;
     this.currentElementOffset = elementOffset;
-    this.currentStyle = baseStyle;
     this.currentNamespace = element.namespaceURI;
     this.currentLocalName = element.localName;
     const prefix =
@@ -3877,10 +3865,8 @@ export class CascadeInstance {
     this.currentXmlId = element.getAttributeNS(Base.NS.XML, "id");
     const classes = element.getAttribute("class");
     const classNames = classes ? classes.split(/\s+/) : EMPTY;
-    this.currentClassNames = classNames;
     const types = element.getAttributeNS(Base.NS.epub, "type");
     const epubTypes = types ? types.split(/\s+/) : EMPTY;
-    this.currentEpubTypes = epubTypes;
     const lang = Base.getLangAttribute(element);
     if (lang) {
       this.stack[this.stack.length - 1].push(new RestoreLangItem(this.lang));
@@ -3929,15 +3915,14 @@ export class CascadeInstance {
       followingNamespaceTypeCounts[this.currentLocalName]--;
     }
     followingSiblingTypeCountsStack.push(emptySiblingTypeCounts());
-    this.applyActions(
-      new ElementCascadeInstance(
-        this,
-        baseStyle,
-        classNames,
-        epubTypes,
-        element,
-      ),
+    const cascadeInstance = new ElementCascadeInstance(
+      this,
+      baseStyle,
+      classNames,
+      epubTypes,
+      element,
     );
+    this.applyActions(cascadeInstance);
     this.currentPageType = savedCurrentPageType;
 
     // Substitute var()
@@ -3984,7 +3969,7 @@ export class CascadeInstance {
       });
       this.counterListener.countersOfId(id, counters);
     }
-    const pseudos = getStyleMap(this.currentStyle, "_pseudos");
+    const pseudos = getStyleMap(baseStyle, "_pseudos");
     if (pseudos) {
       let before = true;
       for (const pseudoName of pseudoNames) {
@@ -3994,7 +3979,7 @@ export class CascadeInstance {
         }
         const pseudoProps = pseudos[pseudoName];
         if (pseudoProps) {
-          const floatValue = getProp(this.currentStyle, "float")?.value;
+          const floatValue = getProp(baseStyle, "float")?.value;
           const isSemanticNoteref =
             element instanceof Element &&
             SemanticFootnote.isSemanticFootnoteNoterefElement(element);
@@ -4002,7 +3987,7 @@ export class CascadeInstance {
             element instanceof Element &&
             SemanticFootnote.isSemanticFootnoteElement(element);
           const isSemanticFootnoteContent = !!getProp(
-            this.currentStyle,
+            baseStyle,
             "--viv-semantic-footnote-content",
           );
           const isFootnoteFloat = floatValue === Css.ident.footnote;
@@ -4077,6 +4062,7 @@ export class CascadeInstance {
                   "list-style-position",
                   styler,
                   element,
+                  baseStyle,
                 );
               if (fnMarkerListStylePos === Css.ident.outside) {
                 // Use native ::marker with CSS custom properties
@@ -4092,8 +4078,7 @@ export class CascadeInstance {
                   "content"
                 ] as CascadeValue;
                 if (footnoteMarkerContent) {
-                  this.currentStyle["_footnote-marker-content"] =
-                    footnoteMarkerContent;
+                  baseStyle["_footnote-marker-content"] = footnoteMarkerContent;
                 }
                 // Set display: list-item for native ::marker to work
                 baseStyle["display"] = new CascadeValue(
@@ -4104,11 +4089,11 @@ export class CascadeInstance {
                   Css.ident.outside,
                   0,
                 );
-                this.currentStyle["list-style-type"] = new CascadeValue(
+                baseStyle["list-style-type"] = new CascadeValue(
                   Css.ident.none,
                   0,
                 );
-                this.currentStyle["list-style-image"] = new CascadeValue(
+                baseStyle["list-style-image"] = new CascadeValue(
                   Css.ident.none,
                   0,
                 );
@@ -4129,7 +4114,7 @@ export class CascadeInstance {
                 initialLetterVal !== Css.ident.normal &&
                 !Css.isDefaultingValue(initialLetterVal)
               ) {
-                this.currentStyle["--viv-initialLetter"] = new CascadeValue(
+                baseStyle["--viv-initialLetter"] = new CascadeValue(
                   initialLetterVal,
                   0,
                 );
@@ -4154,6 +4139,7 @@ export class CascadeInstance {
     if (itemToPushLast) {
       this.stack[this.stack.length - 2].push(itemToPushLast);
     }
+    return cascadeInstance;
   }
 
   private hasNonTrivialViewConditionalPseudoContent(
@@ -4197,7 +4183,7 @@ export class CascadeInstance {
 
   /**
    * Extract ::marker or ::footnote-marker properties into CSS custom
-   * properties (--viv-marker-*) on the parent element's currentStyle,
+   * properties (--viv-marker-*) on the parent element's style,
    * so that the browser's native ::marker can be controlled via polyfill CSS.
    *
    * For ::marker: the content is resolved from list-style-type/list-style-image
@@ -4225,11 +4211,13 @@ export class CascadeInstance {
         "list-style-type",
         styler,
         element,
+        elementStyle,
       );
       const listStyleImage = this.getInheritedPropertyValue(
         "list-style-image",
         styler,
         element,
+        elementStyle,
       );
       if (listStyleImage instanceof Css.URL) {
         // list-style-image: <URL> -> content: <URL> " "
@@ -4305,6 +4293,7 @@ export class CascadeInstance {
         "list-style-position",
         styler,
         element,
+        elementStyle,
       );
       if (
         listStylePosition &&
@@ -4346,18 +4335,18 @@ export class CascadeInstance {
    * @param propName
    * @param styler
    * @param element
+   * @param elementStyle style being cascaded for `element`, which the styler
+   *     cannot serve until the cascade for it finishes
    * @returns the inherited property value, or the initial value (or null) if not found
    */
   getInheritedPropertyValue(
     propName: string,
     styler: CssStyler.AbstractStyler,
     element: Element,
+    elementStyle: ElementStyle,
   ): Css.Val | null {
     for (let e = element; e; e = e.parentElement) {
-      const style =
-        e === this.currentElement
-          ? this.currentStyle
-          : styler.getStyle(e, false);
+      const style = e === element ? elementStyle : styler.getStyle(e, false);
       const prop = style[propName] as CascadeValue;
       if (prop) {
         const val = prop.evaluate(this.context, propName);
@@ -4384,6 +4373,7 @@ export class CascadeInstance {
     propName: string,
     styler: CssStyler.AbstractStyler,
     element: Element,
+    elementStyle: ElementStyle,
   ): Css.Val | null {
     const prop = pseudoProps[propName] as CascadeValue;
     if (prop) {
@@ -4404,7 +4394,12 @@ export class CascadeInstance {
         return val;
       }
     }
-    return this.getInheritedPropertyValue(propName, styler, element);
+    return this.getInheritedPropertyValue(
+      propName,
+      styler,
+      element,
+      elementStyle,
+    );
   }
 
   private applyAttrFilterInner(
@@ -4447,12 +4442,11 @@ export class CascadeInstance {
     styler: CssStyler.AbstractStyler,
     elementStyle: ElementStyle,
   ): void {
-    const currentStyle = elementStyle;
-    const pseudoMap = getStyleMap(currentStyle, "_pseudos");
+    const pseudoMap = getStyleMap(elementStyle, "_pseudos");
     for (const pseudoName in pseudoMap) {
       this.applyAttrFilterInner(styler, element, pseudoMap[pseudoName]);
     }
-    this.applyAttrFilterInner(styler, element, currentStyle);
+    this.applyAttrFilterInner(styler, element, elementStyle);
   }
 
   /**

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -2882,8 +2882,8 @@ export class CheckPageTypeAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
-    return cascadeInstance.currentPageType === this.pageType;
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
+    return cascadeInstance.instance.currentPageType === this.pageType;
   }
 
   override getPriority(): number {
@@ -2902,9 +2902,9 @@ export class IsFirstPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
     const pageNumber = new Exprs.Named(this.scope, "page-number");
-    return pageNumber.evaluate(cascadeInstance.context) === 1;
+    return pageNumber.evaluate(cascadeInstance.instance.context) === 1;
   }
 
   override getPriority(): number {
@@ -2917,9 +2917,9 @@ export class IsBlankPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
     const blankPage = new Exprs.Named(this.scope, "blank-page");
-    return !!blankPage.evaluate(cascadeInstance.context);
+    return !!blankPage.evaluate(cascadeInstance.instance.context);
   }
 
   override getPriority(): number {
@@ -2932,9 +2932,9 @@ export class IsLeftPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
     const leftPage = new Exprs.Named(this.scope, "left-page");
-    return !!leftPage.evaluate(cascadeInstance.context);
+    return !!leftPage.evaluate(cascadeInstance.instance.context);
   }
 
   override getPriority(): number {
@@ -2947,9 +2947,9 @@ export class IsRightPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
     const rightPage = new Exprs.Named(this.scope, "right-page");
-    return !!rightPage.evaluate(cascadeInstance.context);
+    return !!rightPage.evaluate(cascadeInstance.instance.context);
   }
 
   override getPriority(): number {
@@ -2962,9 +2962,9 @@ export class IsRectoPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
     const rectoPage = new Exprs.Named(this.scope, "recto-page");
-    return !!rectoPage.evaluate(cascadeInstance.context);
+    return !!rectoPage.evaluate(cascadeInstance.instance.context);
   }
 
   override getPriority(): number {
@@ -2977,9 +2977,9 @@ export class IsVersoPageAction extends CssCascade.ChainedAction {
     super();
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
     const versoPage = new Exprs.Named(this.scope, "verso-page");
-    return !!versoPage.evaluate(cascadeInstance.context);
+    return !!versoPage.evaluate(cascadeInstance.instance.context);
   }
 
   override getPriority(): number {
@@ -2996,8 +2996,9 @@ export class IsNthPageAction extends CssCascade.IsNthAction {
     super(a, b);
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
-    const styleInstance: any /* Ops.StyleInstance */ = cascadeInstance.context;
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
+    const styleInstance: any /* Ops.StyleInstance */ =
+      cascadeInstance.instance.context;
     let pageNumber = styleInstance.layoutPositionAtPageStart.page;
     if (styleInstance.blankPageAtStart) {
       pageNumber--;
@@ -3020,8 +3021,9 @@ export class IsNthOfPageTypeAction extends CssCascade.IsNthAction {
     super(a, b);
   }
 
-  override matches(cascadeInstance: CssCascade.CascadeInstance): boolean {
-    const pageTypeIndices = cascadeInstance.pageTypePageIndices[this.pageType];
+  override matches(cascadeInstance: CssCascade.StyledCascadeInstance): boolean {
+    const pageTypeIndices =
+      cascadeInstance.instance.pageTypePageIndices[this.pageType];
     if (!pageTypeIndices) {
       return false;
     }
@@ -3048,9 +3050,9 @@ export class ApplyPageRuleAction extends CssCascade.ApplyRuleAction {
     super(style, specificity, null, null, null);
   }
 
-  override apply(cascadeInstance: CssCascade.CascadeInstance): void {
+  override apply(cascadeInstance: CssCascade.StyledCascadeInstance): void {
     mergeInPageRule(
-      cascadeInstance.context,
+      cascadeInstance.instance.context,
       cascadeInstance.currentStyle,
       this.style,
       this.specificity,
@@ -3069,7 +3071,7 @@ export function mergeInPageRule(
   target: CssCascade.ElementStyle,
   style: CssCascade.ElementStyle,
   specificity: number,
-  cascadeInstance: CssCascade.CascadeInstance,
+  cascadeInstance: CssCascade.StyledCascadeInstance,
 ): void {
   CssCascade.mergeIn(context, target, style, specificity, null, null, null);
   const marginBoxes = style[marginBoxesKey];

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -466,9 +466,9 @@ export class BoxStack {
 }
 
 export class Styler implements AbstractStyler {
-  root: Element;
+  root: Base.ChildElement;
   cascadeHolder: CssCascade.Cascade;
-  last: Node;
+  last: Base.RootBoundCursor | null;
   rootStyle = {} as CssCascade.ElementStyle;
   styleMap: { [key: string]: CssCascade.ElementStyle } = {};
   counterSnapshots: CounterSnapshot[] = [];
@@ -505,7 +505,7 @@ export class Styler implements AbstractStyler {
   ) {
     this.root = xmldoc.root;
     this.cascadeHolder = cascade;
-    this.last = this.root;
+    this.last = Base.RootBoundCursor.atRoot(this.root);
     this.cascade = cascade.createInstance(
       context,
       counterListener,
@@ -1026,11 +1026,11 @@ export class Styler implements AbstractStyler {
     }
     const context = this.context;
     while (this.last) {
-      let next: Node = this.last.firstChild;
+      let next = this.last.firstChild;
       if (next == null) {
         while (this.last) {
-          if (this.last.nodeType == 1) {
-            this.cascade.popElement(this.last as Element);
+          if (this.last.node.nodeType == 1) {
+            this.cascade.popElement(this.last.node as Element);
             this.primary = this.primaryStack.pop();
             const box = this.boxStack.pop(this.lastOffset);
             let breakAfter: string | null = null;
@@ -1060,9 +1060,8 @@ export class Styler implements AbstractStyler {
           if (next) {
             break;
           }
-          this.last = this.last.parentNode;
-          if (!this.last || this.last === this.root) {
-            this.last = null;
+          this.last = this.last.parent;
+          if (!this.last) {
             if (startOffset < this.lastOffset) {
               if (targetSlippedOffset < 0) {
                 slippedOffset = this.offsetMap.slippedByFixed(startOffset);
@@ -1077,17 +1076,18 @@ export class Styler implements AbstractStyler {
           }
         }
       }
-      this.last = next;
-      if (this.last.nodeType != 1) {
-        this.lastOffset += this.last.textContent.length;
-        this.boxStack.encounteredTextNode(this.last);
+      const cursor = next;
+      this.last = cursor;
+      if (cursor.node.nodeType != 1) {
+        this.lastOffset += cursor.node.textContent.length;
+        this.boxStack.encounteredTextNode(cursor.node);
         if (this.primary) {
           this.offsetMap.addStuckRange(this.lastOffset);
         } else {
           this.offsetMap.addSlippedRange(this.lastOffset);
         }
       } else {
-        const elem = this.last as Element;
+        const elem = cursor.node as Base.ChildElement;
         const style = this.getAttrStyle(elem);
         this.primaryStack.push(this.primary);
         this.elementWindow = this.cascade.pushElement(
@@ -1184,7 +1184,7 @@ export class Styler implements AbstractStyler {
           }
         }
         if (VIVLIOSTYLE_DEBUG) {
-          const offset = this.xmldoc.getElementOffset(this.last as Element);
+          const offset = this.xmldoc.getElementOffset(elem);
           if (offset != this.lastOffset) {
             throw new Error("Inconsistent offset");
           }

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -478,6 +478,9 @@ export class Styler implements AbstractStyler {
   flowToReach: string | null = null;
   idToReach: string | null = null;
   cascade: CssCascade.CascadeInstance;
+  // the last element the cascade opened, kept across pops: vgen reads it when
+  // it re-evaluates generated content
+  elementWindow: CssCascade.ElementCascadeInstance;
   offsetMap: SlipMap;
   primary: boolean = true;
   primaryStack = [] as boolean[];
@@ -517,7 +520,12 @@ export class Styler implements AbstractStyler {
     this.boxStack = new BoxStack(context);
     this.offsetMap.addStuckRange(rootOffset);
     const style = this.getAttrStyle(this.root);
-    this.cascade.pushElement(this, this.root, style, rootOffset);
+    this.elementWindow = this.cascade.pushElement(
+      this,
+      this.root,
+      style,
+      rootOffset,
+    );
     this.recordCounterSnapshot(
       rootOffset,
       this.cascade.counters,
@@ -1082,7 +1090,12 @@ export class Styler implements AbstractStyler {
         const elem = this.last as Element;
         const style = this.getAttrStyle(elem);
         this.primaryStack.push(this.primary);
-        this.cascade.pushElement(this, elem, style, this.lastOffset);
+        this.elementWindow = this.cascade.pushElement(
+          this,
+          elem,
+          style,
+          this.lastOffset,
+        );
         if (this.cascade.lastCounterChanges.length > 0) {
           this.recordCounterSnapshot(
             this.lastOffset,

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1738,13 +1738,14 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
       // page/margin-box content so sibling margin boxes do not inherit each
       // other's local counter operations.
       cascade.counterScoping.push(null);
-      cascade.pushCounters(style, cascade.currentStyle);
+      // the callers push this box's rule before resolving its content
+      cascade.pushCounters(style, style);
       style["content"] = content.filterValue(
         new CssCascade.ContentPropVisitor(
           cascade,
           null,
           cascade.counterResolver,
-          cascade.currentStyle,
+          style,
         ),
       );
       cascade.popCounters();

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1738,12 +1738,13 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
       // page/margin-box content so sibling margin boxes do not inherit each
       // other's local counter operations.
       cascade.counterScoping.push(null);
-      cascade.pushCounters(style);
+      cascade.pushCounters(style, cascade.currentStyle);
       style["content"] = content.filterValue(
         new CssCascade.ContentPropVisitor(
           cascade,
           null,
           cascade.counterResolver,
+          cascade.currentStyle,
         ),
       );
       cascade.popCounters();

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1423,7 +1423,7 @@ export namespace XmlDoc {
   export interface XMLDocHolder {
     lang: string | null;
     totalOffset: number;
-    root: Element;
+    root: Base.ChildElement;
     body: Element;
     head: Element;
     last: Element;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1222,7 +1222,7 @@ export class ViewFactory
               this.styler.cascade,
               target,
               this.styler.cascade.counterResolver,
-              this.styler.cascade.currentStyle,
+              this.styler.elementWindow.currentStyle,
               "footnote-marker",
             ),
           ).value,
@@ -3806,7 +3806,7 @@ export class ViewFactory
                 this.styler.cascade,
                 contentElement,
                 this.styler.cascade.counterResolver,
-                this.styler.cascade.currentStyle,
+                this.styler.elementWindow.currentStyle,
                 "before",
               ),
             )

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1222,6 +1222,7 @@ export class ViewFactory
               this.styler.cascade,
               target,
               this.styler.cascade.counterResolver,
+              this.styler.cascade.currentStyle,
               "footnote-marker",
             ),
           ).value,
@@ -3805,6 +3806,7 @@ export class ViewFactory
                 this.styler.cascade,
                 contentElement,
                 this.styler.cascade.counterResolver,
+                this.styler.cascade.currentStyle,
                 "before",
               ),
             )

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -29,7 +29,7 @@ export type XMLDocStore = XmlDoc.XMLDocStore;
 export class XMLDocHolder implements XmlDoc.XMLDocHolder {
   lang: string | null = null;
   totalOffset: number = -1;
-  root: Element;
+  root: Base.ChildElement;
   body: Element;
   head: Element;
   last: Element;
@@ -41,7 +41,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
     public readonly url: string,
     public readonly document: Document,
   ) {
-    this.root = document.documentElement; // html element
+    this.root = Base.documentElementOf(document); // html element
     let body: Element = null;
     let head: Element = null;
     if (this.root.namespaceURI == Base.NS.XHTML) {
@@ -168,7 +168,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
     // First, find the last element in the document, such that
     // this.getElementOffset(element) <= offset; if offest matches
     // exactly, just return it.
-    let element = this.root;
+    let element: Element = this.root;
     while (true) {
       elementOffset = this.getElementOffset(element);
       if (elementOffset >= offset) {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -65,6 +65,19 @@ module.exports = [
         file: "css-parse-error/unknown-pseudo-class.html",
         title: "Unknown pseudo-class in a selector list",
       },
+      {
+        file: "pseudo-element-context/after-float-footnote-increment.html",
+        title:
+          "Explicit counter-increment on an element with a footnote ::after",
+      },
+      {
+        file: "pseudo-element-context/after-content-function.html",
+        title: "content(before) in the ::after of an element with children",
+      },
+      {
+        file: "pseudo-element-context/after-list-item-counter.html",
+        title: "list-item counter in the pseudo-elements of an ordered list",
+      },
       { file: "rem_in_page_margin.html", title: "rem in page margin" },
       {
         file: "rlh_unit/root-line-height-normal.html",

--- a/packages/core/test/files/pseudo-element-context/after-content-function.html
+++ b/packages/core/test/files/pseudo-element-context/after-content-function.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>content(before) in the ::after of an element with children</title>
+    <style>
+      p::before {
+        content: "BEFORE";
+      }
+      p::after {
+        content: " / after sees [" content(before) "]";
+      }
+    </style>
+  </head>
+  <body>
+    <p>This paragraph has a child element <span>here</span>.</p>
+  </body>
+</html>

--- a/packages/core/test/files/pseudo-element-context/after-float-footnote-increment.html
+++ b/packages/core/test/files/pseudo-element-context/after-float-footnote-increment.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Explicit counter-increment on an element with a footnote ::after</title>
+    <style>
+      p {
+        counter-increment: footnote 5;
+      }
+      p::after {
+        float: footnote;
+        content: "footnote=" counter(footnote) " (should be 5)";
+      }
+    </style>
+  </head>
+  <body>
+    <p>This paragraph has a child element <span>here</span>.</p>
+  </body>
+</html>

--- a/packages/core/test/files/pseudo-element-context/after-list-item-counter.html
+++ b/packages/core/test/files/pseudo-element-context/after-list-item-counter.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>list-item counter in the pseudo-elements of an ordered list</title>
+    <style>
+      ol::before {
+        display: block;
+        content: "before=" counter(list-item) " (should be 4)";
+      }
+      ol::after {
+        display: block;
+        content: "after=" counter(list-item) " (should be 6)";
+      }
+    </style>
+  </head>
+  <body>
+    <ol start="5">
+      <li>first</li>
+      <li>second</li>
+    </ol>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -50,10 +50,10 @@ describe("css-cascade", function () {
       var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 1 });
+      wired.apply({ instance: { currentSiblingOrder: 1 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 3 });
+      wired.apply({ instance: { currentSiblingOrder: 3 } });
       expect(chained.apply).toHaveBeenCalled();
     });
 
@@ -62,103 +62,103 @@ describe("css-cascade", function () {
       var chained = jasmine.createSpyObj("chained", ["apply"]);
       var wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 1 });
+      wired.apply({ instance: { currentSiblingOrder: 1 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 2 });
+      wired.apply({ instance: { currentSiblingOrder: 2 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 3 });
+      wired.apply({ instance: { currentSiblingOrder: 3 } });
       expect(chained.apply).toHaveBeenCalled();
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 4 });
+      wired.apply({ instance: { currentSiblingOrder: 4 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 5 });
+      wired.apply({ instance: { currentSiblingOrder: 5 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 6 });
+      wired.apply({ instance: { currentSiblingOrder: 6 } });
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(2, 3);
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 1 });
+      wired.apply({ instance: { currentSiblingOrder: 1 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 2 });
+      wired.apply({ instance: { currentSiblingOrder: 2 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 3 });
+      wired.apply({ instance: { currentSiblingOrder: 3 } });
       expect(chained.apply).toHaveBeenCalled();
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 4 });
+      wired.apply({ instance: { currentSiblingOrder: 4 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 5 });
+      wired.apply({ instance: { currentSiblingOrder: 5 } });
       expect(chained.apply).toHaveBeenCalled();
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 6 });
+      wired.apply({ instance: { currentSiblingOrder: 6 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 7 });
+      wired.apply({ instance: { currentSiblingOrder: 7 } });
       expect(chained.apply).toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(-3, 0);
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 1 });
+      wired.apply({ instance: { currentSiblingOrder: 1 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 2 });
+      wired.apply({ instance: { currentSiblingOrder: 2 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 3 });
+      wired.apply({ instance: { currentSiblingOrder: 3 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
       action = new adapt_csscasc.IsNthSiblingAction(-2, 5);
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 1 });
+      wired.apply({ instance: { currentSiblingOrder: 1 } });
       expect(chained.apply).toHaveBeenCalled();
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 2 });
+      wired.apply({ instance: { currentSiblingOrder: 2 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 3 });
+      wired.apply({ instance: { currentSiblingOrder: 3 } });
       expect(chained.apply).toHaveBeenCalled();
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 4 });
+      wired.apply({ instance: { currentSiblingOrder: 4 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 5 });
+      wired.apply({ instance: { currentSiblingOrder: 5 } });
       expect(chained.apply).toHaveBeenCalled();
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
 
-      wired.apply({ currentSiblingOrder: 6 });
+      wired.apply({ instance: { currentSiblingOrder: 6 } });
       expect(chained.apply).not.toHaveBeenCalled();
 
-      wired.apply({ currentSiblingOrder: 7 });
+      wired.apply({ instance: { currentSiblingOrder: 7 } });
       expect(chained.apply).not.toHaveBeenCalled();
     });
   });
@@ -174,9 +174,11 @@ describe("css-cascade", function () {
         currentSiblingTypeCounts.byNamespace[ns] = counts;
       }
       return {
-        currentSiblingTypeCounts: currentSiblingTypeCounts,
-        currentNamespace: element.namespaceURI,
-        currentLocalName: element.localName,
+        instance: {
+          currentSiblingTypeCounts: currentSiblingTypeCounts,
+          currentNamespace: element.namespaceURI,
+          currentLocalName: element.localName,
+        },
       };
     }
 
@@ -315,7 +317,9 @@ describe("css-cascade", function () {
       var wired = action.wire(chained);
 
       var cascadeInstance = dummyCascadeInstance({ bar: 1 }, null);
-      cascadeInstance.currentSiblingTypeCounts.byNamespace["foo"] = { bar: 3 };
+      cascadeInstance.instance.currentSiblingTypeCounts.byNamespace["foo"] = {
+        bar: 3,
+      };
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
     });
@@ -324,8 +328,10 @@ describe("css-cascade", function () {
   describe("IsNthLastSiblingAction", function () {
     function dummyCascadeInstance(count) {
       return {
-        currentFollowingSiblingOrder: null,
-        currentSiblingOrder: 3,
+        instance: {
+          currentFollowingSiblingOrder: null,
+          currentSiblingOrder: 3,
+        },
         currentElement: { parentNode: { childElementCount: count } },
       };
     }
@@ -338,12 +344,12 @@ describe("css-cascade", function () {
       var cascadeInstance = dummyCascadeInstance(4);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(3);
     });
 
     it("when a is non-zero, matches if non-negative n which satisfies currentFollowingSiblingOrder=an+b exists", function () {
@@ -354,17 +360,17 @@ describe("css-cascade", function () {
       var cascadeInstance = dummyCascadeInstance(3);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(1);
 
       cascadeInstance = dummyCascadeInstance(4);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(3);
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
@@ -372,17 +378,17 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(6);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(4);
 
       cascadeInstance = dummyCascadeInstance(7);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(5);
 
       cascadeInstance = dummyCascadeInstance(8);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(6);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(2, 3);
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -391,17 +397,17 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(3);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(1);
 
       cascadeInstance = dummyCascadeInstance(4);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(3);
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
@@ -409,12 +415,12 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(6);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(4);
 
       cascadeInstance = dummyCascadeInstance(7);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(5);
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
@@ -422,12 +428,12 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(8);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(6);
 
       cascadeInstance = dummyCascadeInstance(9);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(7);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(7);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(-3, 0);
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -436,17 +442,17 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(3);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(1);
 
       cascadeInstance = dummyCascadeInstance(4);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(3);
 
       action = new adapt_csscasc.IsNthLastSiblingAction(-2, 5);
       chained = jasmine.createSpyObj("chained", ["apply"]);
@@ -455,7 +461,7 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(3);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(1);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(1);
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
@@ -463,7 +469,7 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(4);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(2);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(2);
 
       cascadeInstance = dummyCascadeInstance(5);
       wired.apply(cascadeInstance);
@@ -471,17 +477,17 @@ describe("css-cascade", function () {
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(3);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(3);
 
       cascadeInstance = dummyCascadeInstance(6);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(4);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(4);
 
       cascadeInstance = dummyCascadeInstance(7);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(5);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(5);
 
       chained = jasmine.createSpyObj("chained", ["apply"]);
       wired = action.wire(chained);
@@ -489,12 +495,12 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance(8);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(6);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(6);
 
       cascadeInstance = dummyCascadeInstance(9);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingOrder).toBe(7);
+      expect(cascadeInstance.instance.currentFollowingSiblingOrder).toBe(7);
     });
   });
 
@@ -512,12 +518,14 @@ describe("css-cascade", function () {
         }
       });
       return {
-        currentFollowingSiblingTypeCounts: {
-          byNamespace: {},
-          noNamespace: null,
+        instance: {
+          currentFollowingSiblingTypeCounts: {
+            byNamespace: {},
+            noNamespace: null,
+          },
+          currentNamespace: currentElement.namespaceURI,
+          currentLocalName: currentElement.localName,
         },
-        currentNamespace: currentElement.namespaceURI,
-        currentLocalName: currentElement.localName,
         currentElement: currentElement,
       };
     }
@@ -530,7 +538,9 @@ describe("css-cascade", function () {
       var cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 2, baz: 2 } },
         noNamespace: null,
       });
@@ -538,7 +548,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 3, baz: 1 } },
         noNamespace: null,
       });
@@ -552,7 +564,9 @@ describe("css-cascade", function () {
       var cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 1, baz: 2 } },
         noNamespace: null,
       });
@@ -560,7 +574,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 2, baz: 2 } },
         noNamespace: null,
       });
@@ -568,7 +584,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 3, baz: 1 } },
         noNamespace: null,
       });
@@ -579,7 +597,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 4, baz: 3 } },
         noNamespace: null,
       });
@@ -587,7 +607,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 5, baz: 3 } },
         noNamespace: null,
       });
@@ -595,7 +617,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 6, baz: 1 } },
         noNamespace: null,
       });
@@ -607,7 +631,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 1, baz: 3 } },
         noNamespace: null,
       });
@@ -615,7 +641,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 2, baz: 3 } },
         noNamespace: null,
       });
@@ -623,7 +651,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 3, baz: 1 } },
         noNamespace: null,
       });
@@ -634,7 +664,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 4, baz: 3 } },
         noNamespace: null,
       });
@@ -642,7 +674,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 5, baz: 1 } },
         noNamespace: null,
       });
@@ -653,7 +687,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 6, baz: 3 } },
         noNamespace: null,
       });
@@ -661,7 +697,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 6, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 7, baz: 3 } },
         noNamespace: null,
       });
@@ -673,7 +711,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 1, baz: 3 } },
         noNamespace: null,
       });
@@ -681,7 +721,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 2, baz: 3 } },
         noNamespace: null,
       });
@@ -689,7 +731,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 3 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 3, baz: 3 } },
         noNamespace: null,
       });
@@ -701,7 +745,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 0, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 1, baz: 2 } },
         noNamespace: null,
       });
@@ -712,7 +758,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 2, baz: 1 } },
         noNamespace: null,
       });
@@ -720,7 +768,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 3, baz: 2 } },
         noNamespace: null,
       });
@@ -731,7 +781,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 3, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 4, baz: 1 } },
         noNamespace: null,
       });
@@ -739,7 +791,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 4, baz: 2 });
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 5, baz: 2 } },
         noNamespace: null,
       });
@@ -750,7 +804,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 5, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 6, baz: 1 } },
         noNamespace: null,
       });
@@ -758,7 +814,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 6, baz: 1 });
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 7, baz: 1 } },
         noNamespace: null,
       });
@@ -772,7 +830,9 @@ describe("css-cascade", function () {
       var cascadeInstance = dummyCascadeInstance({ bar: 1, baz: 2 }, null);
       wired.apply(cascadeInstance);
       expect(chained.apply).not.toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: {},
         noNamespace: { bar: 2, baz: 2 },
       });
@@ -780,7 +840,9 @@ describe("css-cascade", function () {
       cascadeInstance = dummyCascadeInstance({ bar: 2, baz: 1 }, null);
       wired.apply(cascadeInstance);
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: {},
         noNamespace: { bar: 3, baz: 1 },
       });
@@ -801,12 +863,14 @@ describe("css-cascade", function () {
         },
       };
       var cascadeInstance = {
-        currentFollowingSiblingTypeCounts: {
-          byNamespace: {},
-          noNamespace: null,
+        instance: {
+          currentFollowingSiblingTypeCounts: {
+            byNamespace: {},
+            noNamespace: null,
+          },
+          currentNamespace: currentElement.namespaceURI,
+          currentLocalName: currentElement.localName,
         },
-        currentNamespace: currentElement.namespaceURI,
-        currentLocalName: currentElement.localName,
         currentElement: currentElement,
       };
       var action = new adapt_csscasc.IsNthLastSiblingOfTypeAction(0, 2);
@@ -814,7 +878,9 @@ describe("css-cascade", function () {
 
       action.wire(chained).apply(cascadeInstance);
 
-      expect(cascadeInstance.currentFollowingSiblingTypeCounts).toEqual({
+      expect(
+        cascadeInstance.instance.currentFollowingSiblingTypeCounts,
+      ).toEqual({
         byNamespace: { foo: { bar: 2 } },
         noNamespace: { bar: 1 },
       });
@@ -838,17 +904,22 @@ describe("css-cascade", function () {
       var first = dummyElement(null, "bar");
       var current = dummyElement(null, "bar");
       current.previousElementSibling = first;
-      var cascadeInstance = {
-        currentElement: current,
+      var instance = {
         currentNamespace: null,
         currentLocalName: "bar",
         currentId: null,
-        currentClassNames: [],
         currentSiblingOrder: 2,
         currentSiblingTypeCounts: {
           byNamespace: {},
           noNamespace: { bar: 2 },
         },
+      };
+      var cascadeInstance = {
+        instance: instance,
+        currentStyle: {},
+        currentClassNames: [],
+        currentEpubTypes: [],
+        currentElement: current,
       };
       var action = new adapt_csscasc.IsNthSiblingOfSelectorAction(0, 2, [
         [new adapt_csscasc.IsNthSiblingOfTypeAction(0, 2)],
@@ -859,14 +930,81 @@ describe("css-cascade", function () {
 
       // The probe reads the same slot the main walk writes, so no "" bucket
       // is created on the side.
-      expect(cascadeInstance.currentSiblingTypeCounts).toEqual({
+      expect(instance.currentSiblingTypeCounts).toEqual({
         byNamespace: {},
         noNamespace: { bar: 2 },
       });
       expect(chained.apply).toHaveBeenCalled();
-      expect(cascadeInstance.currentElement).toBe(current);
-      expect(cascadeInstance.currentNamespace).toBeNull();
-      expect(cascadeInstance.currentSiblingOrder).toBe(2);
+      expect(instance.currentNamespace).toBeNull();
+      expect(instance.currentLocalName).toBe("bar");
+      expect(instance.currentSiblingOrder).toBe(2);
+    });
+
+    it("probes a sibling in a window carrying that sibling", function () {
+      var first = dummyElement("http://www.w3.org/1999/xhtml", "p");
+      first.classList = ["first"];
+      var current = dummyElement("http://www.w3.org/1999/xhtml", "p");
+      current.previousElementSibling = first;
+      var instance = {
+        currentNamespace: "http://www.w3.org/1999/xhtml",
+        currentLocalName: "p",
+        currentId: null,
+        currentSiblingOrder: 2,
+      };
+      var mainStyle = {};
+      var mainEpubTypes = ["chapter"];
+      var cascadeInstance = {
+        instance: instance,
+        currentStyle: mainStyle,
+        currentClassNames: ["current"],
+        currentEpubTypes: mainEpubTypes,
+        currentElement: current,
+      };
+      var seen = [];
+      var recorder = new adapt_csscasc.ChainedAction();
+      recorder.matches = function (window) {
+        seen.push(window);
+        return true;
+      };
+      var action = new adapt_csscasc.IsNthSiblingOfSelectorAction(0, 2, [
+        [recorder],
+      ]);
+
+      action
+        .wire(jasmine.createSpyObj("chained", ["apply"]))
+        .apply(cascadeInstance);
+
+      expect(seen.length).toBe(2);
+      var probe = seen[1];
+      expect(probe.currentElement).toBe(first);
+      expect(probe.currentClassNames).toEqual(["first"]);
+      expect(probe.currentStyle).toBe(mainStyle);
+      expect(probe.currentEpubTypes).toBe(mainEpubTypes);
+      expect(probe.instance).toBe(instance);
+    });
+  });
+
+  describe("AfterPseudoelementItem", function () {
+    it("processes the after props against the style captured for its element", function () {
+      var afterprop = { content: "after content" };
+      var element = { localName: "p" };
+      var elementStyle = { display: "block" };
+      var item = new adapt_csscasc.AfterPseudoelementItem(
+        afterprop,
+        element,
+        elementStyle,
+      );
+      var cascadeInstance = jasmine.createSpyObj("cascadeInstance", [
+        "processPseudoelementProps",
+      ]);
+
+      expect(item.pop(cascadeInstance, 0)).toBe(true);
+
+      expect(cascadeInstance.processPseudoelementProps).toHaveBeenCalledWith(
+        afterprop,
+        element,
+        elementStyle,
+      );
     });
   });
 
@@ -2143,14 +2281,12 @@ describe("css-cascade", function () {
           return style;
         },
       };
-      var cascadeInstance = {
-        currentStyle: style,
-      };
+      var cascadeInstance = {};
       cascadeInstance.applyAttrFilter =
         adapt_csscasc.CascadeInstance.prototype.applyAttrFilter;
       cascadeInstance.applyAttrFilterInner =
         adapt_csscasc.CascadeInstance.prototype.applyAttrFilterInner;
-      cascadeInstance.applyAttrFilter(element, styler);
+      cascadeInstance.applyAttrFilter(element, styler, style);
     }
 
     it("treats missing typed attr() without fallback as unset", function () {


### PR DESCRIPTION
長いライフタイムを持つ`CascadeInstance`が、いま処理している要素とそのスタイルをnullableの常駐フィールド`currentStyle`, `currentElement`, `current*`に置いており、`strictNullChecks`下ではこれらはアサーションを付けて読み込む必要がありました。また`currentStyle`が最後に開いた要素を指し続けることで、子を持つ要素の`::after`において`float: footnote`の自動`counter-increment`の抑止と`content()`のフォールバックに不正な挙動がありました。`current*`郡を`CascadeInstance`から切り出し、readonlyの`StyledCascadeInstance` / `ElementCascadeInstance`が一度に管理します。

追加したVRTケース3件のうち2件は差分になり、1件は`start`属性を持つ`ol`要素の疑似要素にリグレッションを起こさないためのケースです。 #2083 と合わせて7件出れば想定通りです。