### PR TITLE
refactor: Declare exhaustion and absence null across layout and page floats

### DIFF
--- a/packages/core/src/vivliostyle/break-position.ts
+++ b/packages/core/src/vivliostyle/break-position.ts
@@ -31,7 +31,7 @@ export abstract class AbstractBreakPosition
   abstract findAcceptableBreak(
     column: Layout.Column,
     penalty: number,
-  ): Vtree.NodeContext;
+  ): Vtree.NodeContext | null;
 
   abstract getMinBreakPenalty(): number;
 
@@ -45,7 +45,7 @@ export abstract class AbstractBreakPosition
   /** @override */
   breakPositionChosen(column: Layout.Column): void {}
 
-  getNodeContext(): Vtree.NodeContext {
+  getNodeContext(): Vtree.NodeContext | null {
     return null;
   }
 }
@@ -92,7 +92,7 @@ export class EdgeBreakPosition
   override findAcceptableBreak(
     column: Layout.Column,
     penalty: number,
-  ): Vtree.NodeContext {
+  ): Vtree.NodeContext | null {
     this.updateOverflows(column);
     if (penalty < this.getMinBreakPenalty()) {
       return null;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -707,7 +707,6 @@ export class InheritanceVisitor extends Css.FilterVisitor {
   }
 
   override visitNumeric(numeric: Css.Numeric): Css.Val {
-    Asserts.assert(this.context);
     if (this.propName === "font-size") {
       return convertFontSizeToPx(numeric, this.getFontSize(), this.context);
     } else if (

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -153,7 +153,7 @@ export function getPolyfilledInheritedProps(): string[] {
   );
   return hooks.reduce(
     (props, f) => props.concat(f()),
-    [].concat(polyfilledInheritedProps),
+    ([] as string[]).concat(polyfilledInheritedProps),
   );
 }
 
@@ -835,7 +835,7 @@ export class CompoundAction extends CascadeAction {
   }
 
   override clone(): CascadeAction {
-    return new CompoundAction([].concat(this.list));
+    return new CompoundAction(([] as CascadeAction[]).concat(this.list));
   }
 }
 
@@ -1772,7 +1772,7 @@ export class AbstractConditionItem {
   constructor(
     public readonly condition: string,
     public readonly viewConditionId: string | null,
-    public readonly viewCondition: Matchers.Matcher,
+    public readonly viewCondition: Matchers.Matcher | null,
   ) {}
 
   increment(cascadeInstance: CascadeInstance) {
@@ -1785,7 +1785,7 @@ export class AbstractConditionItem {
 
   buildViewConditionMatcher(
     cascadeInstance: CascadeInstance,
-  ): Matchers.Matcher {
+  ): Matchers.Matcher | null {
     return cascadeInstance.buildViewConditionMatcher(this.viewConditionId);
   }
 }
@@ -1797,7 +1797,7 @@ export class DescendantConditionItem
   constructor(
     condition: string,
     viewConditionId: string | null,
-    viewCondition: Matchers.Matcher,
+    viewCondition: Matchers.Matcher | null,
   ) {
     super(condition, viewConditionId, viewCondition);
   }
@@ -1836,7 +1836,7 @@ export class ChildConditionItem
   constructor(
     condition: string,
     viewConditionId: string | null,
-    viewCondition: Matchers.Matcher,
+    viewCondition: Matchers.Matcher | null,
   ) {
     super(condition, viewConditionId, viewCondition);
   }
@@ -1881,7 +1881,7 @@ export class AdjacentSiblingConditionItem
   constructor(
     condition: string,
     viewConditionId: string | null,
-    viewCondition: Matchers.Matcher,
+    viewCondition: Matchers.Matcher | null,
   ) {
     super(condition, viewConditionId, viewCondition);
   }
@@ -1928,7 +1928,7 @@ export class FollowingSiblingConditionItem
   constructor(
     condition: string,
     viewConditionId: string | null,
-    viewCondition: Matchers.Matcher,
+    viewCondition: Matchers.Matcher | null,
   ) {
     super(condition, viewConditionId, viewCondition);
   }
@@ -3018,7 +3018,8 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
     const container = c.blockContainer;
     const leaderElem = c.viewNode as HTMLElement;
     const pseudoName = pseudoElem.getAttribute("data-adapt-pseudo");
-    const leader = leaderElem.getAttribute("data-viv-leader-value");
+    // written together with data-viv-leader by the leader content listener
+    const leader = leaderElem.getAttribute("data-viv-leader-value")!;
     const { writingMode, direction, marginInlineEnd } =
       column.clientLayout.getElementComputedStyle(pseudoElem);
 
@@ -3233,7 +3234,7 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
     // When content comes back to the normal text flow, then inset effects again.
     function getInset(side: string): number {
       let inset = 0;
-      let p = pseudoElem.parentElement;
+      let p: Element | null = pseudoElem.parentElement;
       while (p && p !== container.viewNode) {
         inset += column.getComputedInsets(p)[side];
         p = p.parentElement;
@@ -3413,7 +3414,7 @@ export class CascadeInstance {
   lastCounterChangeTypes: {
     [key: string]: "reset" | "set" | "increment";
   } = Object.create(null);
-  counterScoping: { [key: string]: boolean }[] = [Object.create(null)];
+  counterScoping: ({ [key: string]: boolean } | null)[] = [Object.create(null)];
   quotes: Css.Str[];
   quoteDepth: number = 0;
   lang: string = "";
@@ -3461,7 +3462,7 @@ export class CascadeInstance {
     this.stack[this.stack.length - 1].push(item);
   }
 
-  increment(condition: string, viewCondition: Matchers.Matcher): void {
+  increment(condition: string, viewCondition: Matchers.Matcher | null): void {
     this.conditions[condition] = (this.conditions[condition] || 0) + 1;
     if (!viewCondition) {
       return;
@@ -3473,7 +3474,7 @@ export class CascadeInstance {
     }
   }
 
-  decrement(condition: string, viewCondition: Matchers.Matcher): void {
+  decrement(condition: string, viewCondition: Matchers.Matcher | null): void {
     this.conditions[condition]--;
     if (!this.viewConditions[condition]) {
       return;
@@ -3486,8 +3487,10 @@ export class CascadeInstance {
     }
   }
 
-  buildViewConditionMatcher(viewConditionId: string | null): Matchers.Matcher {
-    let matcher: Matchers.Matcher = null;
+  buildViewConditionMatcher(
+    viewConditionId: string | null,
+  ): Matchers.Matcher | null {
+    let matcher: Matchers.Matcher | null = null;
     if (viewConditionId) {
       Asserts.assert(this.currentElementOffset);
       matcher = Matchers.MatcherBuilder.buildViewConditionMatcher(
@@ -3501,12 +3504,14 @@ export class CascadeInstance {
         if (conditions && conditions.length > 0) {
           return conditions.length === 1
             ? conditions[0]
-            : Matchers.MatcherBuilder.buildAnyMatcher([].concat(conditions));
+            : Matchers.MatcherBuilder.buildAnyMatcher(
+                ([] as Matchers.Matcher[]).concat(conditions),
+              );
         } else {
           return null;
         }
       })
-      .filter((item) => item);
+      .filter((item): item is Matchers.Matcher => item !== null);
     if (dependentConditionMatchers.length <= 0) {
       return matcher;
     }
@@ -3552,7 +3557,7 @@ export class CascadeInstance {
   defineCounter(counterName: string, value: number) {
     let scoping = this.counterScoping[this.counterScoping.length - 1];
     if (!scoping) {
-      scoping = Object.create(null);
+      scoping = Object.create(null) as { [key: string]: boolean };
       this.counterScoping[this.counterScoping.length - 1] = scoping;
     }
     if (this.counters[counterName]) {
@@ -3594,9 +3599,9 @@ export class CascadeInstance {
     if (float) {
       floatVal = float.evaluate(this.context);
     }
-    let resetMap: { [key: string]: number } = null;
-    let incrementMap: { [key: string]: number } = null;
-    let setMap: { [key: string]: number } = null;
+    let resetMap: { [key: string]: number } | null = null;
+    let incrementMap: { [key: string]: number } | null = null;
+    let setMap: { [key: string]: number } | null = null;
     const reset = props["counter-reset"] as CascadeValue;
     if (reset) {
       const resetVal = reset.evaluate(this.context);
@@ -3623,27 +3628,27 @@ export class CascadeInstance {
       this.currentNamespace == Base.NS.XHTML
     ) {
       if (!resetMap) {
-        resetMap = Object.create(null);
+        resetMap = Object.create(null) as { [key: string]: number };
       }
       resetMap["list-item"] = ((this.currentElement as any)?.start ?? 1) - 1;
     }
     if (Display.isListItem(displayVal)) {
       if (!incrementMap) {
-        incrementMap = Object.create(null);
+        incrementMap = Object.create(null) as { [key: string]: number };
       }
       incrementMap["list-item"] = incrementMap["list-item"] ?? 1;
       if (
         /^\s*[-+]?\d/.test(this.currentElement?.getAttribute("value") ?? "")
       ) {
         if (!setMap) {
-          setMap = Object.create(null);
+          setMap = Object.create(null) as { [key: string]: number };
         }
         setMap["list-item"] = (this.currentElement as any).value;
       }
     }
     if (this.currentElement?.parentNode?.nodeType === Node.DOCUMENT_NODE) {
       if (!resetMap) {
-        resetMap = Object.create(null);
+        resetMap = Object.create(null) as { [key: string]: number };
       }
       // `counter-reset: footnote 0` is implicitly applied on the root element
       if (resetMap["footnote"] === undefined) {
@@ -3655,7 +3660,7 @@ export class CascadeInstance {
       !elementStyle["--viv-semantic-footnote-content"]
     ) {
       if (!incrementMap) {
-        incrementMap = Object.create(null);
+        incrementMap = Object.create(null) as { [key: string]: number };
       }
       // `counter-increment: footnote 1` is implicitly applied on the
       // element (or pseudo element) with `float: footnote`,
@@ -3898,12 +3903,12 @@ export class CascadeInstance {
       (currentNamespaceTypeCounts[this.currentLocalName] || 0) + 1;
     siblingTypeCountsStack.push(emptySiblingTypeCounts());
     const followingSiblingOrderStack = this.followingSiblingOrderStack;
-    if (
-      followingSiblingOrderStack[followingSiblingOrderStack.length - 1] !== null
-    ) {
-      this.currentFollowingSiblingOrder = --followingSiblingOrderStack[
+    const lastOrder =
+      followingSiblingOrderStack[followingSiblingOrderStack.length - 1];
+    if (lastOrder !== null) {
+      this.currentFollowingSiblingOrder = followingSiblingOrderStack[
         followingSiblingOrderStack.length - 1
-      ];
+      ] = lastOrder - 1;
     } else {
       this.currentFollowingSiblingOrder = null;
     }
@@ -4345,7 +4350,7 @@ export class CascadeInstance {
     element: Element,
     elementStyle: ElementStyle,
   ): Css.Val | null {
-    for (let e = element; e; e = e.parentElement) {
+    for (let e: Element | null = element; e; e = e.parentElement) {
       const style = e === element ? elementStyle : this.styles.styleOf(e);
       const prop = style[propName] as CascadeValue;
       if (prop) {
@@ -6136,7 +6141,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     elementStyles: ElementStyle[];
     element: Element | null;
   } {
-    let elem = element ?? this.root;
+    let elem: Element | null = element ?? this.root;
     if (elementStyles?.length) {
       for (let index = 0; index < elementStyles.length; index++) {
         const style = elementStyles[index];
@@ -6273,7 +6278,8 @@ export class VarFilterVisitor extends Css.FilterVisitor {
             );
             if (referencedCycleStart) {
               cycleStartName = referencedCycleStart;
-              return null;
+              // detection-only visitor: the returned value is discarded
+              return func;
             }
           }
         }
@@ -6358,7 +6364,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     nestedVisitor.resolvingCustomProperties.push(name);
     nestedVisitor.varResolutionState = this.varResolutionState;
 
-    let resolvedValue = value;
+    let resolvedValue: Css.Val | null = value;
     const LIMIT_LOOP = 32;
     for (let i = 0; ; i++) {
       if (i >= LIMIT_LOOP) {
@@ -6385,8 +6391,8 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     return hadCycleMembers.has(name) ? null : resolvedValue;
   }
 
-  private getVarValue(name: string): Css.Val {
-    let elem = this.element ?? this.root;
+  private getVarValue(name: string): Css.Val | null {
+    let elem: Element | null = this.element ?? this.root;
     if (this.elementStyles?.length) {
       for (let index = 0; index < this.elementStyles.length; index++) {
         const style = this.elementStyles[index];

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -3119,7 +3119,7 @@ export function takesOnlyNum(propName: string): boolean {
 export function evaluateExprToCSS(
   context: Exprs.Context,
   val: Exprs.Val,
-  propName: string,
+  propName: string | undefined,
 ): Css.Val {
   // Preserve viv-leader expressions as Css.Expr (Issue #1563)
   // leader() must be processed by ContentPropertyHandler, not evaluated here

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -19,7 +19,6 @@
  * @fileoverview CssStyler - Apply CSS cascade to a document incrementally and
  * cache the result.
  */
-import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as Break from "./break";
 import * as CmykStore from "./cmyk-store";
@@ -827,7 +826,6 @@ export class Styler implements AbstractStyler {
     const rootOffset = this.xmldoc.getElementOffset(this.root);
     if (offset < rootOffset) {
       const rootStyle = this.getStyle(this.root, false);
-      Asserts.assert(rootStyle);
       if (!this.cascade.firstPageType) {
         const rootPageCV = rootStyle["page"] as CssCascade.CascadeValue;
         const rootPageType =

--- a/packages/core/src/vivliostyle/css-tokenizer.ts
+++ b/packages/core/src/vivliostyle/css-tokenizer.ts
@@ -1478,7 +1478,7 @@ export class Tokenizer {
 
   constructor(
     public input: string,
-    public readonly handler: TokenizerHandler,
+    public readonly handler: TokenizerHandler | null,
   ) {
     this.indexMask = INITIAL_INDEX_MASK;
     this.buffer = Array(this.indexMask + 1);

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -717,7 +717,7 @@ export const processingOrder = {
   color: 3,
 };
 
-export function isDefaultingValue(value: Val): boolean {
+export function isDefaultingValue(value: Val | null | undefined): boolean {
   return (
     value === ident.inherit ||
     value === ident.initial ||

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -875,7 +875,7 @@ export class OPFDoc {
   epageCount: number = 0;
   prePaginated: boolean = false;
   epageIsRenderedPage: boolean = true;
-  epageCountCallback: (p1: number) => void | null = null;
+  epageCountCallback: ((p1: number) => void) | null = null;
   metadata: Meta = {};
   toc: OPFItem | null = null;
   cover: OPFItem | null = null;
@@ -2417,7 +2417,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
           !nextLayoutPosition &&
           viewItem.item.spineIndex === this.opf.spine.length - 1;
         if (currentPage.isLastPage) {
-          Asserts.assert(this.viewport);
           this.counterStore.finishLastPage(this.viewport);
         }
         currentPage.container.setAttribute(

--- a/packages/core/src/vivliostyle/geometry-util.ts
+++ b/packages/core/src/vivliostyle/geometry-util.ts
@@ -636,7 +636,7 @@ export function addFloatToBands(
   box: Rect,
   bands: Band[],
   floatBox: Rect,
-  floatBands: Band[],
+  floatBands: Band[] | null,
   side: string,
 ): void {
   if (!floatBands) {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -366,7 +366,7 @@ export class BoxBreakPosition
   }
 
   override findAcceptableBreak(
-    column: Column,
+    column: Layout.Column,
     penalty: number,
   ): Vtree.NodeContext | null {
     if (penalty < this.getMinBreakPenalty()) {
@@ -3100,7 +3100,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   findBoxBreakPosition(
     bp: BoxBreakPosition,
     force: boolean,
-  ): Vtree.NodeContext {
+  ): Vtree.NodeContext | null {
     // Workaround for issue #816 (Text with ruby overflowed at column/page break)
     const parentNode = this.element.parentNode;
     const nextSibling = this.element.nextSibling;

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -4896,7 +4896,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * @return holding end position.
    */
   doLayout(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.NodeContext | null,
     leadingEdge: boolean,
     breakAfter?: string | null,
   ): Task.Result<{
@@ -4904,8 +4904,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     overflownNodeContext: Vtree.NodeContext | null;
   }> {
     const frame: Task.Frame<{
-      nodeContext: Vtree.NodeContext;
-      overflownNodeContext: Vtree.NodeContext;
+      nodeContext: Vtree.NodeContext | null;
+      overflownNodeContext: Vtree.NodeContext | null;
     }> = Task.newFrame("doLayout");
     let overflownNodeContext: Vtree.NodeContext | null = null;
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -966,7 +966,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * Remove all the exclusion floats.
    */
   killFloats(): void {
-    let c: Node = this.element.firstChild;
+    let c: Node | null = this.element.firstChild;
     while (c) {
       const nc = c.nextSibling;
       if (c.nodeType == 1) {
@@ -992,7 +992,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const x2 = this.vertical ? this.getBottomEdge() : this.getRightEdge();
     const y1 = this.vertical ? -this.getRightEdge() : this.getTopEdge();
     const y2 = this.vertical ? -this.getLeftEdge() : this.getBottomEdge();
-    let foundNonZeroWidthBand: GeometryUtil.Band = null;
+    let foundNonZeroWidthBand: GeometryUtil.Band | null = null;
 
     // First pass: adjust band edges to column edges if they are almost equal
     // to avoid creating unnecessary floats that may cause layout issues.
@@ -2892,13 +2892,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const range = start.ownerDocument.createRange();
     let wentUp = false;
     let node: Node = start;
-    let lastGood: Node = null;
+    let lastGood: Node | null = null;
     let haveStart = false;
     let endNotReached = true;
     while (endNotReached) {
       let seekRange = true;
       do {
-        let next: Node = null;
+        let next: Node | null = null;
         if (node == end) {
           if (end.nodeType === 1) {
             // If end is an element, continue traversing its children to find
@@ -3745,10 +3745,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * break-after properties from all elements that meet at the edge.
    */
   skipEdges(
-    nodeContext: Vtree.NodeContext,
+    initialNodeContext: Vtree.NodeContext,
     leadingEdge: boolean,
     forcedBreakValue: string | null,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
+    let nodeContext: Vtree.NodeContext | null = initialNodeContext;
     const fc = nodeContext.after
       ? nodeContext.parent?.formattingContext
       : nodeContext.formattingContext;
@@ -4381,10 +4382,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * content remains and null if all content could be skipped.
    */
   skipTailEdges(
-    nodeContext: Vtree.NodeContext,
-  ): Task.Result<Vtree.NodeContext> {
-    let resultNodeContext = nodeContext.copy();
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("skipEdges");
+    initialNodeContext: Vtree.NodeContext,
+  ): Task.Result<Vtree.NodeContext | null> {
+    let nodeContext: Vtree.NodeContext | null = initialNodeContext;
+    let resultNodeContext: Vtree.NodeContext | null = nodeContext.copy();
+    const frame: Task.Frame<Vtree.NodeContext | null> =
+      Task.newFrame("skipEdges");
     let breakAtTheEdge: string | null = null;
     let onStartEdges = false;
     frame
@@ -4583,7 +4586,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       return;
     }
     for (
-      let parent = nodeContext.parent;
+      let parent: Vtree.NodeContext | null = nodeContext.parent;
       nodeContext;
       nodeContext = parent, parent = parent ? parent.parent : null
     ) {
@@ -4742,7 +4745,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     chunkPosition: Vtree.ChunkPosition,
     leadingEdge: boolean,
     breakAfter?: string | null,
-  ): Task.Result<Vtree.ChunkPosition> {
+  ): Task.Result<Vtree.ChunkPosition | null> {
     this.chunkPositions.push(chunkPosition); // So we can re-layout this column later
     if (chunkPosition.primary.after) {
       this.lastAfterPosition = chunkPosition.primary;
@@ -4756,7 +4759,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         chunkPosition.primary.steps.length === 1
       ) {
         // End of contents
-        return Task.newResult(null as Vtree.ChunkPosition);
+        return Task.newResult<Vtree.ChunkPosition | null>(null);
       } else {
         return Task.newResult(chunkPosition as Vtree.ChunkPosition);
       }
@@ -4792,11 +4795,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           initialNodeContext,
           retryer.initialComputedBlockSize,
         ).then((positionAfter) => {
-          let cont: Task.Result<boolean> = null;
+          let cont: Task.Result<boolean>;
           if (!this.pseudoParent) {
             cont = this.doFinishBreakOfFragmentLayoutConstraints(positionAfter);
           } else {
-            cont = Task.newResult(null);
+            // The value is never read. This result only sequences the steps.
+            cont = Task.newResult(true);
           }
           cont.then(() => {
             if (LayoutHelper.isUsingBrowserColumnBreaking(this)) {
@@ -4891,14 +4895,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     leadingEdge: boolean,
     breakAfter?: string | null,
   ): Task.Result<{
-    nodeContext: Vtree.NodeContext;
-    overflownNodeContext: Vtree.NodeContext;
+    nodeContext: Vtree.NodeContext | null;
+    overflownNodeContext: Vtree.NodeContext | null;
   }> {
     const frame: Task.Frame<{
       nodeContext: Vtree.NodeContext;
       overflownNodeContext: Vtree.NodeContext;
     }> = Task.newFrame("doLayout");
-    let overflownNodeContext: Vtree.NodeContext = null;
+    let overflownNodeContext: Vtree.NodeContext | null = null;
 
     // ------ init backtracking list -----
     this.breakPositions = [];
@@ -5287,7 +5291,7 @@ export class ColumnLayoutRetryer extends LayoutRetryers.AbstractLayoutRetryer {
   initialComputedBlockSize: number = 0;
   private initialOverflown: boolean = false;
   private initialLastLineStride: number = 0;
-  context: { overflownNodeContext: Vtree.NodeContext } = {
+  context: { overflownNodeContext: Vtree.NodeContext | null } = {
     overflownNodeContext: null,
   };
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -423,7 +423,7 @@ export function validateCheckPoints(
 }
 
 export class Column extends VtreeImpl.Container implements Layout.Column {
-  last: Node;
+  last: Node | null;
   viewDocument: Document;
   // Issue #1842: true only for columns reached after automatic column overflow.
   isNonFirstColumn: boolean = false;
@@ -596,7 +596,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const steps = position.steps;
     this.layoutContext.setViewRoot(this.element, this.isFootnote);
     let stepIndex = steps.length - 1;
-    let nodeContext: Vtree.NodeContext = null;
+    let nodeContext: Vtree.NodeContext | null = null;
     frame
       .loop(() => {
         while (stepIndex >= 0) {
@@ -2150,8 +2150,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const context = this.pageFloatLayoutContext;
     const stashedFloatFragments =
       context.getStashedFloatFragments(floatReference);
-    const newFloatAreas = [];
-    const newFragments = [];
+    const newFloatAreas: Layout.PageFloatArea[] = [];
+    const newFragments: PageFloats.PageFloatFragment[] = [];
     let failed = false;
     const frame = Task.newFrame<boolean>("layoutStashedPageFloats");
     let i = 0;
@@ -2888,7 +2888,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     start: Element | Text,
     end: Element | Text,
   ): Vtree.ClientRect[] {
-    const arr = [];
+    const arr: Vtree.ClientRect[] = [];
     const range = start.ownerDocument.createRange();
     let wentUp = false;
     let node: Node = start;
@@ -2986,7 +2986,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   findLinePositions(checkPoints: Vtree.RenderedNodeContext[]): number[] {
     const LOW_OVERLAP = 0.2;
     const MID_OVERLAP = 0.6;
-    const positions = [];
+    const positions: number[] = [];
     const boxes = this.getRangeBoxes(
       checkPoints[0].viewNode,
       checkPoints[checkPoints.length - 1].viewNode,
@@ -3479,8 +3479,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * @return true if overflows
    */
   checkOverflowAndSaveEdge(
-    nodeContext: Vtree.NodeContext,
-    trailingEdgeContexts: Vtree.NodeContext[],
+    nodeContext: Vtree.NodeContext | null,
+    trailingEdgeContexts: Vtree.NodeContext[] | null,
   ): boolean {
     if (!nodeContext) {
       return false;
@@ -3534,8 +3534,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * @return true if overflows
    */
   checkOverflowAndSaveEdgeAndBreakPosition(
-    nodeContext: Vtree.NodeContext,
-    trailingEdgeContexts: Vtree.NodeContext[],
+    nodeContext: Vtree.NodeContext | null,
+    trailingEdgeContexts: Vtree.NodeContext[] | null,
     saveEvenOverflown: boolean,
     breakAtTheEdge: string | null,
   ): boolean {
@@ -4769,7 +4769,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
     // ------ start the column -----------
     this.openAllViews(chunkPosition.primary).then((nodeContext) => {
-      let initialNodeContext: Vtree.NodeContext = null;
+      let initialNodeContext: Vtree.NodeContext | null = null;
       if (nodeContext.viewNode) {
         initialNodeContext = nodeContext.copy();
       } else {
@@ -4858,9 +4858,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const frame: Task.Frame<boolean> = Task.newFrame(
       "doFinishBreakOfFragmentLayoutConstraints",
     );
-    const sortedFragmentLayoutConstraints = [].concat(
-      this.fragmentLayoutConstraints,
-    );
+    const sortedFragmentLayoutConstraints =
+      this.fragmentLayoutConstraints.slice();
     sortedFragmentLayoutConstraints.sort(
       (a, b) => a.getPriorityOfFinishBreak() - b.getPriorityOfFinishBreak(),
     );

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2277,7 +2277,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
   resolveFloatReferenceFromColumnSpan(
     floatReference: PageFloats.FloatReference,
-    columnSpan: Css.Val,
+    columnSpan: Css.Val | null,
     nodeContext: Vtree.NodeContext,
   ): Task.Result<PageFloats.FloatReference> {
     const frame = Task.newFrame(

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1714,7 +1714,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   createPageFloatArea(
-    float: PageFloats.PageFloat | null,
+    float: PageFloats.PageFloat,
     floatSide: string,
     anchorEdge: number | null,
     strategy: PageFloats.PageFloatLayoutStrategy,
@@ -1745,7 +1745,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         float.floatReference,
       ).container;
     // The constructor measures through a DOM probe, so attach the element first.
-    floatContainer.element.parentNode.appendChild(floatAreaElement);
+    floatContainer.element.parentNode!.appendChild(floatAreaElement);
     const containingBlockRect = floatContainer.getPaddingRect();
     const floatLeft = containingBlockRect.x1 - floatContainer.originX;
     const floatTop = containingBlockRect.y1 - floatContainer.originY;
@@ -1992,7 +1992,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     // area) need to be cleaned up from ancestor contexts. (Issue #1675)
     const savedInsideFragments = new Set<PageFloats.PageFloatFragment>();
     for (
-      let ctx = context as PageFloats.PageFloatLayoutContext;
+      let ctx: PageFloats.PageFloatLayoutContext | null =
+        context as PageFloats.PageFloatLayoutContext;
       ctx;
       ctx = ctx.effectiveParent
     ) {
@@ -2320,7 +2321,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
   layoutPageFloat(
     nodeContext: Vtree.FloatNodeContext,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const context = this.pageFloatLayoutContext;
     const strategy =
       new PageFloats.PageFloatLayoutStrategyResolver().findByNodeContext(
@@ -2443,7 +2444,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 context.hasInvalidatedForLineFootnote(float)
               ) {
                 if (context.isInvalidated()) {
-                  return Task.newResult(null as Vtree.NodeContext);
+                  return Task.newResult<Vtree.NodeContext | null>(null);
                 }
                 const continuingFragment = strategy.findPageFloatFragment(
                   float,
@@ -2470,7 +2471,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             if (context.generatingNodePosition) {
               return Task.newResult(nodeContextAfter);
             }
-            return Task.newResult(null as Vtree.NodeContext);
+            return Task.newResult<Vtree.NodeContext | null>(null);
           });
         }
       }
@@ -4516,7 +4517,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
   layoutFloatOrFootnote(
     nodeContext: Vtree.FloatNodeContext,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     if (
       PageFloats.isPageFloat(nodeContext.floatReference) ||
       nodeContext.floatSide === "footnote"

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -274,9 +274,9 @@ function processAfterIfContinuesOfNodeContext(
 }
 
 export function processAfterIfContinues(
-  result: Task.Result<Vtree.NodeContext>,
+  result: Task.Result<Vtree.NodeContext | null>,
   column: Layout.Column,
-): Task.Result<Vtree.NodeContext> {
+): Task.Result<Vtree.NodeContext | null> {
   return result.thenAsync((nodeContext) =>
     processAfterIfContinuesOfNodeContext(nodeContext, column),
   );
@@ -368,7 +368,7 @@ export class BoxBreakPosition
   override findAcceptableBreak(
     column: Column,
     penalty: number,
-  ): Vtree.NodeContext {
+  ): Vtree.NodeContext | null {
     if (penalty < this.getMinBreakPenalty()) {
       return null;
     }
@@ -384,7 +384,7 @@ export class BoxBreakPosition
     return this.penalty;
   }
 
-  override getNodeContext(): Vtree.NodeContext {
+  override getNodeContext(): Vtree.NodeContext | null {
     return this.alreadyEvaluated
       ? this.breakNodeContext
       : this.checkPoints[this.checkPoints.length - 1];
@@ -932,7 +932,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * @param height float box progression dimension.
    * @return newly created float element.
    */
-  createFloat(ref: Node, side: string, width: number, height: number): Element {
+  createFloat(
+    ref: Node | null,
+    side: string,
+    width: number,
+    height: number,
+  ): Element {
     const div = this.viewDocument.createElement("div");
     if (this.vertical) {
       if (height >= this.height) {
@@ -1213,7 +1218,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    * @return edge position
    */
   calculateEdge(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.NodeContext | null,
     checkPoints: Vtree.RenderedNodeContext[],
     index: number,
     boxOffset: number,

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1350,7 +1350,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   /**
    * Set element's computed CSS insets to Column Container
    */
-  setComputedInsets(element: Element, container: Column) {
+  setComputedInsets(element: Element, container: Layout.Column) {
     const style = this.clientLayout.getElementComputedStyle(element);
     if (style) {
       container.marginLeft = this.parseComputedLength(style.marginLeft);
@@ -1373,7 +1373,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   /**
    * Set element's computed width and height to Column Container
    */
-  setComputedWidthAndHeight(element: Element, container: Column) {
+  setComputedWidthAndHeight(element: Element, container: Layout.Column) {
     const style = this.clientLayout.getElementComputedStyle(element);
     if (style) {
       container.width = this.parseComputedLength(style.width);
@@ -1719,7 +1719,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     anchorEdge: number | null,
     strategy: PageFloats.PageFloatLayoutStrategy,
     condition: PageFloats.PageFloatPlacementCondition,
-  ): Task.Result<PageFloatArea | null> {
+  ): Task.Result<Layout.PageFloatArea | null> {
     const floatAreaElement = this.element.ownerDocument.createElement("div");
     Base.setCSSProperty(floatAreaElement, "position", "absolute");
     const parentPageFloatLayoutContext =

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1768,7 +1768,8 @@ export class StyleInstance
         }
         return result;
       } else {
-        Asserts.assert("column.lastAfterPosition === null");
+        // Deferred floats do not imply an after position. A column that laid
+        // out no content leaves none.
         return null;
       }
     } else {

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -2027,7 +2027,6 @@ export class AttachedPageFloatLayoutContext
         return null;
       }
     }
-    Asserts.assert(area.clientLayout);
 
     // Preceding page floats on the opposite side should not affect
     // the positioning limit unless clear:inline-start/end is specified.
@@ -2512,7 +2511,6 @@ export class AttachedPageFloatLayoutContext
       }
     }
 
-    Asserts.assert(column.clientLayout);
     const blockStartLimit = this.getLimitValue(
       "block-start",
       null,
@@ -2654,7 +2652,6 @@ export class AttachedPageFloatLayoutContext
   isColumnFullWithPageFloats(column: LayoutType.Column): boolean {
     const layoutContext = column.layoutContext;
     const clientLayout = column.clientLayout;
-    Asserts.assert(clientLayout);
     let context: AttachedPageFloatLayoutContext | null = this;
     let limits: {
       top: number;

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1155,8 +1155,8 @@ export abstract class ParentPageFloatLayoutContext
   }
 
   getFloatsDeferredToNextInChildContexts(): PageFloat[] {
-    let result = [];
-    const done = [];
+    let result: PageFloat[] = [];
+    const done: (string | null)[] = [];
     for (let i = this.state.children.length - 1; i >= 0; i--) {
       const child = this.state.children[i];
       if (done.includes(child.flowName)) {
@@ -1213,7 +1213,8 @@ export abstract class ParentPageFloatLayoutContext
       index = this.state.children.length;
     }
     for (let i = index - 1; i >= 0; i--) {
-      let result = this.state.children[i];
+      let result: AttachedPageFloatLayoutContext | null =
+        this.state.children[i];
       if (
         result.floatReference === floatReference &&
         result.flowName === flowName &&
@@ -1503,7 +1504,7 @@ export class AttachedPageFloatLayoutContext
     const deferredFloats = this.getFloatsDeferredToNextInChildContexts();
     const floatsInFragments = this.floatFragments.reduce(
       (r, fr) => r.concat(fr.continuations.map((c) => c.float)),
-      [],
+      [] as PageFloat[],
     );
     floatsInFragments.sort((f1, f2) => f2.getOrder() - f1.getOrder());
     for (const float of floatsInFragments) {
@@ -1771,7 +1772,7 @@ export class AttachedPageFloatLayoutContext
 
   private getLimitValueInner(
     logicalSide: string,
-    logicalSide2: string | null,
+    logicalSide2: string | null | undefined,
     layoutContext: Vtree.LayoutContext,
     clientLayout: Vtree.ClientLayout,
     condition?: (
@@ -2357,7 +2358,7 @@ export class AttachedPageFloatLayoutContext
     this.floatFragments
       .filter((fragment) => fragment.floatSide.includes("block-start"))
       .filter((fragment) => {
-        if (!isFinite(inlinePos)) {
+        if (inlinePos === undefined || !isFinite(inlinePos)) {
           return true;
         }
         const rect = fragment.getOuterRect();
@@ -2395,7 +2396,7 @@ export class AttachedPageFloatLayoutContext
     this.floatFragments
       .filter((fragment) => fragment.floatSide.includes("block-end"))
       .filter((fragment) => {
-        if (!isFinite(inlinePos)) {
+        if (inlinePos === undefined || !isFinite(inlinePos)) {
           return true;
         }
         const rect = fragment.getOuterRect();
@@ -2652,41 +2653,32 @@ export class AttachedPageFloatLayoutContext
   isColumnFullWithPageFloats(column: LayoutType.Column): boolean {
     const layoutContext = column.layoutContext;
     const clientLayout = column.clientLayout;
-    let context: AttachedPageFloatLayoutContext | null = this;
-    let limits: {
-      top: number;
-      left: number;
-      bottom: number;
-      right: number;
-      floatMinWrapBlockStart: number;
-      floatMinWrapBlockEnd: number;
-    } = null;
-    while (context) {
+    const limits = this.getLimitValuesInner(layoutContext, clientLayout);
+    for (
+      let context = this.attachedParent;
+      context;
+      context = context.attachedParent
+    ) {
       const l = context.getLimitValuesInner(layoutContext, clientLayout);
-      if (limits) {
-        if (column.vertical) {
-          if (l.right < limits.right) {
-            limits.right = l.right;
-            limits.floatMinWrapBlockStart = l.floatMinWrapBlockStart;
-          }
-          if (l.left > limits.left) {
-            limits.left = l.left;
-            limits.floatMinWrapBlockEnd = l.floatMinWrapBlockEnd;
-          }
-        } else {
-          if (l.top > limits.top) {
-            limits.top = l.top;
-            limits.floatMinWrapBlockStart = l.floatMinWrapBlockStart;
-          }
-          if (l.bottom < limits.bottom) {
-            limits.bottom = l.bottom;
-            limits.floatMinWrapBlockEnd = l.floatMinWrapBlockEnd;
-          }
+      if (column.vertical) {
+        if (l.right < limits.right) {
+          limits.right = l.right;
+          limits.floatMinWrapBlockStart = l.floatMinWrapBlockStart;
+        }
+        if (l.left > limits.left) {
+          limits.left = l.left;
+          limits.floatMinWrapBlockEnd = l.floatMinWrapBlockEnd;
         }
       } else {
-        limits = l;
+        if (l.top > limits.top) {
+          limits.top = l.top;
+          limits.floatMinWrapBlockStart = l.floatMinWrapBlockStart;
+        }
+        if (l.bottom < limits.bottom) {
+          limits.bottom = l.bottom;
+          limits.floatMinWrapBlockEnd = l.floatMinWrapBlockEnd;
+        }
       }
-      context = context.attachedParent;
     }
     const floatMinWrapBlock = Math.max(
       limits.floatMinWrapBlockStart,

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -946,7 +946,7 @@ export abstract class PageFloatLayoutContext
 
   getLastFollowingFloatInFragments(float: PageFloat): PageFloat | null {
     const order = float.getOrder();
-    let lastFollowing: PageFloat = null;
+    let lastFollowing: PageFloat | null = null;
     this.floatFragments.forEach((fragment) => {
       fragment.continuations.forEach((c) => {
         const f = c.float;
@@ -1720,7 +1720,7 @@ export class AttachedPageFloatLayoutContext
 
   private getLimitValue(
     side: string,
-    side2: string | null,
+    side2: string | null | undefined,
     layoutContext: Vtree.LayoutContext,
     clientLayout: Vtree.ClientLayout,
     condition?: (

--- a/packages/core/src/vivliostyle/print.ts
+++ b/packages/core/src/vivliostyle/print.ts
@@ -10,7 +10,7 @@ interface IFrameWindowForPrint {
 export interface PrintConfig {
   title: string;
   printCallback: (iframeWin: Window) => void;
-  errorCallback: (message: string) => void | null;
+  errorCallback: ((message: string) => void) | null;
   hideIframe: boolean;
   removeIframe: boolean;
 }
@@ -19,7 +19,7 @@ class VivliostylePrint {
   htmlDoc: string;
   title: string;
   printCallback: (iframeWin: Window) => void;
-  errorCallback: (message: string) => void;
+  errorCallback: ((message: string) => void) | null;
   hideIframe: boolean;
   removeIframe: boolean;
   iframe: HTMLIFrameElement;

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -478,7 +478,6 @@ export abstract class LayoutEntireBlock implements LayoutType.LayoutMode {
   ): boolean {
     const repetitiveElements = this.formattingContext.getRepetitiveElements();
     if (repetitiveElements) {
-      Asserts.assert(column.clientLayout);
       if (!repetitiveElements.doneInitialLayout) {
         repetitiveElements.updateHeight(column);
         repetitiveElements.doneInitialLayout = true;

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -49,7 +49,7 @@ export class TableRow {
 
   constructor(
     public readonly rowIndex: number,
-    public readonly sourceNode: Node,
+    public readonly sourceNode: Node | null,
   ) {}
 
   addCell(cell: TableCell) {
@@ -160,7 +160,7 @@ export class BetweenTableRowBreakPosition
   override findAcceptableBreak(
     column: Layout.Column,
     penalty: number,
-  ): Vtree.NodeContext {
+  ): Vtree.NodeContext | null {
     const breakNodeContext = super.findAcceptableBreak(column, penalty);
     if (penalty < this.getMinBreakPenalty()) {
       return null;
@@ -260,7 +260,7 @@ export class InsideTableRowBreakPosition
   override findAcceptableBreak(
     column: Layout.Column,
     penalty: number,
-  ): Vtree.NodeContext {
+  ): Vtree.NodeContext | null {
     if (
       this !== column.breakPositions[0] && // Fix for issue #1458, case 2
       penalty < this.getMinBreakPenalty()
@@ -531,7 +531,7 @@ export class TableFormattingContext
       } else {
         return uniqueCells;
       }
-    }, []);
+    }, [] as TableCell[]);
   }
 
   getRowSpanningCellsOverflowingTheRow(rowIndex: number): TableCell[] {
@@ -577,12 +577,12 @@ export class TableFormattingContext
    * @return position
    */
   findCellFromColumn(
-    column: Layout.Column,
+    column: Layout.Column | null,
   ): { rowIndex: number; columnIndex: number } | null {
     if (!column) {
       return null;
     }
-    let tableCell: TableCell = null;
+    let tableCell: TableCell | null = null;
     let row = 0;
     let col = 0;
     loop: for (row = 0; row < this.cellFragments.length; row++) {
@@ -613,10 +613,11 @@ export class TableFormattingContext
     return null;
   }
 
-  collectElementsOffsetOfUpperCells(
-    position: { rowIndex: number; columnIndex: number } | null,
-  ): RepetitiveElement.ElementsOffset[] {
-    const collected = [];
+  collectElementsOffsetOfUpperCells(position: {
+    rowIndex: number;
+    columnIndex: number;
+  }): RepetitiveElement.ElementsOffset[] {
+    const collected: TableCellFragment[] = [];
     return this.slots.reduce((repetitiveElements, row, index) => {
       if (index >= position.rowIndex) {
         return repetitiveElements;
@@ -637,7 +638,10 @@ export class TableFormattingContext
   }
 
   collectElementsOffsetOfHighestColumn(): RepetitiveElement.ElementsOffset[] {
-    const elementsInColumn = [];
+    const elementsInColumn: {
+      collected: TableCellFragment[];
+      elements: RepetitiveElement.ElementsOffset[];
+    }[] = [];
     this.rows.forEach((row) => {
       row.cells.forEach((cell, index) => {
         if (!elementsInColumn[index]) {
@@ -686,13 +690,15 @@ export class TableFormattingContext
   }
 
   override saveState(): any {
-    return [].concat(this.cellBreakPositions);
+    return ([] as BrokenTableCellPosition[]).concat(this.cellBreakPositions);
   }
 
   override restoreState(state: any) {
     // Create a fresh copy to prevent the saved state from being mutated
     // during subsequent layout attempts (issue #1667).
-    this.cellBreakPositions = [].concat(state as BrokenTableCellPosition[]);
+    this.cellBreakPositions = ([] as BrokenTableCellPosition[]).concat(
+      state as BrokenTableCellPosition[],
+    );
   }
 }
 
@@ -1135,7 +1141,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     if (cellBreakPositions.length === 0) {
       return [];
     }
-    const rowSpanningCellBreakPositions = [];
+    const rowSpanningCellBreakPositions: BrokenTableCellPosition[][] = [];
     cellBreakPositions.forEach((p) => {
       const cell = p.cell;
       const rowIndex = cell.rowIndex;
@@ -2699,7 +2705,7 @@ export class TableRowLayoutConstraint
   }
 
   getElementsOffsetsForTableCell(
-    column: Layout.Column,
+    column: Layout.Column | null,
   ): RepetitiveElement.ElementsOffset[] {
     const formattingContext = getTableFormattingContext(
       this.nodeContext.formattingContext,

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -467,7 +467,6 @@ export class TableFormattingContext
       this.addRow(rowIndex, new TableRow(rowIndex, null));
       row = this.rows[rowIndex];
     }
-    Asserts.assert(row);
     const rowSlots = this.getRowSlots(rowIndex);
     let anchorColumnIndex = 0;
     while (rowSlots[anchorColumnIndex]) {
@@ -882,7 +881,6 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
         if (!this.inHeaderOrFooter) {
           this.inRow = true;
           this.rowIndex++;
-          Asserts.assert(nodeContext.sourceNode);
           this.columnIndex = 0;
           formattingContext.addRow(
             this.rowIndex,
@@ -1272,7 +1270,6 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     const nodeContext = state.nodeContext;
     const formattingContext = this.formattingContext;
     if (this.currentRowIndex < 0) {
-      Asserts.assert(nodeContext.sourceNode);
       this.currentRowIndex = formattingContext.findRowIndexBySourceNode(
         nodeContext.sourceNode,
       );
@@ -1736,7 +1733,6 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     if (!lastRow) {
       return;
     }
-    Asserts.assert(lastRow);
     formattingContext.lastRowViewNode = null;
     const doc = lastRow.ownerDocument;
     const fragment = doc.createDocumentFragment();
@@ -1786,7 +1782,6 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     );
     formattingContext.vertical = nodeContext.vertical;
     formattingContext.initializeRepetitiveElements(nodeContext.vertical);
-    Asserts.assert(nodeContext.sourceNode);
     const tableLayoutOption = getTableLayoutOption(nodeContext.sourceNode);
     clearTableLayoutOptionCache(nodeContext.sourceNode);
     const frame = Task.newFrame<Vtree.NodeContext>(
@@ -2055,7 +2050,6 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
       nodeContext.formattingContext,
     );
     if (nodeContext.display === "table-row") {
-      Asserts.assert(nodeContext.sourceNode);
       const rowIndex = formattingContext.findRowIndexBySourceNode(
         nodeContext.sourceNode,
       );
@@ -2111,7 +2105,6 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
               cellFragment.pseudoColumn
                 .finishBreak(breakNodeContext, false, true)
                 .then(() => {
-                  Asserts.assert(cellFragment);
                   adjustCellHeight(
                     cellFragment,
                     formattingContext,
@@ -2445,7 +2438,6 @@ export class EntireTableLayoutConstraint
     initialPosition: Vtree.NodeContext,
     column: Layout.Column,
   ) {
-    Asserts.assert(positionAfter.sourceNode);
     tableLayoutOptionCache.push({
       root: positionAfter.sourceNode,
       tableLayoutOption: {
@@ -2684,7 +2676,6 @@ export class TableRowLayoutConstraint
   ): { fragment: TableCellFragment; breakPosition: Vtree.NodeContext }[] {
     let rowIndex = Number.MAX_VALUE;
     if (nodeContext && nodeContext.display === "table-row") {
-      Asserts.assert(nodeContext.sourceNode);
       rowIndex =
         formattingContext.findRowIndexBySourceNode(nodeContext.sourceNode) + 1;
     }

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -517,12 +517,12 @@ export namespace Layout {
      * @return holding end position.
      */
     doLayout(
-      nodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.NodeContext | null,
       leadingEdge: boolean,
       breakAfter?: string | null,
     ): Task.Result<{
-      nodeContext: Vtree.NodeContext;
-      overflownNodeContext: Vtree.NodeContext;
+      nodeContext: Vtree.NodeContext | null;
+      overflownNodeContext: Vtree.NodeContext | null;
     }>;
     saveDistanceToBlockEndFloats(): void;
     collectElementsOffset(): RepetitiveElement.ElementsOffset[];

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -509,7 +509,9 @@ export namespace Layout {
     ): Task.Result<Vtree.ChunkPosition>;
     isFullWithPageFloats(): boolean;
     getMaxBlockSizeOfPageFloats(): number;
-    doFinishBreakOfFragmentLayoutConstraints(nodeContext): void;
+    doFinishBreakOfFragmentLayoutConstraints(
+      nodeContext: Vtree.NodeContext,
+    ): Task.Result<boolean>;
     /**
      * @param nodeContext starting position.
      * @return holding end position.
@@ -583,6 +585,7 @@ export namespace Layout {
     readonly parentContainer: Vtree.Container;
     readonly parentElement: Element | null;
 
+    applyCompactFootnoteDisplay(): void;
     convertPercentageSizesToPx(target: Element): void;
     fixFloatSizeAndPosition(nodeContext: Vtree.NodeContext): void;
     getRootViewNodeCount(): number;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -103,7 +103,10 @@ export namespace Layout {
     /**
      * @return break position, if found
      */
-    findAcceptableBreak(column: Column, penalty: number): Vtree.NodeContext;
+    findAcceptableBreak(
+      column: Column,
+      penalty: number,
+    ): Vtree.NodeContext | null;
     /**
      * @return penalty for this break position
      */
@@ -113,7 +116,7 @@ export namespace Layout {
   }
 
   export interface AbstractBreakPosition extends BreakPosition {
-    getNodeContext(): Vtree.NodeContext;
+    getNodeContext(): Vtree.NodeContext | null;
   }
 
   export type BreakPositionAndNodeContext = {
@@ -431,8 +434,8 @@ export namespace Layout {
      * @return true if overflows
      */
     checkOverflowAndSaveEdge(
-      nodeContext: Vtree.NodeContext,
-      trailingEdgeContexts: Vtree.NodeContext[],
+      nodeContext: Vtree.NodeContext | null,
+      trailingEdgeContexts: Vtree.NodeContext[] | null,
     ): boolean;
     /**
      * Save a possible page break position on a CSS block edge. Check if it
@@ -440,8 +443,8 @@ export namespace Layout {
      * @return true if overflows
      */
     checkOverflowAndSaveEdgeAndBreakPosition(
-      nodeContext: Vtree.NodeContext,
-      trailingEdgeContexts: Vtree.NodeContext[],
+      nodeContext: Vtree.NodeContext | null,
+      trailingEdgeContexts: Vtree.NodeContext[] | null,
       saveEvenOverflown: boolean,
       breakAtTheEdge: string | null,
     ): boolean;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1010,7 +1010,7 @@ export namespace Table {
 
     removeDummyRowNodes(nodeContext: Vtree.NodeContext): void;
     getElementsOffsetsForTableCell(
-      column: Layout.Column,
+      column: Layout.Column | null,
     ): RepetitiveElement.ElementsOffset[];
   }
 

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -349,7 +349,7 @@ export namespace Layout {
     ): Task.Result<PageFloats.FloatReference>;
     layoutPageFloat(
       nodeContext: Vtree.FloatNodeContext,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     processLineStyling(
       nodeContext: Vtree.NodeContext,
       resNodeContext: Vtree.NodeContext,
@@ -401,7 +401,7 @@ export namespace Layout {
     findBoxBreakPosition(
       bp: BoxBreakPosition,
       force: boolean,
-    ): Vtree.NodeContext;
+    ): Vtree.NodeContext | null;
     getAfterEdgeOfBlockContainer(nodeContext: Vtree.NodeContext): number;
     findFirstOverflowingEdgeAndCheckPoint(
       checkPoints: Vtree.RenderedNodeContext[],
@@ -459,7 +459,7 @@ export namespace Layout {
       nodeContext: Vtree.NodeContext,
       leadingEdge: boolean,
       forcedBreakValue: string | null,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     /**
      * Skips non-renderable positions until it hits the end of the flow or some
      * renderable content. Returns the nodeContext that was passed in if some
@@ -467,10 +467,10 @@ export namespace Layout {
      */
     skipTailEdges(
       nodeContext: Vtree.NodeContext,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     layoutFloatOrFootnote(
       nodeContext: Vtree.FloatNodeContext,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     /**
      * Layout next portion of the source.
      */
@@ -506,7 +506,7 @@ export namespace Layout {
       chunkPosition: Vtree.ChunkPosition,
       leadingEdge: boolean,
       breakAfter?: string | null,
-    ): Task.Result<Vtree.ChunkPosition>;
+    ): Task.Result<Vtree.ChunkPosition | null>;
     isFullWithPageFloats(): boolean;
     getMaxBlockSizeOfPageFloats(): number;
     doFinishBreakOfFragmentLayoutConstraints(

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -147,7 +147,7 @@ export namespace Layout {
   }
 
   export interface Column extends Vtree.Container {
-    last: Node;
+    last: Node | null;
     viewDocument: Document;
     flowRootFormattingContext: Vtree.FormattingContext;
     // Issue #1842: distinguishes auto-advanced follow-up columns from the first
@@ -243,7 +243,7 @@ export namespace Layout {
      * @return newly created float element.
      */
     createFloat(
-      ref: Node,
+      ref: Node | null,
       side: string,
       width: number,
       height: number,
@@ -264,7 +264,7 @@ export namespace Layout {
      * @return edge position
      */
     calculateEdge(
-      nodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.NodeContext | null,
       checkPoints: Vtree.RenderedNodeContext[],
       index: number,
       boxOffset: number,

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -318,7 +318,7 @@ export namespace Layout {
       condition: PageFloats.PageFloatPlacementCondition,
     ): Task.Result<boolean>;
     createPageFloatArea(
-      float: PageFloats.PageFloat | null,
+      float: PageFloats.PageFloat,
       floatSide: string,
       anchorEdge: number | null,
       strategy: PageFloats.PageFloatLayoutStrategy,

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -344,7 +344,7 @@ export namespace Layout {
     ): Vtree.RenderedNodeContext;
     resolveFloatReferenceFromColumnSpan(
       floatReference: PageFloats.FloatReference,
-      columnSpan: Css.Val,
+      columnSpan: Css.Val | null,
       nodeContext: Vtree.NodeContext,
     ): Task.Result<PageFloats.FloatReference>;
     layoutPageFloat(
@@ -1260,8 +1260,8 @@ export namespace Vtree {
     getInnerRect(): GeometryUtil.Rect;
     getPaddingRect(): GeometryUtil.Rect;
     getOuterShape(
-      outerShapeProp: Css.Val,
-      context: Exprs.Context,
+      outerShapeProp: Css.Val | null,
+      context: Exprs.Context | null,
     ): GeometryUtil.Shape;
     getOuterRect(): GeometryUtil.Rect;
   }

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -77,19 +77,19 @@ export namespace Layout {
   export interface FragmentLayoutConstraint {
     flagmentLayoutConstraintType: FragmentLayoutConstraintType;
     allowLayout(
-      nodeContext: Vtree.NodeContext,
-      overflownNodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.NodeContext | null,
+      overflownNodeContext: Vtree.NodeContext | null,
       column: Column,
     ): boolean;
-    nextCandidate(nodeContext: Vtree.NodeContext): boolean;
+    nextCandidate(nodeContext: Vtree.NodeContext | null): boolean;
     postLayout(
       allowed: boolean,
-      positionAfter: Vtree.NodeContext,
-      initialPosition: Vtree.NodeContext,
+      positionAfter: Vtree.NodeContext | null,
+      initialPosition: Vtree.NodeContext | null,
       column: Column,
     );
     finishBreak(
-      nodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.NodeContext | null,
       column: Column,
     ): Task.Result<boolean>;
     equalsTo(constraint: FragmentLayoutConstraint): boolean;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2630,7 +2630,6 @@ export class ViewFactory
             const minWidth = computedStyle["min-width"] || Css.numericZero;
             const minHeight = computedStyle["min-height"] || Css.numericZero;
             Asserts.assert(minWidth.isNumeric());
-            Asserts.assert(minWidth.isNumeric());
             const numericMinWidth = minWidth as Css.Numeric;
             const numericMinHeight = minHeight as Css.Numeric;
             if (numericMinWidth.num === 0 && numericMinHeight.num === 0) {
@@ -4099,7 +4098,6 @@ export class ViewFactory
       const fontSize = parseFloat(
         clientLayout.getElementComputedStyle(elem as Element)["font-size"],
       );
-      Asserts.assert(this.context);
       return CssCascade.convertFontRelativeLengthToPx(
         numeric,
         fontSize,

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -1490,8 +1490,8 @@ export class Container implements Vtree.Container {
   }
 
   getOuterShape(
-    outerShapeProp: Css.Val,
-    context: Exprs.Context,
+    outerShapeProp: Css.Val | null,
+    context: Exprs.Context | null,
   ): GeometryUtil.Shape {
     const rect = this.getOuterRect();
     return CssProp.toShape(


### PR DESCRIPTION
コミット数は多いですが内容はほぼ機械的に適用できる`|null`の付け外し、初期値の代入、アサーションの除去、ループ終了条件をnullableに合わせる作業などです。