### PR TITLE
refactor: Declare null contracts across core

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -352,7 +352,7 @@ export class AdaptiveViewer {
   private resolveLength(specified: string): number {
     const value = parseFloat(specified);
     const unitPattern = /[a-z]+$/;
-    let matched: RegExpMatchArray;
+    let matched: RegExpMatchArray | null;
     if (
       typeof specified === "string" &&
       (matched = specified.match(unitPattern))
@@ -529,13 +529,17 @@ export class AdaptiveViewer {
    * Iterate through currently displayed pages and do something
    */
   private forCurrentPages(fn: (p1: Vtree.Page) => any) {
-    const pages = [];
+    const pages: Vtree.Page[] = [];
     if (this.currentPage) {
       pages.push(this.currentPage);
     }
     if (this.currentSpread) {
-      pages.push(this.currentSpread.left);
-      pages.push(this.currentSpread.right);
+      if (this.currentSpread.left) {
+        pages.push(this.currentSpread.left);
+      }
+      if (this.currentSpread.right) {
+        pages.push(this.currentSpread.right);
+      }
     }
     pages.forEach((page) => {
       if (page) {
@@ -668,7 +672,7 @@ export class AdaptiveViewer {
   }
 
   private resolveSpreadView(
-    viewport: Vgen.Viewport,
+    viewport: Vgen.Viewport | null,
     pageSize: { width: number; height: number } | null,
   ): boolean {
     switch (this.pageViewMode) {
@@ -879,7 +883,7 @@ export class AdaptiveViewer {
 
     if (spreadView) {
       return this.opfView
-        .getSpread(this.pagePosition, sync)
+        .getSpread(this.pagePosition, !!sync)
         .thenAsync((spread) => {
           if (!spread.left && !spread.right) {
             return Task.newResult(null);
@@ -1142,17 +1146,15 @@ export class AdaptiveViewer {
       metadata: this.opf.metadata,
       docTitle: this.opf.spine[page.spineIndex].title,
     };
-    this.opf
-      .getEPageFromPosition(this.pagePosition as Epub.Position)
-      .then((epage) => {
-        notification["epage"] = epage;
-        notification["epageCount"] = this.opf.epageCount;
-        if (cfi) {
-          notification["cfi"] = cfi;
-        }
-        this.callback(notification);
-        frame.finish(true);
-      });
+    this.opf.getEPageFromPosition(this.pagePosition).then((epage) => {
+      notification["epage"] = epage;
+      notification["epageCount"] = this.opf.epageCount;
+      if (cfi) {
+        notification["cfi"] = cfi;
+      }
+      this.callback(notification);
+      frame.finish(true);
+    });
     return frame.result();
   }
 
@@ -1417,7 +1419,7 @@ class RenderingCanceledError extends Error {
     // Set the prototype explicitly.
     // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, RenderingCanceledError.prototype);
-    this.stack = new Error().stack;
+    this.stack = new Error().stack ?? "";
   }
 }
 

--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -143,7 +143,7 @@ export function resolveURL(relURL: string, baseURL: string): string {
   if (baseURL.match(/^\w{2,}:\/\/[^\/]+$/)) {
     baseURL = `${baseURL}/`;
   }
-  let r: string[];
+  let r: string[] | null;
   if (relURL.match(/^\/\//)) {
     r = baseURL.match(/^(\w{2,}:)\/\//);
     if (r) {
@@ -224,7 +224,7 @@ export function convertAboutBlankURL(url: string): string {
  * @return converted URL
  */
 export function convertSpecialURL(url: string): string {
-  let r: RegExpMatchArray;
+  let r: RegExpMatchArray | null;
 
   if ((url = convertAboutBlankURL(url)) !== url) {
     // already converted
@@ -368,7 +368,7 @@ export interface Comparable {
  * A priority queue.
  */
 export class PriorityQueue {
-  queue: Comparable[] = [null];
+  queue: (Comparable | null)[] = [null];
 
   length(): number {
     return this.queue.length - 1;
@@ -439,7 +439,7 @@ export class PriorityQueue {
 
 export const knownPrefixes = ["", "-webkit-", "-moz-"];
 
-export const propNameMap: { [key: string]: string[] } = {};
+export const propNameMap: { [key: string]: string[] | null } = {};
 
 export function checkIfPropertySupported(
   prefix: string,
@@ -611,7 +611,7 @@ export class RootBoundCursor {
   }
 }
 
-export function getLangAttribute(element: Element): string {
+export function getLangAttribute(element: Element): string | null {
   let lang = element.getAttributeNS(NS.XML, "lang");
   if (!lang && element.namespaceURI == NS.XHTML) {
     lang = element.getAttribute("lang");

--- a/packages/core/src/vivliostyle/break-position.ts
+++ b/packages/core/src/vivliostyle/break-position.ts
@@ -51,7 +51,7 @@ export abstract class AbstractBreakPosition
 }
 
 export function calculateOffset(
-  nodeContext: Vtree.NodeContext,
+  nodeContext: Vtree.NodeContext | null,
   elementsOffsets: RepetitiveElement.ElementsOffset[],
 ): { current: number; minimum: number } {
   return {

--- a/packages/core/src/vivliostyle/break.ts
+++ b/packages/core/src/vivliostyle/break.ts
@@ -255,7 +255,9 @@ export function resolveEffectiveBreakValue(
 }
 
 export function breakValueToStartBreakType(breakValue: string | null): string {
-  return isForcedBreakValue(breakValue) ? breakValue : "auto";
+  return breakValue != null && isForcedBreakValue(breakValue)
+    ? breakValue
+    : "auto";
 }
 
 Plugin.registerHook("SIMPLE_PROPERTY", convertPageBreakAliases);

--- a/packages/core/src/vivliostyle/break.ts
+++ b/packages/core/src/vivliostyle/break.ts
@@ -154,7 +154,7 @@ export const forcedBreakValues: { [key: string]: boolean | null } = {
  * @param value The break value to be judged. Treats null as 'auto'.
  */
 export function isForcedBreakValue(value: string | null): boolean {
-  return !!forcedBreakValues[value];
+  return value != null && !!forcedBreakValues[value];
 }
 
 export const spreadBreakValues: { [key: string]: boolean | null } = {
@@ -169,7 +169,7 @@ export const spreadBreakValues: { [key: string]: boolean | null } = {
  * @param value The break value to be judged. Treats null as 'auto'.
  */
 export function isSpreadBreakValue(value: string | null): boolean {
-  return !!spreadBreakValues[value];
+  return value != null && !!spreadBreakValues[value];
 }
 
 /**
@@ -193,7 +193,7 @@ export const avoidBreakValues: { [key: string]: boolean | null } = {
  * @param value The break value to be judged. Treats null as 'auto'.
  */
 export function isAvoidBreakValue(value: string | null): boolean {
-  return !!avoidBreakValues[value];
+  return value != null && !!avoidBreakValues[value];
 }
 
 /**

--- a/packages/core/src/vivliostyle/cfi.ts
+++ b/packages/core/src/vivliostyle/cfi.ts
@@ -26,7 +26,7 @@ export type Position = {
   offset: number;
   after: boolean;
   sideBias: string | null;
-  ref: Fragment;
+  ref: Fragment | null;
 };
 
 export function getId(node: Node): string | null {
@@ -59,7 +59,7 @@ export function unescape(str: string): string {
 }
 
 export function parseExtVal(extstr: string): string | string[] {
-  const result = [];
+  const result: string[] = [];
   do {
     const r = extstr.match(/^(\^,|[^,])*/);
     const p = unescape(r[0]);
@@ -134,7 +134,7 @@ export class ChildStep implements Step {
     const elem = pos.node as Element;
     const childElements = elem.children;
     const childElementCount = childElements.length;
-    let child: Node;
+    let child: Node | null;
     const childIndex = Math.floor(this.index / 2) - 1;
     if (childIndex < 0 || childElementCount == 0) {
       child = elem.firstChild;
@@ -240,7 +240,7 @@ export class Fragment {
     }
     const str = decodeURIComponent(r[1]);
     let i = 0;
-    const steps = [];
+    const steps: Step[] = [];
     while (true) {
       let ext: {
         [key: string]: string | string[];
@@ -256,7 +256,7 @@ export class Fragment {
           }
           i += r[0].length;
           const index = parseInt(r[1], 10);
-          const id = r[3];
+          const id = r[3] ?? null;
           ext = parseExt(r[4]);
           steps.push(new ChildStep(index, id, Base.asString(ext["s"])));
           break;
@@ -273,11 +273,11 @@ export class Fragment {
           }
           i += r[0].length;
           const offset = parseInt(r[1], 10);
-          let textBefore = r[4];
+          let textBefore: string | null = r[4] ?? null;
           if (textBefore) {
             textBefore = unescape(textBefore);
           }
-          let textAfter = r[7];
+          let textAfter: string | null = r[7] ?? null;
           if (textAfter) {
             textAfter = unescape(textAfter);
           }

--- a/packages/core/src/vivliostyle/cmyk-store.ts
+++ b/packages/core/src/vivliostyle/cmyk-store.ts
@@ -132,13 +132,13 @@ export function isValidCmykReserveMap(
     const rgbObj = rgb as { r: unknown; g: unknown; b: unknown };
     const cmykObj = cmyk as { c: unknown; m: unknown; y: unknown; k: unknown };
     return (
-      Number.isFinite(rgbObj.r as number) &&
-      Number.isFinite(rgbObj.g as number) &&
-      Number.isFinite(rgbObj.b as number) &&
-      Number.isFinite(cmykObj.c as number) &&
-      Number.isFinite(cmykObj.m as number) &&
-      Number.isFinite(cmykObj.y as number) &&
-      Number.isFinite(cmykObj.k as number)
+      Number.isFinite(rgbObj.r) &&
+      Number.isFinite(rgbObj.g) &&
+      Number.isFinite(rgbObj.b) &&
+      Number.isFinite(cmykObj.c) &&
+      Number.isFinite(cmykObj.m) &&
+      Number.isFinite(cmykObj.y) &&
+      Number.isFinite(cmykObj.k)
     );
   });
 }

--- a/packages/core/src/vivliostyle/cmyk-store.ts
+++ b/packages/core/src/vivliostyle/cmyk-store.ts
@@ -228,36 +228,36 @@ export function parseDeviceCmyk(
 
   const values =
     // Modern syntax: space-separated values in a single SpaceList
-    func.values.length === 1 && func.values[0]! instanceof Css.SpaceList
-      ? (func.values[0]! as Css.SpaceList).values
+    func.values.length === 1 && func.values[0] instanceof Css.SpaceList
+      ? (func.values[0] as Css.SpaceList).values
       : // Legacy syntax: comma-separated values directly in func.values
         func.values;
   if (values.length < 4 || values.length > 6) {
     return null;
   }
 
-  const c = getNumValue(values[0]!);
-  const m = getNumValue(values[1]!);
-  const y = getNumValue(values[2]!);
-  const k = getNumValue(values[3]!);
+  const c = getNumValue(values[0]);
+  const m = getNumValue(values[1]);
+  const y = getNumValue(values[2]);
+  const k = getNumValue(values[3]);
   if (c === null || m === null || y === null || k === null) {
     return null;
   }
 
   let alpha: number | null = null;
   if (values.length >= 5) {
-    if (values[4]! === Css.slash) {
+    if (values[4] === Css.slash) {
       // Modern syntax: c m y k / alpha - must have exactly 6 values
       if (values.length !== 6) {
         return null;
       }
-      alpha = getNumValue(values[5]!);
+      alpha = getNumValue(values[5]);
     } else {
       // Legacy syntax: c, m, y, k, alpha - must have exactly 5 values
       if (values.length !== 5) {
         return null;
       }
-      alpha = getNumValue(values[4]!);
+      alpha = getNumValue(values[4]);
     }
     if (alpha === null) {
       return null;

--- a/packages/core/src/vivliostyle/cmyk-store.ts
+++ b/packages/core/src/vivliostyle/cmyk-store.ts
@@ -226,10 +226,11 @@ export function parseDeviceCmyk(
     return null;
   }
 
+  const first = func.values.length === 1 ? func.values[0] : null;
   const values =
     // Modern syntax: space-separated values in a single SpaceList
-    func.values.length === 1 && func.values[0] instanceof Css.SpaceList
-      ? (func.values[0] as Css.SpaceList).values
+    first instanceof Css.SpaceList
+      ? first.values
       : // Legacy syntax: comma-separated values directly in func.values
         func.values;
   if (values.length < 4 || values.length > 6) {

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -482,8 +482,8 @@ export class CoreViewer {
    * Returns the current structure of the TOC once it has
    * been shown, or the empty array if there is no TOC.
    */
-  getTOC(): Toc.TOCItem[] | undefined {
-    return this.adaptViewer_.opfView?.tocView?.getTOC();
+  getTOC(): Toc.TOCItem[] {
+    return this.adaptViewer_.opfView?.tocView?.getTOC() ?? [];
   }
 
   /**

--- a/packages/core/src/vivliostyle/core-viewer.ts
+++ b/packages/core/src/vivliostyle/core-viewer.ts
@@ -180,7 +180,7 @@ export class CoreViewer {
     private readonly settings: CoreViewerSettings,
     opt_options?: CoreViewerOptions,
   ) {
-    Constants.setDebug(settings.debug);
+    Constants.setDebug(!!settings.debug);
     this.adaptViewer_ = new AdaptiveViewer.AdaptiveViewer(
       settings["window"] || window,
       settings["viewportElement"],
@@ -482,7 +482,7 @@ export class CoreViewer {
    * Returns the current structure of the TOC once it has
    * been shown, or the empty array if there is no TOC.
    */
-  getTOC(): Toc.TOCItem[] {
+  getTOC(): Toc.TOCItem[] | undefined {
     return this.adaptViewer_.opfView?.tocView?.getTOC();
   }
 
@@ -517,7 +517,7 @@ export class CoreViewer {
 }
 
 function convertSingleDocumentOptions(
-  singleDocumentOptions: SingleDocumentOptions | SingleDocumentOptions[],
+  singleDocumentOptions: SingleDocumentOptions | SingleDocumentOptions[] | null,
 ): AdaptiveViewer.SingleDocumentParam[] | null {
   function toNumberOrNull(num: any): number | null {
     return typeof num === "number" ? num : null;

--- a/packages/core/src/vivliostyle/counter-style.ts
+++ b/packages/core/src/vivliostyle/counter-style.ts
@@ -168,8 +168,8 @@ function validateSystem(value: Css.Val): value is SystemDescriptorValue {
     );
   }
   if (value instanceof Css.SpaceList && value.values.length === 2) {
-    const first = value.values[0]!;
-    const second = value.values[1]!;
+    const first = value.values[0];
+    const second = value.values[1];
     if (first instanceof Css.Ident) {
       const name = first.name;
       return (
@@ -299,8 +299,8 @@ function validateNegative(value: Css.Val): value is NegativeDescriptorValue {
     return true;
   }
   if (value instanceof Css.SpaceList && value.values.length === 2) {
-    const first = value.values[0]!;
-    const second = value.values[1]!;
+    const first = value.values[0];
+    const second = value.values[1];
     return validateSymbol(first) && validateSymbol(second);
   }
   return false;
@@ -340,8 +340,8 @@ function validateRangeTuple(value: Css.Val): value is RangeTuple {
   if (!(value instanceof Css.SpaceList && value.values.length === 2)) {
     return false;
   }
-  const first = value.values[0]!;
-  const second = value.values[1]!;
+  const first = value.values[0];
+  const second = value.values[1];
   if (!(validateRangeBound(first) && validateRangeBound(second))) {
     return false;
   }
@@ -402,8 +402,8 @@ function validateNonNegativeIntAndSymbolSet(
   if (!(value instanceof Css.SpaceList && value.values.length === 2)) {
     return false;
   }
-  const first = value.values[0]!;
-  const second = value.values[1]!;
+  const first = value.values[0];
+  const second = value.values[1];
   return (
     (first instanceof Css.Int && first.num >= 0 && validateSymbol(second)) ||
     (validateSymbol(first) && second instanceof Css.Int && second.num >= 0)

--- a/packages/core/src/vivliostyle/counter-style.ts
+++ b/packages/core/src/vivliostyle/counter-style.ts
@@ -866,7 +866,9 @@ abstract class CounterStyle {
   }
 
   protected _getFallback(): CounterStyle | null {
-    return this._store.get(this.#fallbackName) ?? null;
+    return this.#fallbackName != null
+      ? (this._store.get(this.#fallbackName) ?? null)
+      : null;
   }
   protected static _getFallbackFrom(style: CounterStyle): CounterStyle | null {
     return style._getFallback();

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -813,7 +813,7 @@ class CounterResolver implements CssCascade.CounterResolver {
               if (elementAtPageStartOffset) {
                 // Find if the element at the offset is (the first child of)* the element at page start
                 for (
-                  let element = elementAtPageStartOffset;
+                  let element: Element | null = elementAtPageStartOffset;
                   element;
                   element = element.firstElementChild
                 ) {
@@ -1152,7 +1152,7 @@ export class CounterStore {
         incrementMap["page"] = 1;
       }
     } else {
-      incrementMap = Object.create(null);
+      incrementMap = Object.create(null) as { [key: string]: number };
       if (!(docCounterInfo["page"] && docCounterInfo["page"].reset)) {
         incrementMap["page"] = 1;
       }
@@ -1355,7 +1355,7 @@ export class CounterStore {
             if (!unresolvedRefs) {
               unresolvedRefs = this.unresolvedReferences[id] = [];
             }
-            let ref: TargetCounterReference;
+            let ref: TargetCounterReference | undefined;
             while ((ref = resolvedRefs.shift())) {
               ref.unresolve();
               unresolvedRefs.push(ref);
@@ -1366,7 +1366,7 @@ export class CounterStore {
       });
     }
     const prevPageCounters = this.previousPageCounters;
-    let ref: TargetCounterReference;
+    let ref: TargetCounterReference | undefined;
     while ((ref = this.newReferencesOfCurrentPage.shift())) {
       ref.pageCounters = prevPageCounters;
       ref.spineIndex = spineIndex;
@@ -1633,13 +1633,13 @@ export class CounterStore {
     const result: {
       spineIndex: number;
       pageIndex: number;
-      pageCounters: CssCascade.CounterValues;
+      pageCounters: CssCascade.CounterValues | null;
       refs: TargetCounterReference[];
     }[] = [];
     let o: {
       spineIndex: number;
       pageIndex: number;
-      pageCounters: CssCascade.CounterValues;
+      pageCounters: CssCascade.CounterValues | null;
       refs: TargetCounterReference[];
     } = null;
     refs.forEach((ref) => {

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1616,7 +1616,7 @@ export class CounterStore {
   getUnresolvedRefsToPage(page: Vtree.Page): {
     spineIndex: number;
     pageIndex: number;
-    pageCounters: CssCascade.CounterValues;
+    pageCounters: CssCascade.CounterValues | null;
     refs: TargetCounterReference[];
   }[] {
     let refs: TargetCounterReference[] = [];
@@ -1641,7 +1641,7 @@ export class CounterStore {
       pageIndex: number;
       pageCounters: CssCascade.CounterValues | null;
       refs: TargetCounterReference[];
-    } = null;
+    } | null = null;
     refs.forEach((ref) => {
       if (
         !o ||

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4863,8 +4863,8 @@ export class CascadeParserHandler
   constructor(
     scope: Exprs.LexicalScope,
     owner: CssParser.DispatchParserHandler,
-    public readonly condition: Exprs.Val,
-    parent: CascadeParserHandler,
+    public readonly condition: Exprs.Val | null,
+    parent: CascadeParserHandler | null,
     public readonly regionId: string | null,
     public readonly validatorSet: CssValidator.ValidatorSet,
     delegation: CssParser.Delegation | null,
@@ -5856,7 +5856,7 @@ export class PropSetParserHandler
   constructor(
     scope: Exprs.LexicalScope,
     owner: CssParser.DispatchParserHandler,
-    public readonly condition: Exprs.Val,
+    public readonly condition: Exprs.Val | null,
     public readonly elementStyle: ElementStyle,
     public readonly validatorSet: CssValidator.ValidatorSet,
     delegation: CssParser.Delegation,

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -6067,7 +6067,7 @@ export function flattenCascadedStyle(
 
 export function forEachStylesInRegion(
   style: ElementStyle,
-  regionIds: string[],
+  regionIds: string[] | null,
   isFootnote: boolean,
   callback: (p1: string, p2: ElementStyle) => any,
 ): void {
@@ -6285,7 +6285,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
   private collectReferencedCustomProperties(val: Css.Val): string[] {
     const names = new Set<string>();
     class ReferenceVisitor extends Css.Visitor {
-      override visitFunc(func: Css.Func): Css.Val {
+      override visitFunc(func: Css.Func): Css.Val | null {
         const name = func.values[0] instanceof Css.Ident && func.values[0].name;
         if (func.name === "var" && name && Css.isCustomPropName(name)) {
           names.add(name);
@@ -6339,7 +6339,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     let cycleStartName: string | null = null;
     const self = this;
     class FallbackReferenceVisitor extends Css.Visitor {
-      override visitFunc(func: Css.Func): Css.Val {
+      override visitFunc(func: Css.Func): Css.Val | null {
         if (func.name === "var") {
           for (const fallbackVal of func.values.slice(1)) {
             const referencedCycleStart = self.findReferencedCycleStart(

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -2320,7 +2320,7 @@ function buildDeferredStringSetVal(
 export class ContentPropVisitor extends Css.FilterVisitor {
   constructor(
     public cascade: CascadeInstance,
-    public element: Element,
+    public element: Element | null,
     public readonly counterResolver: CounterResolver,
     private readonly elementStyle: ElementStyle,
     private readonly pseudoName?: string,
@@ -6043,7 +6043,7 @@ export function isRtl(
 export function flattenCascadedStyle(
   style: ElementStyle,
   context: Exprs.Context,
-  regionIds: string[],
+  regionIds: string[] | null,
   isFootnote: boolean,
 ): { [key: string]: CascadeValue } {
   const cascMap = {} as { [key: string]: CascadeValue };

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -4963,7 +4963,7 @@ export class CascadeParserHandler
 
   override pseudoclassSelector(
     name: string,
-    params: (number | string)[],
+    params: (number | string)[] | null,
   ): void {
     if (this.invalidContinuationAfterPseudoelement(`:${name}`)) {
       return;
@@ -5105,7 +5105,7 @@ export class CascadeParserHandler
 
   override pseudoelementSelector(
     name: string,
-    params: (number | string)[],
+    params: (number | string)[] | null,
   ): void {
     name = name.toLowerCase();
     if (this.invalidContinuationAfterPseudoelement(`::${name}`)) {

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -214,7 +214,7 @@ export function resolvePageSizeAndBleed(style: {
     /** !type {!Css.Val} */
     const value = size.value;
     let val1: Css.Val;
-    let val2: Css.Val;
+    let val2: Css.Val | null;
     if (value.isSpaceList()) {
       val1 = (value as Css.SpaceList).values[0];
       val2 = (value as Css.SpaceList).values[1];
@@ -701,7 +701,7 @@ export type PageMarginBoxInformation = {
   isInBottomRow: boolean;
   isInLeftColumn: boolean;
   isInRightColumn: boolean;
-  positionAlongVariableDimension: MarginBoxPositionAlongVariableDimension;
+  positionAlongVariableDimension: MarginBoxPositionAlongVariableDimension | null;
 };
 
 /**
@@ -1312,7 +1312,8 @@ export class PageRuleMasterInstance extends PageMaster.PageMasterInstance<PageRu
       );
       if (maxSize) {
         const evaluatedMaxSize = maxSize.evaluate(context) as number;
-        if (sizes[name] > evaluatedMaxSize) {
+        const size = sizes[name];
+        if (size != null && size > evaluatedMaxSize) {
           const p = (boxParams[name] = new FixedSizeMarginBoxSizingParam(
             containers[name],
             boxInstances[name].style,
@@ -1350,7 +1351,8 @@ export class PageRuleMasterInstance extends PageMaster.PageMasterInstance<PageRu
       );
       if (minSize) {
         const evaluatedMinSize = minSize.evaluate(context) as number;
-        if (sizes[name] < evaluatedMinSize) {
+        const size = sizes[name];
+        if (size != null && size < evaluatedMinSize) {
           const p = (boxParams[name] = new FixedSizeMarginBoxSizingParam(
             containers[name],
             boxInstances[name].style,
@@ -1480,8 +1482,8 @@ export class PageRuleMasterInstance extends PageMaster.PageMasterInstance<PageRu
    *     when the size of the corresponding box is 'auto'.
    */
   private distributeAutoMarginBoxSizes(
-    x: MarginBoxSizingParam,
-    y: MarginBoxSizingParam,
+    x: MarginBoxSizingParam | null,
+    y: MarginBoxSizingParam | null,
     availableSize: number,
   ): { xSize: number | null; ySize: number | null } {
     const result: { xSize: number | null; ySize: number | null } = {
@@ -1522,7 +1524,7 @@ export class PageRuleMasterInstance extends PageMaster.PageMasterInstance<PageRu
                 (availableSize * xOuterMinContentSize) / minContentSizeSum;
             }
           }
-          if (result.xSize > 0) {
+          if (result.xSize != null && result.xSize > 0) {
             result.ySize = availableSize - result.xSize;
           }
         } else if (xOuterMaxContentSize > 0) {
@@ -2339,10 +2341,10 @@ export class PageMarginBoxPartitionInstance extends PageMaster.PartitionInstance
     );
     const extent = PageMaster.toExprAuto(scope, style[extentName], pageMargin);
     let result: {
-      extent: Exprs.Result;
-      marginInside: Exprs.Result;
-      marginOutside: Exprs.Result;
-    } = null;
+      extent: Exprs.Result | null;
+      marginInside: Exprs.Result | null;
+      marginOutside: Exprs.Result | null;
+    } | null = null;
 
     function getComputedValues(context: Exprs.Context): {
       extent: Exprs.Result | null;

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -2733,7 +2733,7 @@ export class PageManager {
     pageMasterInstance: PageMaster.PageMasterInstance,
     cascadedPageStyle: CssCascade.ElementStyle,
   ): PageMaster.PageMasterInstance {
-    const pageMaster = pageMasterInstance.pageBox as PageMaster.PageMaster;
+    const pageMaster = pageMasterInstance.pageBox;
 
     // If no properties are specified in @page rules, use the original page
     // master.

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -1427,8 +1427,8 @@ export class PageRuleMasterInstance extends PageMaster.PageMasterInstance<PageRu
     } = {};
     if (!centerBoxParam) {
       const startEndSizes = this.distributeAutoMarginBoxSizes(
-        startBoxParam,
-        endBoxParam,
+        startBoxParam ?? null,
+        endBoxParam ?? null,
         availableSize,
       );
       if (startEndSizes.xSize != null) {
@@ -3209,7 +3209,7 @@ export class PageParserHandler
 
   override pseudoclassSelector(
     name: string,
-    params: (number | string)[],
+    params: (number | string)[] | null,
   ): void {
     name = name.toLowerCase();
     if (params) {
@@ -3283,7 +3283,7 @@ export class PageParserHandler
    * Save currently processed selector and reset variables.
    */
   private finishSelector() {
-    let selectors: string[];
+    let selectors: string[] | null;
     if (
       !this.currentNamedPageSelector &&
       !this.currentPseudoPageClassSelectors.length

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -81,7 +81,7 @@ export class ParserHandler implements CssTokenizer.TokenizerHandler {
     this.flavor = StylesheetFlavor.AUTHOR;
   }
 
-  getCurrentToken(): CssTokenizer.Token {
+  getCurrentToken(): CssTokenizer.Token | null {
     return null;
   }
 
@@ -243,7 +243,7 @@ export class DispatchParserHandler<
     this.slave = delegation.outer;
   }
 
-  override getCurrentToken(): CssTokenizer.Token {
+  override getCurrentToken(): CssTokenizer.Token | null {
     if (this.tokenizer) {
       return this.tokenizer.token();
     }
@@ -444,7 +444,7 @@ export class SkippingParserHandler extends ParserHandler {
     this.flavor = owner.flavor;
   }
 
-  override getCurrentToken(): CssTokenizer.Token {
+  override getCurrentToken(): CssTokenizer.Token | null {
     return this.owner.getCurrentToken();
   }
 
@@ -921,7 +921,7 @@ export class Parser {
       // Check invalid var()
       if (func.name === "var") {
         const name = func.values[0] instanceof Css.Ident && func.values[0].name;
-        if (!Css.isCustomPropName(name)) {
+        if (!Css.isCustomPropName(name || undefined)) {
           this.handler.error(`E_CSS_INVALID_VAR ${func.toString()}`, token);
           this.actions = actionsErrorDecl;
         }
@@ -1131,7 +1131,7 @@ export class Parser {
     return false;
   }
 
-  readSupportsTest(token: CssTokenizer.Token): Exprs.SupportsTest {
+  readSupportsTest(token: CssTokenizer.Token): Exprs.SupportsTest | null {
     // `@supports (prop-name:...)`
     // `@supports func-name(...)`
     const isFunc = token.type === TokenType.FUNC;
@@ -1208,7 +1208,7 @@ export class Parser {
   }
 
   readPseudoParams(): (number | string)[] {
-    const arr = [];
+    const arr: (number | string)[] = [];
     while (true) {
       const token = this.tokenizer.token();
       switch (token.type) {
@@ -1384,7 +1384,7 @@ export class Parser {
     return null;
   }
 
-  makeCondition(classes: string | null, condition: Exprs.Val): Css.Expr {
+  makeCondition(classes: string | null, condition: Exprs.Val): Css.Expr | null {
     const scope = this.handler.getScope();
     condition = condition || scope._true;
     if (classes) {
@@ -2966,7 +2966,7 @@ function parseStylesheetInternal(
 ): Task.Result<boolean> {
   const frame: Task.Frame<boolean> = Task.newFrame("parseStylesheet");
   const parser = new Parser(actionsBase, tokenizer, handler, baseURL);
-  let condition: Css.Expr = null;
+  let condition: Css.Expr | null = null;
   if (media) {
     condition = parseMediaQuery(
       new CssTokenizer.Tokenizer(media, handler),
@@ -3120,7 +3120,7 @@ export const numProp: { [key: string]: boolean } = {
   utilization: true,
 };
 
-export function takesOnlyNum(propName: string): boolean {
+export function takesOnlyNum(propName: string | undefined): boolean {
   return !!numProp[propName];
 }
 

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1140,7 +1140,7 @@ export class Parser {
     const isFunc = token.type === TokenType.FUNC;
     const tokenizer = this.tokenizer;
     let startPosition: number;
-    let name: string | undefined;
+    let name = "";
     if (isFunc) {
       name = token.text;
       startPosition = token.position + name.length + 1;

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -89,7 +89,7 @@ export class ParserHandler implements CssTokenizer.TokenizerHandler {
     return this.scope;
   }
 
-  error(mnemonics: string, token: CssTokenizer.Token): void {}
+  error(mnemonics: string, token: CssTokenizer.Token | null): void {}
 
   startStylesheet(flavor: StylesheetFlavor): void {
     this.flavor = flavor;
@@ -99,9 +99,12 @@ export class ParserHandler implements CssTokenizer.TokenizerHandler {
 
   classSelector(name: string): void {}
 
-  pseudoclassSelector(name: string, params: (number | string)[]): void {}
+  pseudoclassSelector(name: string, params: (number | string)[] | null): void {}
 
-  pseudoelementSelector(name: string, params: (number | string)[]): void {}
+  pseudoelementSelector(
+    name: string,
+    params: (number | string)[] | null,
+  ): void {}
 
   idSelector(id: string): void {}
 
@@ -258,14 +261,14 @@ export class DispatchParserHandler<
    * Forwards call to slave.
    * @override
    */
-  error(mnemonics: string, token: CssTokenizer.Token): void {
+  error(mnemonics: string, token: CssTokenizer.Token | null): void {
     this.slave.error(mnemonics, token);
   }
 
   /**
    * Called by a slave.
    */
-  errorMsg(mnemonics: string, token: CssTokenizer.Token): void {
+  errorMsg(mnemonics: string, token: CssTokenizer.Token | null): void {
     Logging.logger.warn(mnemonics, token?.toString() ?? "");
   }
 
@@ -286,14 +289,14 @@ export class DispatchParserHandler<
 
   override pseudoclassSelector(
     name: string,
-    params: (number | string)[],
+    params: (number | string)[] | null,
   ): void {
     this.slave.pseudoclassSelector(name, params);
   }
 
   override pseudoelementSelector(
     name: string,
-    params: (number | string)[],
+    params: (number | string)[] | null,
   ): void {
     this.slave.pseudoelementSelector(name, params);
   }
@@ -448,7 +451,7 @@ export class SkippingParserHandler extends ParserHandler {
     return this.owner.getCurrentToken();
   }
 
-  override error(mnemonics: string, token: CssTokenizer.Token): void {
+  override error(mnemonics: string, token: CssTokenizer.Token | null): void {
     this.owner.errorMsg(mnemonics, token);
   }
 
@@ -869,7 +872,7 @@ export class Parser {
     return arr;
   }
 
-  valStackReduce(sep: string, token: CssTokenizer.Token): Css.Val {
+  valStackReduce(sep: string, token: CssTokenizer.Token): Css.Val | null {
     const valStack = this.valStack;
     let index = valStack.length;
     let parLevel = 0;
@@ -1384,7 +1387,10 @@ export class Parser {
     return null;
   }
 
-  makeCondition(classes: string | null, condition: Exprs.Val): Css.Expr | null {
+  makeCondition(
+    classes: string | null,
+    condition: Exprs.Val | null,
+  ): Css.Expr | null {
     const scope = this.handler.getScope();
     condition = condition || scope._true;
     if (classes) {
@@ -1462,7 +1468,7 @@ export class Parser {
     let text: string | null;
     let num: number;
     let val: Css.Val | null = null;
-    let params: (number | string)[];
+    let params: (number | string)[] | null;
     let selectorStartPosition: number | null = null;
 
     if (parsingStyleAttr) {
@@ -2924,7 +2930,7 @@ export class ErrorHandler extends ParserHandler {
     super(scope);
   }
 
-  override error(mnemonics: string, token: CssTokenizer.Token): void {
+  override error(mnemonics: string, token: CssTokenizer.Token | null): void {
     // throw new Error(mnemonics + " " + token);
     Logging.logger.warn(mnemonics, token.toString());
   }
@@ -3121,7 +3127,7 @@ export const numProp: { [key: string]: boolean } = {
 };
 
 export function takesOnlyNum(propName: string | undefined): boolean {
-  return !!numProp[propName];
+  return !!(propName && numProp[propName]);
 }
 
 /**

--- a/packages/core/src/vivliostyle/css-prop.ts
+++ b/packages/core/src/vivliostyle/css-prop.ts
@@ -188,12 +188,12 @@ export class ShapeVisitor extends Css.Visitor {
 }
 
 export function toShape(
-  val: Css.Val,
+  val: Css.Val | null,
   x: number,
   y: number,
   width: number,
   height: number,
-  context: Exprs.Context,
+  context: Exprs.Context | null,
 ): GeometryUtil.Shape {
   if (val) {
     const visitor = new ShapeVisitor();

--- a/packages/core/src/vivliostyle/css-prop.ts
+++ b/packages/core/src/vivliostyle/css-prop.ts
@@ -194,7 +194,7 @@ export function toShape(
   width: number,
   height: number,
   context: Exprs.Context | null,
-): GeometryUtil.Shape {
+): GeometryUtil.Shape | null {
   if (val) {
     const visitor = new ShapeVisitor();
     try {

--- a/packages/core/src/vivliostyle/css-prop.ts
+++ b/packages/core/src/vivliostyle/css-prop.ts
@@ -38,7 +38,7 @@ export class SetVisitor extends Css.Visitor {
     return ident;
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     this.visitValues(list.values);
     return list;
   }
@@ -90,26 +90,26 @@ export class ShapeVisitor extends Css.Visitor {
     super();
   }
 
-  override visitNumeric(numeric: Css.Numeric): Css.Val {
+  override visitNumeric(numeric: Css.Numeric): Css.Val | null {
     if (this.collect) {
       this.coords.push(numeric);
     }
     return null;
   }
 
-  override visitNum(num: Css.Num): Css.Val {
+  override visitNum(num: Css.Num): Css.Val | null {
     if (this.collect && num.num == 0) {
       this.coords.push(new Css.Numeric(0, "px"));
     }
     return null;
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     this.visitValues(list.values);
     return null;
   }
 
-  override visitFunc(func: Css.Func): Css.Val {
+  override visitFunc(func: Css.Func): Css.Val | null {
     if (!this.collect) {
       this.collect = true;
       this.visitValues(func.values);
@@ -124,8 +124,8 @@ export class ShapeVisitor extends Css.Visitor {
     y: number,
     width: number,
     height: number,
-    context: Exprs.Context,
-  ): GeometryUtil.Shape {
+    context: Exprs.Context | null,
+  ): GeometryUtil.Shape | null {
     if (this.coords.length > 0) {
       const numbers: number[] = [];
       this.coords.forEach((coord, i) => {
@@ -237,7 +237,7 @@ export class CountersVisitor extends Css.Visitor {
     return num;
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     this.visitValues(list.values);
     return list;
   }

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -159,7 +159,7 @@ export class Box {
   flowName: string;
   isBlockValue: boolean | null = null;
   hasBoxValue: boolean | null = null;
-  styleValues = {} as { [key: string]: Css.Val };
+  styleValues = {} as { [key: string]: Css.Val | null };
   beforeBox: Box | null = null;
   afterBox: Box | null = null;
   breakBefore: string | null = null;

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -623,7 +623,7 @@ export class Styler implements AbstractStyler {
         ? (elemStyle["background-color"] as CssCascade.CascadeValue).evaluate(
             this.context,
           )
-        : (null as Css.Val);
+        : null;
       const backgroundImage = this.hasProp(
         elemStyle,
         this.validatorSet.backgroundProps,
@@ -632,7 +632,7 @@ export class Styler implements AbstractStyler {
         ? (elemStyle["background-image"] as CssCascade.CascadeValue).evaluate(
             this.context,
           )
-        : (null as Css.Val);
+        : null;
       if (
         (backgroundColor && !Css.isDefaultingValue(backgroundColor)) ||
         (backgroundImage && !Css.isDefaultingValue(backgroundImage))
@@ -878,7 +878,7 @@ export class Styler implements AbstractStyler {
       if (nodeOffset >= this.lastOffset) {
         break;
       }
-      let next: Node = node.firstChild;
+      let next: Node | null = node.firstChild;
       if (next == null) {
         while (true) {
           next = node.nextSibling;

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -871,7 +871,7 @@ function isSupportedAttrType(type: AttrType): boolean {
   return false;
 }
 
-export function getImplicitAttrFallback(type: AttrType): Css.Val | null {
+export function getImplicitAttrFallback(type: AttrType): Css.Val {
   switch (type.kind) {
     case "url":
       return new Css.URL("about:invalid");

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -704,7 +704,7 @@ export function parseAttrFunction(func: Css.Func): AttrFunction | null {
   }
 
   let attributeName: string;
-  let type: AttrType = { kind: "string" };
+  let type: AttrType | null = { kind: "string" };
   const attributeArg = func.values[0];
   if (attributeArg instanceof Css.Ident) {
     attributeName = attributeArg.name;
@@ -963,7 +963,7 @@ export class ListValidator extends PropertyValidator {
         continue;
       }
       const inval = arr[index];
-      let outval = inval;
+      let outval: Css.Val | null = inval;
       if (current.isSpecial()) {
         let success = true;
         if (current.isStartGroup()) {

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -42,7 +42,7 @@ export class Node {
   failure: Node | null = null;
   code: number = 0;
 
-  constructor(public validator: PropertyValidator) {}
+  constructor(public validator: PropertyValidator | null) {}
 
   isSpecial(): boolean {
     return this.code != 0;
@@ -377,7 +377,7 @@ export class PropertyValidator extends Css.Visitor {
    * Validate a subsequence of the given values from the given index. Return the
    * list of matched values or null if there is no match.
    */
-  validateForShorthand(values: Css.Val[], index: number): Css.Val[] {
+  validateForShorthand(values: Css.Val[], index: number): Css.Val[] | null {
     const rval = values[index].visit(this);
     if (rval) {
       return [rval];
@@ -399,28 +399,28 @@ export class PrimitiveValidator extends PropertyValidator {
     super();
   }
 
-  override visitEmpty(empty: Css.Val): Css.Val {
+  override visitEmpty(empty: Css.Val): Css.Val | null {
     if (this.allowed & ALLOW_EMPTY) {
       return empty;
     }
     return null;
   }
 
-  override visitSlash(slash: Css.Val): Css.Val {
+  override visitSlash(slash: Css.Val): Css.Val | null {
     if (this.allowed & ALLOW_SLASH) {
       return slash;
     }
     return null;
   }
 
-  override visitStr(str: Css.Str): Css.Val {
+  override visitStr(str: Css.Str): Css.Val | null {
     if (this.allowed & ALLOW_STR) {
       return str;
     }
     return null;
   }
 
-  override visitIdent(ident: Css.Ident): Css.Val {
+  override visitIdent(ident: Css.Ident): Css.Val | null {
     const val = this.idents[ident.name.toLowerCase()];
     if (val) {
       return val;
@@ -436,7 +436,7 @@ export class PrimitiveValidator extends PropertyValidator {
     return null;
   }
 
-  override visitNumeric(numeric: Css.Numeric): Css.Val {
+  override visitNumeric(numeric: Css.Numeric): Css.Val | null {
     if (numeric.num == 0 && !(this.allowed & ALLOW_ZERO)) {
       if (numeric.unit == "%" && this.allowed & ALLOW_ZERO_PERCENT) {
         return numeric;
@@ -452,7 +452,7 @@ export class PrimitiveValidator extends PropertyValidator {
     return null;
   }
 
-  override visitNum(num: Css.Num): Css.Val {
+  override visitNum(num: Css.Num): Css.Val | null {
     if (num.num == 0) {
       return this.allowed & ALLOW_ZERO ? num : null;
     }
@@ -465,7 +465,7 @@ export class PrimitiveValidator extends PropertyValidator {
     return null;
   }
 
-  override visitInt(num: Css.Int): Css.Val {
+  override visitInt(num: Css.Int): Css.Val | null {
     if (num.num == 0) {
       return this.allowed & ALLOW_ZERO ? num : null;
     }
@@ -482,7 +482,7 @@ export class PrimitiveValidator extends PropertyValidator {
     return null;
   }
 
-  override visitHexColor(color: Css.HexColor): Css.Val {
+  override visitHexColor(color: Css.HexColor): Css.Val | null {
     if (this.allowed & ALLOW_COLOR) {
       if (/^([0-9A-F]{3,4}|([0-9A-F]{2}){3,4})$/i.test(color.hex)) {
         return color;
@@ -491,29 +491,29 @@ export class PrimitiveValidator extends PropertyValidator {
     return null;
   }
 
-  override visitURL(url: Css.URL): Css.Val {
+  override visitURL(url: Css.URL): Css.Val | null {
     if (this.allowed & ALLOW_URL) {
       return url;
     }
     return null;
   }
 
-  override visitURange(urange: Css.URange): Css.Val {
+  override visitURange(urange: Css.URange): Css.Val | null {
     if (this.allowed & ALLOW_URANGE) {
       return urange;
     }
     return null;
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     return null;
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     return null;
   }
 
-  override visitFunc(func: Css.Func): Css.Val {
+  override visitFunc(func: Css.Func): Css.Val | null {
     if (func.name.toLowerCase() === "attr") {
       const attr = parseAttrFunction(func);
       if (
@@ -560,7 +560,7 @@ export class PrimitiveValidator extends PropertyValidator {
     return null;
   }
 
-  override visitExpr(expr: Css.Expr): Css.Val {
+  override visitExpr(expr: Css.Expr): Css.Val | null {
     if (this.allowed & 0x7fe) {
       // ALLOW_STR|ALLOW_IDENT|...|ALLOW_ZERO_PERCENT
       return expr;
@@ -871,7 +871,7 @@ function isSupportedAttrType(type: AttrType): boolean {
   return false;
 }
 
-export function getImplicitAttrFallback(type: AttrType): Css.Val {
+export function getImplicitAttrFallback(type: AttrType): Css.Val | null {
   switch (type.kind) {
     case "url":
       return new Css.URL("about:invalid");
@@ -944,7 +944,11 @@ export class ListValidator extends PropertyValidator {
     this.first = group.finish(this.successTerminal, this.failureTerminal);
   }
 
-  validateList(arr: Css.Val[], slice: boolean, startIndex: number): Css.Val[] {
+  validateList(
+    arr: Css.Val[],
+    slice: boolean,
+    startIndex: number,
+  ): Css.Val[] | null {
     let out: Css.Val[] = slice ? [] : arr;
     let current = this.first;
     let index = startIndex;
@@ -1037,64 +1041,64 @@ export class ListValidator extends PropertyValidator {
     return null;
   }
 
-  validateSingle(inval: Css.Val): Css.Val {
+  validateSingle(inval: Css.Val): Css.Val | null {
     const out = this.validateList([inval], false, 0);
     return out ? out[0] : null;
   }
 
-  override visitEmpty(empty: Css.Val): Css.Val {
+  override visitEmpty(empty: Css.Val): Css.Val | null {
     return this.validateSingle(empty);
   }
 
-  override visitSlash(slash: Css.Val): Css.Val {
+  override visitSlash(slash: Css.Val): Css.Val | null {
     return this.validateSingle(slash);
   }
 
-  override visitStr(str: Css.Str): Css.Val {
+  override visitStr(str: Css.Str): Css.Val | null {
     return this.validateSingle(str);
   }
 
-  override visitIdent(ident: Css.Ident): Css.Val {
+  override visitIdent(ident: Css.Ident): Css.Val | null {
     return this.validateSingle(ident);
   }
 
-  override visitNumeric(numeric: Css.Numeric): Css.Val {
+  override visitNumeric(numeric: Css.Numeric): Css.Val | null {
     return this.validateSingle(numeric);
   }
 
-  override visitNum(num: Css.Num): Css.Val {
+  override visitNum(num: Css.Num): Css.Val | null {
     return this.validateSingle(num);
   }
 
-  override visitInt(num: Css.Int): Css.Val {
+  override visitInt(num: Css.Int): Css.Val | null {
     return this.validateSingle(num);
   }
 
-  override visitHexColor(color: Css.HexColor): Css.Val {
+  override visitHexColor(color: Css.HexColor): Css.Val | null {
     return this.validateSingle(color);
   }
 
-  override visitURL(url: Css.URL): Css.Val {
+  override visitURL(url: Css.URL): Css.Val | null {
     return this.validateSingle(url);
   }
 
-  override visitURange(urange: Css.URange): Css.Val {
+  override visitURange(urange: Css.URange): Css.Val | null {
     return this.validateSingle(urange);
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     return null;
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     return null;
   }
 
-  override visitFunc(func: Css.Func): Css.Val {
+  override visitFunc(func: Css.Func): Css.Val | null {
     return this.validateSingle(func);
   }
 
-  override visitExpr(expr: Css.Expr): Css.Val {
+  override visitExpr(expr: Css.Expr): Css.Val | null {
     return null;
   }
 }
@@ -1104,7 +1108,7 @@ export class SpaceListValidator extends ListValidator {
     super(group);
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     const arr = this.validateList(list.values, false, 0);
     if (arr === list.values) {
       return list;
@@ -1115,7 +1119,7 @@ export class SpaceListValidator extends ListValidator {
     return new Css.SpaceList(arr);
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     // Special Case : Issue #156
     let node = this.first;
     let hasCommaListValidator = false;
@@ -1139,7 +1143,10 @@ export class SpaceListValidator extends ListValidator {
     return null;
   }
 
-  override validateForShorthand(values: Css.Val[], index: number): Css.Val[] {
+  override validateForShorthand(
+    values: Css.Val[],
+    index: number,
+  ): Css.Val[] | null {
     return this.validateList(values, true, index);
   }
 }
@@ -1149,11 +1156,11 @@ export class CommaListValidator extends ListValidator {
     super(group);
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     return this.validateSingle(list);
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     const arr = this.validateList(list.values, false, 0);
     if (arr === list.values) {
       return list;
@@ -1164,7 +1171,10 @@ export class CommaListValidator extends ListValidator {
     return new Css.CommaList(arr);
   }
 
-  override validateForShorthand(values: Css.Val[], index: number): Css.Val[] {
+  override validateForShorthand(
+    values: Css.Val[],
+    index: number,
+  ): Css.Val[] | null {
     let current = this.first;
     let rval: Css.Val[];
     while (current !== this.failureTerminal) {
@@ -1186,11 +1196,11 @@ export class FuncValidator extends ListValidator {
     super(group);
   }
 
-  override validateSingle(inval: Css.Val): Css.Val {
+  override validateSingle(inval: Css.Val): Css.Val | null {
     return null;
   }
 
-  override visitFunc(func: Css.Func): Css.Val {
+  override visitFunc(func: Css.Func): Css.Val | null {
     if (func.name.toLowerCase() != this.name) {
       return null;
     }
@@ -1206,11 +1216,11 @@ export class FuncValidator extends ListValidator {
 }
 
 class AttrFuncValidator extends PropertyValidator {
-  validateSingle(_inval: Css.Val): Css.Val {
+  validateSingle(_inval: Css.Val): Css.Val | null {
     return null;
   }
 
-  override visitFunc(func: Css.Func): Css.Val {
+  override visitFunc(func: Css.Func): Css.Val | null {
     const attr = parseAttrFunction(func);
     return attr && isSupportedAttrType(attr.type) ? func : null;
   }
@@ -1386,58 +1396,58 @@ export class ShorthandValidator extends Css.Visitor {
     return 0;
   }
 
-  validateSingle(val: Css.Val): Css.Val {
+  validateSingle(val: Css.Val): Css.Val | null {
     this.validateList([val]);
     return null;
   }
 
-  override visitEmpty(empty: Css.Val): Css.Val {
+  override visitEmpty(empty: Css.Val): Css.Val | null {
     return this.validateSingle(empty);
   }
 
-  override visitStr(str: Css.Str): Css.Val {
+  override visitStr(str: Css.Str): Css.Val | null {
     return this.validateSingle(str);
   }
 
-  override visitIdent(ident: Css.Ident): Css.Val {
+  override visitIdent(ident: Css.Ident): Css.Val | null {
     return this.validateSingle(ident);
   }
 
-  override visitNumeric(numeric: Css.Numeric): Css.Val {
+  override visitNumeric(numeric: Css.Numeric): Css.Val | null {
     return this.validateSingle(numeric);
   }
 
-  override visitNum(num: Css.Num): Css.Val {
+  override visitNum(num: Css.Num): Css.Val | null {
     return this.validateSingle(num);
   }
 
-  override visitInt(num: Css.Int): Css.Val {
+  override visitInt(num: Css.Int): Css.Val | null {
     return this.validateSingle(num);
   }
 
-  override visitHexColor(color: Css.HexColor): Css.Val {
+  override visitHexColor(color: Css.HexColor): Css.Val | null {
     return this.validateSingle(color);
   }
 
-  override visitURL(url: Css.URL): Css.Val {
+  override visitURL(url: Css.URL): Css.Val | null {
     return this.validateSingle(url);
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     this.validateList(list.values);
     return null;
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     this.error = true;
     return null;
   }
 
-  override visitFunc(func: Css.Func): Css.Val {
+  override visitFunc(func: Css.Func): Css.Val | null {
     return this.validateSingle(func);
   }
 
-  override visitExpr(expr: Css.Expr): Css.Val {
+  override visitExpr(expr: Css.Expr): Css.Val | null {
     return this.validateSingle(expr);
   }
 }
@@ -1539,7 +1549,7 @@ export class CommaShorthandValidator extends SimpleShorthandValidator {
     }
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     const acc: { [key: string]: Css.Val[] } = {};
     for (let i = 0; i < list.values.length; i++) {
       this.values = {};
@@ -1653,7 +1663,7 @@ export class FontShorthandValidator extends SimpleShorthandValidator {
     return list.length;
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     list.values[0].visit(this);
     if (this.error) {
       return null;
@@ -1671,7 +1681,7 @@ export class FontShorthandValidator extends SimpleShorthandValidator {
     return null;
   }
 
-  override visitIdent(ident: Css.Ident): Css.Val {
+  override visitIdent(ident: Css.Ident): Css.Val | null {
     const props = this.validatorSet.systemFonts[ident.name];
     if (props) {
       for (const name in props) {
@@ -1782,7 +1792,7 @@ export class ScopedBrowserShorthandValidator extends BrowserShorthandValidator {
     return list.length;
   }
 
-  override visitCommaList(list: Css.CommaList): Css.Val {
+  override visitCommaList(list: Css.CommaList): Css.Val | null {
     this.validateValueText(list.toString());
     return null;
   }
@@ -2144,7 +2154,10 @@ export class ValidatorSet {
     return group;
   }
 
-  private newFunc(fn: string, val: ValidatingGroup): ValidatingGroup {
+  private newFunc(
+    fn: string | undefined,
+    val: ValidatingGroup,
+  ): ValidatingGroup {
     let validator: PropertyValidator;
     switch (fn) {
       case "COMMA":
@@ -2294,7 +2307,12 @@ export class ValidatorSet {
         return;
       }
       let vals: ValidatingGroup[] = [];
-      const stack = [];
+      const stack: {
+        vals: ValidatingGroup[];
+        op: string;
+        b: string;
+        fn?: string;
+      }[] = [];
       let op = "";
       let val: ValidatingGroup;
       let expectval = true;
@@ -2317,7 +2335,7 @@ export class ValidatorSet {
         op = currop;
         expectval = true;
       };
-      let result: ValidatingGroup = null;
+      let result: ValidatingGroup | null = null;
       while (!result) {
         tok.consume();
         let token = tok.token();
@@ -2525,8 +2543,8 @@ export class ValidatorSet {
       let result = false;
       let syntax: ShorthandSyntaxNode[] = [];
       let slash = false;
-      const stack = [];
-      const propList = [];
+      const stack: { slash: boolean; syntax: ShorthandSyntaxNode[] }[] = [];
+      const propList: string[] = [];
       while (!result) {
         tok.consume();
         token = tok.token();
@@ -2732,7 +2750,7 @@ export function baseValidatorSet(): ValidatorSet {
 class VarCheckVisitor extends Css.Visitor {
   varFound = false;
 
-  visitFunc(func: Css.Func): Css.Val {
+  visitFunc(func: Css.Func): Css.Val | null {
     if (func.name === "var") {
       this.varFound = true;
     } else if (!this.varFound) {

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -735,6 +735,6 @@ export function processingOrderFn(name1: string, name2: string): number {
   return n1 - n2;
 }
 
-export function isCustomPropName(name: string): boolean {
-  return name?.length > 2 && name.startsWith("--");
+export function isCustomPropName(name: string | undefined): boolean {
+  return name != null && name.length > 2 && name.startsWith("--");
 }

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -22,69 +22,69 @@ import * as Base from "./base";
 import * as Exprs from "./exprs";
 
 export class Visitor {
-  visitValues(values: Val[]): Val[] {
+  visitValues(values: Val[]): Val[] | null {
     for (let i = 0; i < values.length; i++) {
       values[i].visit(this);
     }
     return null;
   }
 
-  visitEmpty(empty: Val): Val {
+  visitEmpty(empty: Val): Val | null {
     return null;
   }
 
-  visitSlash(slash: Val): Val {
+  visitSlash(slash: Val): Val | null {
     return null;
   }
 
-  visitStr(str: Str): Val {
+  visitStr(str: Str): Val | null {
     return null;
   }
 
-  visitIdent(ident: Ident): Val {
+  visitIdent(ident: Ident): Val | null {
     return null;
   }
 
-  visitNumeric(numeric: Numeric): Val {
+  visitNumeric(numeric: Numeric): Val | null {
     return null;
   }
 
-  visitNum(num: Num): Val {
+  visitNum(num: Num): Val | null {
     return null;
   }
 
-  visitInt(num: Int): Val {
+  visitInt(num: Int): Val | null {
     return this.visitNum(num);
   }
 
-  visitHexColor(color: HexColor): Val {
+  visitHexColor(color: HexColor): Val | null {
     return null;
   }
 
-  visitURL(url: URL): Val {
+  visitURL(url: URL): Val | null {
     return null;
   }
 
-  visitURange(urange: URange): Val {
+  visitURange(urange: URange): Val | null {
     return null;
   }
 
-  visitSpaceList(list: SpaceList): Val {
+  visitSpaceList(list: SpaceList): Val | null {
     this.visitValues(list.values);
     return null;
   }
 
-  visitCommaList(list: CommaList): Val {
+  visitCommaList(list: CommaList): Val | null {
     this.visitValues(list.values);
     return null;
   }
 
-  visitFunc(func: Func): Val {
+  visitFunc(func: Func): Val | null {
     this.visitValues(func.values);
     return null;
   }
 
-  visitExpr(expr: Expr): Val {
+  visitExpr(expr: Expr): Val | null {
     return null;
   }
 }
@@ -237,7 +237,7 @@ export class Val {
     return false;
   }
 
-  visit(visitor: Visitor): Val {
+  visit(visitor: Visitor): Val | null {
     return this;
   }
 }
@@ -262,7 +262,7 @@ export class Empty extends Val {
 
   override appendTo(buf: Base.StringBuffer, toString: boolean): void {}
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitEmpty(this);
   }
 }
@@ -291,7 +291,7 @@ export class Slash extends Val {
     buf.append("/");
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitSlash(this);
   }
 }
@@ -317,7 +317,7 @@ export class Str extends Val {
     }
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitStr(this);
   }
 }
@@ -345,7 +345,7 @@ export class Ident extends Val {
     }
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitIdent(this);
   }
 
@@ -395,7 +395,7 @@ export class Numeric extends Val {
     buf.append(this.unit);
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitNumeric(this);
   }
 
@@ -423,7 +423,7 @@ export class Num extends Val {
     buf.append(this.num.toString());
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitNum(this);
   }
 
@@ -437,7 +437,7 @@ export class Int extends Num {
     super(num);
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitInt(this);
   }
 }
@@ -452,7 +452,7 @@ export class HexColor extends Val {
     buf.append(this.hex);
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitHexColor(this);
   }
 }
@@ -468,7 +468,7 @@ export class URL extends Val {
     buf.append('")');
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitURL(this);
   }
 }
@@ -482,7 +482,7 @@ export class URange extends Val {
     buf.append(this.urangeText);
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitURange(this);
   }
 }
@@ -512,7 +512,7 @@ export class SpaceList extends Val {
     appendList(buf, this.values, " ", toString);
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitSpaceList(this);
   }
 
@@ -530,7 +530,7 @@ export class CommaList extends Val {
     appendList(buf, this.values, ",", toString);
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitCommaList(this);
   }
 }
@@ -550,7 +550,7 @@ export class Func extends Val {
     buf.append(")");
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitFunc(this);
   }
 }
@@ -577,7 +577,7 @@ export class Expr extends Val {
     }
   }
 
-  override visit(visitor: Visitor): Val {
+  override visit(visitor: Visitor): Val | null {
     return visitor.visitExpr(this);
   }
 

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -209,7 +209,7 @@ export class Val {
     return buf.toString();
   }
 
-  toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val): Exprs.Val {
+  toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
     return null;
   }
 
@@ -256,7 +256,7 @@ export class Empty extends Val {
     super();
   }
 
-  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val): Exprs.Val {
+  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
     return new Exprs.Const(scope, "");
   }
 
@@ -283,7 +283,7 @@ export class Slash extends Val {
     super();
   }
 
-  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val): Exprs.Val {
+  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
     return new Exprs.Const(scope, "/");
   }
 
@@ -303,7 +303,7 @@ export class Str extends Val {
     super();
   }
 
-  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val): Exprs.Val {
+  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
     return new Exprs.Const(scope, this.str);
   }
 
@@ -333,7 +333,7 @@ export class Ident extends Val {
     nameTable[name] = this;
   }
 
-  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val): Exprs.Val {
+  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
     return new Exprs.Const(scope, this.name);
   }
 
@@ -373,7 +373,7 @@ export class Numeric extends Val {
     this.unit = unit?.toLowerCase() ?? ""; // units are case-insensitive in CSS
   }
 
-  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val): Exprs.Val {
+  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
     if (this.num == 0) {
       return scope.zero;
     }
@@ -409,7 +409,7 @@ export class Num extends Val {
     super();
   }
 
-  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val): Exprs.Val {
+  override toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
     if (this.num == 0) {
       return scope.zero;
     }

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -97,7 +97,7 @@ export class FilterVisitor extends Visitor {
   }
 
   override visitValues(values: Val[]): Val[] {
-    let arr: Val[] = null;
+    let arr: Val[] | null = null;
     for (let i = 0; i < values.length; i++) {
       const before = values[i];
       const after = before.visit(this);
@@ -209,7 +209,7 @@ export class Val {
     return buf.toString();
   }
 
-  toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val {
+  toExpr(scope: Exprs.LexicalScope, ref: Exprs.Val | null): Exprs.Val | null {
     return null;
   }
 

--- a/packages/core/src/vivliostyle/display.ts
+++ b/packages/core/src/vivliostyle/display.ts
@@ -66,7 +66,9 @@ export function blockify(display: Css.Ident): Css.Ident {
 /**
  * Judge if the generated box is absolutely positioned.
  */
-export function isAbsolutelyPositioned(position: Css.Val): boolean {
+export function isAbsolutelyPositioned(
+  position: Css.Val | null | undefined,
+): boolean {
   return position === Css.ident.absolute || position === Css.ident.fixed;
 }
 
@@ -119,7 +121,7 @@ export function isBlock(
 }
 
 function isDisplayType(
-  display: Css.Val | string | undefined,
+  display: Css.Val | string | null | undefined,
 ): display is Css.Ident | Css.SpaceList | string {
   return (
     display instanceof Css.Ident ||

--- a/packages/core/src/vivliostyle/display.ts
+++ b/packages/core/src/vivliostyle/display.ts
@@ -74,7 +74,7 @@ export function isAbsolutelyPositioned(position: Css.Val): boolean {
  * Check if the position value is 'running()'.
  * https://drafts.csswg.org/css-gcpm/#running-elements
  */
-export function isRunning(position: Css.Val): boolean {
+export function isRunning(position: Css.Val | null | undefined): boolean {
   return position instanceof Css.Func && position.name === "running";
 }
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -140,7 +140,7 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     return this.jsonStore.load(url, opt_required, opt_message);
   }
 
-  loadWebPubManifest(url: string, frame: Task.Frame<OPFDoc>): void {
+  loadWebPubManifest(url: string, frame: Task.Frame<OPFDoc | null>): void {
     this.loadAsJSON(url, true).then((manifestObj) => {
       if (!manifestObj) {
         this.reportLoadError(url);
@@ -155,8 +155,8 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     });
   }
 
-  loadPubDoc(url: string): Task.Result<OPFDoc> {
-    const frame: Task.Frame<OPFDoc> = Task.newFrame("loadPubDoc");
+  loadPubDoc(url: string): Task.Result<OPFDoc | null> {
+    const frame: Task.Frame<OPFDoc | null> = Task.newFrame("loadPubDoc");
 
     if (/\.opf(?:[#?]|$)/i.test(url)) {
       // EPUB OPF
@@ -181,7 +181,7 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     } else {
       // For ambiguous URLs (no recognized extension), use HEAD to check
       // content type and availability before loading.
-      Net.fetchFromURL(url, null, "HEAD").then((response) => {
+      Net.fetchFromURL(url, undefined, "HEAD").then((response) => {
         if (response.status >= 400) {
           // This url can be the root of an unzipped EPUB.
           this.loadEPUBDoc(url).then((opf) => {
@@ -248,8 +248,8 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     return frame.result();
   }
 
-  loadEPUBDoc(url: string): Task.Result<OPFDoc> {
-    const frame: Task.Frame<OPFDoc> = Task.newFrame("loadEPUBDoc");
+  loadEPUBDoc(url: string): Task.Result<OPFDoc | null> {
+    const frame: Task.Frame<OPFDoc | null> = Task.newFrame("loadEPUBDoc");
     if (!url.endsWith("/")) {
       url = url + "/";
     }
@@ -275,13 +275,13 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     return frame.result();
   }
 
-  loadOPF(pubURL: string, root: string): Task.Result<OPFDoc> {
+  loadOPF(pubURL: string, root: string): Task.Result<OPFDoc | null> {
     const url = pubURL + root;
     const opf = this.opfByURL[url];
     if (opf) {
       return Task.newResult(opf);
     }
-    const frame: Task.Frame<OPFDoc> = Task.newFrame("loadOPF");
+    const frame: Task.Frame<OPFDoc | null> = Task.newFrame("loadOPF");
     this.loadAsPlainXML(url, true, `Failed to fetch EPUB OPF ${url}`).then(
       (opfXML) => {
         if (!opfXML) {
@@ -309,8 +309,8 @@ export class EPUBDocStore extends OPS.OPSDocStore {
     return frame.result();
   }
 
-  loadWebPub(url: string): Task.Result<OPFDoc> {
-    const frame: Task.Frame<OPFDoc> = Task.newFrame("loadWebPub");
+  loadWebPub(url: string): Task.Result<OPFDoc | null> {
+    const frame: Task.Frame<OPFDoc | null> = Task.newFrame("loadWebPub");
 
     // Load the primary entry page (X)HTML
     this.load(url).then((xmldoc) => {
@@ -823,7 +823,7 @@ export function readMetadata(
   return metadata;
 }
 
-export function getMathJaxHub(): object {
+export function getMathJaxHub(): object | null {
   const math = window["MathJax"];
   if (math) {
     return math["Hub"];
@@ -1606,7 +1606,7 @@ export type OPFViewItem = {
 
 export class OPFView implements Vgen.CustomRendererFactory {
   spineItems: (OPFViewItem | null)[] = [];
-  spineItemLoadingContinuations: Task.Continuation<any>[][] = [];
+  spineItemLoadingContinuations: (Task.Continuation<any>[] | null)[] = [];
   pref: Exprs.Preferences;
   clientLayout: Vgen.DefaultClientLayout;
   counterStore: Counters.CounterStore;
@@ -1646,7 +1646,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     }
   }
 
-  private getPage(position: Position): Vtree.Page {
+  private getPage(position: Position): Vtree.Page | null {
     const viewItem = this.spineItems[position.spineIndex];
     return viewItem ? viewItem.pages[position.pageIndex] : null;
   }
@@ -2581,7 +2581,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
           frame.finish(null);
           return;
         }
-        let resultPage: Vtree.Page = null;
+        let resultPage: Vtree.Page | null = null;
         let pageIndex: number;
         frame
           .loopWithFrame((loopFrame) => {
@@ -2979,7 +2979,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     }
     const frame: Task.Frame<Vtree.Spread> = Task.newFrame("getSpread");
     const isLeft = page.side === Constants.PageSide.LEFT;
-    let other: Task.Result<PageAndPosition>;
+    let other: Task.Result<PageAndPosition | null>;
     if (this.isRectoPage(page, position)) {
       other = this.previousPage(position, sync);
     } else {
@@ -3377,7 +3377,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       });
       return frame.result();
     }
-    return Task.newResult(null as Element);
+    return Task.newResult<Element | null>(null);
   }
 
   private resolveURLsInMathML(node: Node, xmldoc: XmlDoc.XMLDocHolder) {
@@ -3430,7 +3430,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       ) {
         return this.makeMathJaxView(xmldoc, srcElem, viewParent, computedStyle);
       }
-      return Task.newResult(null as Element);
+      return Task.newResult<Element | null>(null);
     };
   }
 
@@ -3647,7 +3647,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const toc = opf.toc;
     this.tocAutohide = autohide;
     if (!toc) {
-      return Task.newResult(null as Vtree.Page);
+      return Task.newResult<Vtree.Page | null>(null);
     }
     this.tocVisible = true;
     if (this.tocView && this.tocView.page) {

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1605,7 +1605,7 @@ export type OPFViewItem = {
 };
 
 export class OPFView implements Vgen.CustomRendererFactory {
-  spineItems: OPFViewItem[] = [];
+  spineItems: (OPFViewItem | null)[] = [];
   spineItemLoadingContinuations: Task.Continuation<any>[][] = [];
   pref: Exprs.Preferences;
   clientLayout: Vgen.DefaultClientLayout;
@@ -2520,7 +2520,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
   private normalizeSeekPosition(
     position: Position,
     viewItem: OPFViewItem,
-  ): Position | null {
+  ): Position {
     let pageIndex = position.pageIndex;
     let seekOffset = -1;
     if (pageIndex < 0) {
@@ -3434,9 +3434,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
     };
   }
 
-  getPageViewItem(spineIndex: number): Task.Result<OPFViewItem> {
+  getPageViewItem(spineIndex: number): Task.Result<OPFViewItem | null> {
     if (spineIndex === -1 || spineIndex >= this.opf.spine.length) {
-      return Task.newResult(null as OPFViewItem);
+      return Task.newResult<OPFViewItem | null>(null);
     }
     let viewItem = this.spineItems[spineIndex];
     if (viewItem) {

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -88,7 +88,7 @@ export class EPUBDocStore extends OPS.OPSDocStore {
   opfByURL: { [key: string]: OPFDoc } = {};
   primaryOPFByEPubURL: { [key: string]: OPFDoc } = {};
   deobfuscators: { [key: string]: (p1: Blob) => Task.Result<Blob> } = {};
-  documents: { [key: string]: Task.Result<XmlDoc.XMLDocHolder> } = {};
+  documents: { [key: string]: Task.Result<XmlDoc.XMLDocHolder | null> } = {};
 
   private constructor(
     authorStyleSheets: OPS.StyleSheetParam[] | null = null,
@@ -480,7 +480,7 @@ export class EPUBDocStore extends OPS.OPSDocStore {
       return "";
     }
     const vals = {};
-    let r: RegExpMatchArray;
+    let r: RegExpMatchArray | null;
     while (
       (r = content.match(
         /^,?\s*([-A-Za-z_.][-A-Za-z_0-9.]*)\s*=\s*([-+A-Za-z_0-9.]*)\s*/,
@@ -637,7 +637,7 @@ export const metaTerms = {
 
 export function getMetadataComparator(
   term: string,
-  lang: string,
+  lang: string | null,
 ): (p1: MetaItem, p2: MetaItem) => number {
   const empty = {};
   return (item1, item2) => {
@@ -691,7 +691,7 @@ export function readMetadata(
     for (const pn in predefinedPrefixes) {
       prefixMap[pn] = predefinedPrefixes[pn];
     }
-    let r: RegExpMatchArray;
+    let r: RegExpMatchArray | null;
 
     // This code permits any non-ASCII characters in the name to avoid bloating
     // the pattern.
@@ -1358,7 +1358,7 @@ export class OPFDoc {
       }
     }
 
-    const params = [];
+    const params: OPFItemParam[] = [];
     let itemCount = 0;
     let tocFound = -1;
     [manifestObj["readingOrder"], manifestObj["resources"]].forEach(
@@ -2439,7 +2439,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
    */
   private renderSinglePage(
     viewItem: OPFViewItem,
-    pos: Vtree.LayoutPosition,
+    pos: Vtree.LayoutPosition | null,
   ): Task.Result<RenderSinglePageResult> {
     const frame: Task.Frame<RenderSinglePageResult> =
       Task.newFrame("renderSinglePage");
@@ -2479,7 +2479,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     );
 
     viewItem.instance.layoutNextPage(page, pos).then((posParam) => {
-      pos = posParam as Vtree.LayoutPosition;
+      pos = posParam;
       const pageIndex = pos
         ? pos.page - 1
         : viewItem.layoutPositions.length - 1;
@@ -2674,16 +2674,16 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
   // Track renderPage tasks so navigation can wait only until its requested
   // page is available, without canceling background pagination (Issue #2047).
-  private renderingPageTasks = new Map<Task.Task, number>();
+  private renderingPageTasks = new Map<Task.Task | null, number>();
 
-  private beginRenderingPage(task: Task.Task): void {
+  private beginRenderingPage(task: Task.Task | null): void {
     this.renderingPageTasks.set(
       task,
       (this.renderingPageTasks.get(task) || 0) + 1,
     );
   }
 
-  private endRenderingPage(task: Task.Task): void {
+  private endRenderingPage(task: Task.Task | null): void {
     const depth = this.renderingPageTasks.get(task);
     if (depth === 1) {
       this.renderingPageTasks.delete(task);
@@ -2834,7 +2834,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       s = spineIndex;
     }
 
-    let lastResult: PageAndPosition;
+    let lastResult: PageAndPosition | null = null;
     frame
       .loopWithFrame((loopFrame) => {
         const pos = {
@@ -3233,7 +3233,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return frame.result();
   }
 
-  makePage(viewItem: OPFViewItem, pos: Vtree.LayoutPosition): Vtree.Page {
+  makePage(
+    viewItem: OPFViewItem,
+    pos: Vtree.LayoutPosition | null,
+  ): Vtree.Page {
     const viewport = viewItem.instance.viewport;
     const pageCont = viewport.document.createElement("div");
     pageCont.setAttribute("data-vivliostyle-page-container", "true");
@@ -3286,7 +3289,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     srcElem: Element,
     viewParent: Element,
     computedStyle: { [key: string]: Css.Val },
-  ): Task.Result<Element> {
+  ): Task.Result<Element | null> {
     let data = srcElem.getAttribute("data");
     let result: Element | null = null;
     if (data) {
@@ -3314,7 +3317,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
           sb.append(srcParam);
           sb.append("&type=");
           sb.append(typeParam);
-          for (let c: Node = srcElem.firstChild; c; c = c.nextSibling) {
+          for (let c: Node | null = srcElem.firstChild; c; c = c.nextSibling) {
             if (c.nodeType == 1) {
               const ce = c as Element;
               if (ce.localName == "param" && ce.namespaceURI == Base.NS.XHTML) {
@@ -3358,7 +3361,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     srcElem: Element,
     viewParent: Element,
     computedStyle: { [key: string]: Css.Val },
-  ): Task.Result<Element> {
+  ): Task.Result<Element | null> {
     // See if MathJax installed, use it if it is.
     const hub = getMathJaxHub();
     if (hub) {
@@ -3416,7 +3419,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       srcElem: Element,
       viewParent: Element,
       computedStyle: { [key: string]: Css.Val },
-    ): Task.Result<Element> => {
+    ): Task.Result<Element | null> => {
       if (
         srcElem.localName == "object" &&
         srcElem.namespaceURI == Base.NS.XHTML
@@ -3642,7 +3645,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return this.spineItems.some((item) => item && item.pages.length > 0);
   }
 
-  showTOC(autohide: boolean): Task.Result<Vtree.Page> {
+  showTOC(autohide: boolean): Task.Result<Vtree.Page | null> {
     const opf = this.opf;
     const toc = opf.toc;
     this.tocAutohide = autohide;
@@ -3717,5 +3720,5 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
 export interface RenderSinglePageResult {
   pageAndPosition: PageAndPosition;
-  nextLayoutPosition: Vtree.LayoutPosition;
+  nextLayoutPosition: Vtree.LayoutPosition | null;
 }

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -137,7 +137,7 @@ export class LexicalScope {
   builtIns: { [key: string]: (...p1: Result[]) => Result } = {};
 
   constructor(
-    public parent: LexicalScope,
+    public parent: LexicalScope | null,
     public resolver?: (p1: string, p2: boolean) => Val,
   ) {
     this.scopeKey = `S${nextKeyIndex++}`;

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -138,7 +138,7 @@ export class LexicalScope {
 
   constructor(
     public parent: LexicalScope | null,
-    public resolver?: (p1: string, p2: boolean) => Val,
+    public resolver?: (p1: string, p2: boolean) => Val | null,
   ) {
     this.scopeKey = `S${nextKeyIndex++}`;
     this.zero = new Const(this, 0);
@@ -1439,7 +1439,7 @@ export function and(scope: LexicalScope, v1: Val, v2: Val): Val {
   return new And(scope, v1, v2);
 }
 
-export function add(scope: LexicalScope, v1: Val, v2: Val): Val {
+export function add(scope: LexicalScope, v1: Val | null, v2: Val | null): Val {
   if (v1 === scope.zero) {
     return v2;
   }
@@ -1449,7 +1449,7 @@ export function add(scope: LexicalScope, v1: Val, v2: Val): Val {
   return new Add(scope, v1, v2);
 }
 
-export function sub(scope: LexicalScope, v1: Val, v2: Val): Val {
+export function sub(scope: LexicalScope, v1: Val | null, v2: Val | null): Val {
   if (v1 === scope.zero) {
     return new Negate(scope, v2);
   }

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -1330,7 +1330,7 @@ export class MediaTest extends Val {
   constructor(
     scope: LexicalScope,
     public name: MediaName,
-    public value: Val,
+    public value: Val | null,
   ) {
     super(scope);
   }
@@ -1370,7 +1370,7 @@ export class MediaTest extends Val {
 export class SupportsTest extends Val {
   constructor(
     scope: LexicalScope,
-    public name: string,
+    public name: string | undefined,
     public value: string,
     public isFunc: boolean,
   ) {

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -132,7 +132,7 @@ export class LexicalScope {
   one: Const;
   _true: Const;
   _false: Const;
-  values: { [key: string]: Val } = {};
+  values: { [key: string]: Val | null } = {};
   funcs: { [key: string]: Val } = {};
   builtIns: { [key: string]: (...p1: Result[]) => Result } = {};
 
@@ -206,7 +206,7 @@ export class LexicalScope {
     this.values[name] = new Native(this, fn, name);
   }
 
-  defineName(qualifiedName: string, val: Val): void {
+  defineName(qualifiedName: string, val: Val | null): void {
     this.values[qualifiedName] = val;
   }
 

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -546,11 +546,7 @@ export class Context {
     return false;
   }
 
-  evalSupportsTest(
-    name: string | undefined,
-    value: string,
-    isFunc: boolean,
-  ): boolean {
+  evalSupportsTest(name: string, value: string, isFunc: boolean): boolean {
     return false;
   }
 
@@ -1376,7 +1372,7 @@ export class MediaTest extends Val {
 export class SupportsTest extends Val {
   constructor(
     scope: LexicalScope,
-    public name: string | undefined,
+    public name: string,
     public value: string,
     public isFunc: boolean,
   ) {

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -435,19 +435,20 @@ export class Context {
   }
 
   evalName(scope: LexicalScope, qualifiedName: string): Val {
-    do {
-      let val = scope.values[qualifiedName];
+    let s: LexicalScope | null = scope;
+    while (s) {
+      let val: Val | null = s.values[qualifiedName];
       if (val) {
         return val;
       }
-      if (scope.resolver) {
-        val = scope.resolver.call(this, qualifiedName, false);
+      if (s.resolver) {
+        val = s.resolver.call(this, qualifiedName, false);
         if (val) {
           return val;
         }
       }
-      scope = scope.parent;
-    } while (scope);
+      s = s.parent;
+    }
     throw new Error(`Name '${qualifiedName}' is undefined`);
   }
 
@@ -460,30 +461,31 @@ export class Context {
     params: Val[],
     noBuiltInEval: boolean,
   ): Val {
-    do {
-      let body = scope.funcs[qualifiedName];
+    let s: LexicalScope | null = scope;
+    while (s) {
+      let body: Val | null = s.funcs[qualifiedName];
       if (body) {
         return body; // will be expanded by callee
       }
-      if (scope.resolver) {
-        body = scope.resolver.call(this, qualifiedName, true);
+      if (s.resolver) {
+        body = s.resolver.call(this, qualifiedName, true);
         if (body) {
           return body;
         }
       }
-      const fn = scope.builtIns[qualifiedName];
+      const fn = s.builtIns[qualifiedName];
       if (fn) {
         if (noBuiltInEval) {
-          return scope.zero;
+          return s.zero;
         }
         const args = Array(params.length);
         for (let i = 0; i < params.length; i++) {
           args[i] = params[i].evaluate(this);
         }
-        return new Const(scope, fn.apply(this, args));
+        return new Const(s, fn.apply(this, args));
       }
-      scope = scope.parent;
-    } while (scope);
+      s = s.parent;
+    }
     throw new Error(`Function '${qualifiedName}' is undefined`);
   }
 
@@ -492,7 +494,7 @@ export class Context {
     return not ? !enabled : enabled;
   }
 
-  evalMediaTest(feature: string, value: Val): boolean {
+  evalMediaTest(feature: string, value: Val | null): boolean {
     let prefix = "";
     const r = feature.match(/^(min|max)-(.*)$/);
     if (r) {
@@ -544,7 +546,11 @@ export class Context {
     return false;
   }
 
-  evalSupportsTest(name: string, value: string, isFunc: boolean): boolean {
+  evalSupportsTest(
+    name: string | undefined,
+    value: string,
+    isFunc: boolean,
+  ): boolean {
     return false;
   }
 

--- a/packages/core/src/vivliostyle/font.ts
+++ b/packages/core/src/vivliostyle/font.ts
@@ -87,7 +87,7 @@ export class Face {
   /**
    * Create "at" font-face rule.
    */
-  makeAtRule(src: string, fontBytes: Blob): string {
+  makeAtRule(src: string, fontBytes: Blob | null): string {
     const sb = new Base.StringBuffer();
     sb.append("@font-face {\n  font-family: ");
     sb.append(this.family as string);
@@ -175,7 +175,7 @@ export class Mapper {
   /**
    * Maps Face.src to an entry for an already-loaded font.
    */
-  srcURLMap: { [key: string]: TaskUtil.Fetcher<Face> } = {};
+  srcURLMap: { [key: string]: TaskUtil.Fetcher<Face | null> } = {};
   familyPrefix: string;
   familyCounter: number = 0;
 
@@ -203,7 +203,7 @@ export class Mapper {
    */
   private initFont(
     srcFace: Face,
-    fontBytes: Blob,
+    fontBytes: Blob | null,
     documentFaces: DocumentFaces,
   ): Task.Result<Face> {
     const frame: Task.Frame<Face> = Task.newFrame("initFont");
@@ -226,7 +226,7 @@ export class Mapper {
   loadFont(
     srcFace: Face,
     documentFaces: DocumentFaces,
-  ): TaskUtil.Fetcher<Face> {
+  ): TaskUtil.Fetcher<Face | null> {
     const src = srcFace.src as string;
     const faceKey = srcFace.family + ";" + src + ";" + srcFace.fontTraitKey;
     let fetcher = this.srcURLMap[faceKey];
@@ -237,7 +237,7 @@ export class Mapper {
       });
     } else {
       fetcher = new TaskUtil.Fetcher(() => {
-        const frame: Task.Frame<Face> = Task.newFrame("loadFont");
+        const frame: Task.Frame<Face | null> = Task.newFrame("loadFont");
         // Get URL from `@font-face` src value.
         const url = src.replace(/^url\("([^"]+)"\).*$/, "$1");
         const deobfuscator = documentFaces.deobfuscator
@@ -270,7 +270,7 @@ export class Mapper {
     srcFaces: Face[],
     documentFaces: DocumentFaces,
   ): Task.Result<boolean> {
-    const fetchers = [] as TaskUtil.Fetcher<Face>[];
+    const fetchers = [] as TaskUtil.Fetcher<Face | null>[];
     for (const srcFace of srcFaces) {
       if (!srcFace.src || !srcFace.family) {
         Logging.logger.warn("E_FONT_FACE_INVALID");

--- a/packages/core/src/vivliostyle/geometry-util.ts
+++ b/packages/core/src/vivliostyle/geometry-util.ts
@@ -104,7 +104,7 @@ export class Shape {
   }
 
   withOffset(offsetX: number, offsetY: number): Shape {
-    const points = [];
+    const points: Point[] = [];
     for (const p of this.points) {
       points.push(new Point(p.x + offsetX, p.y + offsetY));
     }

--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -630,7 +630,7 @@ export function getElementHeight(
     : rect["height"] + margin["top"] + margin["bottom"];
 }
 
-export function isOrphan(node: Node): boolean {
+export function isOrphan(node: Node | null): boolean {
   while (node) {
     if (node.parentNode === node.ownerDocument) {
       return false;

--- a/packages/core/src/vivliostyle/layout-helper.ts
+++ b/packages/core/src/vivliostyle/layout-helper.ts
@@ -641,7 +641,7 @@ export function isOrphan(node: Node | null): boolean {
 }
 
 export function removeFollowingSiblings(
-  parentNode: Node,
+  parentNode: Node | null,
   viewNode: Node,
 ): void {
   if (!parentNode) {

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -73,7 +73,7 @@ export interface LayoutProcessor {
 
   clearOverflownViewNodes(
     column: Layout.Column,
-    parentNodeContext: Vtree.NodeContext,
+    parentNodeContext: Vtree.NodeContext | null,
     nodeContext: Vtree.NodeContext,
     removeSelf: boolean,
   );
@@ -150,7 +150,7 @@ export class BlockLayoutProcessor implements LayoutProcessor {
   /** @override */
   clearOverflownViewNodes(
     column: Layout.Column,
-    parentNodeContext: Vtree.NodeContext,
+    parentNodeContext: Vtree.NodeContext | null,
     nodeContext: Vtree.NodeContext,
     removeSelf: boolean,
   ) {

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -34,7 +34,7 @@ export interface LayoutProcessor {
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
     leadingEdge: boolean,
-  ): Task.Result<Vtree.NodeContext>;
+  ): Task.Result<Vtree.NodeContext | null>;
 
   /**
    * Potential edge breaking position.
@@ -108,7 +108,7 @@ export class BlockLayoutProcessor implements LayoutProcessor {
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
     leadingEdge: boolean,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const floatNodeContext = column.asFloatNodeContext(nodeContext);
     if (floatNodeContext) {
       return column.layoutFloatOrFootnote(floatNodeContext);
@@ -204,7 +204,7 @@ export class BlockFormattingContext
 {
   formattingContextType: FormattingContextType = "Block";
 
-  constructor(private readonly parent: Vtree.FormattingContext) {}
+  constructor(private readonly parent: Vtree.FormattingContext | null) {}
 
   /** @override */
   getName(): string {
@@ -217,7 +217,7 @@ export class BlockFormattingContext
   }
 
   /** @override */
-  getParent(): Vtree.FormattingContext {
+  getParent(): Vtree.FormattingContext | null {
     return this.parent;
   }
 

--- a/packages/core/src/vivliostyle/layout-retryers.ts
+++ b/packages/core/src/vivliostyle/layout-retryers.ts
@@ -33,7 +33,7 @@ export abstract class AbstractLayoutRetryer {
   layout(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     this.prepareLayout(nodeContext, column);
     return this.tryLayout(nodeContext, column);
   }
@@ -41,8 +41,8 @@ export abstract class AbstractLayoutRetryer {
   private tryLayout(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
-    const frame = Task.newFrame<Vtree.NodeContext>(
+  ): Task.Result<Vtree.NodeContext | null> {
+    const frame = Task.newFrame<Vtree.NodeContext | null>(
       "AbstractLayoutRetryer.tryLayout",
     );
     this.saveState(nodeContext, column);
@@ -80,11 +80,11 @@ export abstract class AbstractLayoutRetryer {
     if (!viewNode) {
       return;
     }
-    let child: Node;
+    let child: Node | null;
     while ((child = viewNode.lastChild)) {
       viewNode.removeChild(child);
     }
-    let sibling: ChildNode;
+    let sibling: ChildNode | null;
     while ((sibling = viewNode.nextSibling)) {
       sibling.remove();
     }
@@ -92,10 +92,12 @@ export abstract class AbstractLayoutRetryer {
 
   saveState(nodeContext: Vtree.NodeContext, column: Layout.Column) {
     this.initialPosition = nodeContext.copy();
-    this.initialBreakPositions = [].concat(column.breakPositions);
-    this.initialFragmentLayoutConstraints = [].concat(
-      column.fragmentLayoutConstraints,
+    this.initialBreakPositions = ([] as Layout.BreakPosition[]).concat(
+      column.breakPositions,
     );
+    this.initialFragmentLayoutConstraints = (
+      [] as Layout.FragmentLayoutConstraint[]
+    ).concat(column.fragmentLayoutConstraints);
     this.initialStateOfFormattingContext =
       nodeContext.formattingContext.saveState();
   }

--- a/packages/core/src/vivliostyle/layout-util.ts
+++ b/packages/core/src/vivliostyle/layout-util.ts
@@ -119,10 +119,10 @@ export class LayoutIterator {
 
   iterate(
     initialNodeContext: Vtree.NodeContext,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const strategy = this.strategy;
     const state = strategy.initialState(initialNodeContext);
-    const frame: Task.Frame<Vtree.NodeContext> =
+    const frame: Task.Frame<Vtree.NodeContext | null> =
       Task.newFrame("LayoutIterator");
     frame
       .loopWithFrame((loopFrame) => {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -782,7 +782,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             ) {
               this.layoutFloatOrFootnote(floatNodeContext).then(
                 (positionParam) => {
-                  position = positionParam as Vtree.NodeContext;
+                  position = positionParam;
                   if (this.pageFloatLayoutContext.isInvalidated()) {
                     position = null;
                   }
@@ -898,7 +898,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             ) {
               this.layoutFloatOrFootnote(floatNodeContext).then(
                 (positionParam) => {
-                  position = positionParam as Vtree.NodeContext;
+                  position = positionParam;
                   if (this.pageFloatLayoutContext.isInvalidated()) {
                     position = null;
                   }

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -244,9 +244,9 @@ export class AfterIfContinuesElementsOffset
 }
 
 function processAfterIfContinuesOfNodeContext(
-  nodeContext: Vtree.NodeContext,
+  nodeContext: Vtree.NodeContext | null,
   column: Layout.Column,
-): Task.Result<Vtree.NodeContext> {
+): Task.Result<Vtree.NodeContext | null> {
   const host =
     nodeContext && VtreeImpl.asAfterIfContinuesNodeContext(nodeContext);
   if (!host || host.after || column.asFloatNodeContext(host)) {
@@ -1386,7 +1386,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    */
   layoutUnbreakable(
     nodeContextIn: Vtree.NodeContext,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     return this.buildDeepElementView(nodeContextIn);
   }
 
@@ -1395,8 +1395,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    */
   layoutFloat(
     nodeContext: Vtree.RenderedNodeContext,
-  ): Task.Result<Vtree.NodeContext> {
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("layoutFloat");
+  ): Task.Result<Vtree.NodeContext | null> {
+    const frame: Task.Frame<Vtree.NodeContext | null> =
+      Task.newFrame("layoutFloat");
     const element = nodeContext.viewNode as Element;
     const floatSide = PageFloats.resolveInlineFloatDirection(
       nodeContext.floatSide,
@@ -2021,7 +2022,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       // contains them was cancelled, so they are orphaned. (Issue #1675)
       const fragmentsToRemove: PageFloats.PageFloatFragment[] = [];
       for (
-        let ctx = context as PageFloats.PageFloatLayoutContext;
+        let ctx: PageFloats.PageFloatLayoutContext | null =
+          context as PageFloats.PageFloatLayoutContext;
         ctx;
         ctx = ctx.effectiveParent
       ) {
@@ -2480,10 +2482,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
   processLineStyling(
     nodeContext: Vtree.NodeContext,
-    resNodeContext: Vtree.NodeContext,
+    resNodeContext: Vtree.NodeContext | null,
     checkPoints: Vtree.RenderedNodeContext[],
-  ): Task.Result<Vtree.NodeContext> {
-    const frame: Task.Frame<Vtree.NodeContext> =
+  ): Task.Result<Vtree.NodeContext | null> {
+    const frame: Task.Frame<Vtree.NodeContext | null> =
       Task.newFrame("processLineStyling");
     if (VIVLIOSTYLE_DEBUG) {
       validateCheckPoints(checkPoints);
@@ -2625,8 +2627,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
    */
   layoutBreakableBlock(
     nodeContext: Vtree.NodeContext,
-  ): Task.Result<Vtree.NodeContext> {
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame(
+  ): Task.Result<Vtree.NodeContext | null> {
+    const frame: Task.Frame<Vtree.NodeContext | null> = Task.newFrame(
       "layoutBreakableBlock",
     );
     const checkPoints: Vtree.RenderedNodeContext[] = [];
@@ -2686,7 +2688,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           edge += this.getTrailingMarginEdgeAdjustment(checkPoints);
         }
         this.updateMaxReachedAfterEdge(edge);
-        let lineCont: Task.Result<Vtree.NodeContext>;
+        let lineCont: Task.Result<Vtree.NodeContext | null>;
         if (nodeContext.firstPseudo) {
           // possibly need to deal with :first-line and friends
           lineCont = this.processLineStyling(
@@ -2732,7 +2734,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   postLayoutBlock(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.NodeContext | null,
     checkPoints: Vtree.RenderedNodeContext[],
   ) {
     const hooks: Plugin.PostLayoutBlockHook[] = Plugin.getHooksForName(
@@ -2814,7 +2816,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     checkPoints: Vtree.RenderedNodeContext[],
     edgePosition: number,
     force: boolean,
-  ): Vtree.NodeContext {
+  ): Vtree.NodeContext | null {
     const position = this.findEndOfLine(edgePosition, checkPoints, true);
     const cpNodeContext = position.nodeContext;
     let nodeContext: Vtree.NodeContext = cpNodeContext;
@@ -3195,7 +3197,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       return null;
     }
     edge = linePositions[lineIndex - 1];
-    let nodeContext: Vtree.NodeContext;
+    let nodeContext: Vtree.NodeContext | null;
     if (forceCutBeforeOverflowing) {
       nodeContext = firstOverflowing.checkPoint;
     } else {
@@ -3329,11 +3331,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   doFinishBreak(
-    nodeContext: Vtree.NodeContext,
-    overflownNodeContext: Vtree.NodeContext,
-    initialNodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.NodeContext | null,
+    overflownNodeContext: Vtree.NodeContext | null,
+    initialNodeContext: Vtree.NodeContext | null,
     initialComputedBlockSize: number,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     if (
       this.pageFloatLayoutContext.isInvalidated() ||
       this.pageBreakType ||
@@ -3341,7 +3343,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     ) {
       return Task.newResult(nodeContext);
     }
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("doFinishBreak");
+    const frame: Task.Frame<Vtree.NodeContext | null> =
+      Task.newFrame("doFinishBreak");
     let forceRemoveSelf = false;
     if (!nodeContext) {
       // Last resort
@@ -3576,9 +3579,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     }
 
     const clear =
-      nodeContext.clearSide === "same"
+      (nodeContext.clearSide === "same"
         ? nodeContext.floatSide
-        : nodeContext.clearSide;
+        : nodeContext.clearSide) ?? "";
     const useRawSpacerGeometry = /^(page|column|region)$/.test(clear);
     // measure where the edge of the element would be without clearance
     const margin = this.getComputedMargin(nodeContext.viewNode as Element);
@@ -3762,7 +3765,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     if (fc && !this.isBFC(fc)) {
       return Task.newResult(nodeContext);
     }
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("skipEdges");
+    const frame: Task.Frame<Vtree.NodeContext | null> =
+      Task.newFrame("skipEdges");
     const column = this;
 
     // If a forced break occurred at the end of the previous column,
@@ -4585,7 +4589,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   clearOverflownViewNodes(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.NodeContext | null,
     removeSelf: boolean,
   ): void {
     if (!nodeContext) {
@@ -4774,7 +4778,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     // Enable page/column breaking using the browser's multi-column feature.
     LayoutHelper.setBrowserColumnBreaking(this);
 
-    const frame: Task.Frame<Vtree.ChunkPosition> = Task.newFrame("layout");
+    const frame: Task.Frame<Vtree.ChunkPosition | null> =
+      Task.newFrame("layout");
 
     // ------ start the column -----------
     this.openAllViews(chunkPosition.primary).then((nodeContext) => {
@@ -4863,7 +4868,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   }
 
   doFinishBreakOfFragmentLayoutConstraints(
-    nodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.NodeContext | null,
   ): Task.Result<boolean> {
     const frame: Task.Frame<boolean> = Task.newFrame(
       "doFinishBreakOfFragmentLayoutConstraints",
@@ -4995,7 +5000,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
   collectElementsOffset(): RepetitiveElement.ElementsOffset[] {
     const repetitiveElements: RepetitiveElement.ElementsOffset[] = [];
-    for (let current: Column = this; current; current = current.pseudoParent) {
+    for (
+      let current: Column | null = this;
+      current;
+      current = current.pseudoParent
+    ) {
       current.fragmentLayoutConstraints.forEach((constraint) => {
         if (
           RepetitiveElement.isInstanceOfRepetitiveElementsOwnerLayoutConstraint(
@@ -5076,7 +5085,7 @@ export class PseudoColumn {
   layout(
     chunkPosition: Vtree.ChunkPosition,
     leadingEdge: boolean,
-  ): Task.Result<Vtree.ChunkPosition> {
+  ): Task.Result<Vtree.ChunkPosition | null> {
     return this.column.layout(chunkPosition, leadingEdge);
   }
   findAcceptableBreakPosition(): Layout.BreakPositionAndNodeContext {
@@ -5362,15 +5371,15 @@ export class DefaultLayoutMode implements Layout.LayoutMode {
   constructor(
     public readonly leadingEdge: boolean,
     public readonly breakAfter: string | null,
-    public readonly context: { overflownNodeContext: Vtree.NodeContext },
+    public readonly context: { overflownNodeContext: Vtree.NodeContext | null },
   ) {}
 
   /** @override */
   doLayout(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame(
+  ): Task.Result<Vtree.NodeContext | null> {
+    const frame: Task.Frame<Vtree.NodeContext | null> = Task.newFrame(
       "DefaultLayoutMode.doLayout",
     );
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -692,7 +692,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         return this.layoutContext.peelOff(textPosition, firstLetterLength);
       }
     }
-    return Task.newResult(position) as Task.Result<Vtree.NodeContext>;
+    return Task.newResult<Vtree.NodeContext>(position);
   }
 
   /**

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1975,7 +1975,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     continuation: PageFloats.PageFloatContinuation,
     strategy: PageFloats.PageFloatLayoutStrategy,
     anchorEdge: number | null,
-    pageFloatFragment?: PageFloats.PageFloatFragment,
+    pageFloatFragment?: PageFloats.PageFloatFragment | null,
   ): Task.Result<boolean> {
     const context = this.pageFloatLayoutContext;
     const float = continuation.float;

--- a/packages/core/src/vivliostyle/logging.ts
+++ b/packages/core/src/vivliostyle/logging.ts
@@ -30,7 +30,7 @@ export enum LogLevel {
 }
 
 export type ErrorInfo = {
-  error: Error;
+  error: Error | null;
   messages: any[];
 };
 
@@ -135,7 +135,7 @@ export class Logger {
  */
 function argumentsToErrorInfo(args: IArguments): ErrorInfo {
   const a = Array.from(args);
-  let e: Error = null;
+  let e: Error | null = null;
   if (a[0] instanceof Error) {
     e = a.shift();
   }
@@ -145,7 +145,7 @@ function argumentsToErrorInfo(args: IArguments): ErrorInfo {
 function buildMessageAndStackTrace(args: ErrorInfo): string[] {
   const e = args.error;
   const stack = e && (e["frameTrace"] || e["stack"]);
-  let messages = [].concat(args["messages"]);
+  let messages = ([] as any[]).concat(args["messages"]);
   if (e) {
     if (messages.length > 0) {
       messages = messages.concat(["\n"]);

--- a/packages/core/src/vivliostyle/matchers.ts
+++ b/packages/core/src/vivliostyle/matchers.ts
@@ -95,7 +95,7 @@ export class MatcherBuilder {
   static buildViewConditionMatcher(
     elementOffset: number,
     viewCondition: string,
-  ): Matcher {
+  ): Matcher | null {
     const strs = viewCondition.split("_");
     if (strs[0] == "NFS") {
       return new NthFragmentMatcher(

--- a/packages/core/src/vivliostyle/net.ts
+++ b/packages/core/src/vivliostyle/net.ts
@@ -66,10 +66,9 @@ export function fetchFromURL(
       response.status = res.status;
       response.url = res.url;
       response.statusText = res.statusText;
-      response.contentType = res.headers
-        .get("Content-Type")
-        ?.replace(/;.*$/, "")
-        .toLowerCase();
+      response.contentType =
+        res.headers.get("Content-Type")?.replace(/;.*$/, "").toLowerCase() ??
+        null;
 
       if (!res.ok) {
         throw new Error(
@@ -172,14 +171,14 @@ export function createObjectURL(blob: Blob): string {
  * @template Resource
  */
 export class ResourceStore<Resource> implements Net.ResourceStore<Resource> {
-  resources: { [key: string]: Resource } = {};
-  fetchers: { [key: string]: TaskUtil.Fetcher<Resource> } = {};
+  resources: { [key: string]: Resource | null } = {};
+  fetchers: { [key: string]: TaskUtil.Fetcher<Resource | null> } = {};
 
   constructor(
     public readonly parser: (
       p1: FetchResponse,
       p2: ResourceStore<Resource>,
-    ) => Task.Result<Resource>,
+    ) => Task.Result<Resource | null>,
     public readonly type: FetchResponseType,
   ) {}
 
@@ -190,7 +189,7 @@ export class ResourceStore<Resource> implements Net.ResourceStore<Resource> {
     url: string,
     opt_required?: boolean,
     opt_message?: string,
-  ): Task.Result<Resource> {
+  ): Task.Result<Resource | null> {
     url = Base.stripFragment(url);
     const resource = this.resources[url];
     if (typeof resource != "undefined") {
@@ -203,8 +202,8 @@ export class ResourceStore<Resource> implements Net.ResourceStore<Resource> {
     url: string,
     opt_required?: boolean,
     opt_message?: string,
-  ): Task.Result<Resource> {
-    const frame: Task.Frame<Resource> = Task.newFrame("fetch");
+  ): Task.Result<Resource | null> {
+    const frame: Task.Frame<Resource | null> = Task.newFrame("fetch");
 
     // Hack for TOCView.showTOC()
     const isTocBox = Base.isTocBoxURL(url);
@@ -256,7 +255,7 @@ export class ResourceStore<Resource> implements Net.ResourceStore<Resource> {
     url: string,
     opt_required?: boolean,
     opt_message?: string,
-  ): TaskUtil.Fetcher<Resource> {
+  ): TaskUtil.Fetcher<Resource | null> | null {
     url = Base.stripFragment(url);
     const resource = this.resources[url];
     if (resource) {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -636,7 +636,7 @@ export class StyleInstance
   }
 
   override evalSupportsTest(
-    name: string,
+    name: string | undefined,
     value: string,
     isFunc: boolean,
   ): boolean {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -333,7 +333,7 @@ export class StyleInstance
     pref: Exprs.Preferences,
     pubTitle: string | null,
     docTitle: string | null,
-    pageProgression?: Constants.PageProgression,
+    pageProgression?: Constants.PageProgression | null,
     isVersoFirstPage?: boolean,
   ) {
     super(
@@ -487,7 +487,7 @@ export class StyleInstance
     pref: Exprs.Preferences,
     pubTitle: string | null,
     docTitle: string | null,
-    pageProgression?: Constants.PageProgression,
+    pageProgression?: Constants.PageProgression | null,
     isVersoFirstPage?: boolean,
   ): Task.Result<StyleInstance> {
     const instance = new StyleInstance(

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -66,7 +66,7 @@ import {
 
 export type FontFace = {
   properties: CssCascade.ElementStyle;
-  condition: Exprs.Val;
+  condition: Exprs.Val | null;
 };
 
 class CounterStyleParserHandler extends CssCascade.PropSetParserHandler {
@@ -542,7 +542,7 @@ export class StyleInstance
     return frame.result();
   }
 
-  private matchStartPageSide(side: string): boolean {
+  private matchStartPageSide(side: string | null): boolean {
     const isRectoStart =
       this.pageNumberOffset % 2 == (this.isVersoFirstPage ? 1 : 0);
     const isLTR = this.pageProgression == Constants.PageProgression.LTR;
@@ -779,7 +779,7 @@ export class StyleInstance
   }
 
   private getPageStartOffset(
-    layoutPosition?: Vtree.LayoutPosition,
+    layoutPosition?: Vtree.LayoutPosition | null,
     noLookAhead?: boolean,
   ): number {
     if (!layoutPosition) {
@@ -866,7 +866,7 @@ export class StyleInstance
   }
 
   private getPageStartElement(
-    layoutPosition: Vtree.LayoutPosition,
+    layoutPosition: Vtree.LayoutPosition | null,
     pageStartOffset: number = this.getPageStartOffset(layoutPosition),
   ): Element | null {
     if (!isFinite(pageStartOffset)) {
@@ -1468,7 +1468,7 @@ export class StyleInstance
    */
   selectPageMaster(
     cascadedPageStyle: CssCascade.ElementStyle,
-  ): PageMaster.PageMasterInstance {
+  ): PageMaster.PageMasterInstance | null {
     const cp = this.currentLayoutPosition;
 
     // 3.5. Page Layout Processing Model
@@ -2241,7 +2241,7 @@ export class StyleInstance
     layoutContainer: Vtree.Container,
     flowNameStr: string,
     columnCount: number,
-  ): Task.Result<LayoutType.Column[]> {
+  ): Task.Result<LayoutType.Column[] | null> {
     const positionAtContainerStart = this.currentLayoutPosition.clone();
     const regionPageFloatLayoutContext = this.getRegionPageFloatLayoutContext(
       pagePageFloatLayoutContext,
@@ -2382,7 +2382,7 @@ export class StyleInstance
       this.semanticFootnoteFirstRefOffsetsInitialized,
     );
     let columnIndex = 0;
-    let column: LayoutType.Column = null;
+    let column: LayoutType.Column | null = null;
     let columns: LayoutType.Column[] = [];
     frame
       .loopWithFrame((loopFrame) => {
@@ -3062,8 +3062,8 @@ export class StyleInstance
 
   layoutNextPage(
     page: Vtree.Page,
-    cp?: Vtree.LayoutPosition,
-  ): Task.Result<Vtree.LayoutPosition> {
+    cp?: Vtree.LayoutPosition | null,
+  ): Task.Result<Vtree.LayoutPosition | null> {
     // TOC box is special page container, no pagination
     const isTocBox = page.container === page.bleedBox;
 
@@ -3169,7 +3169,7 @@ export class StyleInstance
     const pageMaster = this.selectPageMaster(cascadedPageStyle);
     if (!pageMaster) {
       // end of primary content
-      return Task.newResult(null as Vtree.LayoutPosition);
+      return Task.newResult<Vtree.LayoutPosition | null>(null);
     }
     let bleedBoxPaddingEdge = 0;
     if (!isTocBox) {
@@ -3249,7 +3249,7 @@ export class StyleInstance
       null,
       page.side,
     );
-    const frame: Task.Frame<Vtree.LayoutPosition> =
+    const frame: Task.Frame<Vtree.LayoutPosition | null> =
       Task.newFrame("layoutNextPage");
     let attachedPageFloatLayoutContext: PageFloats.AttachedPageFloatLayoutContext | null =
       null;
@@ -3352,8 +3352,8 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
     owner: CssParser.DispatchParserHandler,
     scope: Exprs.LexicalScope,
     validatorSet: CssValidator.ValidatorSet,
-    condition: Exprs.Val,
-    parent: BaseParserHandler,
+    condition: Exprs.Val | null,
+    parent: BaseParserHandler | null,
     regionId: string | null,
     delegation: CssParser.Delegation | null,
   ) {
@@ -3620,7 +3620,7 @@ function toStyleSource(
 export function parseOPSResource(
   response: Net.FetchResponse,
   store: XmlDoc.XMLDocStore,
-): Task.Result<XmlDoc.XMLDocHolder> {
+): Task.Result<XmlDoc.XMLDocHolder | null> {
   return (store as OPSDocStore).parseOPSResource(response);
 }
 
@@ -3686,8 +3686,8 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
 
   parseOPSResource(
     response: Net.FetchResponse,
-  ): Task.Result<XmlDoc.XMLDocHolder> {
-    const frame: Task.Frame<XmlDoc.XMLDocHolder> =
+  ): Task.Result<XmlDoc.XMLDocHolder | null> {
+    const frame: Task.Frame<XmlDoc.XMLDocHolder | null> =
       Task.newFrame("OPSDocStore.load");
     const url = response.url;
 
@@ -3695,7 +3695,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
     const isTocBox = Base.isTocBoxURL(url);
 
     XmlDoc.parseXMLResource(response, this).then(
-      (xmldoc: XmlDoc.XMLDocHolder) => {
+      (xmldoc: XmlDoc.XMLDocHolder | null) => {
         if (!xmldoc) {
           frame.finish(null);
           return;
@@ -3714,7 +3714,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
             }
           }
         }
-        const triggers = [];
+        const triggers: Vtree.Trigger[] = [];
         const triggerList = xmldoc.document.getElementsByTagNameNS(
           Base.NS.epub,
           "trigger",

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -636,7 +636,7 @@ export class StyleInstance
   }
 
   override evalSupportsTest(
-    name: string | undefined,
+    name: string,
     value: string,
     isFunc: boolean,
   ): boolean {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -1380,7 +1380,7 @@ export class StyleInstance
    * @return document offset of the given layoutPosition
    */
   getPosition(
-    layoutPosition?: Vtree.LayoutPosition,
+    layoutPosition?: Vtree.LayoutPosition | null,
     noLookAhead?: boolean,
   ): number {
     if (!layoutPosition) {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -959,7 +959,7 @@ export class StyleInstance
   }
 
   getPageStartPageType(
-    layoutPosition: Vtree.LayoutPosition,
+    layoutPosition: Vtree.LayoutPosition | null,
   ): string | null | undefined {
     const pageStartOffset = this.getPageStartOffset(layoutPosition, true);
     const startElement = this.getPageStartElement(
@@ -983,7 +983,7 @@ export class StyleInstance
   }
 
   getPageStartPageTypeOverride(
-    layoutPosition: Vtree.LayoutPosition,
+    layoutPosition: Vtree.LayoutPosition | null,
   ): string | null | undefined {
     const pageStartPageType = this.getPageStartPageType(layoutPosition);
     if (pageStartPageType !== "") {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -2055,7 +2055,7 @@ export class StyleInstance
     columnCount: number,
     columnGap: number,
     columnWidth: number,
-    innerShape: GeometryUtil.Shape,
+    innerShape: GeometryUtil.Shape | null,
     layoutContext: Vtree.LayoutContext,
     forceNonFitting: boolean,
   ): Task.Result<LayoutType.Column> {

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -78,7 +78,7 @@ export function resolveInlineFloatDirection(
   floatSide: string,
   vertical: boolean,
   direction: string,
-  pageSide: Constants.PageSide,
+  pageSide: Constants.PageSide | null,
 ): string {
   const writingMode = vertical ? "vertical-rl" : "horizontal-tb";
   if (floatSide === "top" || floatSide === "bottom") {

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -1823,7 +1823,7 @@ export class AttachedPageFloatLayoutContext
       p2: AttachedPageFloatLayoutContext,
     ) => boolean,
     logicalSide?: string,
-    logicalSide2?: string,
+    logicalSide2?: string | null,
     excludedArea?: LayoutType.PageFloatArea,
   ): {
     top: number;

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -58,7 +58,7 @@ export abstract class PageBox<
     public readonly name: string | null,
     public readonly pseudoName: string | null,
     public readonly classes: string[],
-    public readonly parent: PageBox,
+    public readonly parent: PageBox | null,
   ) {
     this._scope = scope;
     this.key = `p${keyCount++}`;
@@ -163,7 +163,7 @@ export class PageMaster<
     pseudoName: string | null,
     classes: string[],
     parent: RootPageBox,
-    public readonly condition: Exprs.Val,
+    public readonly condition: Exprs.Val | null,
     public readonly specificity: number,
   ) {
     super(scope, name, pseudoName, classes, parent);
@@ -331,8 +331,8 @@ export function toExprIdent(
 export function toExprAuto(
   scope: Exprs.LexicalScope,
   val: Css.Val,
-  ref: Exprs.Val,
-): Exprs.Val {
+  ref: Exprs.Val | null,
+): Exprs.Val | null {
   if (!val || val === Css.ident.auto || Css.isDefaultingValue(val)) {
     return null;
   }
@@ -342,8 +342,8 @@ export function toExprAuto(
 export function toExprNormal(
   scope: Exprs.LexicalScope,
   val: Css.Val,
-  ref: Exprs.Val,
-): Exprs.Val {
+  ref: Exprs.Val | null,
+): Exprs.Val | null {
   if (!val || val === Css.ident.normal || Css.isDefaultingValue(val)) {
     return null;
   }
@@ -353,7 +353,7 @@ export function toExprNormal(
 export function toExprZero(
   scope: Exprs.LexicalScope,
   val: Css.Val,
-  ref: Exprs.Val,
+  ref: Exprs.Val | null,
 ): Exprs.Val {
   if (!val || val === Css.ident.auto || Css.isDefaultingValue(val)) {
     return scope.zero;
@@ -369,8 +369,8 @@ export function toExprZero(
 export function toExprZeroAuto(
   scope: Exprs.LexicalScope,
   val: Css.Val,
-  ref: Exprs.Val,
-): Exprs.Val {
+  ref: Exprs.Val | null,
+): Exprs.Val | null {
   if (!val || Css.isDefaultingValue(val)) {
     return scope.zero;
   } else if (val === Css.ident.auto) {
@@ -384,7 +384,7 @@ export function toExprZeroBorder(
   scope: Exprs.LexicalScope,
   val: Css.Val,
   styleVal: Css.Val,
-  ref: Exprs.Val,
+  ref: Exprs.Val | null,
 ): Exprs.Val {
   if (!val || styleVal === Css.ident.none || Css.isDefaultingValue(val)) {
     return scope.zero;
@@ -456,7 +456,7 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
   borderBoxSizing: boolean = false;
 
   constructor(
-    public readonly parentInstance: PageBoxInstance,
+    public readonly parentInstance: PageBoxInstance | null,
     public readonly pageBox: P,
   ) {
     if (parentInstance) {
@@ -1062,7 +1062,7 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
     return Css.toNumber(val, context);
   }
 
-  getSpecial(context: Exprs.Context, name: string): Css.Val[] {
+  getSpecial(context: Exprs.Context, name: string): Css.Val[] | null {
     const arr = CssCascade.getSpecial(this.cascaded, name);
     if (arr) {
       const result = [] as Css.Val[];
@@ -1079,7 +1079,7 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
     return null;
   }
 
-  getActiveRegions(context: Exprs.Context): string[] {
+  getActiveRegions(context: Exprs.Context): string[] | null {
     const arr = this.getSpecial(context, "region-id");
     if (arr) {
       const result = [] as string[];
@@ -1470,7 +1470,7 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
     }
     const readHeight = (this.vertical || !column) && this.isAutoHeight;
     const readWidth = (!this.vertical || !column) && this.isAutoWidth;
-    let bbox: Vtree.ClientRect = null;
+    let bbox: Vtree.ClientRect | null = null;
     if (readWidth || readHeight) {
       if (readWidth) {
         Base.setCSSProperty(container.element, "width", "auto");
@@ -1581,11 +1581,11 @@ export class PageBoxInstance<P extends PageBox = PageBox<any>> {
           const blockStartFloatEndEdge =
             columnLike.pageFloatLayoutContext?.parent?.getBlockEndEdgeOfBlockStartFloats?.(
               physicalInlinePos,
-            );
+            ) ?? NaN;
           const blockEndFloatStartEdge =
             columnLike.pageFloatLayoutContext?.parent?.getBlockStartEdgeOfBlockEndFloats?.(
               physicalInlinePos,
-            );
+            ) ?? NaN;
           const blockStartLimit = isFinite(blockStartFloatEndEdge)
             ? this.vertical
               ? blockStartFloatEndEdge - basePaddingRect.x1
@@ -1992,7 +1992,7 @@ export class PartitionInstance<
     listVal: Css.Val,
     conflicting: boolean,
   ): Exprs.Val {
-    let list: Css.Val[] = null;
+    let list: Css.Val[] | null = null;
     if (listVal instanceof Css.Ident) {
       list = [listVal];
     }

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -186,7 +186,7 @@ export type ResolveLayoutProcessorHook = (
 ) => LayoutProcessor.LayoutProcessor;
 
 export type PostLayoutBlockHook = (
-  p1: Vtree.NodeContext,
+  p1: Vtree.NodeContext | null,
   p2: Vtree.RenderedNodeContext[],
   p3: Layout.Column,
 ) => void;

--- a/packages/core/src/vivliostyle/pseudo-element.ts
+++ b/packages/core/src/vivliostyle/pseudo-element.ts
@@ -86,7 +86,7 @@ export class PseudoelementStyler implements PseudoElement.PseudoelementStyler {
     const style = pseudoMap?.[pseudoName] || ({} as CssCascade.ElementStyle);
     if (pseudoName.match(/^first-/) && !style["x-first-pseudo"]) {
       let nest = 1;
-      let r: RegExpMatchArray;
+      let r: RegExpMatchArray | null;
       if (pseudoName == "first-letter") {
         nest = 0;
       } else if ((r = pseudoName.match(/^first-([0-9]+)-lines$/)) != null) {

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -528,7 +528,7 @@ export class LayoutEntireOwnerBlock extends LayoutEntireBlock {
   override doLayout(
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     // FIXME: LayoutEntireBlock.prototype.doLayout is undefined because it's abstract method.
     //        Probably, removing this call is ok.
     // LayoutEntireBlock.prototype.doLayout.call(this, nodeContext, column);
@@ -554,7 +554,7 @@ export class LayoutFragmentedOwnerBlock extends LayoutFragmentedBlock {
   override doLayout(
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     if (!nodeContext.belongsTo(this.formattingContext) && !nodeContext.after) {
       column.fragmentLayoutConstraints.unshift(
         new RepetitiveElementsOwnerLayoutConstraint(nodeContext),
@@ -669,7 +669,7 @@ export class RepetitiveElementsOwnerLayoutConstraint
     );
   }
 
-  getRepetitiveElements(): RepetitiveElement.RepetitiveElements {
+  getRepetitiveElements(): RepetitiveElement.RepetitiveElements | null {
     const formattingContext = getRepetitiveElementsOwnerFormattingContext(
       this.nodeContext.formattingContext,
     );
@@ -822,7 +822,7 @@ export class RepetitiveElementsOwnerLayoutProcessor
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
     leadingEdge: boolean,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const floatNodeContext = column.asFloatNodeContext(nodeContext);
     if (floatNodeContext) {
       return column.layoutFloatOrFootnote(floatNodeContext);
@@ -876,11 +876,11 @@ export class RepetitiveElementsOwnerLayoutProcessor
   doInitialLayout(
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const formattingContext = getRepetitiveElementsOwnerFormattingContext(
       nodeContext.formattingContext,
     );
-    const frame = Task.newFrame<Vtree.NodeContext>(
+    const frame = Task.newFrame<Vtree.NodeContext | null>(
       "BlockLayoutProcessor.doInitialLayout",
     );
     this.layoutEntireBlock(nodeContext, column).thenFinish(frame);
@@ -890,7 +890,7 @@ export class RepetitiveElementsOwnerLayoutProcessor
   private layoutEntireBlock(
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const formattingContext = getRepetitiveElementsOwnerFormattingContext(
       nodeContext.formattingContext,
     );
@@ -905,11 +905,12 @@ export class RepetitiveElementsOwnerLayoutProcessor
   doLayout(
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const formattingContext = getRepetitiveElementsOwnerFormattingContext(
       nodeContext.formattingContext,
     );
-    const frame: Task.Frame<Vtree.NodeContext> = Task.newFrame("doLayout");
+    const frame: Task.Frame<Vtree.NodeContext | null> =
+      Task.newFrame("doLayout");
     const cont = column.layoutContext.nextInTree(nodeContext, false);
     Layout.processAfterIfContinues(cont, column).then((resNodeContext) => {
       let nextNodeContext = resNodeContext;
@@ -1105,7 +1106,7 @@ function getRepetitiveElementsOwnerFormattingContextOrNull(
 }
 
 function getRepetitiveElementsOwnerFormattingContext(
-  formattingContext: Vtree.FormattingContext,
+  formattingContext: Vtree.FormattingContext | null,
 ): RepetitiveElement.RepetitiveElementsOwnerFormattingContext {
   Asserts.assert(
     formattingContext instanceof RepetitiveElementsOwnerFormattingContext,

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -45,7 +45,7 @@ export class RepetitiveElementsOwnerFormattingContext
   repetitiveElements: RepetitiveElement.RepetitiveElements | null = null;
 
   constructor(
-    public readonly parent: Vtree.FormattingContext,
+    public readonly parent: Vtree.FormattingContext | null,
     public readonly rootSourceNode: Element,
   ) {}
 

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -64,7 +64,7 @@ export class RepetitiveElementsOwnerFormattingContext
     return this.parent;
   }
 
-  getRepetitiveElements(): RepetitiveElement.RepetitiveElements {
+  getRepetitiveElements(): RepetitiveElement.RepetitiveElements | null {
     return this.repetitiveElements;
   }
 
@@ -355,7 +355,7 @@ export class RepetitiveElements
     nodeContext: Vtree.NodeContext,
     includeChildren: boolean,
   ): boolean {
-    const parentsOfNode = [];
+    const parentsOfNode: Node[] = [];
     for (let n: Node | null = node; n; n = n.parentNode) {
       if (nodeContext.sourceNode === n) {
         return nodeContext.after;

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -276,7 +276,7 @@ export class RepetitiveElements
   }
 
   /** @override */
-  calculateOffset(nodeContext: Vtree.NodeContext): number {
+  calculateOffset(nodeContext: Vtree.NodeContext | null): number {
     let offset = 0;
     if (nodeContext && !this.affectTo(nodeContext)) {
       return offset;
@@ -294,7 +294,7 @@ export class RepetitiveElements
   }
 
   /** @override */
-  calculateMinimumOffset(nodeContext: Vtree.NodeContext): number {
+  calculateMinimumOffset(nodeContext: Vtree.NodeContext | null): number {
     let offset = 0;
     if (nodeContext && !this.affectTo(nodeContext)) {
       return offset;

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -60,7 +60,7 @@ export class RepetitiveElementsOwnerFormattingContext
   }
 
   /** @override */
-  getParent(): Vtree.FormattingContext {
+  getParent(): Vtree.FormattingContext | null {
     return this.parent;
   }
 
@@ -462,7 +462,7 @@ export abstract class LayoutEntireBlock implements LayoutType.LayoutMode {
   abstract doLayout(
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
-  ): Task.Result<Vtree.NodeContext>;
+  ): Task.Result<Vtree.NodeContext | null>;
 
   /** @override */
   accept(nodeContext: Vtree.NodeContext, column: LayoutType.Column): boolean {
@@ -499,7 +499,7 @@ export abstract class LayoutFragmentedBlock implements LayoutType.LayoutMode {
   abstract doLayout(
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
-  ): Task.Result<Vtree.NodeContext>;
+  ): Task.Result<Vtree.NodeContext | null>;
 
   /** @override */
   accept(nodeContext: Vtree.NodeContext, column: LayoutType.Column): boolean {

--- a/packages/core/src/vivliostyle/scripts.ts
+++ b/packages/core/src/vivliostyle/scripts.ts
@@ -143,8 +143,8 @@ export function loadScript(
   if (src) {
     scriptElem.src = src;
   }
-  scriptElem.async = async;
-  scriptElem.defer = defer;
+  scriptElem.async = !!async;
+  scriptElem.defer = !!defer;
   scriptElem.setAttribute("data-vivliostyle-scripting", "true");
 
   for (const attr of srcScriptElem.attributes) {

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -374,7 +374,7 @@ export class TableFormattingContext
   vertical: boolean = false;
   columnCount: number = -1;
   tableWidth: number = 0;
-  captions: TableCaptionView[] = [];
+  captions: (TableCaptionView | null)[] = [];
   colGroups: DocumentFragment | null = null;
   colWidths: number[] | null = null;
   inlineBorderSpacing: number = 0;
@@ -386,7 +386,7 @@ export class TableFormattingContext
   repetitiveElements: RepetitiveElement.RepetitiveElements | null = null;
 
   constructor(
-    parent: Vtree.FormattingContext,
+    parent: Vtree.FormattingContext | null,
     public readonly tableSourceNode: Element,
   ) {
     super(parent, tableSourceNode);
@@ -441,7 +441,7 @@ export class TableFormattingContext
     }
   }
 
-  override getParent(): Vtree.FormattingContext {
+  override getParent(): Vtree.FormattingContext | null {
     return this.parent;
   }
 
@@ -739,7 +739,7 @@ export class ElementsOffsetOfTableCell
 }
 
 function getTableFormattingContext(
-  formattingContext: Vtree.FormattingContext,
+  formattingContext: Vtree.FormattingContext | null,
 ): TableFormattingContext {
   Asserts.assert(formattingContext instanceof TableFormattingContext);
   return formattingContext as TableFormattingContext;
@@ -1623,7 +1623,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
   private layoutEntireTable(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const formattingContext = getTableFormattingContext(
       nodeContext.formattingContext,
     );
@@ -1643,7 +1643,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
   ): number[] {
     const doc = lastRow.ownerDocument;
     const dummyRow = doc.createElement("tr");
-    const dummyCells = [];
+    const dummyCells: HTMLTableCellElement[] = [];
     for (let i = 0; i < columnCount; i++) {
       const cell = doc.createElement("td");
       dummyRow.appendChild(cell);
@@ -1666,7 +1666,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
   }
 
   private getColGroupElements(tableElement: Element): Element[] {
-    const colGroups = [];
+    const colGroups: Element[] = [];
     let child = tableElement.firstElementChild;
     while (child) {
       if (child.localName === "colgroup") {
@@ -1678,7 +1678,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
   }
 
   private normalizeAndGetColElements(colGroups: Element[]): Element[] {
-    const cols = [];
+    const cols: Element[] = [];
     colGroups.forEach((colGroup) => {
       // Replace colgroup[span=n] with colgroup with n col elements
       let span = (colGroup as any).span;
@@ -1691,7 +1691,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
           col.removeAttribute("span");
           span -= s;
           while (s-- > 1) {
-            const cloned = col.cloneNode(true);
+            const cloned = col.cloneNode(true) as Element;
             colGroup.insertBefore(cloned, col);
             cols.push(cloned);
           }
@@ -1782,7 +1782,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
   doInitialLayout(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const formattingContext = getTableFormattingContext(
       nodeContext.formattingContext,
     );
@@ -1790,7 +1790,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     formattingContext.initializeRepetitiveElements(nodeContext.vertical);
     const tableLayoutOption = getTableLayoutOption(nodeContext.sourceNode);
     clearTableLayoutOptionCache(nodeContext.sourceNode);
-    const frame = Task.newFrame<Vtree.NodeContext>(
+    const frame = Task.newFrame<Vtree.NodeContext | null>(
       "TableLayoutProcessor.doInitialLayout",
     );
     const initialNodeContext = nodeContext.copy();
@@ -1938,7 +1938,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
 
   removeColGroups(
     formattingContext: TableFormattingContext,
-    rootViewNode: Element,
+    rootViewNode: Element | null,
   ) {
     if (formattingContext.colGroups && rootViewNode) {
       const colGroups = this.getColGroupElements(rootViewNode);
@@ -1953,7 +1953,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
   doLayout(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const formattingContext = getTableFormattingContext(
       nodeContext.formattingContext,
     );
@@ -1968,7 +1968,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
       strategy,
       column.layoutContext,
     );
-    const frame = Task.newFrame<Vtree.NodeContext>(
+    const frame = Task.newFrame<Vtree.NodeContext | null>(
       "TableFormattingContext.doLayout",
     );
     iterator.iterate(nodeContext).thenFinish(frame);
@@ -1980,7 +1980,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
     leadingEdge: boolean,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const formattingContext = getTableFormattingContext(
       nodeContext.formattingContext,
     );
@@ -2306,7 +2306,7 @@ function adjustRowHeight(nodeContext: Vtree.NodeContext): void {
     rowToBeAdjusted.querySelector(":scope>*>div>div")
   ) {
     for (
-      let row = rowToBeAdjusted;
+      let row: Element | null = rowToBeAdjusted;
       row && row !== tbodyElement.lastElementChild;
       row = row.nextElementSibling
     ) {
@@ -2384,7 +2384,7 @@ export class LayoutEntireTable extends RepetitiveElementImpl.LayoutEntireBlock {
   override doLayout(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     return this.processor.doInitialLayout(nodeContext, column);
   }
 }
@@ -2487,7 +2487,7 @@ export class LayoutFragmentedTable
   override doLayout(
     nodeContext: Vtree.NodeContext,
     column: Layout.Column,
-  ): Task.Result<Vtree.NodeContext> {
+  ): Task.Result<Vtree.NodeContext | null> {
     const repetitiveElements = this.formattingContext.getRepetitiveElements();
     if (
       repetitiveElements &&
@@ -2511,7 +2511,7 @@ export class TableRowLayoutConstraint
   flagmentLayoutConstraintType: FragmentLayoutConstraintType = "TableRow";
   cellFragmentLayoutConstraints: {
     constraints: Layout.FragmentLayoutConstraint[];
-    breakPosition: Vtree.NodeContext;
+    breakPosition: Vtree.NodeContext | null;
   }[] = [];
 
   constructor(nodeContext: Vtree.NodeContext) {
@@ -2621,7 +2621,10 @@ export class TableRowLayoutConstraint
             breakPosition: entry.breakPosition,
           })),
         ),
-      [],
+      [] as {
+        constraint: Layout.FragmentLayoutConstraint;
+        breakPosition: Vtree.NodeContext | null;
+      }[],
     );
     let i = 0;
     frame
@@ -2665,7 +2668,7 @@ export class TableRowLayoutConstraint
     formattingContext: TableFormattingContext,
   ): {
     constraints: Layout.FragmentLayoutConstraint[];
-    breakPosition: Vtree.NodeContext;
+    breakPosition: Vtree.NodeContext | null;
   }[] {
     return this.getCellFragemnts(nodeContext, formattingContext).map(
       (entry) => ({
@@ -2679,14 +2682,20 @@ export class TableRowLayoutConstraint
   private getCellFragemnts(
     nodeContext: Vtree.NodeContext,
     formattingContext: TableFormattingContext,
-  ): { fragment: TableCellFragment; breakPosition: Vtree.NodeContext }[] {
+  ): {
+    fragment: TableCellFragment;
+    breakPosition: Vtree.NodeContext | null;
+  }[] {
     let rowIndex = Number.MAX_VALUE;
     if (nodeContext && nodeContext.display === "table-row") {
       rowIndex =
         formattingContext.findRowIndexBySourceNode(nodeContext.sourceNode) + 1;
     }
     rowIndex = Math.min(formattingContext.cellFragments.length, rowIndex);
-    const cellFragments = [];
+    const cellFragments: {
+      fragment: TableCellFragment;
+      breakPosition: Vtree.NodeContext | null;
+    }[] = [];
     for (let i = 0; i < rowIndex; i++) {
       if (!formattingContext.cellFragments[i]) {
         continue;

--- a/packages/core/src/vivliostyle/task-util.ts
+++ b/packages/core/src/vivliostyle/task-util.ts
@@ -31,7 +31,7 @@ import * as Task from "./task";
  *    a resource; it will be run in a separate task.
  */
 export class Fetcher<T> {
-  name: string;
+  name: string | undefined;
   arrived: boolean = false;
   resource: T | null = null;
   task: Task.Task | null = null;

--- a/packages/core/src/vivliostyle/task.ts
+++ b/packages/core/src/vivliostyle/task.ts
@@ -342,7 +342,7 @@ export class Continuation<T> implements Base.Comparable {
   result: T | null = null;
   canceled: boolean = false;
 
-  constructor(public task: Task) {}
+  constructor(public task: Task | null) {}
 
   /** @override */
   compare(otherComp: Base.Comparable): number {
@@ -492,7 +492,7 @@ export class Task {
     }
   }
 
-  raise(err: Error, opt_frame?: Frame<any>): void {
+  raise(err: Error, opt_frame?: Frame<any> | null): void {
     this.fillStack(err);
     if (opt_frame) {
       let f = this.top;
@@ -642,7 +642,7 @@ export class Frame<T> {
 
   constructor(
     public task: Task,
-    public parent: Frame<T>,
+    public parent: Frame<T> | null,
     public name: string,
   ) {
     this.state = FrameState.INIT;
@@ -822,7 +822,7 @@ export class Frame<T> {
 }
 
 export class LoopBodyFrame extends Frame<boolean> {
-  constructor(task: Task, parent: Frame<boolean>) {
+  constructor(task: Task, parent: Frame<boolean> | null) {
     super(task, parent, "loop");
   }
 
@@ -838,7 +838,7 @@ export class LoopBodyFrame extends Frame<boolean> {
 export class EventItem {
   next: EventItem | null = null;
 
-  constructor(public event: Base.Event) {}
+  constructor(public event: Base.Event | null) {}
 }
 
 /**
@@ -894,7 +894,7 @@ export class EventSource {
       target: Base.SimpleEventTarget;
       type: string;
       listener: Base.EventListener;
-    } = null;
+    } | null = null;
     while (i < this.listeners.length) {
       item = this.listeners[i];
       if (item.type == type && item.target === target) {

--- a/packages/core/src/vivliostyle/task.ts
+++ b/packages/core/src/vivliostyle/task.ts
@@ -259,11 +259,10 @@ export class Scheduler {
   }
 
   schedule(continuation: Continuation<any>, opt_delay?: number): void {
-    const c = continuation as Continuation<any>;
     const now = this.timer.currentTime();
-    c.order = this.order++;
-    c.scheduledTime = now + (opt_delay || 0);
-    this.queue.add(c);
+    continuation.order = this.order++;
+    continuation.scheduledTime = now + (opt_delay || 0);
+    this.queue.add(continuation);
     this.arm();
   }
 

--- a/packages/core/src/vivliostyle/task.ts
+++ b/packages/core/src/vivliostyle/task.ts
@@ -353,7 +353,7 @@ export class Continuation<T> implements Base.Comparable {
   /**
    * Continuation's task
    */
-  getTask(): Task {
+  getTask(): Task | null {
     return this.task;
   }
 
@@ -363,7 +363,10 @@ export class Continuation<T> implements Base.Comparable {
    */
   schedule(result: T, opt_delay?: number) {
     this.result = result;
-    this.task.scheduler.schedule(this, opt_delay);
+    const task = this.task;
+    if (task) {
+      task.scheduler.schedule(this, opt_delay);
+    }
   }
 
   resumeInternal(): boolean {

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -1219,7 +1219,7 @@ export function processGeneratedContent(
   textAutospace: Css.Val,
   textSpacingTrim: Css.Val,
   hangingPunctuation: Css.Val,
-  lang: string,
+  lang: string | null,
   vertical: boolean,
 ): void {
   textPolyfill.processGeneratedContent(

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -24,7 +24,7 @@ import * as Plugin from "./plugin";
 import * as PseudoElement from "./pseudo-element";
 import * as Vtree from "./vtree";
 
-type PropertyValue = string | number | Css.Val;
+type PropertyValue = string | number | Css.Val | undefined;
 
 type HangingPunctuation = {
   first: boolean;
@@ -277,7 +277,7 @@ function isTextSpacingNone(
   );
 }
 
-function normalizeLang(lang: string): string | null {
+function normalizeLang(lang: string | null | undefined): string | null {
   if (lang) {
     // Normalize CJK lang
     lang = lang.toLowerCase();
@@ -373,7 +373,7 @@ class TextSpacingPolyfill {
     autospaceVal: Css.Val,
     spacingTrimVal: Css.Val,
     hangingPunctuationVal: Css.Val,
-    lang: string,
+    lang: string | null,
     vertical: boolean,
   ): void {
     lang = normalizeLang(lang);
@@ -455,7 +455,7 @@ class TextSpacingPolyfill {
       return (
         position === "absolute" ||
         position === "fixed" ||
-        (float && float !== "none")
+        !!(float && float !== "none")
       );
     }
 
@@ -582,12 +582,12 @@ class TextSpacingPolyfill {
         ) {
           continue;
         }
-        if (/\b(flex|grid)\b/.test(textP.parent.display)) {
+        if (/\b(flex|grid)\b/.test(textP.parent.display ?? "")) {
           // Cannot process if parent is flex or grid. (Issue #926)
           continue;
         }
-        let prevNode: Node = null;
-        let nextNode: Node = null;
+        let prevNode: Node | null = null;
+        let nextNode: Node | null = null;
         let isFirstAfterBreak = i === iFirst;
         let isFirstInBlock = i === iFirst && isFirstFragment;
         let isFirstAfterForcedLineBreak =
@@ -791,12 +791,12 @@ class TextSpacingPolyfill {
     isFirstAfterForcedLineBreak: boolean,
     isLastBeforeForcedLineBreak: boolean,
     isLastInBlock: boolean,
-    prevNode: Node,
-    nextNode: Node,
+    prevNode: Node | null,
+    nextNode: Node | null,
     autospace: Autospace,
     spacingTrim: SpacingTrim,
     hangingPunctuation: HangingPunctuation,
-    lang: string,
+    lang: string | null,
     vertical: boolean,
   ): number {
     const text = textNode.textContent;

--- a/packages/core/src/vivliostyle/toc.ts
+++ b/packages/core/src/vivliostyle/toc.ts
@@ -64,7 +64,7 @@ export function findTocElements(doc: Document): Array<Element> {
     if (tocElems.find((e) => e.contains(elem))) {
       continue; // Skip nested TOC elements.
     }
-    let tocElem = elem;
+    let tocElem: Element | null = elem;
     if (/^h[1-6]$/.test(tocElem.localName)) {
       // If the element is a heading, use its parent or next sibling as TOC element.
       if (!tocElem.previousElementSibling) {
@@ -120,7 +120,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
     if (depth-- == 0) {
       return;
     }
-    for (let c: Node = elem.firstChild; c; c = c.nextSibling) {
+    for (let c: Node | null = elem.firstChild; c; c = c.nextSibling) {
       if (c.nodeType == 1) {
         const e = c as Element;
         if (Base.getCSSProperty(e, "height", "auto") != "auto") {
@@ -142,7 +142,7 @@ export class TOCView implements Vgen.CustomRendererFactory {
       srcElem: Element,
       viewParent: Element,
       computedStyle: { [key: string]: Css.Val },
-    ): Task.Result<Element> => {
+    ): Task.Result<Element | null> => {
       const behavior = computedStyle["behavior"];
       if (behavior) {
         switch (behavior.toString()) {
@@ -362,7 +362,7 @@ export function toggleNodeExpansion(evt: Event): void {
   const tocNodeElem = elem.parentNode as Element;
   elem.setAttribute("aria-expanded", open ? "true" : "false");
   tocNodeElem.setAttribute("aria-expanded", open ? "true" : "false");
-  let c: Node = tocNodeElem.firstChild;
+  let c: Node | null = tocNodeElem.firstChild;
   while (c) {
     if (c.nodeType === 1) {
       const ce = c as HTMLElement;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1008,7 +1008,7 @@ export namespace Table {
     extends RepetitiveElement.RepetitiveElementsOwnerLayoutConstraint {
     cellFragmentLayoutConstraints: {
       constraints: Layout.FragmentLayoutConstraint[];
-      breakPosition: Vtree.NodeContext;
+      breakPosition: Vtree.NodeContext | null;
     }[];
 
     removeDummyRowNodes(nodeContext: Vtree.NodeContext): void;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -614,7 +614,7 @@ export namespace Net {
     contentType: string | null;
     responseText: string | null;
     responseXML: Document;
-    responseBlob: Blob;
+    responseBlob: Blob | null;
   };
 
   export interface ResourceStore<Resource> {

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -218,9 +218,9 @@ export namespace Layout {
      * @return holding box edge position reached or null if the source is exhausted.
      */
     buildViewToNextBlockEdge(
-      position: Vtree.NodeContext,
+      position: Vtree.NodeContext | null,
       checkPoints: Vtree.RenderedNodeContext[],
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     nextInTree(
       position: Vtree.NodeContext,
       atUnforcedBreak?: boolean,
@@ -231,8 +231,8 @@ export namespace Layout {
      * @return holding box edge position reached or null if the source is exhausted.
      */
     buildDeepElementView(
-      position: Vtree.NodeContext,
-    ): Task.Result<Vtree.NodeContext>;
+      position: Vtree.NodeContext | null,
+    ): Task.Result<Vtree.NodeContext | null>;
 
     /**
      * Create a single floating element (for exclusion areas).

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1343,10 +1343,10 @@ export namespace Vtree {
     inheritedProps: { [key: string]: number | string | Css.Val | undefined };
     vertical: boolean;
     direction: string;
-    firstPseudo: FirstPseudo;
+    firstPseudo: FirstPseudo | null;
     lang: string | null;
     preprocessedTextContent: Diff.Change[] | null;
-    formattingContext: FormattingContext;
+    formattingContext: FormattingContext | null;
     repeatOnBreak: string | null;
     pluginProps: {
       [key: string]: string | number | undefined | null | (number | null)[];

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1432,7 +1432,7 @@ export namespace XmlDoc {
     last: Element;
     lastOffset: number;
     idMap: { [key: string]: Element } | null;
-    readonly store: XMLDocStore;
+    readonly store: XMLDocStore | null;
     readonly url: string;
     readonly document: Document;
 
@@ -1470,7 +1470,7 @@ export namespace XmlDoc {
     predicate(pr: Predicate): NodeList;
     forEachNode(fn: (p1: Node, p2: (p1: Node) => void) => void): NodeList;
     forEach<T>(fn: (p1: Node) => T): T[];
-    forEachNonNull<T>(fn: (p1: Node) => T): T[];
+    forEachNonNull<T>(fn: (p1: Node) => T | null): T[];
     child(tag: string): NodeList;
     childElements(): NodeList;
     attribute(name: string): (string | null)[];

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1265,7 +1265,7 @@ export namespace Vtree {
     getOuterShape(
       outerShapeProp: Css.Val | null,
       context: Exprs.Context | null,
-    ): GeometryUtil.Shape;
+    ): GeometryUtil.Shape | null;
     getOuterRect(): GeometryUtil.Rect;
   }
 

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -337,7 +337,7 @@ export namespace Layout {
       continuation: PageFloats.PageFloatContinuation,
       strategy: PageFloats.PageFloatLayoutStrategy,
       anchorEdge: number | null,
-      pageFloatFragment?: PageFloats.PageFloatFragment,
+      pageFloatFragment?: PageFloats.PageFloatFragment | null,
     ): Task.Result<boolean>;
     setFloatAnchorViewNode(
       nodeContext: Vtree.RenderedNodeContext,
@@ -613,17 +613,17 @@ export namespace Net {
     url: string;
     contentType: string | null;
     responseText: string | null;
-    responseXML: Document;
+    responseXML: Document | null;
     responseBlob: Blob | null;
   };
 
   export interface ResourceStore<Resource> {
-    resources: { [key: string]: Resource };
-    fetchers: { [key: string]: TaskUtil.Fetcher<Resource> };
+    resources: { [key: string]: Resource | null };
+    fetchers: { [key: string]: TaskUtil.Fetcher<Resource | null> };
     readonly parser: (
       p1: FetchResponse,
       p2: ResourceStore<Resource>,
-    ) => Task.Result<Resource>;
+    ) => Task.Result<Resource | null>;
     readonly type: XMLHttpRequestResponseType;
 
     /**
@@ -633,7 +633,7 @@ export namespace Net {
       url: string,
       opt_required?: boolean,
       opt_message?: string,
-    ): Task.Result<Resource>;
+    ): Task.Result<Resource | null>;
     /**
      * @return fetcher for the resource for the given URL
      */
@@ -641,7 +641,7 @@ export namespace Net {
       url: string,
       opt_required?: boolean,
       opt_message?: string,
-    ): TaskUtil.Fetcher<Resource>;
+    ): TaskUtil.Fetcher<Resource | null> | null;
     get(url: string): XmlDoc.XMLDocHolder;
     delete(url: string): void;
   }
@@ -903,7 +903,7 @@ export namespace RepetitiveElement {
     extends Vtree.FormattingContext {
     isRoot: boolean;
     repetitiveElements: RepetitiveElements | null;
-    readonly parent: Vtree.FormattingContext;
+    readonly parent: Vtree.FormattingContext | null;
     readonly rootSourceNode: Element;
     getRepetitiveElements(): RepetitiveElements | null;
     getRootViewNode(position: Vtree.NodeContext): Element | null;
@@ -1155,7 +1155,7 @@ export namespace Vtree {
     formattingContextType: FormattingContextType;
     getName(): string;
     isFirstTime(nodeContext: NodeContext, firstTime: boolean): boolean;
-    getParent(): FormattingContext;
+    getParent(): FormattingContext | null;
     saveState(): any;
     restoreState(state: any);
   }

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -905,7 +905,7 @@ export namespace RepetitiveElement {
     repetitiveElements: RepetitiveElements | null;
     readonly parent: Vtree.FormattingContext;
     readonly rootSourceNode: Element;
-    getRepetitiveElements(): RepetitiveElements;
+    getRepetitiveElements(): RepetitiveElements | null;
     getRootViewNode(position: Vtree.NodeContext): Element | null;
     getRootNodeContext(
       nodeContext: Vtree.NodeContext,
@@ -975,7 +975,7 @@ export namespace RepetitiveElement {
 
   export interface RepetitiveElementsOwnerLayoutConstraint
     extends Layout.FragmentLayoutConstraint {
-    getRepetitiveElements(): RepetitiveElements;
+    getRepetitiveElements(): RepetitiveElements | null;
   }
 
   export function isInstanceOfRepetitiveElementsOwnerLayoutConstraint(

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1349,7 +1349,7 @@ export namespace Vtree {
     firstPseudo: FirstPseudo | null;
     lang: string | null;
     preprocessedTextContent: Diff.Change[] | null;
-    formattingContext: FormattingContext | null;
+    formattingContext: FormattingContext;
     repeatOnBreak: string | null;
     pluginProps: {
       [key: string]: string | number | undefined | null | (number | null)[];

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -301,13 +301,13 @@ export namespace Layout {
      */
     layoutUnbreakable(
       nodeContextIn: Vtree.NodeContext,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     /**
      * Layout a single float element.
      */
     layoutFloat(
       nodeContext: Vtree.RenderedNodeContext,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
 
     setupFloatArea(
       area: PageFloatArea,
@@ -352,9 +352,9 @@ export namespace Layout {
     ): Task.Result<Vtree.NodeContext | null>;
     processLineStyling(
       nodeContext: Vtree.NodeContext,
-      resNodeContext: Vtree.NodeContext,
+      resNodeContext: Vtree.NodeContext | null,
       checkPoints: Vtree.RenderedNodeContext[],
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     isLoneImage(checkPoints: Vtree.RenderedNodeContext[]): boolean;
     getTrailingMarginEdgeAdjustment(
       trailingEdgeContexts: Vtree.NodeContext[],
@@ -364,9 +364,9 @@ export namespace Layout {
      */
     layoutBreakableBlock(
       nodeContext: Vtree.NodeContext,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     postLayoutBlock(
-      nodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.NodeContext | null,
       checkPoints: Vtree.RenderedNodeContext[],
     ): void;
     findEndOfLine(
@@ -382,7 +382,7 @@ export namespace Layout {
       checkPoints: Vtree.RenderedNodeContext[],
       edgePosition: number,
       force: boolean,
-    ): Vtree.NodeContext;
+    ): Vtree.NodeContext | null;
     resolveTextNodeBreaker(nodeContext: Vtree.NodeContext): TextNodeBreaker;
     /**
      * Read ranges skipping special elments
@@ -421,11 +421,11 @@ export namespace Layout {
     ): Task.Result<boolean>;
     findAcceptableBreakPosition(): BreakPositionAndNodeContext | null;
     doFinishBreak(
-      nodeContext: Vtree.NodeContext,
-      overflownNodeContext: Vtree.NodeContext,
-      initialNodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.NodeContext | null,
+      overflownNodeContext: Vtree.NodeContext | null,
+      initialNodeContext: Vtree.NodeContext | null,
       initialComputedBlockSize: number,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     /**
      * Determines if a page break is acceptable at this position
      */
@@ -480,7 +480,7 @@ export namespace Layout {
       forcedBreakValue?: string | null,
     ): Task.Result<Vtree.NodeContext>;
     clearOverflownViewNodes(
-      nodeContext: Vtree.NodeContext,
+      nodeContext: Vtree.NodeContext | null,
       removeSelf: boolean,
     ): void;
     /**
@@ -569,7 +569,7 @@ export namespace Layout {
     doLayout(
       nodeContext: Vtree.NodeContext,
       column: Layout.Column,
-    ): Task.Result<Vtree.NodeContext>;
+    ): Task.Result<Vtree.NodeContext | null>;
     accept(nodeContext: Vtree.NodeContext, column: Layout.Column): boolean;
     postLayout(
       positionAfter: Vtree.NodeContext,
@@ -924,8 +924,8 @@ export namespace RepetitiveElement {
   }
 
   export interface ElementsOffset {
-    calculateOffset(nodeContext: Vtree.NodeContext): number;
-    calculateMinimumOffset(nodeContext: Vtree.NodeContext): number;
+    calculateOffset(nodeContext: Vtree.NodeContext | null): number;
+    calculateMinimumOffset(nodeContext: Vtree.NodeContext | null): number;
   }
 
   export interface RepetitiveElements extends ElementsOffset {

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -570,9 +570,12 @@ export namespace Layout {
       nodeContext: Vtree.NodeContext,
       column: Layout.Column,
     ): Task.Result<Vtree.NodeContext | null>;
-    accept(nodeContext: Vtree.NodeContext, column: Layout.Column): boolean;
+    accept(
+      nodeContext: Vtree.NodeContext | null,
+      column: Layout.Column,
+    ): boolean;
     postLayout(
-      positionAfter: Vtree.NodeContext,
+      positionAfter: Vtree.NodeContext | null,
       initialPosition: Vtree.NodeContext,
       column: Layout.Column,
       accepted: boolean,

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -132,7 +132,7 @@ export type CustomRenderer = (
   p1: Element,
   p2: Element,
   p3: { [key: string]: Css.Val },
-) => Task.Result<Element>;
+) => Task.Result<Element | null>;
 
 export interface CustomRendererFactory {
   makeCustomRenderer(xmldoc: XmlDoc.XMLDocHolder): CustomRenderer;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -207,7 +207,7 @@ export class ViewFactory
     public readonly context: Exprs.Context,
     public readonly viewport: Viewport,
     public readonly styler: CssStyler.Styler,
-    public readonly regionIds: string[],
+    public readonly regionIds: string[] | null,
     public readonly xmldoc: XmlDoc.XMLDocHolder,
     public readonly docFaces: Font.DocumentFaces,
     public readonly footnoteStyle: CssCascade.ElementStyle,
@@ -217,7 +217,7 @@ export class ViewFactory
     public readonly fallbackMap: { [key: string]: string },
     public readonly documentURLTransformer: Base.DocumentURLTransformer,
     public readonly pageProps?: { [key: string]: CssCascade.ElementStyle },
-    public readonly cascadedPageStyle?: CssCascade.ElementStyle,
+    public readonly cascadedPageStyle?: CssCascade.ElementStyle | null,
     private readonly semanticFootnoteFirstRefOffsets: Map<
       string,
       number
@@ -553,7 +553,7 @@ export class ViewFactory
 
   getPseudoMap(
     cascStyle: CssCascade.ElementStyle,
-    regionIds: string[],
+    regionIds: string[] | null,
     isFootnote: boolean,
     nodeContext: Vtree.NodeContext,
     context: Exprs.Context,
@@ -2471,11 +2471,13 @@ export class ViewFactory
       }
     }
 
-    const startBreakType = (
-      this.context as Exprs.Context & {
-        currentLayoutPosition: Vtree.LayoutPosition;
-      }
-    )?.currentLayoutPosition?.flowPositions[this.flowName]?.startBreakType;
+    const startBreakType =
+      (
+        this.context as Exprs.Context & {
+          currentLayoutPosition: Vtree.LayoutPosition | null;
+        }
+      )?.currentLayoutPosition?.flowPositions[this.flowName]?.startBreakType ??
+      null;
 
     if (Break.isForcedBreakValue(startBreakType)) {
       return startBreakType; // forced break

--- a/packages/core/src/vivliostyle/viewer-app.ts
+++ b/packages/core/src/vivliostyle/viewer-app.ts
@@ -61,9 +61,13 @@ export function navigateToRightPage(): void {
   });
 }
 
-export function keydown(evt: KeyboardEvent): void {
+interface LegacyKeyboardEvent extends KeyboardEvent {
+  keyIdentifier?: string;
+}
+
+export function keydown(evt: LegacyKeyboardEvent): void {
   const key = evt.key;
-  const keyIdentifier = (evt as any).keyIdentifier;
+  const keyIdentifier = evt.keyIdentifier;
   const location = evt.location;
   if (key === "End" || keyIdentifier === "End") {
     sendCommand({ a: "moveTo", where: "last" });

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -391,8 +391,8 @@ export type NodePositionStep = Vtree.NodePositionStep;
 export type RootNodePositionStep = Vtree.RootNodePositionStep;
 
 export function isSameNodePositionStep(
-  nps1: NodePositionStep,
-  nps2: NodePositionStep,
+  nps1: NodePositionStep | null,
+  nps2: NodePositionStep | null,
 ): boolean {
   if (nps1 === nps2) {
     return true;
@@ -572,8 +572,8 @@ export class ShadowContext implements Vtree.ShadowContext {
 }
 
 export function isSameShadowContext(
-  sc1: Vtree.ShadowContext,
-  sc2: Vtree.ShadowContext,
+  sc1: Vtree.ShadowContext | null,
+  sc2: Vtree.ShadowContext | null,
 ): boolean {
   return sc1 === sc2 || (!!sc1 && !!sc2 && sc1.equals(sc2));
 }
@@ -636,7 +636,7 @@ export class NodeContext implements Vtree.NodeContext {
   inheritedProps: { [key: string]: number | string | Css.Val | undefined };
   vertical: boolean;
   direction: string;
-  firstPseudo: FirstPseudo;
+  firstPseudo: FirstPseudo | null;
   lang: string | null = null;
   preprocessedTextContent: Diff.Change[] | null = null;
   repeatOnBreak: string | null = null;
@@ -1450,7 +1450,7 @@ export class Container implements Vtree.Container {
 
   clear() {
     const parent = this.element;
-    let c: Node;
+    let c: Node | null;
     while ((c = parent.lastChild)) {
       parent.removeChild(c);
     }
@@ -1542,12 +1542,12 @@ export class ContentPropertyHandler extends Css.Visitor {
     this.elem.appendChild(node);
   }
 
-  override visitStr(str: Css.Str): Css.Val {
+  override visitStr(str: Css.Str): Css.Val | null {
     this.visitStrInner(str.str);
     return null;
   }
 
-  override visitURL(url: Css.URL): Css.Val {
+  override visitURL(url: Css.URL): Css.Val | null {
     if (this.rootContentValue instanceof Css.URL) {
       this.elem.setAttribute("src", url.url);
     } else {
@@ -1558,12 +1558,12 @@ export class ContentPropertyHandler extends Css.Visitor {
     return null;
   }
 
-  override visitSpaceList(list: Css.SpaceList): Css.Val {
+  override visitSpaceList(list: Css.SpaceList): Css.Val | null {
     this.visitValues(list.values);
     return null;
   }
 
-  override visitExpr(expr: Css.Expr): Css.Val {
+  override visitExpr(expr: Css.Expr): Css.Val | null {
     const ex = expr.toExpr();
     // When a named string (string()) holds a content list with page-based
     // counters, render that list so the counters become patchable nodes

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -382,7 +382,11 @@ export function eachAncestorFormattingContext(
   if (!nodeContext) {
     return;
   }
-  for (let fc = nodeContext.formattingContext; fc; fc = fc.getParent()) {
+  for (
+    let fc: FormattingContext | null = nodeContext.formattingContext;
+    fc;
+    fc = fc.getParent()
+  ) {
     callback(fc);
   }
 }

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -1139,7 +1139,7 @@ export class LayoutPosition {
     return newcp;
   }
 
-  isSamePosition(other: LayoutPosition): boolean {
+  isSamePosition(other: LayoutPosition | null): boolean {
     if (this === other) {
       return true;
     }

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -1492,7 +1492,7 @@ export class Container implements Vtree.Container {
   getOuterShape(
     outerShapeProp: Css.Val | null,
     context: Exprs.Context | null,
-  ): GeometryUtil.Shape {
+  ): GeometryUtil.Shape | null {
     const rect = this.getOuterRect();
     return CssProp.toShape(
       outerShapeProp,

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -253,8 +253,8 @@ export class Page extends Base.SimpleEventTarget {
 }
 
 export type Spread = {
-  left: Page;
-  right: Page;
+  left: Page | null;
+  right: Page | null;
 };
 
 export const Whitespace = Vtree.Whitespace;

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -37,7 +37,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
   idMap: { [key: string]: Element } | null = null;
 
   constructor(
-    public readonly store: XMLDocStore,
+    public readonly store: XMLDocStore | null,
     public readonly url: string,
     public readonly document: Document,
   ) {

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -498,8 +498,8 @@ export class NodeList implements XmlDoc.NodeList {
   /**
    * @template T
    */
-  forEachNonNull<T>(fn: (p1: Node) => T): T[] {
-    const arr = [];
+  forEachNonNull<T>(fn: (p1: Node) => T | null): T[] {
+    const arr: T[] = [];
     for (let i = 0; i < this.nodes.length; i++) {
       const t = fn(this.nodes[i]);
       if (t != null) {

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -410,7 +410,7 @@ export function parseXMLResource(
 }
 
 export function newXMLDocStore(): XMLDocStore {
-  return new Net.ResourceStore(
+  return new Net.ResourceStore<XmlDoc.XMLDocHolder>(
     parseXMLResource,
     Net.FetchResponseType.DOCUMENT,
   );

--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -42,11 +42,11 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
     public readonly document: Document,
   ) {
     this.root = Base.documentElementOf(document); // html element
-    let body: Element = null;
-    let head: Element = null;
+    let body: Element | null = null;
+    let head: Element | null = null;
     if (this.root.namespaceURI == Base.NS.XHTML) {
       for (
-        let child: Node = this.root.firstChild;
+        let child: Node | null = this.root.firstChild;
         child;
         child = child.nextSibling
       ) {
@@ -259,7 +259,7 @@ export class XMLDocHolder implements XmlDoc.XMLDocHolder {
       return null;
     }
     const id = m[2];
-    let r: Element = this.document.getElementById(id);
+    let r: Element | null = this.document.getElementById(id);
     if (!r && this.document.getElementsByName) {
       r = this.document.getElementsByName(id)[0];
     }
@@ -359,8 +359,8 @@ export function resolveContentType(response: Net.FetchResponse): string | null {
 export function parseXMLResource(
   response: Net.FetchResponse,
   store: XMLDocStore,
-): Task.Result<XmlDoc.XMLDocHolder> {
-  let doc = response.responseXML;
+): Task.Result<XmlDoc.XMLDocHolder | null> {
+  let doc: Document | null = response.responseXML;
   if (!doc) {
     const parser = new DOMParser();
     const text = response.responseText;
@@ -464,7 +464,7 @@ export class NodeList implements XmlDoc.NodeList {
    * Filter with predicate
    */
   predicate(pr: Predicate): NodeList {
-    const arr = [];
+    const arr: Node[] = [];
     for (const n of this.nodes) {
       if (pr.check(n)) {
         arr.push(n);
@@ -474,7 +474,7 @@ export class NodeList implements XmlDoc.NodeList {
   }
 
   forEachNode(fn: (p1: Node, p2: (p1: Node) => void) => void): NodeList {
-    const arr = [];
+    const arr: Node[] = [];
     const add = (n) => {
       arr.push(n);
     };
@@ -488,7 +488,7 @@ export class NodeList implements XmlDoc.NodeList {
    * @template T
    */
   forEach<T>(fn: (p1: Node) => T): T[] {
-    const arr = [];
+    const arr: T[] = [];
     for (let i = 0; i < this.nodes.length; i++) {
       arr.push(fn(this.nodes[i]));
     }
@@ -511,7 +511,7 @@ export class NodeList implements XmlDoc.NodeList {
 
   child(tag: string): NodeList {
     return this.forEachNode((node, add) => {
-      for (let c: Node = node.firstChild; c; c = c.nextSibling) {
+      for (let c: Node | null = node.firstChild; c; c = c.nextSibling) {
         if (c.nodeType == 1 && (c as Element).localName == tag) {
           add(c);
         }
@@ -521,7 +521,7 @@ export class NodeList implements XmlDoc.NodeList {
 
   childElements(): NodeList {
     return this.forEachNode((node, add) => {
-      for (let c: Node = node.firstChild; c; c = c.nextSibling) {
+      for (let c: Node | null = node.firstChild; c; c = c.nextSibling) {
         if (c.nodeType == 1) {
           add(c);
         }


### PR DESCRIPTION
`strictNullChecks`有効化の続きです。
おおむね機械的な`| null` / `| undefined`の付け外し、初期値の正規化です。