### PR TITLE
refactor: Fix up earlier refactors

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -26,6 +26,7 @@ import * as Epub from "./epub";
 import * as Exprs from "./exprs";
 import * as Font from "./font";
 import * as Logging from "./logging";
+import * as OPS from "./ops";
 import * as Plugin from "./plugin";
 import * as Profile from "./profile";
 import * as Scripts from "./scripts";
@@ -252,14 +253,10 @@ export class AdaptiveViewer {
     this.setReadyState(Constants.ReadyState.LOADING);
     const url = command["url"] as string;
     const fragment = command["fragment"] as string | null;
-    const authorStyleSheet = command["authorStyleSheet"] as {
-      url: string | null;
-      text: string | null;
-    }[];
-    const userStyleSheet = command["userStyleSheet"] as {
-      url: string | null;
-      text: string | null;
-    }[];
+    const authorStyleSheet = command[
+      "authorStyleSheet"
+    ] as OPS.StyleSheetParam[];
+    const userStyleSheet = command["userStyleSheet"] as OPS.StyleSheetParam[];
     this.cmykReserveMapUrl = command["cmykReserveMapUrl"] as string | undefined;
     this.viewport = null;
     const frame: Task.Frame<boolean> = Task.newFrame("loadPublication");
@@ -295,14 +292,10 @@ export class AdaptiveViewer {
     const params: SingleDocumentParam[] = command["url"];
     const doc = command["document"] as Document;
     const fragment = command["fragment"] as string | null;
-    const authorStyleSheet = command["authorStyleSheet"] as {
-      url: string | null;
-      text: string | null;
-    }[];
-    const userStyleSheet = command["userStyleSheet"] as {
-      url: string | null;
-      text: string | null;
-    }[];
+    const authorStyleSheet = command[
+      "authorStyleSheet"
+    ] as OPS.StyleSheetParam[];
+    const userStyleSheet = command["userStyleSheet"] as OPS.StyleSheetParam[];
     this.cmykReserveMapUrl = command["cmykReserveMapUrl"] as string | undefined;
 
     // force relayout

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -22,6 +22,7 @@ import * as Base from "./base";
 import * as CmykStore from "./cmyk-store";
 import * as Constants from "./constants";
 import * as Epub from "./epub";
+import * as OPS from "./ops";
 import * as Profile from "./profile";
 import * as Toc from "./toc";
 import { ErrorInfo } from "./logging";
@@ -324,9 +325,20 @@ export class CoreViewer {
   ) {
     const documentOptions = opt_documentOptions || {};
 
-    function convertStyleSheetArray(arr) {
+    function convertStyleSheetArray(
+      arr?: { url?: string; text?: string }[],
+    ): OPS.StyleSheetParam[] | undefined {
       if (arr) {
-        return arr.map((s) => ({ url: s.url || null, text: s.text || null }));
+        return arr.flatMap((s): OPS.StyleSheetParam[] => {
+          const url = s.url || null;
+          const text = s.text || null;
+          // An entry with neither url nor text names no style sheet to read.
+          return text !== null
+            ? [{ url, text }]
+            : url !== null
+              ? [{ url }]
+              : [];
+        });
       } else {
         return undefined;
       }

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -1015,14 +1015,6 @@ export class PageAreaPartition extends PageMaster.Partition<PageAreaPartitionIns
       0,
     );
   }
-
-  override createInstance(
-    parentInstance: PageMaster.PageBoxInstance,
-    context: Exprs.Context,
-    docElementStyle: CssCascade.ElementStyle,
-  ): PageMaster.PageBoxInstance {
-    return new PageAreaPartitionInstance(parentInstance, this);
-  }
 }
 
 /**
@@ -2018,12 +2010,14 @@ export class PageAreaPartitionInstance
   implements PageMaster.PageAreaEstablishing
 {
   readonly pageAreaEstablishingChild = null;
+  private readonly pageRulePartitionInstance: PageRulePartitionInstance;
 
   constructor(
-    parentInstance: PageMaster.PageBoxInstance,
+    parentInstance: PageRulePartitionInstance,
     pageAreaPartition: PageAreaPartition,
   ) {
     super(parentInstance, pageAreaPartition);
+    this.pageRulePartitionInstance = parentInstance;
   }
 
   override applyCascadeAndInit(
@@ -2040,12 +2034,11 @@ export class PageAreaPartitionInstance
 
   override initHorizontal(): void {
     const style = this.style;
-    const parentStyle = this.parentInstance.style;
+    const parent = this.pageRulePartitionInstance;
+    const parentStyle = parent.style;
     const scope = this.pageBox.scope;
     style["left"] = parentStyle["padding-left"];
-    style["width"] = (
-      this.parentInstance as PageRulePartitionInstance
-    ).contentBoxWidth;
+    style["width"] = parent.contentBoxWidth;
 
     // Use negative margins and transparent borders to improve text selection behavior.
     style["margin-left"] = new Css.Expr(
@@ -2064,12 +2057,11 @@ export class PageAreaPartitionInstance
 
   override initVertical(): void {
     const style = this.style;
-    const parentStyle = this.parentInstance.style;
+    const parent = this.pageRulePartitionInstance;
+    const parentStyle = parent.style;
     const scope = this.pageBox.scope;
     style["top"] = parentStyle["padding-top"];
-    style["height"] = (
-      this.parentInstance as PageRulePartitionInstance
-    ).contentBoxHeight;
+    style["height"] = parent.contentBoxHeight;
 
     // Use negative margins and transparent borders to improve text selection behavior.
     style["margin-top"] = new Css.Expr(

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -2926,21 +2926,24 @@ export class ErrorHandler extends ParserHandler {
 export function parseStylesheet(
   tokenizer: CssTokenizer.Tokenizer,
   handler: DispatchParserHandler,
-  baseURL: string,
+  baseURL: string | null,
   classes: string | null,
   media: string | null,
 ): Task.Result<boolean> {
+  // A style sheet given as text alone has no base. resolveURL() reads the
+  // empty string as no base.
+  const base = baseURL ?? "";
   const expandedText = expandNesting(tokenizer.input);
   if (expandedText !== tokenizer.input) {
     return parseStylesheetInternal(
       new CssTokenizer.Tokenizer(expandedText, handler),
       handler,
-      baseURL,
+      base,
       classes,
       media,
     );
   }
-  return parseStylesheetInternal(tokenizer, handler, baseURL, classes, media);
+  return parseStylesheetInternal(tokenizer, handler, base, classes, media);
 }
 
 function parseStylesheetInternal(
@@ -3010,7 +3013,7 @@ function parseStylesheetInternal(
 export function parseStylesheetFromText(
   text: string,
   handler: DispatchParserHandler,
-  baseURL: string,
+  baseURL: string | null,
   classes: string | null,
   media: string | null,
 ): Task.Result<boolean> {

--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -303,7 +303,7 @@ export class FootnoteLayoutStrategy
 
   /** @override */
   createPageFloat(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.FloatNodeContext,
     pageFloatLayoutContext: PageFloats.AttachedPageFloatLayoutContext,
     column: Layout.Column,
   ): Task.Result<PageFloats.PageFloat> {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2318,7 +2318,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   layoutPageFloat(
-    nodeContext: Vtree.RenderedNodeContext,
+    nodeContext: Vtree.FloatNodeContext,
   ): Task.Result<Vtree.NodeContext> {
     const context = this.pageFloatLayoutContext;
     const strategy =
@@ -4513,7 +4513,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   layoutFloatOrFootnote(
-    nodeContext: Vtree.RenderedNodeContext,
+    nodeContext: Vtree.FloatNodeContext,
   ): Task.Result<Vtree.NodeContext> {
     if (
       PageFloats.isPageFloat(nodeContext.floatReference) ||
@@ -4530,7 +4530,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         generatingNodePosition &&
         nodeContext.sourceNode === generatingNodePosition.steps[0].node
       ) {
-        const nodeContextMod = nodeContext.modify();
+        const nodeContextMod: Vtree.NodeContext = nodeContext.modify();
         nodeContextMod.floatSide = null;
         nodeContextMod.floatReference = PageFloats.FloatReference.INLINE;
         nodeContextMod.clearSide = null;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -3586,15 +3586,32 @@ export class StyleParserHandler extends CssParser.DispatchParserHandler<BasePars
   }
 }
 
-export type StyleSource = {
-  url: string;
-  text: string | null;
+export type StyleSheetParam =
+  | { url: string; text?: null }
+  // url, if present, is the base for resolving relative URLs in the text
+  | { url: string | null; text: string };
+
+export type StyleSource = StyleSheetParam & {
   flavor: CssParser.StylesheetFlavor;
   classes: string | null;
   media: string | null;
 };
 
-export type StyleSheetParam = { url: string | null; text: string | null };
+function toStyleSource(
+  stylesheet: StyleSheetParam,
+  flavor: CssParser.StylesheetFlavor,
+): StyleSource {
+  if (stylesheet.text != null) {
+    const url = stylesheet.url
+      ? Base.resolveURL(Base.convertSpecialURL(stylesheet.url), Base.baseURL)
+      : stylesheet.url;
+    return { url, text: stylesheet.text, flavor, classes: null, media: null };
+  }
+  const url = stylesheet.url
+    ? Base.resolveURL(Base.convertSpecialURL(stylesheet.url), Base.baseURL)
+    : stylesheet.url;
+  return { url, flavor, classes: null, media: null };
+}
 
 export function parseOPSResource(
   response: Net.FetchResponse,
@@ -3619,7 +3636,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
     userStyleSheets: StyleSheetParam[] | null = null,
   ) {
     super(parseOPSResource, Net.FetchResponseType.DOCUMENT);
-    this.setStyleSheets(authorStyleSheets as any, userStyleSheets as any);
+    this.setStyleSheets(authorStyleSheets, userStyleSheets);
   }
 
   getStyleForDoc(xmldoc: XmlDoc.XMLDocHolder): Style {
@@ -3635,8 +3652,8 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
    * removed.
    */
   private setStyleSheets(
-    authorStyleSheets: StyleSource[] | null,
-    userStyleSheets: StyleSource[] | null,
+    authorStyleSheets: StyleSheetParam[] | null,
+    userStyleSheets: StyleSheetParam[] | null,
   ) {
     this.clearStyleSheets();
     if (authorStyleSheets) {
@@ -3651,32 +3668,16 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
     this.styleSheets.splice(0);
   }
 
-  private addAuthorStyleSheet(stylesheet: StyleSource) {
-    let url = stylesheet.url;
-    if (url) {
-      url = Base.resolveURL(Base.convertSpecialURL(url), Base.baseURL);
-    }
-    this.styleSheets.push({
-      url,
-      text: stylesheet.text,
-      flavor: CssParser.StylesheetFlavor.AUTHOR,
-      classes: null,
-      media: null,
-    });
+  private addAuthorStyleSheet(stylesheet: StyleSheetParam) {
+    this.styleSheets.push(
+      toStyleSource(stylesheet, CssParser.StylesheetFlavor.AUTHOR),
+    );
   }
 
-  private addUserStyleSheet(stylesheet: StyleSource) {
-    let url = stylesheet.url;
-    if (url) {
-      url = Base.resolveURL(Base.convertSpecialURL(url), Base.baseURL);
-    }
-    this.styleSheets.push({
-      url,
-      text: stylesheet.text,
-      flavor: CssParser.StylesheetFlavor.USER,
-      classes: null,
-      media: null,
-    });
+  private addUserStyleSheet(stylesheet: StyleSheetParam) {
+    this.styleSheets.push(
+      toStyleSource(stylesheet, CssParser.StylesheetFlavor.USER),
+    );
   }
 
   parseOPSResource(
@@ -3841,7 +3842,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
                 if (index < sources.length) {
                   const source = sources[index++];
                   sph.startStylesheet(source.flavor);
-                  if (source.text !== null) {
+                  if (source.text != null) {
                     return CssParser.parseStylesheetFromText(
                       source.text,
                       sph,

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -2764,13 +2764,12 @@ export class NormalPageFloatLayoutStrategy implements PageFloatLayoutStrategy {
 
   /** @override */
   createPageFloat(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.FloatNodeContext,
     pageFloatLayoutContext: AttachedPageFloatLayoutContext,
     column: LayoutType.Column,
   ): Task.Result<PageFloat> {
     let floatReference = nodeContext.floatReference;
-    Asserts.assert(nodeContext.floatSide);
-    const floatSide: string = nodeContext.floatSide;
+    const floatSide = nodeContext.floatSide;
     const nodePosition = nodeContext.toNodePosition();
     const insidePageFloat = !!pageFloatLayoutContext.generatingNodePosition;
     return column

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1710,22 +1710,6 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
     }
   }
 
-  protected initChildren(
-    cascade: CssCascade.CascadeInstance,
-    docElementStyle: CssCascade.ElementStyle,
-  ): void {
-    cascade.pushRule(this.pageBox.classes, null, this.cascaded);
-    for (const child of this.pageBox.children) {
-      const childInstance = child.createInstance(
-        this,
-        cascade.context,
-        docElementStyle,
-      );
-      childInstance.applyCascadeAndInit(cascade, docElementStyle);
-    }
-    cascade.popRule();
-  }
-
   protected resolveContent(cascade: CssCascade.CascadeInstance): void {
     const style = this.cascaded;
     const content = style["content"] as CssCascade.CascadeValue;

--- a/packages/core/src/vivliostyle/pseudo-element.ts
+++ b/packages/core/src/vivliostyle/pseudo-element.ts
@@ -63,12 +63,14 @@ export function setPseudoName(element: Element, name: string): void {
 export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
   contentProcessed: { [key: string]: boolean } = {};
 
-  // after content: update style
+  // The ::after style is first asked for only after all of the element's
+  // descendants are processed.
+  private afterStyleTaken = false;
 
   constructor(
     public readonly element: Element,
     public style: CssCascade.ElementStyle,
-    public styler: CssStyler.AbstractStyler,
+    public readonly styler: CssStyler.AbstractStyler,
     public readonly context: Exprs.Context,
     public readonly exprContentListener: Vtree.ExprContentListener,
   ) {}
@@ -76,9 +78,9 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
   /** @override */
   getStyle(element: Element, deep: boolean): CssCascade.ElementStyle {
     const pseudoName = getPseudoName(element);
-    if (this.styler && pseudoName && pseudoName.match(/after$/)) {
+    if (!this.afterStyleTaken && pseudoName && pseudoName.match(/after$/)) {
       this.style = this.styler.getStyle(this.element, true);
-      this.styler = null;
+      this.afterStyleTaken = true;
     }
     const pseudoMap = CssCascade.getStyleMap(this.style, "_pseudos");
     const style = pseudoMap?.[pseudoName] || ({} as CssCascade.ElementStyle);

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -802,9 +802,11 @@ function layoutFloatOrFootnoteIfNeeded(
   column: Layout.Column,
   state: LayoutUtil.RenderedActiveLayoutIteratorState,
 ): Task.Result<boolean> | null {
-  const nodeContext = state.nodeContext;
+  // Column.asFloatNodeContext drops the float that opened a page float area.
+  // This edge asks about that float too.
+  const nodeContext = VtreeImpl.asFloatNodeContext(state.nodeContext);
   if (
-    !nodeContext.floatSide ||
+    !nodeContext ||
     !(
       PageFloats.isPageFloat(nodeContext.floatReference) ||
       nodeContext.floatSide === "footnote"

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -886,7 +886,7 @@ export namespace PseudoElement {
     contentProcessed: { [key: string]: boolean };
     readonly element: Element;
     style: CssCascade.ElementStyle;
-    styler: CssStyler.AbstractStyler;
+    readonly styler: CssStyler.AbstractStyler;
     readonly context: Exprs.Context;
     readonly exprContentListener: Vtree.ExprContentListener;
   }

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -345,7 +345,7 @@ export namespace Layout {
       nodeContext: Vtree.NodeContext,
     ): Task.Result<PageFloats.FloatReference>;
     layoutPageFloat(
-      nodeContext: Vtree.RenderedNodeContext,
+      nodeContext: Vtree.FloatNodeContext,
     ): Task.Result<Vtree.NodeContext>;
     processLineStyling(
       nodeContext: Vtree.NodeContext,
@@ -466,7 +466,7 @@ export namespace Layout {
       nodeContext: Vtree.NodeContext,
     ): Task.Result<Vtree.NodeContext>;
     layoutFloatOrFootnote(
-      nodeContext: Vtree.RenderedNodeContext,
+      nodeContext: Vtree.FloatNodeContext,
     ): Task.Result<Vtree.NodeContext>;
     /**
      * Layout next portion of the source.
@@ -819,7 +819,7 @@ export namespace PageFloats {
     appliesToNodeContext(nodeContext: Vtree.NodeContext): boolean;
     appliesToFloat(float: PageFloat): boolean;
     createPageFloat(
-      nodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.FloatNodeContext,
       pageFloatLayoutContext: AttachedPageFloatLayoutContext,
       column: Layout.Column,
     ): Task.Result<PageFloat>;

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -930,6 +930,7 @@ export function asTextNodeContext(
 
 export type RenderedNodeContext = NodeContext & Vtree.RenderedNodeContext;
 export type ElementNodeContext = NodeContext & Vtree.ElementNodeContext;
+export type FloatNodeContext = NodeContext & Vtree.FloatNodeContext;
 export type ClearNodeContext = NodeContext & Vtree.ClearNodeContext;
 export type AfterIfContinuesNodeContext = NodeContext &
   Vtree.AfterIfContinuesNodeContext;
@@ -939,6 +940,14 @@ export function asElementNodeContext(
 ): ElementNodeContext | null {
   return nc.viewNode !== null && nc.viewNode.nodeType === 1
     ? (nc as ElementNodeContext)
+    : null;
+}
+
+export function asFloatNodeContext(
+  nc: Vtree.NodeContext,
+): FloatNodeContext | null {
+  return nc.floatSide !== null && nc.viewNode?.nodeType === 1
+    ? (nc as FloatNodeContext)
     : null;
 }
 


### PR DESCRIPTION
はじめの方のPRの範囲で、後からよりよい方法で解決できるようになった箇所をやり直したものです。コミットはそれぞれ独立した変更で、subjectで参照しているPRに対応します。

- aa871e176 `NodeContext`のまま`Asserts.assert`で`floatSide`を読んでいますが、役割型`FloatNodeContext`を導入すればアサーションは不要です。
- 2c44e5dd0 元の実装で、urlもtextもnullのスタイルシート入力は`fetch(null)`（相対URL`"null"`）まで運ばれていましたが、`StyleSheetParam`で両方nullの形をはじいてfetchまで流れ込まないようにします。
- a4add2f79 コンストラクタから注入でき、二段階初期化を解消できます。
- e7ad70bfb `getStyle`は`this.styler = null`で「`::after`のスタイルを取得済み」を表していました。取得済みかを`afterStyleTaken`のフラグへ移し、`styler`は非nullにします。