### PR TITLE
refactor: Supply the formatting context at construction from flow to node context

### DIFF
--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -31,6 +31,7 @@ import * as CssProp from "./css-prop";
 import * as CssValidator from "./css-validator";
 import * as Display from "./display";
 import * as Exprs from "./exprs";
+import * as LayoutProcessor from "./layout-processor";
 import * as Vtree from "./vtree";
 import { CssStyler, XmlDoc } from "./types";
 
@@ -976,7 +977,11 @@ export class Styler implements AbstractStyler {
     let flow = this.flows[flowName];
     if (!flow) {
       const parentFlowName = this.boxStack.lastFlowName();
-      flow = this.flows[flowName] = new Vtree.Flow(flowName, parentFlowName);
+      flow = this.flows[flowName] = new Vtree.Flow(
+        flowName,
+        parentFlowName,
+        new LayoutProcessor.BlockFormattingContext(null),
+      );
     }
     const flowChunk = new Vtree.FlowChunk(
       flowName,

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -17,7 +17,6 @@
  * @fileoverview LayoutProcessor - Definitions of LayoutProcessor.
  */
 import * as BreakPosition from "./break-position";
-import * as Display from "./display";
 import * as LayoutHelper from "./layout-helper";
 import * as Plugin from "./plugin";
 import * as Task from "./task";
@@ -234,30 +233,15 @@ export const blockLayoutProcessor = new BlockLayoutProcessor();
 export const isInstanceOfBlockFormattingContext =
   LayoutProcessor.isInstanceOfBlockFormattingContext;
 
-Plugin.registerHook(
-  Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
-  (nodeContext, firstTime, display, position, floatSide, isRoot) => {
-    const parent = nodeContext.parent;
-    if (!parent && nodeContext.formattingContext) {
-      return null;
-    } else if (
-      parent &&
-      nodeContext.formattingContext !== parent.formattingContext
-    ) {
-      return null;
-    } else if (
-      nodeContext.establishesBFC ||
-      (!nodeContext.formattingContext &&
-        Display.isBlock(display, position, floatSide, isRoot))
-    ) {
-      return new BlockFormattingContext(
-        parent ? parent.formattingContext : null,
-      );
-    } else {
-      return null;
-    }
-  },
-);
+Plugin.registerHook(Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT, (nodeContext) => {
+  const parent = nodeContext.parent;
+  if (!parent || nodeContext.formattingContext !== parent.formattingContext) {
+    return null;
+  }
+  return nodeContext.establishesBFC
+    ? new BlockFormattingContext(parent.formattingContext)
+    : null;
+});
 
 Plugin.registerHook(
   Plugin.HOOKS.RESOLVE_LAYOUT_PROCESSOR,

--- a/packages/core/src/vivliostyle/layout-retryers.ts
+++ b/packages/core/src/vivliostyle/layout-retryers.ts
@@ -25,7 +25,7 @@ import { Layout, Vtree } from "./types";
  */
 export abstract class AbstractLayoutRetryer {
   initialBreakPositions: Layout.BreakPosition[] | null = null;
-  initialStateOfFormattingContext: Vtree.NodeContext | null = null;
+  initialStateOfFormattingContext: unknown = null;
   initialPosition: Vtree.NodeContext | null = null;
   initialFragmentLayoutConstraints: Layout.FragmentLayoutConstraint[] | null =
     null;

--- a/packages/core/src/vivliostyle/layout-retryers.ts
+++ b/packages/core/src/vivliostyle/layout-retryers.ts
@@ -96,19 +96,15 @@ export abstract class AbstractLayoutRetryer {
     this.initialFragmentLayoutConstraints = [].concat(
       column.fragmentLayoutConstraints,
     );
-    if (nodeContext.formattingContext) {
-      this.initialStateOfFormattingContext =
-        nodeContext.formattingContext.saveState();
-    }
+    this.initialStateOfFormattingContext =
+      nodeContext.formattingContext.saveState();
   }
 
   restoreState(nodeContext: Vtree.NodeContext, column: Layout.Column) {
     column.breakPositions = this.initialBreakPositions;
     column.fragmentLayoutConstraints = this.initialFragmentLayoutConstraints;
-    if (nodeContext.formattingContext) {
-      nodeContext.formattingContext.restoreState(
-        this.initialStateOfFormattingContext,
-      );
-    }
+    nodeContext.formattingContext.restoreState(
+      this.initialStateOfFormattingContext,
+    );
   }
 }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -425,7 +425,6 @@ export function validateCheckPoints(
 export class Column extends VtreeImpl.Container implements Layout.Column {
   last: Node;
   viewDocument: Document;
-  flowRootFormattingContext: Vtree.FormattingContext | null = null;
   // Issue #1842: true only for columns reached after automatic column overflow.
   isNonFirstColumn: boolean = false;
   isFloat: boolean = false;
@@ -466,6 +465,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     geometry: Vtree.ContainerGeometry,
     innerShape: GeometryUtil.Shape | null,
     exclusions: GeometryUtil.Shape[],
+    public flowRootFormattingContext: Vtree.FormattingContext,
   ) {
     super(element);
 
@@ -1787,6 +1787,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       },
       null,
       (floatContainer.exclusions || []).concat(),
+      this.flowRootFormattingContext,
     );
     floatArea.isFloat = true;
     floatArea.forceNonfitting =
@@ -5443,6 +5444,7 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
     geometry: Vtree.ContainerGeometry,
     innerShape: GeometryUtil.Shape | null,
     exclusions: GeometryUtil.Shape[],
+    flowRootFormattingContext: Vtree.FormattingContext,
   ) {
     super(
       element,
@@ -5453,6 +5455,7 @@ export class PageFloatArea extends Column implements Layout.PageFloatArea {
       geometry,
       innerShape,
       exclusions,
+      flowRootFormattingContext,
     );
     this.parentElement = parentContainer.element;
   }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -608,13 +608,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               )
             : VtreeImpl.makeRootNodeContextFromNodePositionStep(
                 VtreeImpl.rootStepOfNodePosition(position),
+                this.flowRootFormattingContext,
               );
-          if (
-            stepIndex === steps.length - 1 &&
-            !nodeContext.formattingContext
-          ) {
-            nodeContext.formattingContext = this.flowRootFormattingContext;
-          }
           if (stepIndex == 0) {
             nodeContext.offsetInNode =
               this.calculateOffsetInNodeForNodeContext(position);
@@ -3279,7 +3274,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     forceRemoveSelf: boolean,
     endOfColumn: boolean,
   ): Task.Result<boolean> {
-    Asserts.assert(nodeContext.formattingContext);
     const layoutProcessor = new LayoutProcessor.LayoutProcessorResolver().find(
       nodeContext.formattingContext,
     );
@@ -3978,7 +3972,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     frame
       .loopWithFrame((loopFrame) => {
         while (nodeContext) {
-          Asserts.assert(nodeContext.formattingContext);
           const layoutProcessor =
             new LayoutProcessor.LayoutProcessorResolver().find(
               nodeContext.formattingContext,
@@ -4569,7 +4562,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           frame.finish(nodeContext);
         } else {
           const formattingContext = nodeContext.formattingContext;
-          Asserts.assert(formattingContext);
           const layoutProcessor =
             new LayoutProcessor.LayoutProcessorResolver().find(
               formattingContext,
@@ -4596,7 +4588,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       nodeContext = parent, parent = parent ? parent.parent : null
     ) {
       const formattingContext = (parent || nodeContext).formattingContext;
-      Asserts.assert(formattingContext);
       const layoutProcessor =
         new LayoutProcessor.LayoutProcessorResolver().find(formattingContext);
       layoutProcessor.clearOverflownViewNodes(
@@ -4705,7 +4696,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     breakAtEdge: string | null,
     overflows: boolean,
   ): void {
-    Asserts.assert(position.formattingContext);
     const copy = position.copy();
     const layoutProcessor = new LayoutProcessor.LayoutProcessorResolver().find(
       position.formattingContext,

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1604,11 +1604,6 @@ export class StyleInstance
     return false;
   }
 
-  setFormattingContextToColumn(column: LayoutType.Column, flowName: string) {
-    column.flowRootFormattingContext =
-      this.currentLayoutPosition.flows[flowName].formattingContext;
-  }
-
   beginIsolatedRootPageFloatLayoutContext(
     previousPageFloatLayoutContext?: PageFloatsType.AttachedPageFloatLayoutContext | null,
   ): PageFloats.RootPageFloatLayoutContext {
@@ -1781,6 +1776,17 @@ export class StyleInstance
     }
   }
 
+  // A flow is registered only once a chunk of it is encountered, so a column
+  // for a flow that has none has no root to share a context with.
+  private flowRootFormattingContextFor(
+    flowName: string,
+  ): Vtree.FormattingContext {
+    return (
+      this.currentLayoutPosition.flows[flowName]?.formattingContext ??
+      new LayoutProcessor.BlockFormattingContext(null)
+    );
+  }
+
   /**
    * @return holding true
    */
@@ -1794,13 +1800,11 @@ export class StyleInstance
       // still try to place deferred page floats such as footnotes that were
       // deferred from the previous page. (Issue #1880)
       if (flowPosition) {
-        this.setFormattingContextToColumn(column, flowName);
         return this.layoutDeferredPageFloats(column);
       }
       return Task.newResult(true);
     }
 
-    this.setFormattingContextToColumn(column, flowName);
     if (this.primaryFlows[flowName] && column.bands.length > 0) {
       // In general, we force non-fitting content. Exception is only for primary
       // flow columns that have exclusions.
@@ -2153,6 +2157,7 @@ export class StyleInstance
             },
             innerShape,
             dontApplyExclusions ? [] : exclusions.concat(),
+            this.flowRootFormattingContextFor(flowNameStr),
           );
           // Issue #1842: columns after the first treat already-satisfied leading
           // column breaks differently.
@@ -2168,6 +2173,7 @@ export class StyleInstance
             layoutContainer,
             innerShape,
             dontApplyExclusions ? [] : exclusions.concat(),
+            this.flowRootFormattingContextFor(flowNameStr),
           );
           // Single-column layout always behaves like the first column on a page.
           column.isNonFirstColumn = false;

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1605,11 +1605,8 @@ export class StyleInstance
   }
 
   setFormattingContextToColumn(column: LayoutType.Column, flowName: string) {
-    const flow = this.currentLayoutPosition.flows[flowName];
-    if (!flow.formattingContext) {
-      flow.formattingContext = new LayoutProcessor.BlockFormattingContext(null);
-    }
-    column.flowRootFormattingContext = flow.formattingContext;
+    column.flowRootFormattingContext =
+      this.currentLayoutPosition.flows[flowName].formattingContext;
   }
 
   beginIsolatedRootPageFloatLayoutContext(

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -1004,7 +1004,6 @@ function eachAncestorNodeContext(
   for (let nc = nodeContext; nc; nc = nc.parent) {
     const formattingContext = nc.formattingContext;
     if (
-      formattingContext &&
       formattingContext instanceof RepetitiveElementsOwnerFormattingContext &&
       !nc.belongsTo(formattingContext)
     ) {
@@ -1098,9 +1097,6 @@ function getRepetitiveElementsOwnerFormattingContextOrNull(
   nodeContext: Vtree.NodeContext,
 ): RepetitiveElement.RepetitiveElementsOwnerFormattingContext | null {
   const formattingContext = nodeContext.formattingContext;
-  if (!formattingContext) {
-    return null;
-  }
   if (
     !(formattingContext instanceof RepetitiveElementsOwnerFormattingContext)
   ) {

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -146,7 +146,7 @@ export namespace Layout {
   export interface Column extends Vtree.Container {
     last: Node;
     viewDocument: Document;
-    flowRootFormattingContext: Vtree.FormattingContext | null;
+    flowRootFormattingContext: Vtree.FormattingContext;
     // Issue #1842: distinguishes auto-advanced follow-up columns from the first
     // column on a page so leading-edge forced breaks can be handled differently.
     isNonFirstColumn: boolean;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -596,7 +596,7 @@ export namespace LayoutProcessor {
   export function isInstanceOfBlockFormattingContext(
     object: Vtree.FormattingContext,
   ): object is BlockFormattingContext {
-    return object && object.formattingContextType === "Block";
+    return object.formattingContextType === "Block";
   }
 }
 
@@ -910,9 +910,6 @@ export namespace RepetitiveElement {
   export function isInstanceOfRepetitiveElementsOwnerFormattingContext(
     object: Vtree.FormattingContext,
   ): object is RepetitiveElementsOwnerFormattingContext {
-    if (!object) {
-      return false;
-    }
     const type = object.formattingContextType;
     return (
       type === "RepetitiveElementsOwner" ||
@@ -998,7 +995,7 @@ export namespace Table {
   export function isInstanceOfTableFormattingContext(
     object: Vtree.FormattingContext,
   ): object is TableFormattingContext {
-    return object && object.formattingContextType === "Table";
+    return object.formattingContextType === "Table";
   }
 
   export interface TableRowLayoutConstraint

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -3698,6 +3698,7 @@ export class ViewFactory
             pn.sourceNode,
             parentContext,
             boxOffset,
+            (parentContext ?? container).formattingContext,
           );
           child.blockContainer =
             parentContext && Vtree.blockContainerForChildrenOf(parentContext);

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1769,7 +1769,7 @@ export class ViewFactory
         floatSide,
         isRoot,
       );
-      if (nodeContext.parent && nodeContext.parent.formattingContext) {
+      if (nodeContext.parent) {
         firstTime = nodeContext.parent.formattingContext.isFirstTime(
           nodeContext,
           firstTime,
@@ -2724,7 +2724,7 @@ export class ViewFactory
         return;
       }
       const parent = nodeContext.parent;
-      const parentFormattingContext = parent && parent.formattingContext;
+      const parentFormattingContext = parent ? parent.formattingContext : null;
       nodeContext.formattingContext =
         new RepetitiveElement.RepetitiveElementsOwnerFormattingContext(
           parentFormattingContext,

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -490,7 +490,12 @@ export function makeNodeContextFromNodePositionStep(
   parent: Vtree.NodeContext,
 ): NodeContext {
   const parentContext = parent as NodeContext;
-  const nodeContext = new NodeContext(step.node, parentContext, 0);
+  const nodeContext = new NodeContext(
+    step.node,
+    parentContext,
+    0,
+    step.formattingContext ?? parentContext.formattingContext,
+  );
   nodeContext.blockContainer = blockContainerForChildrenOf(parentContext);
   applyNodePositionStep(nodeContext, step);
   nodeContext.shadowSibling = step.shadowSibling
@@ -501,8 +506,14 @@ export function makeNodeContextFromNodePositionStep(
 
 export function makeRootNodeContextFromNodePositionStep(
   step: RootNodePositionStep,
+  flowRootFormattingContext: FormattingContext,
 ): NodeContext {
-  const nodeContext = new NodeContext(step.node, null, 0);
+  const nodeContext = new NodeContext(
+    step.node,
+    null,
+    0,
+    step.formattingContext ?? flowRootFormattingContext,
+  );
   applyNodePositionStep(nodeContext, step);
   nodeContext.shadowSibling = step.shadowSibling;
   return nodeContext;
@@ -515,7 +526,6 @@ function applyNodePositionStep(
   nodeContext.shadowType = step.shadowType;
   nodeContext.shadowContext = step.shadowContext;
   nodeContext.nodeShadow = step.nodeShadow;
-  nodeContext.formattingContext = step.formattingContext;
   nodeContext.fragmentIndex = step.fragmentIndex + 1;
 }
 
@@ -629,7 +639,6 @@ export class NodeContext implements Vtree.NodeContext {
   firstPseudo: FirstPseudo;
   lang: string | null = null;
   preprocessedTextContent: Diff.Change[] | null = null;
-  formattingContext: FormattingContext;
   repeatOnBreak: string | null = null;
   pluginProps: {
     [key: string]: string | number | undefined | null | (number | null)[];
@@ -645,7 +654,12 @@ export class NodeContext implements Vtree.NodeContext {
     parent: NodeContext,
     boxOffset: number,
   ): ChildNodeContext {
-    const nodeContext = new NodeContext(sourceNode, parent, boxOffset);
+    const nodeContext = new NodeContext(
+      sourceNode,
+      parent,
+      boxOffset,
+      parent.formattingContext,
+    );
     nodeContext.blockContainer = blockContainerForChildrenOf(parent);
     return nodeContext as ChildNodeContext;
   }
@@ -655,7 +669,13 @@ export class NodeContext implements Vtree.NodeContext {
     sibling: NodeContext,
     boxOffset: number,
   ): NodeContext {
-    const nodeContext = new NodeContext(sourceNode, sibling.parent, boxOffset);
+    const parent = sibling.parent;
+    const nodeContext = new NodeContext(
+      sourceNode,
+      parent,
+      boxOffset,
+      (parent ?? sibling).formattingContext,
+    );
     nodeContext.blockContainer = sibling.blockContainer;
     return nodeContext;
   }
@@ -664,6 +684,7 @@ export class NodeContext implements Vtree.NodeContext {
     public sourceNode: Node,
     public parent: NodeContext | null,
     public boxOffset: number,
+    public formattingContext: FormattingContext,
   ) {
     this.shadowType = ShadowType.NONE;
     this.shadowContext = parent ? parent.shadowContext : null;
@@ -676,7 +697,6 @@ export class NodeContext implements Vtree.NodeContext {
     this.vertical = parent ? parent.vertical : false;
     this.direction = parent ? parent.direction : "ltr";
     this.firstPseudo = parent ? parent.firstPseudo : null;
-    this.formattingContext = parent ? parent.formattingContext : null;
     this.pageType = parent ? parent.pageType : null;
   }
 
@@ -707,7 +727,9 @@ export class NodeContext implements Vtree.NodeContext {
     this.vertical = this.parent ? this.parent.vertical : false;
     this.nodeShadow = null;
     this.preprocessedTextContent = null;
-    this.formattingContext = this.parent ? this.parent.formattingContext : null;
+    if (this.parent) {
+      this.formattingContext = this.parent.formattingContext;
+    }
     this.repeatOnBreak = null;
     this.pluginProps = {};
     this.fragmentIndex = 1;
@@ -721,6 +743,7 @@ export class NodeContext implements Vtree.NodeContext {
       this.sourceNode,
       this.parent,
       this.boxOffset,
+      this.formattingContext,
     ) as this;
     np.offsetInNode = this.offsetInNode;
     np.after = this.after;
@@ -753,7 +776,6 @@ export class NodeContext implements Vtree.NodeContext {
     np.vertical = this.vertical;
     np.overflow = this.overflow;
     np.preprocessedTextContent = this.preprocessedTextContent;
-    np.formattingContext = this.formattingContext;
     np.repeatOnBreak = this.repeatOnBreak;
     np.pluginProps = Object.create(this.pluginProps);
     np.fragmentIndex = this.fragmentIndex;

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -306,11 +306,11 @@ export function canIgnoreText(text: string, whitespace?: Whitespace): boolean {
 
 export class Flow {
   forcedBreakOffsets = [] as number[];
-  formattingContext: FormattingContext | null = null;
 
   constructor(
     public readonly flowName: string,
     public readonly parentFlowName: string | null,
+    public readonly formattingContext: FormattingContext,
   ) {}
 }
 

--- a/packages/core/test/spec/vivliostyle/layout-spec.js
+++ b/packages/core/test/spec/vivliostyle/layout-spec.js
@@ -16,6 +16,7 @@
  */
 
 import * as adapt_layout from "../../../src/vivliostyle/layout";
+import * as adapt_layoutprocessor from "../../../src/vivliostyle/layout-processor";
 import * as adapt_vtree from "../../../src/vivliostyle/vtree";
 import * as adapt_css from "../../../src/vivliostyle/css";
 import * as adapt_csscasc from "../../../src/vivliostyle/css-cascade";
@@ -35,7 +36,12 @@ describe("layout", function () {
       };
       spyOn(textNode, "replaceData").and.callThrough();
 
-      nodeContext = new adapt_vtree.NodeContext({}, null, 3);
+      nodeContext = new adapt_vtree.NodeContext(
+        {},
+        null,
+        3,
+        new adapt_layoutprocessor.BlockFormattingContext(null),
+      );
       nodeContext.preprocessedTextContent = [
         [0, "abcdeabcde"],
         [1, "\u00AD"],


### PR DESCRIPTION
`NodeContext.formattingContext`の`| null`を解消するリファクタリングです。コンストラクタ引数にして後からの代入を取り除くのが変更の中心部です。