### PR TITLE
fix: Fix body content overflowing the page when writing-mode is specified on the body element

### DIFF
--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -791,6 +791,29 @@ export class ViewFactory
     }
     const verticalParent = vertical;
     vertical = CssCascade.isVertical(cascMap, context, vertical);
+    // When writing-mode is propagated from the body element to the root
+    // element as a used value (CSS Writing Modes spec), the root element's
+    // used writing mode is the propagated one although its computed style is
+    // unchanged. Return the used value verticality for the root so that the
+    // body element is not treated as a writing-mode change (which would
+    // cause the vertical-in-horizontal treatment (Issue #1264), e.g.,
+    // `inline-size: auto` becoming `max-content`). (Issue #1122 follow-up)
+    let usedVertical = vertical;
+    if (isRoot && !vertical) {
+      const rootWritingModeCasc = this.styler.rootStyle[
+        "writing-mode"
+      ] as CssCascade.CascadeValue;
+      if (
+        rootWritingModeCasc &&
+        this.styler.bodyPropagatedStyle["writing-mode"] === rootWritingModeCasc
+      ) {
+        usedVertical = CssCascade.isVertical(
+          { "writing-mode": rootWritingModeCasc },
+          context,
+          vertical,
+        );
+      }
+    }
     const verticalChanged = !isRoot && vertical !== verticalParent;
     rtl = CssCascade.isRtl(cascMap, context, rtl);
 
@@ -848,7 +871,7 @@ export class ViewFactory
       // Running elements
       computedStyle["position"] = Css.ident.fixed;
       computedStyle["visibility"] = Css.ident.hidden;
-      return vertical;
+      return usedVertical;
     }
 
     // Compute values of display, position and float
@@ -871,7 +894,7 @@ export class ViewFactory
         computedStyle[name] = displayValues[name];
       }
     });
-    return vertical;
+    return usedVertical;
   }
 
   private inheritFromSourceParent(

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -4,14 +4,16 @@
   file: writing-mode-body-page-context.html
   type: difference
   decision: expected  # regression / expected / skip
-  notes: "Fix for Issue #1122: writing-mode on body is propagated to the root as a used value only, so the page context (@top-center margin box) stays horizontal while the page area content follows the body writing mode."
-  approvedViewer: git-fix-issue1122  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  notes: >-
+    Fix for Issue #1122: writing-mode on body is propagated to the root as a used value only, so the page context
+    (@top-center margin box) stays horizontal while the page area content follows the body writing mode.
+  approvedViewer: git-fix-issue1122a  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
   actualLabel: dev
   actualUrl: >-
     http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/writing-mode-body-page-context.html&zoom=1&spread=false
   baselineLabel: canary
   baselineUrl: >-
-    https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/writing-mode-body-page-context.html&zoom=1&spread=false
+    https://vivliostyle-git-fix-issue1122-vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/writing-mode-body-page-context.html&zoom=1&spread=false
   diffPages:
     - 1
 - category: General


### PR DESCRIPTION
Follow-up to PR #2104 (fix for Issue #1122). That fix removed the body-propagated `writing-mode` from the root element's computed style, which made the root's `nodeContext.vertical` become `false`. As a result, the body element was incorrectly treated as a writing-mode change (horizontal → vertical) and got the vertical-in-horizontal treatment (Issue #1264), i.e., `inline-size: auto` was changed to `max-content`, preventing line wrapping and causing the body content to overflow the page.

Fix by returning the root element's used writing-mode verticality from `ViewFactory.computeStyle()` when the `writing-mode` was propagated from the body element as a used value, so that the body element's `parent.vertical` is already true and `verticalChanged` stays false. This keeps the root element's computed style unchanged (required for Issue #1122) without adding any state to `NodeContext`.

Refs #1122, #2104

Assisted-by: GitHub Copilot Chat:kimi-k3

<details>
<summary>How the AI was used</summary>

- The human author discovered and diagnosed this regression from PR #2104 themselves, pinpointing the root cause (an incorrect `verticalChanged` computation producing `height: max-content`) with a specific technical hypothesis referencing `vgen.ts` and the earlier issue #1264 fix.
- The AI implemented an initial fix by adding a new `usedVerticalParent` field to `NodeContext`; the human author proposed a simpler alternative — have `computeStyle()` return the used verticality for the root directly — that avoided adding new state, and asked the AI to use that approach instead.
- The AI reimplemented the fix per the human author's design; `/draft-commit` finalized the PR.

</details>
