### PR TITLE
fix: Fix parser error with lowercase `<!doctype html>`

### DIFF
--- a/packages/core/src/vivliostyle/xml-doc.ts
+++ b/packages/core/src/vivliostyle/xml-doc.ts
@@ -302,18 +302,19 @@ export function parseAndReturnNullIfError(
   } catch (e) {}
   if (!doc) {
     return null;
-  } else {
-    const docElement = doc.documentElement;
-    const errorTagName = "parsererror";
-    if (docElement.localName === errorTagName) {
-      return null;
-    } else {
-      for (let c = docElement.firstElementChild; c; c = c.nextElementSibling) {
-        if (c.localName === errorTagName) {
-          return null;
-        }
-      }
-    }
+  }
+  // XML parsing errors are reported as a "parsererror" element in the result
+  // document. It is not always a direct child of the documentElement: e.g.,
+  // when XML-parsing a lowercase "<!doctype html>" the parsererror element is
+  // nested inside <body>. Search the whole document so such parse errors are
+  // detected. HTML parsing never generates a "parsererror" element, so skip
+  // this check for text/html to avoid rejecting valid HTML that happens to
+  // contain a literal "<parsererror>" element. (Issue #2101)
+  if (
+    type !== DOMParserSupportedType.TEXT_HTML &&
+    doc.querySelector("parsererror")
+  ) {
+    return null;
   }
   return doc;
 }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -36,6 +36,10 @@ module.exports = [
         skipLayoutRegression: true,
       },
       { file: "case_sensitivity/html.html", title: "HTML case sensitivity" },
+      {
+        file: "lowercase-doctype",
+        title: "Lowercase doctype must not cause parser error (Issue #2101)",
+      },
       { file: "ruby-broken-pagination.html", title: "Ruby broken pagination" },
       {
         file: "css-parse-error/gradient-background-image.html",

--- a/packages/core/test/files/lowercase-doctype
+++ b/packages/core/test/files/lowercase-doctype
@@ -1,0 +1,26 @@
+<!-- Test case for Issue #2101: Lowercase `<!doctype html>` may cause parser error -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lowercase doctype test</title>
+    <style>
+      @page {
+        size: 200mm 150mm;
+        @bottom-center {
+          content: counter(page);
+        }
+      }
+      h1 {
+        color: #b00000;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Test</h1>
+    <p>
+      This document starts with a lowercase <code>&lt;!doctype html&gt;</code>.
+      It should render normally instead of showing a parser error page.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/xmldoc-spec.js
+++ b/packages/core/test/spec/vivliostyle/xmldoc-spec.js
@@ -113,6 +113,53 @@ describe("xml-doc", function () {
         adapt_xmldoc.parseAndReturnNullIfError("<test><t></test>", "text/xml"),
       ).toBe(null);
     });
+
+    it("returns null when a parsererror element is nested in the document", function () {
+      // A lowercase "<!doctype html>" parsed as XML produces a parsererror
+      // element nested inside <body>, not as a direct child of the
+      // documentElement, so it must be detected anywhere in the document.
+      // (Issue #2101)
+      var parsererrorDoc = new DOMParser().parseFromString(
+        "<html><body><div><parsererror>error</parsererror></div></body></html>",
+        "text/xml",
+      );
+      var stubParser = {
+        parseFromString: function () {
+          return parsererrorDoc;
+        },
+      };
+
+      expect(
+        adapt_xmldoc.parseAndReturnNullIfError(
+          "<test>",
+          "text/xml",
+          stubParser,
+        ),
+      ).toBe(null);
+    });
+
+    it("returns a Document for HTML containing a literal parsererror element", function () {
+      // HTML parsing never generates a parsererror element, so a literal
+      // "<parsererror>" in the source must not be treated as a parse error.
+      // (Issue #2101)
+      var parsererrorDoc = new DOMParser().parseFromString(
+        "<html><body><div><parsererror>content</parsererror></div></body></html>",
+        "text/html",
+      );
+      var stubParser = {
+        parseFromString: function () {
+          return parsererrorDoc;
+        },
+      };
+
+      var d = adapt_xmldoc.parseAndReturnNullIfError(
+        "<test>",
+        "text/html",
+        stubParser,
+      );
+      expect(d).toBeTruthy();
+      expect(d.querySelector("parsererror")).toBeTruthy();
+    });
   });
 
   describe("parseXMLResource", function () {


### PR DESCRIPTION
XML parsing of a lowercase `<!doctype html>` (which is invalid XML) produces a document whose `parsererror` element is nested inside `<body>`, not as a direct child of the documentElement. The previous detection in `parseAndReturnNullIfError()` only checked the documentElement and its direct children, so this parse error went undetected and the error page was rendered instead of falling back to HTML parsing.

Detect a `parsererror` element anywhere in the parsed document with `querySelector("parsererror")` and return `null` in that case, so `parseXMLResource()` correctly falls back to `text/html` parsing.

Add a unit test and a test case (a file without extension, since an `.html` extension bypasses the XML-first parsing path).

Closes #2101

Assisted-by: GitHub Copilot Chat:deepseek-v4-flash

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #2101; their observation that adding a `.html` extension avoided the bug helped confirm the root cause was in the XML-first parsing path.
- The AI implemented the fix (detecting `parsererror` anywhere in the parsed document) plus unit and regression tests.
- `/draft-commit` and `/address-pr-comments` finalized the PR.

</details>
