### PR TITLE
refactor: Return the break position together with the context it broke at

### DIFF
--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3299,21 +3299,19 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     return result;
   }
 
-  findAcceptableBreakPosition(): BreakPositionAndNodeContext {
-    let bp: Layout.BreakPosition = null;
-    let nodeContext: Vtree.NodeContext = null;
+  findAcceptableBreakPosition(): BreakPositionAndNodeContext | null {
+    let found: BreakPositionAndNodeContext | null = null;
     let penalty = 0;
     let nextPenalty = 0;
     do {
       penalty = nextPenalty;
       nextPenalty = Number.MAX_VALUE;
-      for (
-        let i = this.breakPositions.length - 1;
-        i >= 0 && !nodeContext;
-        --i
-      ) {
-        bp = this.breakPositions[i];
-        nodeContext = bp.findAcceptableBreak(this, penalty);
+      for (let i = this.breakPositions.length - 1; i >= 0 && !found; --i) {
+        const bp = this.breakPositions[i];
+        const nodeContext = bp.findAcceptableBreak(this, penalty);
+        if (nodeContext) {
+          found = { breakPosition: bp, nodeContext };
+        }
         const minPenalty = bp.getMinBreakPenalty();
         if (minPenalty > penalty) {
           nextPenalty = Math.min(nextPenalty, minPenalty);
@@ -3323,10 +3321,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       // Don't need to find a non-optimal break position if
       // forceNonfitting=false
       nextPenalty > penalty &&
-      !nodeContext &&
+      !found &&
       this.forceNonfitting
     );
-    return { breakPosition: nodeContext ? bp : null, nodeContext };
+    return found;
   }
 
   doFinishBreak(
@@ -4947,8 +4945,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // page break
                 overflownNodeContext = nodeContext;
                 const bp = this.findAcceptableBreakPosition();
-                nodeContext = bp.nodeContext;
-                if (bp.breakPosition) {
+                nodeContext = bp && bp.nodeContext;
+                if (bp) {
                   bp.breakPosition.breakPositionChosen(this);
                 }
                 loopFrame.breakLoop(); // Loop end
@@ -5081,24 +5079,19 @@ export class PseudoColumn {
   ): Task.Result<Vtree.ChunkPosition> {
     return this.column.layout(chunkPosition, leadingEdge);
   }
-  findAcceptableBreakPosition(
-    allowBreakAtStartPosition: boolean,
-  ): Layout.BreakPositionAndNodeContext {
+  findAcceptableBreakPosition(): Layout.BreakPositionAndNodeContext {
     const p = this.column.findAcceptableBreakPosition();
-    if (allowBreakAtStartPosition) {
-      const startNodeContext = this.startNodeContexts[0].copy();
-      const bp = new BreakPosition.EdgeBreakPosition(
-        startNodeContext,
-        null,
-        startNodeContext.overflow,
-        0,
-      );
-      bp.findAcceptableBreak(this.column, 0);
-      if (!p.nodeContext) {
-        return { breakPosition: bp, nodeContext: startNodeContext };
-      }
-    }
-    return p;
+    const startNodeContext = this.startNodeContexts[0].copy();
+    const bp = new BreakPosition.EdgeBreakPosition(
+      startNodeContext,
+      null,
+      startNodeContext.overflow,
+      0,
+    );
+    // updates the column's overflow state, so it runs whether or not the
+    // start position is the one taken
+    bp.findAcceptableBreak(this.column, 0);
+    return p ?? { breakPosition: bp, nodeContext: startNodeContext };
   }
   /**
    * @return holing true

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -121,7 +121,7 @@ export class TableCellFragment {
     if (alignContent && alignContent !== "normal") {
       Base.setCSSProperty(element, "align-content", "normal");
     }
-    const bp = this.pseudoColumn.findAcceptableBreakPosition(true);
+    const bp = this.pseudoColumn.findAcceptableBreakPosition();
     Base.setCSSProperty(element, "vertical-align", verticalAlign);
     if (alignContent && alignContent !== "normal") {
       Base.setCSSProperty(element, "align-content", alignContent);
@@ -200,10 +200,7 @@ export class BetweenTableRowBreakPosition
       const cellFragment = this.formattingContext.getCellFragmentOfCell(cell);
       if (cellFragment) {
         const bp = cellFragment.findAcceptableBreakPosition();
-        if (
-          bp.nodeContext &&
-          !cellFragment.pseudoColumn.isLastAfterNodeContext(bp.nodeContext)
-        ) {
+        if (!cellFragment.pseudoColumn.isLastAfterNodeContext(bp.nodeContext)) {
           return true;
         }
       }
@@ -280,18 +277,16 @@ export class InsideTableRowBreakPosition
     }
     const cellFragments = this.getCellFragments();
     const acceptableCellBreakPositions = this.getAcceptableCellBreakPositions();
-    const allCellsBreakable =
-      acceptableCellBreakPositions.every((bp) => !!bp.nodeContext) &&
-      acceptableCellBreakPositions.some((bp, index) => {
-        const pseudoColumn = cellFragments[index].pseudoColumn;
-        const nodeContext = bp.nodeContext;
-        return (
-          !pseudoColumn.isStartNodeContext(nodeContext) &&
-          !pseudoColumn.isLastAfterNodeContext(nodeContext)
-        );
-      });
+    const allCellsBreakable = acceptableCellBreakPositions.some((bp, index) => {
+      const pseudoColumn = cellFragments[index].pseudoColumn;
+      const nodeContext = bp.nodeContext;
+      return (
+        !pseudoColumn.isStartNodeContext(nodeContext) &&
+        !pseudoColumn.isLastAfterNodeContext(nodeContext)
+      );
+    });
     this.beforeNodeContext.overflow = acceptableCellBreakPositions.some(
-      (bp) => bp.nodeContext && bp.nodeContext.overflow,
+      (bp) => bp.nodeContext.overflow,
     );
     if (allCellsBreakable) {
       return this.beforeNodeContext;

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -165,22 +165,14 @@ export class BetweenTableRowBreakPosition
     if (penalty < this.getMinBreakPenalty()) {
       return null;
     }
-    const allCellsBreakable = this.getAcceptableCellBreakPositions().every(
-      (bp) => !!bp.nodeContext,
-    );
-    if (allCellsBreakable) {
-      // Also verify that all non-spanning cells in the row have fully rendered.
-      // If any cell has remaining content, this between-row break would lose it
-      // because finishBreak for between-row breaks only saves break positions
-      // for row-spanning cells. An InsideTableRowBreakPosition should be used
-      // instead. (Issue #1663)
-      if (this.hasUnfinishedCells()) {
-        return null;
-      }
-      return breakNodeContext;
-    } else {
+    // If any cell has remaining content, this between-row break would lose it
+    // because finishBreak for between-row breaks only saves break positions
+    // for row-spanning cells. An InsideTableRowBreakPosition should be used
+    // instead. (Issue #1663)
+    if (this.hasUnfinishedCells()) {
       return null;
     }
+    return breakNodeContext;
   }
 
   /**
@@ -277,18 +269,20 @@ export class InsideTableRowBreakPosition
     }
     const cellFragments = this.getCellFragments();
     const acceptableCellBreakPositions = this.getAcceptableCellBreakPositions();
-    const allCellsBreakable = acceptableCellBreakPositions.some((bp, index) => {
-      const pseudoColumn = cellFragments[index].pseudoColumn;
-      const nodeContext = bp.nodeContext;
-      return (
-        !pseudoColumn.isStartNodeContext(nodeContext) &&
-        !pseudoColumn.isLastAfterNodeContext(nodeContext)
-      );
-    });
+    const foundBreakInsideCell = acceptableCellBreakPositions.some(
+      (bp, index) => {
+        const pseudoColumn = cellFragments[index].pseudoColumn;
+        const nodeContext = bp.nodeContext;
+        return (
+          !pseudoColumn.isStartNodeContext(nodeContext) &&
+          !pseudoColumn.isLastAfterNodeContext(nodeContext)
+        );
+      },
+    );
     this.beforeNodeContext.overflow = acceptableCellBreakPositions.some(
       (bp) => bp.nodeContext.overflow,
     );
-    if (allCellsBreakable) {
+    if (foundBreakInsideCell) {
       return this.beforeNodeContext;
     } else {
       return null;
@@ -2093,7 +2087,6 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
             const cellFragment = formattingContext.getCellFragmentOfCell(cell);
             const breakNodeContext =
               cellFragment.findAcceptableBreakPosition().nodeContext;
-            Asserts.assert(breakNodeContext);
             const cellNodeContext = cellFragment.cellNodeContext;
             const cellNodePosition = cellNodeContext.toNodePosition();
             const breakChunkPosition = new VtreeImpl.ChunkPosition(

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -416,7 +416,7 @@ export namespace Layout {
       forceRemoveSelf: boolean,
       endOfColumn: boolean,
     ): Task.Result<boolean>;
-    findAcceptableBreakPosition(): BreakPositionAndNodeContext;
+    findAcceptableBreakPosition(): BreakPositionAndNodeContext | null;
     doFinishBreak(
       nodeContext: Vtree.NodeContext,
       overflownNodeContext: Vtree.NodeContext,


### PR DESCRIPTION
`Column.findAcceptableBreakPosition`の戻り値は、2つは常に同時に有無が決まるのに、宣言は片方ずつnullableになっていました。nullableでないペアと`| null`で表します。

`PseudoColumn.findAcceptableBreakPosition`は引数`allowBreakAtStartPosition`がtrueの場合、必ず対を返す関数でした。呼び出しは1箇所で引数は常にtrueです。引数を削除し常に対を返す関数にすれば、複数のnullチェックが不要になります。