### PR TITLE
fix: Prevent writing-mode on the body element from being inherited by the page context

### DIFF
--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -1104,11 +1104,22 @@ export class PageRuleMasterInstance extends PageMaster.PageMasterInstance<PageRu
     docElementStyle: CssCascade.ElementStyle,
   ) {
     super(parentInstance, pageRuleMaster);
+    const bodyPropagatedStyle = (
+      context as Exprs.Context & {
+        styler?: { bodyPropagatedStyle?: CssCascade.ElementStyle };
+      }
+    ).styler?.bodyPropagatedStyle;
     for (const name in docElementStyle) {
       if (Object.prototype.hasOwnProperty.call(docElementStyle, name)) {
         switch (name) {
           case "writing-mode":
           case "direction":
+            // writing-mode and direction propagated from the body element
+            // are used values of the root element and must not be inherited
+            // by the page context. (Issue #1122)
+            if (bodyPropagatedStyle?.[name] === docElementStyle[name]) {
+              break;
+            }
             this.cascaded[name] = docElementStyle[name];
         }
       }

--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -484,6 +484,13 @@ export class Styler implements AbstractStyler {
   cascadeHolder: CssCascade.Cascade;
   last: Base.RootBoundCursor | null;
   rootStyle = {} as CssCascade.ElementStyle;
+  /**
+   * writing-mode and direction values propagated from the body element to
+   * the root element. Per CSS Writing Modes spec, this propagation is done
+   * on used values rather than computed values, so these values must not be
+   * inherited by the page context. (Issue #1122)
+   */
+  bodyPropagatedStyle = {} as CssCascade.ElementStyle;
   styles: StyleStore;
   counterSnapshots: CounterSnapshot[] = [];
   flows = {} as { [key: string]: Vtree.Flow };
@@ -602,9 +609,12 @@ export class Styler implements AbstractStyler {
   ): void {
     if (isBody) {
       for (const propName of ["writing-mode", "direction"]) {
-        if (elemStyle[propName] && !(isBody && this.rootStyle[propName])) {
-          // Copy it over, but keep it at the root element as well.
+        if (elemStyle[propName] && !this.rootStyle[propName]) {
+          // Copy it over, but keep it at the body element as well.
           this.rootStyle[propName] = elemStyle[propName];
+          // Record the value propagated from the body element so that it
+          // can be excluded from the page context inheritance. (Issue #1122)
+          this.bodyPropagatedStyle[propName] = elemStyle[propName];
         }
       }
     } else {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -762,16 +762,31 @@ export class ViewFactory
     );
     const isRoot = !this.nodeContext?.parent;
     if (isRoot) {
-      // Ensure that writing-mode and direction are set on the root element.
-      if (!cascMap["writing-mode"] && this.styler.rootStyle["writing-mode"]) {
-        cascMap["writing-mode"] = this.styler.rootStyle[
-          "writing-mode"
-        ] as CssCascade.CascadeValue;
+      // Ensure that writing-mode and direction are set on the root element,
+      // except when the values are propagated from the body element. That
+      // propagation is done on used values rather than computed values
+      // (CSS Writing Modes spec), so it must not affect the root element's
+      // computed style; otherwise the values would be inherited by the page
+      // context (e.g., page margin boxes). (Issue #1122)
+      const rootWritingMode = this.styler.rootStyle[
+        "writing-mode"
+      ] as CssCascade.CascadeValue;
+      if (
+        !cascMap["writing-mode"] &&
+        rootWritingMode &&
+        this.styler.bodyPropagatedStyle["writing-mode"] !== rootWritingMode
+      ) {
+        cascMap["writing-mode"] = rootWritingMode;
       }
-      if (!cascMap["direction"] && this.styler.rootStyle["direction"]) {
-        cascMap["direction"] = this.styler.rootStyle[
-          "direction"
-        ] as CssCascade.CascadeValue;
+      const rootDirection = this.styler.rootStyle[
+        "direction"
+      ] as CssCascade.CascadeValue;
+      if (
+        !cascMap["direction"] &&
+        rootDirection &&
+        this.styler.bodyPropagatedStyle["direction"] !== rootDirection
+      ) {
+        cascMap["direction"] = rootDirection;
       }
     }
     const verticalParent = vertical;

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -165,6 +165,11 @@ module.exports = [
         file: "page-writing-mode-vertical.html",
         title: "writing-mode on @page, vertical root (Issue #2001)",
       },
+      {
+        file: "writing-mode-body-page-context.html",
+        title:
+          "writing-mode on body not inherited by page context (Issue #1122)",
+      },
       { file: "font-feature-settings.html", title: "Font feature settings" },
       {
         file: "font-variation-settings.html",

--- a/packages/core/test/files/writing-mode-body-page-context.html
+++ b/packages/core/test/files/writing-mode-body-page-context.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #1122: writing-mode specified on the body element should not be inherited by the page context -->
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <style>
+      @page {
+        size: 400px 300px;
+        margin: 40px;
+        @top-center {
+          content: "ここは横書きのはず";
+          border: 1px solid blue;
+        }
+      }
+      body {
+        writing-mode: vertical-rl;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>ここは縦書き</h1>
+    <p>body要素に指定されたwriting-modeプロパティはルート要素に指定された場合と異なり、ページコンテキスト（@pageルール内）に継承されるべきではない。</p>
+  </body>
+</html>

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -1,3 +1,19 @@
+- id: "0045"
+  category: General
+  title: "writing-mode on body not inherited by page context (Issue #1122)"
+  file: writing-mode-body-page-context.html
+  type: difference
+  decision: expected  # regression / expected / skip
+  notes: "Fix for Issue #1122: writing-mode on body is propagated to the root as a used value only, so the page context (@top-center margin box) stays horizontal while the page area content follows the body writing mode."
+  approvedViewer: git-fix-issue1122  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/writing-mode-body-page-context.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: >-
+    https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/writing-mode-body-page-context.html&zoom=1&spread=false
+  diffPages:
+    - 1
 - category: General
   title: "Lowercase doctype must not cause parser error (Issue #2101)"
   file: lowercase-doctype


### PR DESCRIPTION
Per the CSS Writing Modes spec, propagation of `writing-mode` and `direction` from the body element to the root element is done on used values rather than computed values, so these values must not affect the page context (`@page` rules and page margin boxes). However, the values copied from the body element to `Styler.rootStyle` leaked into the page context through two paths:

1. `PageRuleMasterInstance` copied `docElementStyle` (`rootStyle`) `writing-mode`/`direction` into its cascaded style, making page margin boxes inherit the body's writing mode.
2. `ViewFactory.computeStyle` forced `rootStyle`'s `writing-mode`/ `direction` into the root element's computed style, which was then propagated to the page-box container element (Issue #568 logic) and inherited by the margin boxes in the browser.

Fix by recording the body-propagated values in the new `Styler.bodyPropagatedStyle` and excluding them from the page context inheritance in both paths. The principal writing mode still follows the body's writing mode as before: the page progression, the page area content writing mode (Issue #2001), and the page box verticality are unchanged, while `writing-mode` specified on the root element itself is still inherited by the page context as the spec requires.

Adds test case `writing-mode-body-page-context.html`.

Closes #1122

Assisted-by: GitHub Copilot Chat:kimi-k3

<details>
<summary>How the AI was used</summary>

- The human author ran `/resolve-issue` for #1122; the AI diagnosed the two leak paths and implemented the `Styler.bodyPropagatedStyle` fix.
- The human author ran `/draft-commit`, then corrected the AI when the generated trailer did not match the `draft-commit` skill's required format, and had it fix the trailer before finalizing.

</details>
