### PR TITLE
fix: Fix writing-mode at `@page` not working correctly

### DIFF
--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -649,6 +649,10 @@ export const propertiesAppliedToPartition = (() => {
     height: true,
     "block-size": true,
     "inline-size": true,
+    // The page box's own writing mode and direction, used to resolve logical
+    // properties (margin/padding/etc.) on the `@page` context. (Issue #2001)
+    "writing-mode": true,
+    direction: true,
     margin: true,
     padding: true,
     border: true,
@@ -2031,6 +2035,15 @@ export class PageAreaPartitionInstance
         this.cascaded[name] = docElementStyle[name];
       }
     }
+    // The page area content follows the root element's writing mode and
+    // direction, not those of the `@page` context. (Issue #2001)
+    // The root element defaults to horizontal-tb / ltr when not specified.
+    this.cascaded["writing-mode"] =
+      docElementStyle["writing-mode"] ??
+      new CssCascade.CascadeValue(Css.ident.horizontal_tb, 0);
+    this.cascaded["direction"] =
+      docElementStyle["direction"] ??
+      new CssCascade.CascadeValue(Css.ident.ltr, 0);
     super.applyCascadeAndInit(cascade, {});
   }
 

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -153,6 +153,14 @@ module.exports = [
         file: "outline-offset-at-page.html",
         title: "outline-offset on @page (Issue #2000)",
       },
+      {
+        file: "page-writing-mode.html",
+        title: "writing-mode on @page (Issue #2001)",
+      },
+      {
+        file: "page-writing-mode-vertical.html",
+        title: "writing-mode on @page, vertical root (Issue #2001)",
+      },
       { file: "font-feature-settings.html", title: "Font feature settings" },
       {
         file: "font-variation-settings.html",

--- a/packages/core/test/files/page-writing-mode-vertical.html
+++ b/packages/core/test/files/page-writing-mode-vertical.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2001: writing-mode at @page (root also vertical) -->
+<meta charset="utf-8">
+<style>
+  @page {
+    writing-mode: vertical-rl;
+    size: 400px 800px;
+    margin-inline-start: 2%;
+    margin-block-start: 8%;
+    margin-inline-end: 6%;
+    margin-block-end: 20%;
+    background: blue;
+  }
+  :root {
+    writing-mode: vertical-rl;
+  }
+  body {
+    margin: 0;
+    background: hotpink;
+  }
+</style>
+<div style="box-sizing:border-box; padding:4px; height:100vh; background:yellow;">
+  This document should be in vertical-rl writing mode (inherited from the root).
+  The page margins (in blue) should be smallest at the top, larger at the right,
+  even larger at the bottom, and largest at the left.
+</div>

--- a/packages/core/test/files/page-writing-mode.html
+++ b/packages/core/test/files/page-writing-mode.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2001: writing-mode at @page not working correctly -->
+<!-- Based on WPT test: css/css-page/page-box-009-print.html -->
+<meta charset="utf-8">
+<style>
+  @page {
+    writing-mode: vertical-rl;
+    size: 400px 800px;
+    margin-inline-start: 2%;
+    margin-block-start: 8%;
+    margin-inline-end: 6%;
+    margin-block-end: 20%;
+    padding-inline-start: 2%;
+    padding-block-start: 8%;
+    padding-inline-end: 6%;
+    padding-block-end: 20%;
+    background: blue;
+  }
+  :root {
+    print-color-adjust: exact;
+  }
+  body {
+    margin: 0;
+    background: hotpink;
+  }
+</style>
+<div style="box-sizing:border-box; padding:4px; height:100vh; background:yellow;">
+  This document should be in horizontal-tb writing mode.<br>
+  The page padding (in hotpink) and margins (in blue) should be identical.  They
+  should be smallest at the top, larger at the right, even larger at the bottom,
+  and largest at the left.
+</div>

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -1,4 +1,16 @@
 - category: General
+  title: "writing-mode on @page (Issue #2001)"
+  file: page-writing-mode.html
+  decision: expected  # regression / expected / skip
+  notes: "Fix for Issue #2001: @page writing-mode now correctly resolves logical page margins/padding."
+  approvedViewer: git-fix-issue2001  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/page-writing-mode.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: >-
+    https://vivliostyle.vercel.app/#src=https://raw.githubusercontent.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/page-writing-mode.html&zoom=1&spread=false
+- category: General
   title: ":dir() pseudo-class"
   file: css-parse-error/dir-pseudo-class.html
   decision: expected  # regression / expected / skip


### PR DESCRIPTION
`writing-mode` specified on `@page` was ignored when resolving the page box's logical properties. The `PageRulePartition` did not receive `writing-mode`/`direction` from the `@page` style, so logical properties such as `margin-inline-start` and `padding-block-end` were mapped to physical sides using the root element's writing mode instead of the `@page` one, producing incorrect page margins and padding.

Add `writing-mode` and `direction` to `propertiesAppliedToPartition` so the page box resolves its logical margin/padding/border with the `@page` writing mode, while the page area content continues to follow the root element's writing mode (as established for issue #1392).

Adds test cases `page-writing-mode.html` (based on WPT `page-box-009-print.html`) and `page-writing-mode-vertical.html`.

Closes #2001

Assisted-by: GitHub Copilot Chat:deepseek-v4-flash

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2001; the AI diagnosed that `writing-mode`/`direction` were missing from the `@page` partition's applied properties and implemented the fix plus WPT-based regression tests.
- `/draft-commit` finalized the PR after human review.

</details>
