### PR TITLE
refactor: Give the cascade its environment at construction

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4481,10 +4481,9 @@ export class CascadeInstance {
       }
       if (value !== cascVal.value) {
         // all variables substituted
-        const scope = this.scope;
         const shorthand = this.validatorSet
           .getShorthand(name, value)
-          ?.clone(scope);
+          ?.clone(this.scope);
         if (shorthand) {
           if (Css.isDefaultingValue(value)) {
             for (const nameLH of shorthand.propList) {
@@ -4499,7 +4498,7 @@ export class CascadeInstance {
             // cannot handle directly, so normalize it through parseValue
             // before expanding the shorthand to longhands.
             const valueSH = CssParser.parseValue(
-              scope,
+              this.scope,
               new CssTokenizer.Tokenizer(value.toString(), null),
               "",
             );

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -600,6 +600,7 @@ export function mergeIn(
   pseudoelement: string | null,
   regionId: string | null,
   viewConditionMatcher: Matchers.Matcher | null,
+  validatorSet: CssValidator.ValidatorSet | null,
 ): void {
   const hierarchy = [
     { id: pseudoelement, styleKey: "_pseudos" },
@@ -643,11 +644,6 @@ export function mergeIn(
 
       // Reserve longhand slots for shorthand declarations, including
       // browser-supported shorthands discovered lazily by ValidatorSet.
-      const validatorSet = (
-        context as Exprs.Context & {
-          style: { validatorSet: CssValidator.ValidatorSet };
-        }
-      ).style?.validatorSet;
       const propListLH = validatorSet?.getShorthand(prop, av.value)?.propList;
       if (propListLH) {
         for (const propLH of propListLH) {
@@ -665,7 +661,7 @@ export function mergeAll(
 ): ElementStyle {
   const target = {} as ElementStyle;
   for (let k = 0; k < styles.length; k++) {
-    mergeIn(context, target, styles[k], 0, null, null, null);
+    mergeIn(context, target, styles[k], 0, null, null, null, null);
   }
   return target;
 }
@@ -864,6 +860,7 @@ export class ApplyRuleAction extends CascadeAction {
       this.pseudoelement,
       this.regionId,
       cascadeInstance.instance.buildViewConditionMatcher(this.viewConditionId),
+      cascadeInstance.instance.mergeValidatorSet,
     );
   }
 }
@@ -3368,6 +3365,7 @@ export class Cascade {
     scope: Exprs.LexicalScope,
     validatorSet: CssValidator.ValidatorSet,
     styles: StyleReader,
+    mergeValidatorSet: CssValidator.ValidatorSet | null,
   ): CascadeInstance {
     return new CascadeInstance(
       this,
@@ -3381,6 +3379,7 @@ export class Cascade {
       scope,
       validatorSet,
       styles,
+      mergeValidatorSet,
     );
   }
 
@@ -3445,6 +3444,7 @@ export class CascadeInstance {
     public readonly scope: Exprs.LexicalScope,
     public readonly validatorSet: CssValidator.ValidatorSet,
     public readonly styles: StyleReader,
+    public readonly mergeValidatorSet: CssValidator.ValidatorSet | null,
   ) {
     this.code = cascade;
     this.quotes = [

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -37,7 +37,6 @@ import * as SemanticFootnote from "./semantic-footnote";
 import * as Vtree from "./vtree";
 import { CssCascade, CssStyler, Layout } from "./types";
 import { TokenType } from "./css-tokenizer";
-import { AbstractStyler } from "./css-styler";
 
 export type ElementStyle = {
   [key: string]:
@@ -2160,7 +2159,7 @@ export class AttrValueFilterVisitor extends Css.FilterVisitor {
     public element: Element,
     private readonly scope: Exprs.LexicalScope,
     private readonly propName: string,
-    private readonly validatorSet?: CssValidator.ValidatorSet,
+    private readonly validatorSet: CssValidator.ValidatorSet,
   ) {
     super();
   }
@@ -2169,7 +2168,7 @@ export class AttrValueFilterVisitor extends Css.FilterVisitor {
     if (Css.isDefaultingValue(value)) {
       return value;
     }
-    const validator = this.validatorSet?.validators[this.propName];
+    const validator = this.validatorSet.validators[this.propName];
     if (validator) {
       return value.visit(validator) ?? Css.ident.unset;
     }
@@ -3365,6 +3364,10 @@ export class Cascade {
     lang,
     counterStyleStore: CounterStyle.CounterStyleStore,
     cmykStore: CmykStore.CmykStore,
+    root: Element,
+    scope: Exprs.LexicalScope,
+    validatorSet: CssValidator.ValidatorSet,
+    styles: StyleReader,
   ): CascadeInstance {
     return new CascadeInstance(
       this,
@@ -3374,12 +3377,20 @@ export class Cascade {
       lang,
       counterStyleStore,
       cmykStore,
+      root,
+      scope,
+      validatorSet,
+      styles,
     );
   }
 
   nextOrder(): number {
     return (this.order += ORDER_INCREMENT);
   }
+}
+
+export interface StyleReader {
+  styleOf(element: Element): ElementStyle;
 }
 
 export class CascadeInstance {
@@ -3430,6 +3441,10 @@ export class CascadeInstance {
     lang: string,
     public readonly counterStyleStore: CounterStyle.CounterStyleStore,
     public readonly cmykStore: CmykStore.CmykStore,
+    public readonly root: Element,
+    public readonly scope: Exprs.LexicalScope,
+    public readonly validatorSet: CssValidator.ValidatorSet,
+    public readonly styles: StyleReader,
   ) {
     this.code = cascade;
     this.quotes = [
@@ -3831,7 +3846,6 @@ export class CascadeInstance {
   }
 
   pushElement(
-    styler: CssStyler.AbstractStyler,
     element: Base.ChildElement,
     baseStyle: ElementStyle,
     elementOffset: number,
@@ -3922,7 +3936,7 @@ export class CascadeInstance {
     this.currentPageType = savedCurrentPageType;
 
     // Substitute var()
-    this.applyVarFilter([baseStyle], styler, element);
+    this.applyVarFilter([baseStyle], element);
 
     // Calculate calc()
     this.applyCalcFilter(baseStyle, this.context);
@@ -3930,7 +3944,7 @@ export class CascadeInstance {
     // Convert device-cmyk() to color(srgb ...)
     this.applyCmykFilter(baseStyle, element);
 
-    this.applyAttrFilter(element, styler, baseStyle);
+    this.applyAttrFilter(element, baseStyle);
     const quotesCasc = baseStyle["quotes"] as CascadeValue;
     let itemToPushLast: QuotesScopeItem | null = null;
     if (quotesCasc) {
@@ -4042,7 +4056,6 @@ export class CascadeInstance {
               this.processMarkerPseudoelementProps(
                 pseudoProps,
                 element,
-                styler,
                 baseStyle,
               );
               // Delete the pseudo to prevent fake element generation
@@ -4056,7 +4069,6 @@ export class CascadeInstance {
                 this.resolvePseudoelementInheritedPropertyValue(
                   pseudoProps,
                   "list-style-position",
-                  styler,
                   element,
                   baseStyle,
                 );
@@ -4065,7 +4077,6 @@ export class CascadeInstance {
                 this.processMarkerPseudoelementProps(
                   pseudoProps,
                   element,
-                  styler,
                   baseStyle,
                 );
                 // Preserve the original footnote-marker content for semantic
@@ -4189,7 +4200,6 @@ export class CascadeInstance {
   processMarkerPseudoelementProps(
     pseudoProps: ElementStyle,
     element: Element,
-    styler: CssStyler.AbstractStyler,
     elementStyle: ElementStyle,
   ): void {
     const isListItem = Display.isListItem(
@@ -4205,13 +4215,11 @@ export class CascadeInstance {
     ) {
       const listStyleType = this.getInheritedPropertyValue(
         "list-style-type",
-        styler,
         element,
         elementStyle,
       );
       const listStyleImage = this.getInheritedPropertyValue(
         "list-style-image",
-        styler,
         element,
         elementStyle,
       );
@@ -4287,7 +4295,6 @@ export class CascadeInstance {
     if (!Display.isInlineLevel(getProp(elementStyle, "display")?.value)) {
       const listStylePosition = this.getInheritedPropertyValue(
         "list-style-position",
-        styler,
         element,
         elementStyle,
       );
@@ -4329,20 +4336,18 @@ export class CascadeInstance {
   /**
    * Get inherited property value
    * @param propName
-   * @param styler
    * @param element
-   * @param elementStyle style being cascaded for `element`, which the styler
-   *     cannot serve until the cascade for it finishes
+   * @param elementStyle style being cascaded for `element`, which the style
+   *     store cannot serve until the cascade for it finishes
    * @returns the inherited property value, or the initial value (or null) if not found
    */
   getInheritedPropertyValue(
     propName: string,
-    styler: CssStyler.AbstractStyler,
     element: Element,
     elementStyle: ElementStyle,
   ): Css.Val | null {
     for (let e = element; e; e = e.parentElement) {
-      const style = e === element ? elementStyle : styler.getStyle(e, false);
+      const style = e === element ? elementStyle : this.styles.styleOf(e);
       const prop = style[propName] as CascadeValue;
       if (prop) {
         const val = prop.evaluate(this.context, propName);
@@ -4358,16 +4363,12 @@ export class CascadeInstance {
         return val;
       }
     }
-    const validatorSet = (
-      styler as AbstractStyler & { validatorSet: CssValidator.ValidatorSet }
-    ).validatorSet;
-    return validatorSet?.defaultValues[propName] ?? null;
+    return this.validatorSet.defaultValues[propName] ?? null;
   }
 
   resolvePseudoelementInheritedPropertyValue(
     pseudoProps: ElementStyle,
     propName: string,
-    styler: CssStyler.AbstractStyler,
     element: Element,
     elementStyle: ElementStyle,
   ): Css.Val | null {
@@ -4380,44 +4381,26 @@ export class CascadeInstance {
         val !== Css.ident.revert
       ) {
         if (val === Css.ident.initial) {
-          const validatorSet = (
-            styler as AbstractStyler & {
-              validatorSet: CssValidator.ValidatorSet;
-            }
-          ).validatorSet;
-          return validatorSet?.defaultValues[propName] ?? null;
+          return this.validatorSet.defaultValues[propName] ?? null;
         }
         return val;
       }
     }
-    return this.getInheritedPropertyValue(
-      propName,
-      styler,
-      element,
-      elementStyle,
-    );
+    return this.getInheritedPropertyValue(propName, element, elementStyle);
   }
 
   private applyAttrFilterInner(
-    styler: CssStyler.AbstractStyler,
     element: Element,
     elementStyle: ElementStyle,
   ): void {
-    const scope = (styler as AbstractStyler & { scope: Exprs.LexicalScope })
-      .scope;
-    const validatorSet = (
-      styler as AbstractStyler & {
-        validatorSet: CssValidator.ValidatorSet;
-      }
-    ).validatorSet;
     for (const propName in elementStyle) {
       if (isPropName(propName) && !Css.isCustomPropName(propName)) {
         const cascVal = elementStyle[propName] as CascadeValue;
         const visitor = new AttrValueFilterVisitor(
           element,
-          scope,
+          this.scope,
           propName,
-          validatorSet,
+          this.validatorSet,
         );
         const filtered = cascVal.filterValue(visitor);
         if (!visitor.hadAttrFunction) {
@@ -4433,26 +4416,18 @@ export class CascadeInstance {
     }
   }
 
-  private applyAttrFilter(
-    element: Element,
-    styler: CssStyler.AbstractStyler,
-    elementStyle: ElementStyle,
-  ): void {
+  private applyAttrFilter(element: Element, elementStyle: ElementStyle): void {
     const pseudoMap = getStyleMap(elementStyle, "_pseudos");
     for (const pseudoName in pseudoMap) {
-      this.applyAttrFilterInner(styler, element, pseudoMap[pseudoName]);
+      this.applyAttrFilterInner(element, pseudoMap[pseudoName]);
     }
-    this.applyAttrFilterInner(styler, element, elementStyle);
+    this.applyAttrFilterInner(element, elementStyle);
   }
 
   /**
    * Substitute all variables in property values in elementStyle
    */
-  applyVarFilter(
-    elementStyles: ElementStyle[],
-    styler: CssStyler.AbstractStyler,
-    element: Element | null,
-  ): void {
+  applyVarFilter(elementStyles: ElementStyle[], element: Element | null): void {
     const elementStyle = elementStyles[0];
     const sourceElementStyles = elementStyles.map((style) => ({ ...style }));
     const LIMIT_LOOP = 32; // prevent cyclic or too deep dependency
@@ -4468,7 +4443,8 @@ export class CascadeInstance {
         : elementStyles;
       const visitor = new VarFilterVisitor(
         lookupElementStyles,
-        styler,
+        this.styles,
+        this.root,
         element,
         Css.isCustomPropName(name) ? name : null,
       );
@@ -4505,10 +4481,10 @@ export class CascadeInstance {
       }
       if (value !== cascVal.value) {
         // all variables substituted
-        const validatorSet = (styler as any)
-          .validatorSet as CssValidator.ValidatorSet;
-        const scope = (styler as any).scope as Exprs.LexicalScope;
-        const shorthand = validatorSet?.getShorthand(name, value)?.clone(scope);
+        const scope = this.scope;
+        const shorthand = this.validatorSet
+          .getShorthand(name, value)
+          ?.clone(scope);
         if (shorthand) {
           if (Css.isDefaultingValue(value)) {
             for (const nameLH of shorthand.propList) {
@@ -4533,7 +4509,7 @@ export class CascadeInstance {
                 for (const nameLH of shorthand.propList) {
                   const avLH = new CascadeValue(
                     shorthand.values[nameLH] ??
-                      validatorSet.defaultValues[nameLH] ??
+                      this.validatorSet.defaultValues[nameLH] ??
                       Css.ident.initial,
                     cascVal.priority,
                   );
@@ -4569,7 +4545,6 @@ export class CascadeInstance {
         for (const pseudoName in pseudoMap) {
           this.applyVarFilter(
             [pseudoMap[pseudoName], ...elementStyles],
-            styler,
             element,
           );
         }
@@ -4589,7 +4564,6 @@ export class CascadeInstance {
       for (const pseudoName in pendingPseudoMap) {
         this.applyVarFilter(
           [pendingPseudoMap[pseudoName], ...elementStyles],
-          styler,
           element,
         );
       }
@@ -6143,7 +6117,8 @@ export class VarFilterVisitor extends Css.FilterVisitor {
 
   constructor(
     public elementStyles: ElementStyle[],
-    public styler: CssStyler.AbstractStyler,
+    public readonly styles: StyleReader,
+    public readonly root: Element,
     public element: Element | null,
     private readonly currentCustomPropertyName: string | null = null,
   ) {
@@ -6163,7 +6138,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     elementStyles: ElementStyle[];
     element: Element | null;
   } {
-    let elem = element ?? ((this.styler as any).root as Element);
+    let elem = element ?? this.root;
     if (elementStyles?.length) {
       for (let index = 0; index < elementStyles.length; index++) {
         const style = elementStyles[index];
@@ -6198,7 +6173,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
       }
     }
     for (; elem; elem = elem.parentElement) {
-      const style = this.styler.getStyle(elem, false);
+      const style = this.styles.styleOf(elem);
       const val = (style?.[name] as CascadeValue)?.value;
       if (!val) {
         continue;
@@ -6376,7 +6351,8 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     this.varResolutionState.cycleMembers = new Set();
     const nestedVisitor = new VarFilterVisitor(
       elementStyles,
-      this.styler,
+      this.styles,
+      this.root,
       element,
       name,
     );
@@ -6412,7 +6388,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
   }
 
   private getVarValue(name: string): Css.Val {
-    let elem = this.element ?? ((this.styler as any).root as Element);
+    let elem = this.element ?? this.root;
     if (this.elementStyles?.length) {
       for (let index = 0; index < this.elementStyles.length; index++) {
         const style = this.elementStyles[index];
@@ -6437,7 +6413,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
       }
     }
     for (; elem; elem = elem.parentElement) {
-      const style = this.styler.getStyle(elem, false);
+      const style = this.styles.styleOf(elem);
       const resolved = this.resolveCustomProperty(
         name,
         (style?.[name] as CascadeValue)?.value,

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -3073,7 +3073,16 @@ export function mergeInPageRule(
   specificity: number,
   cascadeInstance: CssCascade.StyledCascadeInstance,
 ): void {
-  CssCascade.mergeIn(context, target, style, specificity, null, null, null);
+  CssCascade.mergeIn(
+    context,
+    target,
+    style,
+    specificity,
+    null,
+    null,
+    null,
+    cascadeInstance.instance.mergeValidatorSet,
+  );
   const marginBoxes = style[marginBoxesKey];
   if (marginBoxes) {
     const targetMap = CssCascade.getMutableStyleMap(target, marginBoxesKey);
@@ -3092,6 +3101,7 @@ export function mergeInPageRule(
           null,
           null,
           null,
+          cascadeInstance.instance.mergeValidatorSet,
         );
       }
     }

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -465,12 +465,26 @@ export class BoxStack {
   }
 }
 
+export class StyleStore {
+  private readonly map: { [key: string]: CssCascade.ElementStyle } = {};
+
+  constructor(private readonly xmldoc: XmlDoc.XMLDocHolder) {}
+
+  setAt(offset: number, style: CssCascade.ElementStyle): void {
+    this.map[`e${offset}`] = style;
+  }
+
+  styleOf(element: Element): CssCascade.ElementStyle {
+    return this.map[`e${this.xmldoc.getElementOffset(element)}`];
+  }
+}
+
 export class Styler implements AbstractStyler {
   root: Base.ChildElement;
   cascadeHolder: CssCascade.Cascade;
   last: Base.RootBoundCursor | null;
   rootStyle = {} as CssCascade.ElementStyle;
-  styleMap: { [key: string]: CssCascade.ElementStyle } = {};
+  styles: StyleStore;
   counterSnapshots: CounterSnapshot[] = [];
   flows = {} as { [key: string]: Vtree.Flow };
   flowChunks = [] as Vtree.FlowChunk[];
@@ -505,6 +519,7 @@ export class Styler implements AbstractStyler {
   ) {
     this.root = xmldoc.root;
     this.cascadeHolder = cascade;
+    this.styles = new StyleStore(xmldoc);
     this.last = Base.RootBoundCursor.atRoot(this.root);
     this.cascade = cascade.createInstance(
       context,
@@ -540,8 +555,7 @@ export class Styler implements AbstractStyler {
         break;
     }
     this.primaryStack.push(true);
-    this.styleMap = {};
-    this.styleMap[`e${rootOffset}`] = style;
+    this.styles.setAt(rootOffset, style);
     this.lastOffset++;
     this.replayFlowElementsFromOffset(-1);
   }
@@ -1189,7 +1203,7 @@ export class Styler implements AbstractStyler {
             throw new Error("Inconsistent offset");
           }
         }
-        this.styleMap[`e${this.lastOffset}`] = style;
+        this.styles.setAt(this.lastOffset, style);
         this.lastOffset++;
         if (this.primary) {
           this.offsetMap.addStuckRange(this.lastOffset);
@@ -1219,14 +1233,13 @@ export class Styler implements AbstractStyler {
   /** @override */
   getStyle(element: Element, deep: boolean): CssCascade.ElementStyle {
     let offset = this.xmldoc.getElementOffset(element);
-    const key = `e${offset}`;
     if (deep) {
       offset = this.xmldoc.getNodeOffset(element, 0, true);
     }
     if (this.lastOffset <= offset) {
       this.styleUntil(offset, 0);
     }
-    return this.styleMap[key];
+    return this.styles.styleOf(element);
   }
 
   /** @override */

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -465,7 +465,7 @@ export class BoxStack {
   }
 }
 
-export class StyleStore {
+export class StyleStore implements CssCascade.StyleReader {
   private readonly map: { [key: string]: CssCascade.ElementStyle } = {};
 
   constructor(private readonly xmldoc: XmlDoc.XMLDocHolder) {}
@@ -528,6 +528,10 @@ export class Styler implements AbstractStyler {
       xmldoc.lang,
       counterStyleStore,
       cmykStore,
+      this.root,
+      scope,
+      validatorSet,
+      this.styles,
     );
     this.offsetMap = new SlipMap();
     const rootOffset = xmldoc.getElementOffset(this.root);
@@ -535,12 +539,7 @@ export class Styler implements AbstractStyler {
     this.boxStack = new BoxStack(context);
     this.offsetMap.addStuckRange(rootOffset);
     const style = this.getAttrStyle(this.root);
-    this.elementWindow = this.cascade.pushElement(
-      this,
-      this.root,
-      style,
-      rootOffset,
-    );
+    this.elementWindow = this.cascade.pushElement(this.root, style, rootOffset);
     this.recordCounterSnapshot(
       rootOffset,
       this.cascade.counters,
@@ -1105,7 +1104,6 @@ export class Styler implements AbstractStyler {
         const style = this.getAttrStyle(elem);
         this.primaryStack.push(this.primary);
         this.elementWindow = this.cascade.pushElement(
-          this,
           elem,
           style,
           this.lastOffset,

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -516,6 +516,7 @@ export class Styler implements AbstractStyler {
     counterResolver: CssCascade.CounterResolver,
     counterStyleStore: CounterStyle.CounterStyleStore,
     cmykStore: CmykStore.CmykStore,
+    mergeValidatorSet: CssValidator.ValidatorSet | null,
   ) {
     this.root = xmldoc.root;
     this.cascadeHolder = cascade;
@@ -532,6 +533,7 @@ export class Styler implements AbstractStyler {
       scope,
       validatorSet,
       this.styles,
+      mergeValidatorSet,
     );
     this.offsetMap = new SlipMap();
     const rootOffset = xmldoc.getElementOffset(this.root);

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -417,6 +417,10 @@ export class StyleInstance
       this.lang,
       this.style.counterStyleStore,
       this.cmykStore,
+      this.xmldoc.root,
+      this.style.rootScope,
+      this.style.validatorSet,
+      this.styler.styles,
     );
 
     // Named page type at first page
@@ -446,7 +450,7 @@ export class StyleInstance
       };
 
       // Substitute var() in @page
-      this.styler.cascade.applyVarFilter([pageStyle], this.styler, null);
+      this.styler.cascade.applyVarFilter([pageStyle], null);
 
       // Calculate calc()
       this.styler.cascade.applyCalcFilter(pageStyle, this.styler.context);
@@ -3135,7 +3139,7 @@ export class StyleInstance
     this.currentCascadedPageStyle = cascadedPageStyle;
 
     // Substitute var()
-    this.styler.cascade.applyVarFilter([cascadedPageStyle], this.styler, null);
+    this.styler.cascade.applyVarFilter([cascadedPageStyle], null);
 
     // Calculate calc()
     this.styler.cascade.applyCalcFilter(cascadedPageStyle, this.styler.context);

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -388,6 +388,7 @@ export class StyleInstance
       counterResolver,
       this.style.counterStyleStore,
       this.cmykStore,
+      this.style.validatorSet,
     );
     counterResolver.setStyler(this.styler);
     this.styler.resetFlowChunkStream(this);
@@ -421,6 +422,7 @@ export class StyleInstance
       this.style.rootScope,
       this.style.validatorSet,
       this.styler.styles,
+      this.style.validatorSet,
     );
 
     // Named page type at first page
@@ -592,6 +594,7 @@ export class StyleInstance
         counterResolver,
         style.counterStyleStore,
         this.cmykStore,
+        null,
       );
       this.stylerMap[xmldoc.url] = styler;
     }

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -2020,20 +2020,20 @@ describe("css-cascade", function () {
         defaultValues: {},
       };
 
-      var styler = {
-        root: element,
-        validatorSet: validatorSet,
-        scope: new adapt_exprs.LexicalScope(null),
-        getStyle: function (currentElement) {
-          return styleMap.get(currentElement) || null;
-        },
-      };
       var cascadeInstance = {
         context: {},
+        root: element,
+        scope: new adapt_exprs.LexicalScope(null),
+        validatorSet: validatorSet,
+        styles: {
+          styleOf: function (currentElement) {
+            return styleMap.get(currentElement) || null;
+          },
+        },
       };
       cascadeInstance.applyVarFilter =
         adapt_csscasc.CascadeInstance.prototype.applyVarFilter;
-      cascadeInstance.applyVarFilter([style], styler, element);
+      cascadeInstance.applyVarFilter([style], element);
     }
 
     it("keeps self-referential custom properties guaranteed-invalid instead of using their fallback", function () {
@@ -2273,20 +2273,15 @@ describe("css-cascade", function () {
     function applyAttrFilter(style, element, validatorSet) {
       validatorSet = validatorSet || adapt_cssvalid.baseValidatorSet();
 
-      var styler = {
-        root: element,
-        validatorSet: validatorSet,
+      var cascadeInstance = {
         scope: new adapt_exprs.LexicalScope(null),
-        getStyle: function () {
-          return style;
-        },
+        validatorSet: validatorSet,
       };
-      var cascadeInstance = {};
       cascadeInstance.applyAttrFilter =
         adapt_csscasc.CascadeInstance.prototype.applyAttrFilter;
       cascadeInstance.applyAttrFilterInner =
         adapt_csscasc.CascadeInstance.prototype.applyAttrFilterInner;
-      cascadeInstance.applyAttrFilter(element, styler, style);
+      cascadeInstance.applyAttrFilter(element, style);
     }
 
     it("treats missing typed attr() without fallback as unset", function () {


### PR DESCRIPTION
直接`strictNullChecks`の改善とは関係ないのですが、後段で変な抽象を導入しないために必要になったリファクタリングです。

`Styler`のコンストラクタが`CascadeInstance`を初期化する相互依存関係がありました。`CascadeInstance`は`AbstractStyler`を使うことになっているのですが、実際には内部ではキャストを多用してコンクリートクラスのメンバにアクセスしており、抽象は破られていました。`CascadeInstance`は`getStyle(e, false)`,`scope`,`validatorSet`,`root`を参照しますが、`getStyle`以外にはキャストが必要です。

```mermaid
classDiagram
    direction LR
    namespace css-styler {
        class Styler {
            -styleMap
            +Element root
            +LexicalScope scope
            +ValidatorSet validatorSet
            +getStyle(element, deep) ElementStyle
        }
    }
    namespace css-cascade {
        class CascadeInstance {
            +pushElement(styler, element, style, offset)
        }
    }
    Styler --> CascadeInstance : 構築し this を渡す
    CascadeInstance ..> Styler : root / scope / validatorSet をキャストで読む
    CascadeInstance ..> Styler : getStyle で祖先を読む
```

改めて整理すると、`root`,`scope`,`validatorSet`は`CascadeInstance`の初期化時には確定している、文書に寿命が紐づく定数です。`getStyle`は、要求された位置まで走査を進めてスタイルを計算する仕事と、計算済みのものを引く仕事を兼ねています。

このPRの主要部分は、計算済みスタイルを格納する`StyleStore`と、要素を渡すとその要素についてカスケードが計算し終えたスタイルが返る`StyleReader`を分離し、依存の方向を整えることです。

```mermaid
classDiagram
    direction LR
    namespace css-styler {
        class Styler {
            +getStyle(element, deep) ElementStyle
        }
        class StyleStore {
            +setAt(offset, style)
            +styleOf(element) ElementStyle
        }
    }
    namespace css-cascade {
        class StyleReader {
            <<interface>>
            +styleOf(element) ElementStyle
        }
        class CascadeInstance {
            +Element root
            +LexicalScope scope
            +ValidatorSet validatorSet
            +StyleReader styles
            +pushElement(element, style, offset)
        }
    }
    StyleStore ..|> StyleReader
    Styler --> StyleStore : setAt で書く
    Styler --> StyleStore : getStyle が styleUntil の後に引く
    Styler --> CascadeInstance : 構築時に注入
    CascadeInstance --> StyleReader : styleOf で読む
```