### PR TITLE
refactor: Rebuild node contexts as kind-tagged immutable values

### DIFF
--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -179,4 +179,29 @@ export default [
       "prettier/prettier": "warn",
     },
   },
+  {
+    files: ["src/**/*.ts"],
+
+    ignores: [
+      "src/vivliostyle/legacy-plugin-surface.ts",
+      "src/vivliostyle/layout.ts",
+      "src/vivliostyle/plugin.ts",
+      "src/vivliostyle/vgen.ts",
+    ],
+
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["./legacy-plugin-surface", "**/legacy-plugin-surface"],
+              message:
+                "legacy-plugin-surface is the deprecated plugin compatibility layer; only the hook boundaries in vgen.ts, layout.ts and plugin.ts may import it.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -184,8 +184,13 @@ export default [
 
     ignores: [
       "src/vivliostyle/legacy-plugin-surface.ts",
+      "src/vivliostyle/layout-processor.ts",
+      "src/vivliostyle/layout-retryers.ts",
+      "src/vivliostyle/layout-util.ts",
       "src/vivliostyle/layout.ts",
+      "src/vivliostyle/node-context.ts",
       "src/vivliostyle/plugin.ts",
+      "src/vivliostyle/table.ts",
       "src/vivliostyle/vgen.ts",
     ],
 
@@ -197,7 +202,7 @@ export default [
             {
               group: ["./legacy-plugin-surface", "**/legacy-plugin-surface"],
               message:
-                "legacy-plugin-surface is the deprecated plugin compatibility layer; only the hook boundaries in vgen.ts, layout.ts and plugin.ts may import it.",
+                "legacy-plugin-surface is the deprecated plugin compatibility layer; only the hook boundaries (vgen.ts, layout.ts, plugin.ts) and the node context retention sites (layout.ts, layout-processor.ts, layout-retryers.ts, layout-util.ts, table.ts, node-context.ts) may import it.",
             },
           ],
         },

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -200,11 +200,117 @@ export default [
         {
           patterns: [
             {
-              group: ["./legacy-plugin-surface", "**/legacy-plugin-surface"],
+              group: [
+                "./legacy-plugin-surface",
+                "**/legacy-plugin-surface",
+                "./legacy-plugin-surface.*",
+                "**/legacy-plugin-surface.*",
+              ],
               message:
                 "legacy-plugin-surface is the deprecated plugin compatibility layer; only the hook boundaries (vgen.ts, layout.ts, plugin.ts) and the node context retention sites (layout.ts, layout-processor.ts, layout-retryers.ts, layout-util.ts, table.ts, node-context.ts) may import it.",
             },
           ],
+        },
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ImportExpression[source.value=/legacy-plugin-surface/]",
+          message:
+            "legacy-plugin-surface is the deprecated plugin compatibility layer; a dynamic import reaches it just as a static one does, and only the hook boundaries (vgen.ts, layout.ts, plugin.ts) and the node context retention sites (layout.ts, layout-processor.ts, layout-retryers.ts, layout-util.ts, table.ts, node-context.ts) may import it.",
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      "src/vivliostyle/layout-retryers.ts",
+      "src/vivliostyle/layout-util.ts",
+      "src/vivliostyle/node-context.ts",
+      "src/vivliostyle/table.ts",
+    ],
+
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "MemberExpression[object.name='LegacyPluginSurface'][property.name!='noteRetained']",
+          message:
+            "A node context retention site records retained positions and nothing else; LegacyPluginSurface.noteRetained is the only member it may reach. The rest of the compatibility layer belongs to the hook boundaries (vgen.ts, layout.ts, plugin.ts).",
+        },
+        {
+          selector:
+            "ImportDeclaration[source.value=/legacy-plugin-surface/] ImportSpecifier[imported.name!='noteRetained']",
+          message:
+            "A node context retention site records retained positions and nothing else; noteRetained is the only name it may import from legacy-plugin-surface. The rest of the compatibility layer belongs to the hook boundaries (vgen.ts, layout.ts, plugin.ts).",
+        },
+        {
+          selector:
+            "ImportDeclaration[source.value=/legacy-plugin-surface/] ImportNamespaceSpecifier[local.name!='LegacyPluginSurface']",
+          message:
+            "A node context retention site imports legacy-plugin-surface as LegacyPluginSurface so that the member restriction applies to every use of it.",
+        },
+        {
+          selector:
+            "Identifier[name='LegacyPluginSurface']:not(MemberExpression > .object):not(ImportNamespaceSpecifier > .local)",
+          message:
+            "A node context retention site reaches LegacyPluginSurface.noteRetained through the namespace itself; every other reference to the namespace, whether it binds it to another name, casts it, wraps it in an expression or passes it on, puts the rest of the compatibility layer out of the member restriction's reach.",
+        },
+        {
+          selector: "ImportExpression[source.value=/legacy-plugin-surface/]",
+          message:
+            "A node context retention site imports legacy-plugin-surface statically as LegacyPluginSurface; a dynamic import hands back the whole namespace under a name the member restriction cannot reach.",
+        },
+        {
+          selector:
+            ":matches(ExportAllDeclaration, ExportNamedDeclaration)[source.value=/legacy-plugin-surface/]",
+          message:
+            "A node context retention site keeps legacy-plugin-surface to itself; re-exporting it hands the whole compatibility layer to the files the import restriction covers.",
+        },
+      ],
+    },
+  },
+  {
+    files: ["src/vivliostyle/layout-processor.ts"],
+
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "MemberExpression[object.name='LegacyPluginSurface'][property.name!='noteRetained'][property.name!='adaptLegacyLayoutProcessor']",
+          message:
+            "layout-processor.ts reaches LegacyPluginSurface.noteRetained to record a retained position and LegacyPluginSurface.adaptLegacyLayoutProcessor at the RESOLVE_LAYOUT_PROCESSOR boundary; the rest of the compatibility layer belongs to the hook boundaries (vgen.ts, layout.ts, plugin.ts).",
+        },
+        {
+          selector:
+            "ImportDeclaration[source.value=/legacy-plugin-surface/] ImportSpecifier[imported.name!='noteRetained'][imported.name!='adaptLegacyLayoutProcessor']",
+          message:
+            "layout-processor.ts imports noteRetained and adaptLegacyLayoutProcessor from legacy-plugin-surface and nothing else; the rest of the compatibility layer belongs to the hook boundaries (vgen.ts, layout.ts, plugin.ts).",
+        },
+        {
+          selector:
+            "ImportDeclaration[source.value=/legacy-plugin-surface/] ImportNamespaceSpecifier[local.name!='LegacyPluginSurface']",
+          message:
+            "layout-processor.ts imports legacy-plugin-surface as LegacyPluginSurface so that the member restriction applies to every use of it.",
+        },
+        {
+          selector:
+            "Identifier[name='LegacyPluginSurface']:not(MemberExpression > .object):not(ImportNamespaceSpecifier > .local)",
+          message:
+            "layout-processor.ts reaches LegacyPluginSurface through the namespace itself; every other reference to the namespace, whether it binds it to another name, casts it, wraps it in an expression or passes it on, puts the rest of the compatibility layer out of the member restriction's reach.",
+        },
+        {
+          selector: "ImportExpression[source.value=/legacy-plugin-surface/]",
+          message:
+            "layout-processor.ts imports legacy-plugin-surface statically as LegacyPluginSurface; a dynamic import hands back the whole namespace under a name the member restriction cannot reach.",
+        },
+        {
+          selector:
+            ":matches(ExportAllDeclaration, ExportNamedDeclaration)[source.value=/legacy-plugin-surface/]",
+          message:
+            "layout-processor.ts keeps legacy-plugin-surface to itself; re-exporting it hands the whole compatibility layer to the files the import restriction covers.",
         },
       ],
     },

--- a/packages/core/src/vivliostyle/base.ts
+++ b/packages/core/src/vivliostyle/base.ts
@@ -818,6 +818,9 @@ export type Event = {
   anchorElement?;
   href?;
   content?;
+  nodeContext?;
+  previousNodeContext?;
+  cursorAdvance?;
 };
 
 export type EventListener = (p1: Event) => void;

--- a/packages/core/src/vivliostyle/break-position.ts
+++ b/packages/core/src/vivliostyle/break-position.ts
@@ -18,6 +18,7 @@
  */
 import * as Break from "./break";
 import * as LayoutHelper from "./layout-helper";
+import * as NodeContext from "./node-context";
 import { Layout, RepetitiveElement, Vtree } from "./types";
 
 /**
@@ -148,7 +149,7 @@ export class EdgeBreakPosition
   private edge: number = 0;
 
   constructor(
-    public readonly position: Vtree.NodeContext,
+    public position: Vtree.NodeContext,
     public readonly breakOnEdge: string | null,
     public overflows: boolean,
     public readonly computedBlockSize: number,
@@ -255,6 +256,7 @@ export class EdgeBreakPosition
       edge + (column.vertical ? -1 : 1) * offsets.current,
     );
     recordEdgeOverflow(column, this.position, this.overflows);
+    this.position = NodeContext.setOverflow(this.position, this.overflows);
   }
 
   override getNodeContext(): Vtree.NodeContext {

--- a/packages/core/src/vivliostyle/break-position.ts
+++ b/packages/core/src/vivliostyle/break-position.ts
@@ -26,42 +26,14 @@ import { Layout, RepetitiveElement, Vtree } from "./types";
  */
 export type BreakPosition = Layout.BreakPosition;
 
-type LayoutPass = Record<string, never>;
+export type EdgeOverflow = Readonly<{
+  before: ReadonlyMap<number, boolean>;
+  after: ReadonlyMap<number, boolean>;
+}>;
 
-type EdgeOverflow = {
-  pass: LayoutPass;
-  before: Map<number, boolean>;
-  after: Map<number, boolean>;
-};
-
-const edgeOverflown = new WeakMap<Element | Text, EdgeOverflow>();
-
-const layoutPassOfColumn = new WeakMap<Layout.Column, LayoutPass>();
-
-function layoutPassOf(column: Layout.Column): LayoutPass {
-  let pass = layoutPassOfColumn.get(column);
-  if (!pass) {
-    pass = {};
-    layoutPassOfColumn.set(column, pass);
-  }
-  return pass;
-}
-
-export function beginLayoutPass(column: Layout.Column): void {
-  layoutPassOfColumn.set(column, {});
-}
-
-function edgesAt(
-  column: Layout.Column,
-  nodeContext: Vtree.NodeContext,
-): Map<number, boolean> | null {
-  const viewNode = nodeContext.viewNode;
-  const edges = viewNode === null ? undefined : edgeOverflown.get(viewNode);
-  if (!edges || edges.pass !== layoutPassOf(column)) {
-    return null;
-  }
-  return nodeContext.after ? edges.after : edges.before;
-}
+export type EdgeOverflowStore = Readonly<{
+  edgeOverflowByViewNode: WeakMap<Element | Text, EdgeOverflow>;
+}>;
 
 export function recordEdgeOverflow(
   column: Layout.Column,
@@ -72,26 +44,34 @@ export function recordEdgeOverflow(
   if (!viewNode) {
     return;
   }
-  let edges = edgesAt(column, nodeContext);
-  if (!edges) {
-    const created = {
-      pass: layoutPassOf(column),
-      before: new Map<number, boolean>(),
-      after: new Map<number, boolean>(),
-    };
-    edgeOverflown.set(viewNode, created);
-    edges = nodeContext.after ? created.after : created.before;
-  }
-  edges.set(nodeContext.boxOffset, overflows);
+  const edgeOverflowByViewNode =
+    column.edgeOverflowStore.edgeOverflowByViewNode;
+  const edgeOverflow = edgeOverflowByViewNode.get(viewNode) ?? {
+    before: new Map<number, boolean>(),
+    after: new Map<number, boolean>(),
+  };
+  const updated = new Map(
+    nodeContext.after ? edgeOverflow.after : edgeOverflow.before,
+  );
+  updated.set(nodeContext.boxOffset, overflows);
+  edgeOverflowByViewNode.set(
+    viewNode,
+    nodeContext.after
+      ? { ...edgeOverflow, after: updated }
+      : { ...edgeOverflow, before: updated },
+  );
 }
 
 export function effectiveOverflow(
   column: Layout.Column,
   nodeContext: Vtree.NodeContext,
 ): boolean {
-  const edges = edgesAt(column, nodeContext);
-  const recorded = edges ? edges.get(nodeContext.boxOffset) : undefined;
-  return nodeContext.overflow || recorded === true;
+  const viewNode = nodeContext.viewNode;
+  const edgeOverflow = viewNode
+    ? column.edgeOverflowStore.edgeOverflowByViewNode.get(viewNode)
+    : undefined;
+  const edges = nodeContext.after ? edgeOverflow?.after : edgeOverflow?.before;
+  return nodeContext.overflow || edges?.get(nodeContext.boxOffset) === true;
 }
 
 export abstract class AbstractBreakPosition

--- a/packages/core/src/vivliostyle/break-position.ts
+++ b/packages/core/src/vivliostyle/break-position.ts
@@ -25,6 +25,74 @@ import { Layout, RepetitiveElement, Vtree } from "./types";
  */
 export type BreakPosition = Layout.BreakPosition;
 
+type LayoutPass = Record<string, never>;
+
+type EdgeOverflow = {
+  pass: LayoutPass;
+  before: Map<number, boolean>;
+  after: Map<number, boolean>;
+};
+
+const edgeOverflown = new WeakMap<Element | Text, EdgeOverflow>();
+
+const layoutPassOfColumn = new WeakMap<Layout.Column, LayoutPass>();
+
+function layoutPassOf(column: Layout.Column): LayoutPass {
+  let pass = layoutPassOfColumn.get(column);
+  if (!pass) {
+    pass = {};
+    layoutPassOfColumn.set(column, pass);
+  }
+  return pass;
+}
+
+export function beginLayoutPass(column: Layout.Column): void {
+  layoutPassOfColumn.set(column, {});
+}
+
+function edgesAt(
+  column: Layout.Column,
+  nodeContext: Vtree.NodeContext,
+): Map<number, boolean> | null {
+  const viewNode = nodeContext.viewNode;
+  const edges = viewNode === null ? undefined : edgeOverflown.get(viewNode);
+  if (!edges || edges.pass !== layoutPassOf(column)) {
+    return null;
+  }
+  return nodeContext.after ? edges.after : edges.before;
+}
+
+export function recordEdgeOverflow(
+  column: Layout.Column,
+  nodeContext: Vtree.NodeContext,
+  overflows: boolean,
+): void {
+  const viewNode = nodeContext.viewNode;
+  if (!viewNode) {
+    return;
+  }
+  let edges = edgesAt(column, nodeContext);
+  if (!edges) {
+    const created = {
+      pass: layoutPassOf(column),
+      before: new Map<number, boolean>(),
+      after: new Map<number, boolean>(),
+    };
+    edgeOverflown.set(viewNode, created);
+    edges = nodeContext.after ? created.after : created.before;
+  }
+  edges.set(nodeContext.boxOffset, overflows);
+}
+
+export function effectiveOverflow(
+  column: Layout.Column,
+  nodeContext: Vtree.NodeContext,
+): boolean {
+  const edges = edgesAt(column, nodeContext);
+  const recorded = edges ? edges.get(nodeContext.boxOffset) : undefined;
+  return nodeContext.overflow || recorded === true;
+}
+
 export abstract class AbstractBreakPosition
   implements Layout.AbstractBreakPosition
 {
@@ -183,9 +251,10 @@ export class EdgeBreakPosition
     this.overflowIfRepetitiveElementsDropped = column.isOverflown(
       edge + (column.vertical ? -1 : 1) * offsets.minimum,
     );
-    this.overflows = this.position.overflow = column.isOverflown(
+    this.overflows = column.isOverflown(
       edge + (column.vertical ? -1 : 1) * offsets.current,
     );
+    recordEdgeOverflow(column, this.position, this.overflows);
   }
 
   override getNodeContext(): Vtree.NodeContext {

--- a/packages/core/src/vivliostyle/break.ts
+++ b/packages/core/src/vivliostyle/break.ts
@@ -19,6 +19,7 @@
  */
 import * as Css from "./css";
 import * as Plugin from "./plugin";
+import { Vtree } from "./types";
 
 /**
  * Check if style="box-decoration-break: clone" is set
@@ -258,6 +259,92 @@ export function breakValueToStartBreakType(breakValue: string | null): string {
   return breakValue != null && isForcedBreakValue(breakValue)
     ? breakValue
     : "auto";
+}
+
+const suppressedColumnBreakBefore = new WeakSet<Element | Text>();
+const suppressedColumnBreakAfter = new WeakSet<Element | Text>();
+
+export function suppressColumnBreakBefore(viewNode: Element | Text): void {
+  suppressedColumnBreakBefore.add(viewNode);
+}
+
+export function suppressColumnBreakAfter(viewNode: Element | Text): void {
+  suppressedColumnBreakAfter.add(viewNode);
+}
+
+export function unsuppressColumnBreakBefore(viewNode: Element | Text): void {
+  suppressedColumnBreakBefore.delete(viewNode);
+}
+
+export function unsuppressColumnBreakAfter(viewNode: Element | Text): void {
+  suppressedColumnBreakAfter.delete(viewNode);
+}
+
+const reportedBreakBefore = new WeakMap<Vtree.NodeContext, string>();
+const reportedBreakAfter = new WeakMap<Vtree.NodeContext, string>();
+
+function rawBreakBefore(nodeContext: Vtree.NodeContext): string | null {
+  const reported = reportedBreakBefore.get(nodeContext);
+  return reported !== undefined && nodeContext.breakBefore === null
+    ? reported
+    : nodeContext.breakBefore;
+}
+
+function rawBreakAfter(nodeContext: Vtree.NodeContext): string | null {
+  const reported = reportedBreakAfter.get(nodeContext);
+  return reported !== undefined && nodeContext.breakAfter === null
+    ? reported
+    : nodeContext.breakAfter;
+}
+
+export function effectiveBreakBefore(
+  nodeContext: Vtree.NodeContext,
+): string | null {
+  const viewNode = nodeContext.viewNode;
+  const breakBefore = rawBreakBefore(nodeContext);
+  return viewNode !== null &&
+    breakBefore === "column" &&
+    suppressedColumnBreakBefore.has(viewNode)
+    ? null
+    : breakBefore;
+}
+
+export function effectiveBreakAfter(
+  nodeContext: Vtree.NodeContext,
+): string | null {
+  const viewNode = nodeContext.viewNode;
+  const breakAfter = rawBreakAfter(nodeContext);
+  return viewNode !== null &&
+    breakAfter === "column" &&
+    suppressedColumnBreakAfter.has(viewNode)
+    ? null
+    : breakAfter;
+}
+
+export function reportEffectiveBreakBefore(
+  nodeContext: Vtree.NodeContext,
+): string | null {
+  const breakBefore = rawBreakBefore(nodeContext);
+  const effective = effectiveBreakBefore(nodeContext);
+  if (effective === breakBefore) {
+    reportedBreakBefore.delete(nodeContext);
+  } else {
+    reportedBreakBefore.set(nodeContext, breakBefore);
+  }
+  return effective;
+}
+
+export function reportEffectiveBreakAfter(
+  nodeContext: Vtree.NodeContext,
+): string | null {
+  const breakAfter = rawBreakAfter(nodeContext);
+  const effective = effectiveBreakAfter(nodeContext);
+  if (effective === breakAfter) {
+    reportedBreakAfter.delete(nodeContext);
+  } else {
+    reportedBreakAfter.set(nodeContext, breakAfter);
+  }
+  return effective;
 }
 
 Plugin.registerHook("SIMPLE_PROPERTY", convertPageBreakAliases);

--- a/packages/core/src/vivliostyle/break.ts
+++ b/packages/core/src/vivliostyle/break.ts
@@ -347,4 +347,4 @@ export function reportEffectiveBreakAfter(
   return effective;
 }
 
-Plugin.registerHook("SIMPLE_PROPERTY", convertPageBreakAliases);
+Plugin.registerCoreHook("SIMPLE_PROPERTY", convertPageBreakAliases);

--- a/packages/core/src/vivliostyle/break.ts
+++ b/packages/core/src/vivliostyle/break.ts
@@ -21,6 +21,15 @@ import * as Css from "./css";
 import * as Plugin from "./plugin";
 import { Vtree } from "./types";
 
+export type BreakSuppression = Readonly<{
+  before: boolean;
+  after: boolean;
+}>;
+
+export type BreakSuppressionStore = Readonly<{
+  breakSuppressionByViewNode: WeakMap<Element | Text, BreakSuppression>;
+}>;
+
 /**
  * Check if style="box-decoration-break: clone" is set
  */
@@ -261,23 +270,62 @@ export function breakValueToStartBreakType(breakValue: string | null): string {
     : "auto";
 }
 
-const suppressedColumnBreakBefore = new WeakSet<Element | Text>();
-const suppressedColumnBreakAfter = new WeakSet<Element | Text>();
-
-export function suppressColumnBreakBefore(viewNode: Element | Text): void {
-  suppressedColumnBreakBefore.add(viewNode);
+function updateBreakSuppression(
+  store: BreakSuppressionStore,
+  viewNode: Element | Text,
+  transform: (suppression: BreakSuppression) => BreakSuppression,
+): void {
+  const suppression = transform(
+    store.breakSuppressionByViewNode.get(viewNode) ?? {
+      before: false,
+      after: false,
+    },
+  );
+  if (suppression.before || suppression.after) {
+    store.breakSuppressionByViewNode.set(viewNode, suppression);
+  } else {
+    store.breakSuppressionByViewNode.delete(viewNode);
+  }
 }
 
-export function suppressColumnBreakAfter(viewNode: Element | Text): void {
-  suppressedColumnBreakAfter.add(viewNode);
+export function suppressColumnBreakBefore(
+  store: BreakSuppressionStore,
+  viewNode: Element | Text,
+): void {
+  updateBreakSuppression(store, viewNode, (suppression) => ({
+    ...suppression,
+    before: true,
+  }));
 }
 
-export function unsuppressColumnBreakBefore(viewNode: Element | Text): void {
-  suppressedColumnBreakBefore.delete(viewNode);
+export function suppressColumnBreakAfter(
+  store: BreakSuppressionStore,
+  viewNode: Element | Text,
+): void {
+  updateBreakSuppression(store, viewNode, (suppression) => ({
+    ...suppression,
+    after: true,
+  }));
 }
 
-export function unsuppressColumnBreakAfter(viewNode: Element | Text): void {
-  suppressedColumnBreakAfter.delete(viewNode);
+export function unsuppressColumnBreakBefore(
+  store: BreakSuppressionStore,
+  viewNode: Element | Text,
+): void {
+  updateBreakSuppression(store, viewNode, (suppression) => ({
+    ...suppression,
+    before: false,
+  }));
+}
+
+export function unsuppressColumnBreakAfter(
+  store: BreakSuppressionStore,
+  viewNode: Element | Text,
+): void {
+  updateBreakSuppression(store, viewNode, (suppression) => ({
+    ...suppression,
+    after: false,
+  }));
 }
 
 const reportedBreakBefore = new WeakMap<Vtree.NodeContext, string>();
@@ -298,34 +346,37 @@ function rawBreakAfter(nodeContext: Vtree.NodeContext): string | null {
 }
 
 export function effectiveBreakBefore(
+  store: BreakSuppressionStore,
   nodeContext: Vtree.NodeContext,
 ): string | null {
   const viewNode = nodeContext.viewNode;
   const breakBefore = rawBreakBefore(nodeContext);
   return viewNode !== null &&
     breakBefore === "column" &&
-    suppressedColumnBreakBefore.has(viewNode)
+    store.breakSuppressionByViewNode.get(viewNode)?.before === true
     ? null
     : breakBefore;
 }
 
 export function effectiveBreakAfter(
+  store: BreakSuppressionStore,
   nodeContext: Vtree.NodeContext,
 ): string | null {
   const viewNode = nodeContext.viewNode;
   const breakAfter = rawBreakAfter(nodeContext);
   return viewNode !== null &&
     breakAfter === "column" &&
-    suppressedColumnBreakAfter.has(viewNode)
+    store.breakSuppressionByViewNode.get(viewNode)?.after === true
     ? null
     : breakAfter;
 }
 
 export function reportEffectiveBreakBefore(
+  store: BreakSuppressionStore,
   nodeContext: Vtree.NodeContext,
 ): string | null {
   const breakBefore = rawBreakBefore(nodeContext);
-  const effective = effectiveBreakBefore(nodeContext);
+  const effective = effectiveBreakBefore(store, nodeContext);
   if (effective === breakBefore) {
     reportedBreakBefore.delete(nodeContext);
   } else {
@@ -335,10 +386,11 @@ export function reportEffectiveBreakBefore(
 }
 
 export function reportEffectiveBreakAfter(
+  store: BreakSuppressionStore,
   nodeContext: Vtree.NodeContext,
 ): string | null {
   const breakAfter = rawBreakAfter(nodeContext);
-  const effective = effectiveBreakAfter(nodeContext);
+  const effective = effectiveBreakAfter(store, nodeContext);
   if (effective === breakAfter) {
     reportedBreakAfter.delete(nodeContext);
   } else {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -3030,7 +3030,7 @@ function asLeaderNodeContext(
  * @param checkPoints
  * @param column
  */
-const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
+const postLayoutBlockLeader = (
   nodeContext: Vtree.NodeContext,
   checkPoints: Vtree.RenderedNodeContext[],
   column: Layout.Column,
@@ -3301,7 +3301,7 @@ const postLayoutBlockLeader: Plugin.PostLayoutBlockHook = (
   }
 };
 
-Plugin.registerHook(Plugin.HOOKS.POST_LAYOUT_BLOCK, postLayoutBlockLeader);
+Plugin.registerCoreHook(Plugin.HOOKS.POST_LAYOUT_BLOCK, postLayoutBlockLeader);
 
 export function roman(num: number): string {
   if (num <= 0 || num != Math.round(num) || num > 3999) {

--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -21,6 +21,7 @@ import * as Asserts from "./asserts";
 import * as Base from "./base";
 import * as Css from "./css";
 import * as LayoutHelper from "./layout-helper";
+import * as NodeContext from "./node-context";
 import * as PageFloats from "./page-floats";
 import * as SemanticFootnote from "./semantic-footnote";
 import * as Task from "./task";
@@ -283,7 +284,7 @@ export class LineFootnotePolicyLayoutConstraint
         );
       }
     }
-    const nodePosition = nodeContext.toNodePosition();
+    const nodePosition = NodeContext.toNodePosition(nodeContext);
     return !Vtree.isSameNodePosition(nodePosition, this.footnote.nodePosition);
   }
 }
@@ -328,7 +329,7 @@ export class FootnoteLayoutStrategy
       floatReference = PageFloats.FloatReference.PAGE;
     }
 
-    const nodePosition = nodeContext.toNodePosition();
+    const nodePosition = NodeContext.toNodePosition(nodeContext);
     Asserts.assert(pageFloatLayoutContext.flowName);
     let policyAnchorNode: Node = nodeContext.sourceNode;
     const shadowOwner = nodeContext.shadowContext?.owner;

--- a/packages/core/src/vivliostyle/footnotes.ts
+++ b/packages/core/src/vivliostyle/footnotes.ts
@@ -39,6 +39,7 @@ export class Footnote extends PageFloats.PageFloat {
     public readonly footnotePolicy: Css.Ident | null,
     floatMinWrapBlock: Css.Numeric | null,
     public readonly policyAnchorNode: Node,
+    public readonly continuationStore: NodeContext.ContinuationStore,
   ) {
     super(
       nodePosition,
@@ -284,7 +285,10 @@ export class LineFootnotePolicyLayoutConstraint
         );
       }
     }
-    const nodePosition = NodeContext.toNodePosition(nodeContext);
+    const nodePosition = NodeContext.toNodePosition(
+      nodeContext,
+      this.footnote.continuationStore,
+    );
     return !Vtree.isSameNodePosition(nodePosition, this.footnote.nodePosition);
   }
 }
@@ -329,7 +333,10 @@ export class FootnoteLayoutStrategy
       floatReference = PageFloats.FloatReference.PAGE;
     }
 
-    const nodePosition = NodeContext.toNodePosition(nodeContext);
+    const nodePosition = NodeContext.toNodePosition(
+      nodeContext,
+      column.layoutContext.continuationStore,
+    );
     Asserts.assert(pageFloatLayoutContext.flowName);
     let policyAnchorNode: Node = nodeContext.sourceNode;
     const shadowOwner = nodeContext.shadowContext?.owner;
@@ -350,6 +357,7 @@ export class FootnoteLayoutStrategy
       nodeContext.footnotePolicy,
       nodeContext.floatMinWrapBlock,
       policyAnchorNode,
+      column.layoutContext.continuationStore,
     );
     float.insidePageFloatArea = insidePageFloat;
     if (insidePageFloat) {

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -87,7 +87,10 @@ export class LayoutProcessorResolver {
   /**
    * Find LayoutProcessor corresponding to given formatting context.
    */
-  find(formattingContext: Vtree.FormattingContext): LayoutProcessor {
+  find(
+    formattingContext: Vtree.FormattingContext,
+    layoutContext: Vtree.LayoutContext,
+  ): LayoutProcessor {
     const hooks: Plugin.ResolveLayoutProcessorHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.RESOLVE_LAYOUT_PROCESSOR,
     );
@@ -97,6 +100,7 @@ export class LayoutProcessorResolver {
         return LegacyPluginSurface.adaptLegacyLayoutProcessor(
           hooks[i],
           processor,
+          layoutContext,
         );
       }
     }

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -127,7 +127,7 @@ export class BlockLayoutProcessor implements LayoutProcessor {
     columnBlockSize: number,
   ): Layout.BreakPosition {
     return new BreakPosition.EdgeBreakPosition(
-      position.copy(),
+      position,
       breakOnEdge,
       overflows,
       columnBlockSize,

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -18,6 +18,7 @@
  */
 import * as BreakPosition from "./break-position";
 import * as LayoutHelper from "./layout-helper";
+import * as LegacyPluginSurface from "./legacy-plugin-surface";
 import * as Plugin from "./plugin";
 import * as Task from "./task";
 import { FormattingContextType, Layout, LayoutProcessor, Vtree } from "./types";
@@ -126,6 +127,7 @@ export class BlockLayoutProcessor implements LayoutProcessor {
     overflows: boolean,
     columnBlockSize: number,
   ): Layout.BreakPosition {
+    LegacyPluginSurface.noteRetained(position);
     return new BreakPosition.EdgeBreakPosition(
       position,
       breakOnEdge,

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -233,17 +233,20 @@ export const blockLayoutProcessor = new BlockLayoutProcessor();
 export const isInstanceOfBlockFormattingContext =
   LayoutProcessor.isInstanceOfBlockFormattingContext;
 
-Plugin.registerHook(Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT, (nodeContext) => {
-  const parent = nodeContext.parent;
-  if (!parent || nodeContext.formattingContext !== parent.formattingContext) {
-    return null;
-  }
-  return nodeContext.establishesBFC
-    ? new BlockFormattingContext(parent.formattingContext)
-    : null;
-});
+Plugin.registerCoreHook(
+  Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
+  (nodeContext) => {
+    const parent = nodeContext.parent;
+    if (!parent || nodeContext.formattingContext !== parent.formattingContext) {
+      return null;
+    }
+    return nodeContext.establishesBFC
+      ? new BlockFormattingContext(parent.formattingContext)
+      : null;
+  },
+);
 
-Plugin.registerHook(
+Plugin.registerCoreHook(
   Plugin.HOOKS.RESOLVE_LAYOUT_PROCESSOR,
   (formattingContext) => {
     if (formattingContext instanceof BlockFormattingContext) {

--- a/packages/core/src/vivliostyle/layout-processor.ts
+++ b/packages/core/src/vivliostyle/layout-processor.ts
@@ -94,7 +94,10 @@ export class LayoutProcessorResolver {
     for (let i = 0; i < hooks.length; i++) {
       const processor = hooks[i](formattingContext);
       if (processor) {
-        return processor;
+        return LegacyPluginSurface.adaptLegacyLayoutProcessor(
+          hooks[i],
+          processor,
+        );
       }
     }
     throw new Error(

--- a/packages/core/src/vivliostyle/layout-retryers.ts
+++ b/packages/core/src/vivliostyle/layout-retryers.ts
@@ -91,7 +91,7 @@ export abstract class AbstractLayoutRetryer {
   }
 
   saveState(nodeContext: Vtree.NodeContext, column: Layout.Column) {
-    this.initialPosition = nodeContext.copy();
+    this.initialPosition = nodeContext;
     this.initialBreakPositions = ([] as Layout.BreakPosition[]).concat(
       column.breakPositions,
     );

--- a/packages/core/src/vivliostyle/layout-retryers.ts
+++ b/packages/core/src/vivliostyle/layout-retryers.ts
@@ -17,6 +17,7 @@
  * @fileoverview LayoutRetryers - Definitions of LayoutRetryer.
  */
 import * as Asserts from "./asserts";
+import * as LegacyPluginSurface from "./legacy-plugin-surface";
 import * as Task from "./task";
 import { Layout, Vtree } from "./types";
 
@@ -91,6 +92,7 @@ export abstract class AbstractLayoutRetryer {
   }
 
   saveState(nodeContext: Vtree.NodeContext, column: Layout.Column) {
+    LegacyPluginSurface.noteRetained(nodeContext);
     this.initialPosition = nodeContext;
     this.initialBreakPositions = ([] as Layout.BreakPosition[]).concat(
       column.breakPositions,

--- a/packages/core/src/vivliostyle/layout-util.ts
+++ b/packages/core/src/vivliostyle/layout-util.ts
@@ -296,8 +296,8 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
       state.breakAtTheEdge,
     );
     if (overflow) {
-      state.nodeContext = NodeContext.withOverflow(
-        state.lastAfterNodeContext || state.nodeContext,
+      state.nodeContext = NodeContext.setOverflow(
+        NodeContext.derived(state.lastAfterNodeContext || state.nodeContext),
         true,
       );
     }
@@ -321,8 +321,8 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
         false,
         state.breakAtTheEdge,
       );
-      nodeContext = state.nodeContext = NodeContext.withOverflow(
-        nodeContext,
+      nodeContext = state.nodeContext = NodeContext.setOverflow(
+        NodeContext.derived(nodeContext),
         true,
       );
     }

--- a/packages/core/src/vivliostyle/layout-util.ts
+++ b/packages/core/src/vivliostyle/layout-util.ts
@@ -236,7 +236,10 @@ export class LayoutIterator {
 }
 
 export class EdgeSkipper extends LayoutIteratorStrategy {
-  constructor(protected readonly leadingEdge?: boolean) {
+  constructor(
+    protected readonly breakSuppressionStore: Break.BreakSuppressionStore,
+    protected readonly leadingEdge?: boolean,
+  ) {
     super();
   }
 
@@ -343,7 +346,7 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
     state.leadingEdgeContexts.push(state.nodeContext);
     state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
       state.breakAtTheEdge,
-      Break.effectiveBreakBefore(state.nodeContext),
+      Break.effectiveBreakBefore(this.breakSuppressionStore, state.nodeContext),
     );
     state.onStartEdges = true;
     return this.startNonInlineBox(state);
@@ -377,7 +380,10 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
         state.lastAfterNodeContext = state.nodeContext;
         state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
           state.breakAtTheEdge,
-          Break.effectiveBreakAfter(state.nodeContext),
+          Break.effectiveBreakAfter(
+            this.breakSuppressionStore,
+            state.nodeContext,
+          ),
         );
       }
       return Task.newResult(true);

--- a/packages/core/src/vivliostyle/layout-util.ts
+++ b/packages/core/src/vivliostyle/layout-util.ts
@@ -60,6 +60,19 @@ export function asRenderedActiveState(
     : null;
 }
 
+export interface ElementActiveLayoutIteratorState extends RenderedActiveLayoutIteratorState {
+  get nodeContext(): Vtree.ElementNodeContext;
+  set nodeContext(nodeContext: Vtree.NodeContext | null);
+}
+
+export function asElementActiveState(
+  state: RenderedActiveLayoutIteratorState,
+): ElementActiveLayoutIteratorState | null {
+  return VtreeImpl.asElementNodeContext(state.nodeContext) !== null
+    ? (state as ElementActiveLayoutIteratorState)
+    : null;
+}
+
 export class LayoutIteratorStrategy {
   initialState(initialNodeContext: Vtree.NodeContext): LayoutIteratorState {
     return {
@@ -94,19 +107,19 @@ export class LayoutIteratorStrategy {
   ): void | Task.Result<boolean> {}
 
   startInlineElementNode(
-    state: RenderedActiveLayoutIteratorState,
+    state: ElementActiveLayoutIteratorState,
   ): void | Task.Result<boolean> {}
 
   afterInlineElementNode(
-    state: RenderedActiveLayoutIteratorState,
+    state: ElementActiveLayoutIteratorState,
   ): void | Task.Result<boolean> {}
 
   startNonInlineElementNode(
-    state: RenderedActiveLayoutIteratorState,
+    state: ElementActiveLayoutIteratorState,
   ): void | Task.Result<boolean> {}
 
   afterNonInlineElementNode(
-    state: RenderedActiveLayoutIteratorState,
+    state: ElementActiveLayoutIteratorState,
   ): void | Task.Result<boolean> {}
 
   finish(state: LayoutIteratorState): void | Task.Result<boolean> {}
@@ -171,37 +184,40 @@ export class LayoutIterator {
       } else {
         r = strategy.startNonDisplayableNode(state);
       }
-    } else if (rendered.nodeContext.viewNode.nodeType !== 1) {
-      if (
-        VtreeImpl.canIgnore(
-          rendered.nodeContext.viewNode,
-          rendered.nodeContext.whitespace,
-        )
-      ) {
-        if (rendered.nodeContext.after) {
-          r = strategy.afterIgnoredTextNode(rendered);
-        } else {
-          r = strategy.startIgnoredTextNode(rendered);
-        }
-      } else {
-        if (rendered.nodeContext.after) {
-          r = strategy.afterNonElementNode(rendered);
-        } else {
-          r = strategy.startNonElementNode(rendered);
-        }
-      }
     } else {
-      if (rendered.nodeContext.inline) {
-        if (rendered.nodeContext.after) {
-          r = strategy.afterInlineElementNode(rendered);
+      const element = asElementActiveState(rendered);
+      if (!element) {
+        if (
+          VtreeImpl.canIgnore(
+            rendered.nodeContext.viewNode,
+            rendered.nodeContext.whitespace,
+          )
+        ) {
+          if (rendered.nodeContext.after) {
+            r = strategy.afterIgnoredTextNode(rendered);
+          } else {
+            r = strategy.startIgnoredTextNode(rendered);
+          }
         } else {
-          r = strategy.startInlineElementNode(rendered);
+          if (rendered.nodeContext.after) {
+            r = strategy.afterNonElementNode(rendered);
+          } else {
+            r = strategy.startNonElementNode(rendered);
+          }
         }
       } else {
-        if (rendered.nodeContext.after) {
-          r = strategy.afterNonInlineElementNode(rendered);
+        if (element.nodeContext.inline) {
+          if (element.nodeContext.after) {
+            r = strategy.afterInlineElementNode(element);
+          } else {
+            r = strategy.startInlineElementNode(element);
+          }
         } else {
-          r = strategy.startNonInlineElementNode(rendered);
+          if (element.nodeContext.after) {
+            r = strategy.afterNonInlineElementNode(element);
+          } else {
+            r = strategy.startNonInlineElementNode(element);
+          }
         }
       }
     }
@@ -322,7 +338,7 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
   override startNonInlineElementNode(
     state: RenderedActiveLayoutIteratorState,
   ): void | Task.Result<boolean> {
-    state.leadingEdgeContexts.push(state.nodeContext.copy());
+    state.leadingEdgeContexts.push(state.nodeContext);
     state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
       state.breakAtTheEdge,
       Break.effectiveBreakBefore(state.nodeContext),
@@ -355,7 +371,7 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
     return cont.thenAsync(() => {
       if (!state.break) {
         state.onStartEdges = false;
-        state.lastAfterNodeContext = state.nodeContext.copy();
+        state.lastAfterNodeContext = state.nodeContext;
         state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
           state.breakAtTheEdge,
           Break.effectiveBreakAfter(state.nodeContext),

--- a/packages/core/src/vivliostyle/layout-util.ts
+++ b/packages/core/src/vivliostyle/layout-util.ts
@@ -18,6 +18,7 @@
  * @fileoverview LayoutUtil - Utilities related to layout.
  */
 import * as Break from "./break";
+import * as LegacyPluginSurface from "./legacy-plugin-surface";
 import * as NodeContext from "./node-context";
 import * as Task from "./task";
 import * as VtreeImpl from "./vtree";
@@ -338,6 +339,7 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
   override startNonInlineElementNode(
     state: RenderedActiveLayoutIteratorState,
   ): void | Task.Result<boolean> {
+    LegacyPluginSurface.noteRetained(state.nodeContext);
     state.leadingEdgeContexts.push(state.nodeContext);
     state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
       state.breakAtTheEdge,
@@ -371,6 +373,7 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
     return cont.thenAsync(() => {
       if (!state.break) {
         state.onStartEdges = false;
+        LegacyPluginSurface.noteRetained(state.nodeContext);
         state.lastAfterNodeContext = state.nodeContext;
         state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
           state.breakAtTheEdge,

--- a/packages/core/src/vivliostyle/layout-util.ts
+++ b/packages/core/src/vivliostyle/layout-util.ts
@@ -18,6 +18,7 @@
  * @fileoverview LayoutUtil - Utilities related to layout.
  */
 import * as Break from "./break";
+import * as NodeContext from "./node-context";
 import * as Task from "./task";
 import * as VtreeImpl from "./vtree";
 import { Layout, Vtree } from "./types";
@@ -279,10 +280,10 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
       state.breakAtTheEdge,
     );
     if (overflow) {
-      state.nodeContext = (
-        state.lastAfterNodeContext || state.nodeContext
-      ).modify();
-      state.nodeContext.overflow = true;
+      state.nodeContext = NodeContext.withOverflow(
+        state.lastAfterNodeContext || state.nodeContext,
+        true,
+      );
     }
     return overflow;
   }
@@ -304,8 +305,10 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
         false,
         state.breakAtTheEdge,
       );
-      nodeContext = state.nodeContext = nodeContext.modify();
-      nodeContext.overflow = true;
+      nodeContext = state.nodeContext = NodeContext.withOverflow(
+        nodeContext,
+        true,
+      );
     }
     return violateConstraint;
   }

--- a/packages/core/src/vivliostyle/layout-util.ts
+++ b/packages/core/src/vivliostyle/layout-util.ts
@@ -322,7 +322,7 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
     state.leadingEdgeContexts.push(state.nodeContext.copy());
     state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
       state.breakAtTheEdge,
-      state.nodeContext.breakBefore,
+      Break.effectiveBreakBefore(state.nodeContext),
     );
     state.onStartEdges = true;
     return this.startNonInlineBox(state);
@@ -355,7 +355,7 @@ export class EdgeSkipper extends LayoutIteratorStrategy {
         state.lastAfterNodeContext = state.nodeContext.copy();
         state.breakAtTheEdge = Break.resolveEffectiveBreakValue(
           state.breakAtTheEdge,
-          state.nodeContext.breakAfter,
+          Break.effectiveBreakAfter(state.nodeContext),
         );
       }
       return Task.newResult(true);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2850,6 +2850,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         position.checkPointIndex,
         force,
       );
+      if (cpNodeContext.after) {
+        const brokenCheckPoint = VtreeImpl.asRenderedNodeContext(nodeContext);
+        if (brokenCheckPoint) {
+          checkPoints[position.checkPointIndex] = brokenCheckPoint;
+        }
+      }
     } else {
       // Fix for issue #821, #885, #1459
       const p = LayoutHelper.findAncestorSpecialInlineNodeContext(nodeContext);
@@ -5232,6 +5238,7 @@ export class TextNodeBreaker implements Layout.TextNodeBreaker {
     force: boolean,
   ): Vtree.NodeContext {
     if (nodeContext.after) {
+      nodeContext = nodeContext.modify();
       nodeContext.offsetInNode = textNode.length;
     } else {
       // Character with index low is the last one that fits.

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -1559,7 +1559,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       const containingBlockForAbsolute = parent
         ? parent.containingBlockForAbsolute
           ? VtreeImpl.asElementNodeContext(parent)
-          : parent.getContainingBlockForAbsolute()
+          : NodeContext.containingBlockForAbsoluteOf(parent)
         : null;
       if (containingBlockForAbsolute) {
         const containingBlockViewNode = containingBlockForAbsolute.viewNode;
@@ -2329,7 +2329,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       );
     let cont: Task.Result<PageFloats.PageFloat>;
     const float = context.findPageFloatByNodePosition(
-      nodeContext.toNodePosition(),
+      NodeContext.toNodePosition(nodeContext),
     );
     if (!float) {
       cont = strategy.createPageFloat(nodeContext, context, this);
@@ -4412,7 +4412,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       })
       .then(() => {
         if (lastAfterNodeContext) {
-          this.lastAfterPosition = lastAfterNodeContext.toNodePosition();
+          this.lastAfterPosition =
+            NodeContext.toNodePosition(lastAfterNodeContext);
         }
         frame.finish(nodeContext);
       });
@@ -4879,7 +4880,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             } else {
               this.overflown = true;
               const result = new VtreeImpl.ChunkPosition(
-                positionAfter.toNodePosition(),
+                NodeContext.toNodePosition(positionAfter),
               );
               frame.finish(result);
             }
@@ -5160,7 +5161,7 @@ export class PseudoColumn {
   isLastAfterNodeContext(nodeContext: Vtree.NodeContext): boolean {
     return (
       VtreeImpl.isSameNodePosition(
-        nodeContext.toNodePosition(),
+        NodeContext.toNodePosition(nodeContext),
         this.column.lastAfterPosition,
       ) || this.isEffectivelyLastAfterNodeContext(nodeContext)
     );

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -35,6 +35,7 @@ import * as Css from "./css";
 import * as GeometryUtil from "./geometry-util";
 import * as LayoutHelper from "./layout-helper";
 import * as LayoutProcessor from "./layout-processor";
+import * as LegacyPluginSurface from "./legacy-plugin-surface";
 import * as PageFloats from "./page-floats";
 import * as Plugin from "./plugin";
 import * as Matchers from "./matchers";
@@ -2774,7 +2775,17 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       Plugin.HOOKS.POST_LAYOUT_BLOCK,
     );
     hooks.forEach((hook) => {
-      hook(nodeContext, checkPoints, this);
+      hook(
+        LegacyPluginSurface.asLegacyNodeContextOrNull(
+          Plugin.HOOKS.POST_LAYOUT_BLOCK,
+          nodeContext,
+        ),
+        LegacyPluginSurface.asLegacyRenderedNodeContexts(
+          Plugin.HOOKS.POST_LAYOUT_BLOCK,
+          checkPoints,
+        ),
+        this,
+      );
     });
   }
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3254,7 +3254,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     edge: number;
     checkPoint: Vtree.RenderedNodeContext | null;
   } {
-    const index = checkPoints.findIndex((cp) => cp.overflow);
+    const index = checkPoints.findIndex((cp) =>
+      BreakPosition.effectiveOverflow(this, cp),
+    );
     if (index < 0) {
       return { edge: NaN, checkPoint: null };
     }
@@ -3270,6 +3272,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   ): Vtree.NodeContext {
     this.computedBlockSize =
       bp.computedBlockSize + this.getOffsetByRepetitiveElements(bp);
+    bp.position.overflow = bp.overflows;
     return bp.position;
   }
 
@@ -4935,6 +4938,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let overflownNodeContext: Vtree.NodeContext | null = null;
 
     // ------ init backtracking list -----
+    BreakPosition.beginLayoutPass(this);
     this.breakPositions = [];
     this.nodeContextOverflowingDueToRepetitiveElements = null;
 
@@ -5116,9 +5120,10 @@ export class PseudoColumn {
       startNodeContext.overflow,
       0,
     );
+    bp.findAcceptableBreak(this.column, 0);
     // updates the column's overflow state, so it runs whether or not the
     // start position is the one taken
-    bp.findAcceptableBreak(this.column, 0);
+    startNodeContext.overflow = bp.overflows;
     return p ?? { breakPosition: bp, nodeContext: startNodeContext };
   }
   /**

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -775,7 +775,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               !this.layoutConstraint.allowLayout(position)
             ) {
               violateConstraint = true;
-              position = NodeContext.withOverflow(position, true);
+              position = NodeContext.setOverflow(
+                NodeContext.derived(position),
+                true,
+              );
             }
             const floatNodeContext = this.asFloatNodeContext(position);
             if (
@@ -886,7 +889,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               return;
             }
             if (!this.layoutConstraint.allowLayout(position)) {
-              position = NodeContext.withOverflow(position, true);
+              position = NodeContext.setOverflow(
+                NodeContext.derived(position),
+                true,
+              );
               if (this.stopAtOverflow) {
                 bodyFrame.breakLoop();
                 return;
@@ -1659,7 +1665,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         this.updateMaxReachedAfterEdge(floatBoxEdge);
         frame.finish(nodeContextAfter);
       } else {
-        nodeContext = NodeContext.withOverflow(nodeContext, true);
+        nodeContext = NodeContext.setOverflow(
+          NodeContext.derived(nodeContext),
+          true,
+        );
         frame.finish(nodeContext);
       }
     });
@@ -2724,7 +2733,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             this.findLineFootnoteOverflowBreak(checkPoints);
           if (lineFootnoteOverflowBreak) {
             const overflowNodeContext = NodeContext.setPluginProp(
-              NodeContext.withOverflow(lineFootnoteOverflowBreak, true),
+              NodeContext.setOverflow(
+                NodeContext.derived(lineFootnoteOverflowBreak),
+                true,
+              ),
               "lineFootnoteOverflow",
               1,
             );
@@ -2741,7 +2753,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
             // TODO: how to signal overflow in the last pagargaph???
             if (overflown && !this.isLoneImage(checkPoints) && nodeContext) {
-              nodeContext = NodeContext.withOverflow(nodeContext, true);
+              nodeContext = NodeContext.setOverflow(
+                NodeContext.derived(nodeContext),
+                true,
+              );
             }
           }
           frame.finish(nodeContext);
@@ -3259,7 +3274,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       blockParent = blockParent.parent;
     } while (blockParent && blockParent.inline);
     if (blockParent) {
-      blockParent = NodeContext.detachedAfterEdgeOf(blockParent);
+      blockParent = NodeContext.afterEdgeOf(blockParent);
       return LayoutHelper.calculateEdge(
         blockParent,
         this.clientLayout,
@@ -3377,7 +3392,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         Logging.logger.warn("Could not find any page breaks?!!");
         this.skipTailEdges(overflownNodeContext).then((nodeContext) => {
           if (nodeContext) {
-            nodeContext = NodeContext.withOverflow(nodeContext, false);
+            nodeContext = NodeContext.setOverflow(
+              NodeContext.derived(nodeContext),
+              false,
+            );
             this.finishBreak(nodeContext, forceRemoveSelf, true).then(() => {
               frame.finish(nodeContext);
             });
@@ -4087,10 +4105,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     breakAtTheEdge,
                   )
                 ) {
-                  nodeContext = NodeContext.withOverflow(
-                    this.stopAtOverflow
-                      ? lastAfterNodeContext || nodeContext
-                      : nodeContext,
+                  nodeContext = NodeContext.setOverflow(
+                    NodeContext.derived(
+                      this.stopAtOverflow
+                        ? lastAfterNodeContext || nodeContext
+                        : nodeContext,
+                    ),
                     true,
                   );
                 } else {
@@ -4118,8 +4138,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   if (breakAtTheEdge === "column" && nodeContext.viewNode) {
                     Break.unsuppressColumnBreakBefore(nodeContext.viewNode);
                   }
-                  nodeContext = NodeContext.withBreakBefore(
-                    nodeContext,
+                  nodeContext = NodeContext.setBreakBefore(
+                    NodeContext.derived(nodeContext),
                     breakAtTheEdge,
                   );
                 }
@@ -4221,10 +4241,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   !this.layoutConstraint.allowLayout(nodeContext)
                 ) {
                   // overflow
-                  nodeContext = NodeContext.withOverflow(
-                    this.stopAtOverflow
-                      ? lastAfterNodeContext || nodeContext
-                      : nodeContext,
+                  nodeContext = NodeContext.setOverflow(
+                    NodeContext.derived(
+                      this.stopAtOverflow
+                        ? lastAfterNodeContext || nodeContext
+                        : nodeContext,
+                    ),
                     true,
                   );
                 }
@@ -4372,7 +4394,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   !this.stopAtOverflow,
                   breakAtTheEdge,
                 );
-                nodeContext = NodeContext.withOverflow(nodeContext, true);
+                nodeContext = NodeContext.setOverflow(
+                  NodeContext.derived(nodeContext),
+                  true,
+                );
                 if (this.stopAtOverflow) {
                   loopFrame.breakLoop();
                   return;
@@ -4393,10 +4418,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   )
                 ) {
                   // overflow
-                  nodeContext = NodeContext.withOverflow(
-                    this.stopAtOverflow
-                      ? lastAfterNodeContext || nodeContext
-                      : nodeContext,
+                  nodeContext = NodeContext.setOverflow(
+                    NodeContext.derived(
+                      this.stopAtOverflow
+                        ? lastAfterNodeContext || nodeContext
+                        : nodeContext,
+                    ),
                     true,
                   );
                 }
@@ -4433,7 +4460,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           )
         ) {
           if (lastAfterNodeContext && this.stopAtOverflow) {
-            nodeContext = NodeContext.withOverflow(lastAfterNodeContext, true);
+            nodeContext = NodeContext.setOverflow(
+              NodeContext.derived(lastAfterNodeContext),
+              true,
+            );
           } else {
             // TODO: what to return here??
           }
@@ -5285,7 +5315,7 @@ export class TextNodeBreaker implements Layout.TextNodeBreaker {
     force: boolean,
   ): Vtree.NodeContext {
     if (nodeContext.after) {
-      nodeContext = NodeContext.withOffsetInNode(nodeContext, textNode.length);
+      nodeContext = NodeContext.setOffsetInNode(nodeContext, textNode.length);
     } else {
       // Character with index low is the last one that fits.
       let viewIndex = low - nodeContext.boxOffset;

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3820,8 +3820,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         nc;
         nc = nc.parent
       ) {
-        if (nc.breakBefore === "column") {
-          nc.breakBefore = null;
+        if (nc.viewNode && Break.effectiveBreakBefore(nc) === "column") {
+          Break.suppressColumnBreakBefore(nc.viewNode);
         }
         if (nc.viewNode?.nodeType === 1) {
           const elem = nc.viewNode as HTMLElement;
@@ -3850,8 +3850,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         nc;
         nc = nc.parent
       ) {
-        if (nc.breakBefore === "column") {
-          nc.breakBefore = null;
+        if (nc.viewNode && Break.effectiveBreakBefore(nc) === "column") {
+          Break.suppressColumnBreakBefore(nc.viewNode);
         }
         if (nc.viewNode?.nodeType === 1) {
           const elem = nc.viewNode as HTMLElement;
@@ -3874,8 +3874,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         nc;
         nc = nc.parent
       ) {
-        if (nc.breakAfter === "column") {
-          nc.breakAfter = null;
+        if (nc.viewNode && Break.effectiveBreakAfter(nc) === "column") {
+          Break.suppressColumnBreakAfter(nc.viewNode);
         }
         if (nc.viewNode?.nodeType === 1) {
           const elem = nc.viewNode as HTMLElement;
@@ -4034,7 +4034,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 break;
               }
               if (!nodeContext.after) {
-                setBreakAtTheEdge(nodeContext.breakBefore);
+                setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
                 // Leading edge of non-empty block -> finished going through
@@ -4076,6 +4076,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                       breakAtTheEdge,
                       false,
                     );
+                  }
+                  if (breakAtTheEdge === "column" && nodeContext.viewNode) {
+                    Break.unsuppressColumnBreakBefore(nodeContext.viewNode);
                   }
                   nodeContext = nodeContext.modify();
                   nodeContext.breakBefore = breakAtTheEdge;
@@ -4159,7 +4162,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // new formatting context, or float or flex container,
                 // or empty block box (unbreakable)
                 leadingEdgeContexts.push(rendered.copy());
-                setBreakAtTheEdge(nodeContext.breakBefore);
+                setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
 
@@ -4217,7 +4220,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 lastAfterNodeContext = elementContext.copy();
                 trailingEdgeContexts.push(lastAfterNodeContext);
                 breakAtTheEdge = null;
-                setBreakAtTheEdge(nodeContext.breakAfter);
+                setBreakAtTheEdge(Break.effectiveBreakAfter(nodeContext));
                 suppressWeakerTrailingColumnBreaks(nodeContext);
                 this.checkOverflowAndSaveEdgeAndBreakPosition(
                   lastAfterNodeContext,
@@ -4284,7 +4287,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 lastAfterNodeContext = elementContext.copy();
                 trailingEdgeContexts.push(lastAfterNodeContext);
               }
-              setBreakAtTheEdge(nodeContext.breakAfter);
+              setBreakAtTheEdge(Break.effectiveBreakAfter(nodeContext));
               suppressWeakerTrailingColumnBreaks(nodeContext);
               if (
                 style &&
@@ -4301,7 +4304,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             } else {
               // Leading edge
               leadingEdgeContexts.push(elementContext.copy());
-              setBreakAtTheEdge(nodeContext.breakBefore);
+              setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
               suppressWeakerLeadingColumnBreaks(nodeContext);
               consumeSatisfiedLeadingColumnBreak(nodeContext);
 
@@ -4460,7 +4463,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // float or flex container (unbreakable)
                 breakAtTheEdge = Break.resolveEffectiveBreakValue(
                   breakAtTheEdge,
-                  nodeContext.breakBefore,
+                  Break.effectiveBreakBefore(nodeContext),
                 );
 
                 // check if a forced break must occur before the block.
@@ -4494,13 +4497,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               onStartEdges = false; // we are now on end edges.
               breakAtTheEdge = Break.resolveEffectiveBreakValue(
                 breakAtTheEdge,
-                nodeContext.breakAfter,
+                Break.effectiveBreakAfter(nodeContext),
               );
             } else {
               // Leading edge
               breakAtTheEdge = Break.resolveEffectiveBreakValue(
                 breakAtTheEdge,
-                nodeContext.breakBefore,
+                Break.effectiveBreakBefore(nodeContext),
               );
               const viewTag = viewElement.localName;
               if (Base.mediaTags[viewTag]) {

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -724,6 +724,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           // Prevent breaking inside SVG etc. (Issue #1406)
           renderedPos.viewNode.parentElement?.namespaceURI === Base.NS.XHTML
         ) {
+          LegacyPluginSurface.noteRetained(renderedPos);
           checkPoints.push(renderedPos);
 
           // Prevent performance degradation when the text block is very large.
@@ -761,6 +762,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               renderedPeeled &&
               !LayoutHelper.isSpecialNodeContext(renderedPeeled)
             ) {
+              LegacyPluginSurface.noteRetained(renderedPeeled);
               checkPoints.push(renderedPeeled);
             }
           }
@@ -855,6 +857,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           renderedPos.inline &&
           !LayoutHelper.isSpecialNodeContext(renderedPos)
         ) {
+          LegacyPluginSurface.noteRetained(renderedPos);
           checkPoints.push(renderedPos);
         } else {
           if (checkPoints.length > 0) {
@@ -880,6 +883,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               renderedPeeled &&
               !LayoutHelper.isSpecialNodeContext(renderedPeeled)
             ) {
+              LegacyPluginSurface.noteRetained(renderedPeeled);
               checkPoints.push(renderedPeeled);
             }
           }
@@ -2314,6 +2318,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       columnContext.container.width < regionContext.container.width;
     if (isRegionWider && floatReference === PageFloats.FloatReference.COLUMN) {
       if (columnSpan === Css.ident.auto) {
+        LegacyPluginSurface.noteRetained(nodeContext);
         this.buildDeepElementView(nodeContext).then((position) => {
           const element = position.viewNode as Element;
           let inlineSize = Sizing.getSize(this.clientLayout, element, [
@@ -3285,6 +3290,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       blockParent = blockParent.parent;
     } while (blockParent && blockParent.inline);
     if (blockParent) {
+      LegacyPluginSurface.noteRetained(blockParent);
       blockParent = NodeContext.afterEdgeOf(blockParent);
       return LayoutHelper.calculateEdge(
         blockParent,
@@ -4187,6 +4193,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   nodeContext = cleared;
                   rendered = cleared;
                   if (leadingEdge && this.breakPositions.length === 0) {
+                    LegacyPluginSurface.noteRetained(nodeContext);
                     this.saveEdgeBreakPosition(
                       nodeContext,
                       breakAtTheEdge,
@@ -4215,6 +4222,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     // break opportunity above. (Issue #1786)
                     (!leadingEdge && leadingEdgeContexts.length === 0))
               ) {
+                LegacyPluginSurface.noteRetained(nodeContext);
                 this.saveEdgeBreakPosition(nodeContext, breakAtTheEdge, false);
               }
               if (
@@ -4234,6 +4242,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               ) {
                 // new formatting context, or float or flex container,
                 // or empty block box (unbreakable)
+                LegacyPluginSurface.noteRetained(rendered);
                 leadingEdgeContexts.push(rendered);
                 setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
                 suppressWeakerLeadingColumnBreaks(nodeContext);
@@ -4292,6 +4301,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 element.getAttribute("data-math-typeset") === "true"
               ) {
                 onStartEdges = false;
+                LegacyPluginSurface.noteRetained(elementContext);
                 lastAfterNodeContext = elementContext;
                 trailingEdgeContexts.push(lastAfterNodeContext);
                 breakAtTheEdge = null;
@@ -4359,6 +4369,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               // which are positioned in normal flow and are needed for
               // break position tracking. (Issue #1790)
               if (!LayoutHelper.isCssOutOfFlow(elementContext.viewNode)) {
+                LegacyPluginSurface.noteRetained(elementContext);
                 lastAfterNodeContext = elementContext;
                 trailingEdgeContexts.push(lastAfterNodeContext);
               }
@@ -4378,6 +4389,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               }
             } else {
               // Leading edge
+              LegacyPluginSurface.noteRetained(elementContext);
               leadingEdgeContexts.push(elementContext);
               setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
               suppressWeakerLeadingColumnBreaks(nodeContext);
@@ -4502,6 +4514,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     initialNodeContext: Vtree.NodeContext,
   ): Task.Result<Vtree.NodeContext | null> {
     let nodeContext: Vtree.NodeContext | null = initialNodeContext;
+    LegacyPluginSurface.noteRetained(nodeContext);
     let resultNodeContext: Vtree.NodeContext | null = nodeContext;
     const frame: Task.Frame<Vtree.NodeContext | null> =
       Task.newFrame("skipEdges");
@@ -4814,6 +4827,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     breakAtEdge: string | null,
     overflows: boolean,
   ): void {
+    LegacyPluginSurface.noteRetained(position);
     const copy = position;
     const layoutProcessor = new LayoutProcessor.LayoutProcessorResolver().find(
       position.formattingContext,
@@ -4910,6 +4924,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         }
       };
       if (nodeContext.viewNode) {
+        LegacyPluginSurface.noteRetained(nodeContext);
         this.initialNodeContext = nodeContext;
       } else {
         this.layoutContext.addEventListener("nextInTree", nextInTreeListener);
@@ -5199,6 +5214,7 @@ export class PseudoColumn {
       return Column.prototype.openAllViews
         .call(this, position)
         .thenAsync((result) => {
+          LegacyPluginSurface.noteRetained(result);
           pseudoColumn.startNodeContexts.push(result);
           return Task.newResult(result);
         });
@@ -5216,6 +5232,7 @@ export class PseudoColumn {
   }
   findAcceptableBreakPosition(): Layout.BreakPositionAndNodeContext {
     const p = this.column.findAcceptableBreakPosition();
+    LegacyPluginSurface.noteRetained(this.startNodeContexts[0]);
     const startNodeContext = this.startNodeContexts[0];
     const bp = new BreakPosition.EdgeBreakPosition(
       startNodeContext,

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -450,6 +450,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   pseudoParent: Column | null = null;
   nodeContextOverflowingDueToRepetitiveElements: Vtree.NodeContext | null =
     null;
+  private initialNodeContext: Vtree.NodeContext | null = null;
   blockDistanceToBlockEndFloats: number = NaN;
   lastLineStride: number = 0;
   breakAtTheEdgeBeforeFloat: string | null = null;
@@ -598,10 +599,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     this.layoutContext.setViewRoot(this.element, this.isFootnote);
     let stepIndex = steps.length - 1;
     let nodeContext: Vtree.NodeContext | null = null;
+    let openContext: Vtree.ParentNodeContext | null = null;
     frame
       .loop(() => {
         while (stepIndex >= 0) {
-          const prevContext = nodeContext;
+          const prevContext = openContext;
           const head =
             stepIndex == 0
               ? NodeContext.afterHeadFromPosition(
@@ -609,20 +611,24 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   this.calculateOffsetInNodeForNodeContext(position),
                 )
               : undefined;
-          nodeContext = prevContext
+          const opened = prevContext
             ? NodeContext.openFromStep(steps[stepIndex], prevContext, head)
             : NodeContext.openRootFromStep(
                 VtreeImpl.rootStepOfNodePosition(position),
                 this.flowRootFormattingContext,
                 head,
               );
-          if (head?.after) {
+          nodeContext = opened;
+          if (opened.after === true) {
             break;
           }
-          const r = this.layoutContext.setCurrent(
-            nodeContext,
-            stepIndex == 0 && nodeContext.offsetInNode == 0,
-          );
+          const r = this.layoutContext
+            .setCurrent(opened, stepIndex == 0 && opened.offsetInNode == 0)
+            .thenAsync(({ nodeContext: rendered, processChildren }) => {
+              nodeContext = rendered;
+              openContext = rendered;
+              return Task.newResult(processChildren);
+            });
           stepIndex--;
           if (r.isPending()) {
             return r;
@@ -717,7 +723,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           // Prevent breaking inside SVG etc. (Issue #1406)
           renderedPos.viewNode.parentElement?.namespaceURI === Base.NS.XHTML
         ) {
-          checkPoints.push(renderedPos.copy());
+          checkPoints.push(renderedPos);
 
           // Prevent performance degradation when the text block is very large.
           // (Issue #1256)
@@ -754,7 +760,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               renderedPeeled &&
               !LayoutHelper.isSpecialNodeContext(renderedPeeled)
             ) {
-              checkPoints.push(renderedPeeled.copy());
+              checkPoints.push(renderedPeeled);
             }
           }
           this.nextInTree(position).then((positionParam) => {
@@ -845,7 +851,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           renderedPos.inline &&
           !LayoutHelper.isSpecialNodeContext(renderedPos)
         ) {
-          checkPoints.push(renderedPos.copy());
+          checkPoints.push(renderedPos);
         } else {
           if (checkPoints.length > 0) {
             this.postLayoutBlock(position, checkPoints);
@@ -870,7 +876,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               renderedPeeled &&
               !LayoutHelper.isSpecialNodeContext(renderedPeeled)
             ) {
-              checkPoints.push(renderedPeeled.copy());
+              checkPoints.push(renderedPeeled);
             }
           }
           this.nextInTree(position1).then((positionParam) => {
@@ -1608,9 +1614,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       if (nodeContext.clearSpacer) {
         const clearSpacer = nodeContext.clearSpacer;
         clearSpacer.remove();
-        NodeContext.setClearSpacer(nodeContext, null);
+        const uncleared = NodeContext.setClearSpacer(nodeContext, null);
+        this.followWalkedContext(nodeContext, uncleared);
+        nodeContext = uncleared;
         if (nodeContextAfter.clearSpacer === clearSpacer) {
-          NodeContext.setClearSpacer(nodeContextAfter, null);
+          const unclearedAfter = NodeContext.setClearSpacer(
+            nodeContextAfter,
+            null,
+          );
+          this.followWalkedContext(nodeContextAfter, unclearedAfter);
+          nodeContextAfter = unclearedAfter;
         }
       }
       const floatBoxEdge = this.vertical ? floatBox.x1 : floatBox.y2;
@@ -2291,7 +2304,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       columnContext.container.width < regionContext.container.width;
     if (isRegionWider && floatReference === PageFloats.FloatReference.COLUMN) {
       if (columnSpan === Css.ident.auto) {
-        this.buildDeepElementView(nodeContext.copy()).then((position) => {
+        this.buildDeepElementView(nodeContext).then((position) => {
           const element = position.viewNode as Element;
           let inlineSize = Sizing.getSize(this.clientLayout, element, [
             Sizing.Size.MIN_CONTENT_INLINE_SIZE,
@@ -3594,18 +3607,32 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     return overflown;
   }
 
-  applyClearance(nodeContext: Vtree.RenderedNodeContext): boolean {
+  private followWalkedContext(
+    previous: Vtree.NodeContext,
+    next: Vtree.NodeContext,
+    cursorAdvance = false,
+  ): void {
+    if (cursorAdvance) {
+      return;
+    }
+    NodeContext.followContinuation(previous, next);
+    if (this.initialNodeContext === previous) {
+      this.initialNodeContext = next;
+    }
+  }
+
+  applyClearance(nodeContext: Vtree.RenderedNodeContext): Element | null {
     if (!nodeContext.viewNode.parentNode) {
       // Cannot do clearance for nodes without parents
-      return false;
+      return null;
     }
     if (nodeContext.floatReference !== PageFloats.FloatReference.INLINE) {
       // For page floats, clearance is handled differently
-      return false;
+      return null;
     }
     if (nodeContext.floatSide) {
       // Clear on inline floats is handled in layoutFloat()
-      return false;
+      return null;
     }
 
     const clear =
@@ -3715,7 +3742,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     if (edge * dir + tolerance > clearEdge * dir) {
       // No need for clearance
       nodeContext.viewNode.parentNode.removeChild(spacer);
-      return false;
+      return null;
     } else {
       // Need some clearance, determine how much. Add the clearance node,
       // measure its after edge and adjust after margin (required due to
@@ -3745,8 +3772,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           spacer.style.marginBottom = `${hAdj}px`;
         }
       }
-      NodeContext.setClearSpacer(nodeContext, spacer);
-      return true;
+      return spacer;
     }
   }
 
@@ -3981,7 +4007,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         return false;
       }
       let sawOutOfFlowSibling = false;
-      for (let nc = nodeContext; nc?.parent && !nc.after; nc = nc.parent) {
+      for (
+        let nc: Vtree.NodeContext | null = nodeContext;
+        nc?.parent && !nc.after;
+        nc = nc.parent
+      ) {
         if (nc !== nodeContext && LayoutHelper.isOutOfFlow(nc.viewNode)) {
           return false;
         }
@@ -4021,7 +4051,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           // A code block to be able to use break. Break moves to the next
           // node position.
           do {
-            const rendered = VtreeImpl.asRenderedNodeContext(nodeContext);
+            let rendered = VtreeImpl.asRenderedNodeContext(nodeContext);
             if (!rendered) {
               // Non-displayable content, skip
               break;
@@ -4116,16 +4146,22 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 VtreeImpl.asClearNodeContext(nodeContext);
               if (clearNodeContext) {
                 // clear
-                if (
-                  this.applyClearance(clearNodeContext) &&
-                  leadingEdge &&
-                  this.breakPositions.length === 0
-                ) {
-                  this.saveEdgeBreakPosition(
-                    nodeContext.copy(),
-                    breakAtTheEdge,
-                    false,
+                const clearSpacer = this.applyClearance(clearNodeContext);
+                if (clearSpacer) {
+                  const cleared = NodeContext.setClearSpacer(
+                    clearNodeContext,
+                    clearSpacer,
                   );
+                  this.followWalkedContext(nodeContext, cleared);
+                  nodeContext = cleared;
+                  rendered = cleared;
+                  if (leadingEdge && this.breakPositions.length === 0) {
+                    this.saveEdgeBreakPosition(
+                      nodeContext,
+                      breakAtTheEdge,
+                      false,
+                    );
+                  }
                 }
               }
               // Check break opportunity between anonymous block box and block-level box
@@ -4148,11 +4184,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     // break opportunity above. (Issue #1786)
                     (!leadingEdge && leadingEdgeContexts.length === 0))
               ) {
-                this.saveEdgeBreakPosition(
-                  nodeContext.copy(),
-                  breakAtTheEdge,
-                  false,
-                );
+                this.saveEdgeBreakPosition(nodeContext, breakAtTheEdge, false);
               }
               if (
                 !this.isBFC(nodeContext.formattingContext) ||
@@ -4171,7 +4203,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               ) {
                 // new formatting context, or float or flex container,
                 // or empty block box (unbreakable)
-                leadingEdgeContexts.push(rendered.copy());
+                leadingEdgeContexts.push(rendered);
                 setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
@@ -4227,7 +4259,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 element.getAttribute("data-math-typeset") === "true"
               ) {
                 onStartEdges = false;
-                lastAfterNodeContext = elementContext.copy();
+                lastAfterNodeContext = elementContext;
                 trailingEdgeContexts.push(lastAfterNodeContext);
                 breakAtTheEdge = null;
                 setBreakAtTheEdge(Break.effectiveBreakAfter(nodeContext));
@@ -4294,7 +4326,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               // which are positioned in normal flow and are needed for
               // break position tracking. (Issue #1790)
               if (!LayoutHelper.isCssOutOfFlow(elementContext.viewNode)) {
-                lastAfterNodeContext = elementContext.copy();
+                lastAfterNodeContext = elementContext;
                 trailingEdgeContexts.push(lastAfterNodeContext);
               }
               setBreakAtTheEdge(Break.effectiveBreakAfter(nodeContext));
@@ -4313,7 +4345,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               }
             } else {
               // Leading edge
-              leadingEdgeContexts.push(elementContext.copy());
+              leadingEdgeContexts.push(elementContext);
               setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
               suppressWeakerLeadingColumnBreaks(nodeContext);
               consumeSatisfiedLeadingColumnBreak(nodeContext);
@@ -4429,7 +4461,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     initialNodeContext: Vtree.NodeContext,
   ): Task.Result<Vtree.NodeContext | null> {
     let nodeContext: Vtree.NodeContext | null = initialNodeContext;
-    let resultNodeContext: Vtree.NodeContext | null = nodeContext.copy();
+    let resultNodeContext: Vtree.NodeContext | null = nodeContext;
     const frame: Task.Frame<Vtree.NodeContext | null> =
       Task.newFrame("skipEdges");
     let breakAtTheEdge: string | null = null;
@@ -4741,7 +4773,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     breakAtEdge: string | null,
     overflows: boolean,
   ): void {
-    const copy = position.copy();
+    const copy = position;
     const layoutProcessor = new LayoutProcessor.LayoutProcessorResolver().find(
       position.formattingContext,
     );
@@ -4815,27 +4847,46 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
     // ------ start the column -----------
     this.openAllViews(chunkPosition.primary).then((nodeContext) => {
-      let initialNodeContext: Vtree.NodeContext | null = null;
+      this.initialNodeContext = null;
+      const replaceWalkedContextListener = (evt) => {
+        this.followWalkedContext(
+          evt.previousNodeContext,
+          evt.nodeContext,
+          evt.cursorAdvance,
+        );
+      };
+      this.layoutContext.addEventListener(
+        "replaceWalkedContext",
+        replaceWalkedContextListener,
+      );
+      const nextInTreeListener = (evt) => {
+        if (evt.nodeContext.viewNode) {
+          this.initialNodeContext = evt.nodeContext;
+          this.layoutContext.removeEventListener(
+            "nextInTree",
+            nextInTreeListener,
+          );
+        }
+      };
       if (nodeContext.viewNode) {
-        initialNodeContext = nodeContext.copy();
+        this.initialNodeContext = nodeContext;
       } else {
-        const nextInTreeListener = (evt) => {
-          if (evt.nodeContext.viewNode) {
-            initialNodeContext = evt.nodeContext;
-            this.layoutContext.removeEventListener(
-              "nextInTree",
-              nextInTreeListener,
-            );
-          }
-        };
         this.layoutContext.addEventListener("nextInTree", nextInTreeListener);
       }
       const retryer = new ColumnLayoutRetryer(leadingEdge, breakAfter);
       retryer.layout(nodeContext, this).then((nodeContextParam) => {
+        this.layoutContext.removeEventListener(
+          "replaceWalkedContext",
+          replaceWalkedContextListener,
+        );
+        this.layoutContext.removeEventListener(
+          "nextInTree",
+          nextInTreeListener,
+        );
         this.doFinishBreak(
           nodeContextParam,
           retryer.context.overflownNodeContext,
-          initialNodeContext,
+          this.initialNodeContext,
           retryer.initialComputedBlockSize,
         ).then((positionAfter) => {
           let cont: Task.Result<boolean>;
@@ -5107,7 +5158,7 @@ export class PseudoColumn {
       return Column.prototype.openAllViews
         .call(this, position)
         .thenAsync((result) => {
-          pseudoColumn.startNodeContexts.push(result.copy());
+          pseudoColumn.startNodeContexts.push(result);
           return Task.newResult(result);
         });
     };
@@ -5124,7 +5175,7 @@ export class PseudoColumn {
   }
   findAcceptableBreakPosition(): Layout.BreakPositionAndNodeContext {
     const p = this.column.findAcceptableBreakPosition();
-    const startNodeContext = this.startNodeContexts[0].copy();
+    const startNodeContext = this.startNodeContexts[0];
     const bp = new BreakPosition.EdgeBreakPosition(
       startNodeContext,
       null,
@@ -5281,8 +5332,9 @@ export class TextNodeBreaker implements Layout.TextNodeBreaker {
         : "",
     );
     if (zwj) {
-      const p = nodeContext.preprocessedTextContent[0][1] as string;
-      nodeContext.preprocessedTextContent[0][1] =
+      const preprocessedTextContent = nodeContext.preprocessedTextContent;
+      const p = preprocessedTextContent[0][1] as string;
+      preprocessedTextContent[0][1] =
         p.slice(0, viewIndex + 1) + zwj + p.slice(viewIndex + 1);
     }
     return viewIndex + 1;

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -38,6 +38,7 @@ import * as LayoutProcessor from "./layout-processor";
 import * as PageFloats from "./page-floats";
 import * as Plugin from "./plugin";
 import * as Matchers from "./matchers";
+import * as NodeContext from "./node-context";
 import * as PseudoElement from "./pseudo-element";
 import * as SemanticFootnote from "./semantic-footnote";
 import * as Task from "./task";
@@ -601,24 +602,22 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       .loop(() => {
         while (stepIndex >= 0) {
           const prevContext = nodeContext;
+          const head =
+            stepIndex == 0
+              ? NodeContext.afterHeadFromPosition(
+                  position,
+                  this.calculateOffsetInNodeForNodeContext(position),
+                )
+              : undefined;
           nodeContext = prevContext
-            ? VtreeImpl.makeNodeContextFromNodePositionStep(
-                steps[stepIndex],
-                prevContext,
-              )
-            : VtreeImpl.makeRootNodeContextFromNodePositionStep(
+            ? NodeContext.openFromStep(steps[stepIndex], prevContext, head)
+            : NodeContext.openRootFromStep(
                 VtreeImpl.rootStepOfNodePosition(position),
                 this.flowRootFormattingContext,
+                head,
               );
-          if (stepIndex == 0) {
-            nodeContext.offsetInNode =
-              this.calculateOffsetInNodeForNodeContext(position);
-            nodeContext.after = position.after;
-            nodeContext.preprocessedTextContent =
-              position.preprocessedTextContent;
-            if (nodeContext.after) {
-              break;
-            }
+          if (head?.after) {
+            break;
           }
           const r = this.layoutContext.setCurrent(
             nodeContext,

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3484,23 +3484,40 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     };
   }
 
-  /**
-   * @return true if overflows
-   */
+  private matchesRepetitiveOverflowRecord(
+    nodeContext: Vtree.NodeContext,
+  ): boolean {
+    const recorded = this.nodeContextOverflowingDueToRepetitiveElements;
+    return (
+      !!recorded &&
+      recorded.sourceNode === nodeContext.sourceNode &&
+      recorded.after === nodeContext.after &&
+      recorded.boxOffset === nodeContext.boxOffset
+    );
+  }
+
   checkOverflowAndSaveEdge(
     nodeContext: Vtree.NodeContext | null,
     trailingEdgeContexts: Vtree.NodeContext[] | null,
-  ): boolean {
+  ): Layout.OverflowCheckResult {
     if (!nodeContext) {
-      return false;
+      return { overflown: false, recordedRepetitiveOverflow: false };
     }
     for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
       if (LayoutHelper.isOutOfFlow(nc.viewNode)) {
-        return false;
+        return {
+          overflown: false,
+          recordedRepetitiveOverflow:
+            this.matchesRepetitiveOverflowRecord(nodeContext),
+        };
       }
     }
     if (LayoutHelper.isOrphan(nodeContext.viewNode)) {
-      return false;
+      return {
+        overflown: false,
+        recordedRepetitiveOverflow:
+          this.matchesRepetitiveOverflowRecord(nodeContext),
+      };
     }
     const restoreInset = this.suppressOpenAncestorBlockEndInset(nodeContext);
     let edge = LayoutHelper.calculateEdge(
@@ -3533,8 +3550,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         ? Math.min(edge, Math.max(marginEdge, footnoteEdge))
         : Math.max(edge, Math.min(marginEdge, footnoteEdge));
     }
+    const recordedRepetitiveOverflow =
+      this.matchesRepetitiveOverflowRecord(nodeContext);
     this.updateMaxReachedAfterEdge(edge);
-    return overflown;
+    return { overflown, recordedRepetitiveOverflow };
   }
 
   /**
@@ -3554,7 +3573,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     if (LayoutHelper.isOrphan(nodeContext.viewNode)) {
       return false;
     }
-    const overflown = this.checkOverflowAndSaveEdge(
+    const { overflown } = this.checkOverflowAndSaveEdge(
       nodeContext,
       trailingEdgeContexts,
     );

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -456,6 +456,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   lastLineStride: number = 0;
   breakAtTheEdgeBeforeFloat: string | null = null;
   private lineFootnoteOverflowEdge: number | null = null;
+  edgeOverflowStore: BreakPosition.EdgeOverflowStore = {
+    edgeOverflowByViewNode: new WeakMap(),
+  };
 
   readonly pageFloatLayoutContext: PageFloats.AttachedPageFloatLayoutContext;
 
@@ -2357,7 +2360,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       );
     let cont: Task.Result<PageFloats.PageFloat>;
     const float = context.findPageFloatByNodePosition(
-      NodeContext.toNodePosition(nodeContext),
+      NodeContext.toNodePosition(
+        nodeContext,
+        this.layoutContext.continuationStore,
+      ),
     );
     if (!float) {
       cont = strategy.createPageFloat(nodeContext, context, this);
@@ -2783,10 +2789,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       hooks[i](
         LegacyPluginSurface.asLegacyNodeContextOrNull(
           Plugin.HOOKS.POST_LAYOUT_BLOCK,
+          this.layoutContext,
           nodeContext,
         ),
         LegacyPluginSurface.asLegacyRenderedNodeContexts(
           Plugin.HOOKS.POST_LAYOUT_BLOCK,
+          this.layoutContext,
           checkPoints,
         ),
         LegacyPluginSurface.asLegacyColumn(hooks[i], this),
@@ -2952,11 +2960,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       const breaker = hook(
         LegacyPluginSurface.asLegacyNodeContext(
           Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
+          this.layoutContext,
           nodeContext,
         ),
       );
       return breaker
-        ? LegacyPluginSurface.adaptLegacyTextNodeBreaker(hook, breaker)
+        ? LegacyPluginSurface.adaptLegacyTextNodeBreaker(
+            hook,
+            breaker,
+            this.layoutContext,
+          )
         : prev;
     }, TextNodeBreaker.instance);
     LegacyPluginSurface.retagLegacyNodeContext(
@@ -3363,6 +3376,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   ): Task.Result<boolean> {
     const layoutProcessor = new LayoutProcessor.LayoutProcessorResolver().find(
       nodeContext.formattingContext,
+      this.layoutContext,
     );
     let result = layoutProcessor.finishBreak(
       this,
@@ -3672,7 +3686,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     if (cursorAdvance) {
       return;
     }
-    NodeContext.followContinuation(previous, next);
+    NodeContext.followContinuation(
+      this.layoutContext.continuationStore,
+      previous,
+      next,
+    );
     if (this.initialNodeContext === previous) {
       this.initialNodeContext = next;
     }
@@ -3881,6 +3899,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const frame: Task.Frame<Vtree.NodeContext | null> =
       Task.newFrame("skipEdges");
     const column = this;
+    const breakStore = this.layoutContext.breakSuppressionStore;
 
     // If a forced break occurred at the end of the previous column,
     // nodeContext.after should be false.
@@ -3911,8 +3930,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         nc;
         nc = nc.parent
       ) {
-        if (nc.viewNode && Break.effectiveBreakBefore(nc) === "column") {
-          Break.suppressColumnBreakBefore(nc.viewNode);
+        if (
+          nc.viewNode &&
+          Break.effectiveBreakBefore(breakStore, nc) === "column"
+        ) {
+          Break.suppressColumnBreakBefore(breakStore, nc.viewNode);
         }
         if (nc.viewNode?.nodeType === 1) {
           const elem = nc.viewNode as HTMLElement;
@@ -3941,8 +3963,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         nc;
         nc = nc.parent
       ) {
-        if (nc.viewNode && Break.effectiveBreakBefore(nc) === "column") {
-          Break.suppressColumnBreakBefore(nc.viewNode);
+        if (
+          nc.viewNode &&
+          Break.effectiveBreakBefore(breakStore, nc) === "column"
+        ) {
+          Break.suppressColumnBreakBefore(breakStore, nc.viewNode);
         }
         if (nc.viewNode?.nodeType === 1) {
           const elem = nc.viewNode as HTMLElement;
@@ -3965,8 +3990,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         nc;
         nc = nc.parent
       ) {
-        if (nc.viewNode && Break.effectiveBreakAfter(nc) === "column") {
-          Break.suppressColumnBreakAfter(nc.viewNode);
+        if (
+          nc.viewNode &&
+          Break.effectiveBreakAfter(breakStore, nc) === "column"
+        ) {
+          Break.suppressColumnBreakAfter(breakStore, nc.viewNode);
         }
         if (nc.viewNode?.nodeType === 1) {
           const elem = nc.viewNode as HTMLElement;
@@ -4103,6 +4131,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           const layoutProcessor =
             new LayoutProcessor.LayoutProcessorResolver().find(
               nodeContext.formattingContext,
+              this.layoutContext,
             );
 
           // A code block to be able to use break. Break moves to the next
@@ -4129,7 +4158,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 break;
               }
               if (!nodeContext.after) {
-                setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
+                setBreakAtTheEdge(
+                  Break.effectiveBreakBefore(breakStore, nodeContext),
+                );
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
                 // Leading edge of non-empty block -> finished going through
@@ -4175,7 +4206,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     );
                   }
                   if (breakAtTheEdge === "column" && nodeContext.viewNode) {
-                    Break.unsuppressColumnBreakBefore(nodeContext.viewNode);
+                    Break.unsuppressColumnBreakBefore(
+                      breakStore,
+                      nodeContext.viewNode,
+                    );
                   }
                   nodeContext = NodeContext.setBreakBefore(
                     NodeContext.derived(nodeContext),
@@ -4266,7 +4300,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // or empty block box (unbreakable)
                 LegacyPluginSurface.noteRetained(rendered);
                 leadingEdgeContexts.push(rendered);
-                setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
+                setBreakAtTheEdge(
+                  Break.effectiveBreakBefore(breakStore, nodeContext),
+                );
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
 
@@ -4327,7 +4363,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 lastAfterNodeContext = elementContext;
                 trailingEdgeContexts.push(lastAfterNodeContext);
                 breakAtTheEdge = null;
-                setBreakAtTheEdge(Break.effectiveBreakAfter(nodeContext));
+                setBreakAtTheEdge(
+                  Break.effectiveBreakAfter(breakStore, nodeContext),
+                );
                 suppressWeakerTrailingColumnBreaks(nodeContext);
                 this.checkOverflowAndSaveEdgeAndBreakPosition(
                   lastAfterNodeContext,
@@ -4395,7 +4433,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 lastAfterNodeContext = elementContext;
                 trailingEdgeContexts.push(lastAfterNodeContext);
               }
-              setBreakAtTheEdge(Break.effectiveBreakAfter(nodeContext));
+              setBreakAtTheEdge(
+                Break.effectiveBreakAfter(breakStore, nodeContext),
+              );
               suppressWeakerTrailingColumnBreaks(nodeContext);
               if (
                 style &&
@@ -4413,7 +4453,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               // Leading edge
               LegacyPluginSurface.noteRetained(elementContext);
               leadingEdgeContexts.push(elementContext);
-              setBreakAtTheEdge(Break.effectiveBreakBefore(nodeContext));
+              setBreakAtTheEdge(
+                Break.effectiveBreakBefore(breakStore, nodeContext),
+              );
               suppressWeakerLeadingColumnBreaks(nodeContext);
               consumeSatisfiedLeadingColumnBreak(nodeContext);
 
@@ -4519,8 +4561,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       })
       .then(() => {
         if (lastAfterNodeContext) {
-          this.lastAfterPosition =
-            NodeContext.toNodePosition(lastAfterNodeContext);
+          this.lastAfterPosition = NodeContext.toNodePosition(
+            lastAfterNodeContext,
+            this.layoutContext.continuationStore,
+          );
         }
         frame.finish(nodeContext);
       });
@@ -4536,6 +4580,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     initialNodeContext: Vtree.NodeContext,
   ): Task.Result<Vtree.NodeContext | null> {
     let nodeContext: Vtree.NodeContext | null = initialNodeContext;
+    const breakStore = this.layoutContext.breakSuppressionStore;
     LegacyPluginSurface.noteRetained(nodeContext);
     let resultNodeContext: Vtree.NodeContext | null = nodeContext;
     const frame: Task.Frame<Vtree.NodeContext | null> =
@@ -4580,7 +4625,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 // float or flex container (unbreakable)
                 breakAtTheEdge = Break.resolveEffectiveBreakValue(
                   breakAtTheEdge,
-                  Break.effectiveBreakBefore(nodeContext),
+                  Break.effectiveBreakBefore(breakStore, nodeContext),
                 );
 
                 // check if a forced break must occur before the block.
@@ -4614,13 +4659,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               onStartEdges = false; // we are now on end edges.
               breakAtTheEdge = Break.resolveEffectiveBreakValue(
                 breakAtTheEdge,
-                Break.effectiveBreakAfter(nodeContext),
+                Break.effectiveBreakAfter(breakStore, nodeContext),
               );
             } else {
               // Leading edge
               breakAtTheEdge = Break.resolveEffectiveBreakValue(
                 breakAtTheEdge,
-                Break.effectiveBreakBefore(nodeContext),
+                Break.effectiveBreakBefore(breakStore, nodeContext),
               );
               const viewTag = viewElement.localName;
               if (Base.mediaTags[viewTag]) {
@@ -4718,6 +4763,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           const layoutProcessor =
             new LayoutProcessor.LayoutProcessorResolver().find(
               formattingContext,
+              this.layoutContext,
             );
           layoutProcessor
             .layout(nodeContext, this, leadingEdge)
@@ -4742,7 +4788,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     ) {
       const formattingContext = (parent || nodeContext).formattingContext;
       const layoutProcessor =
-        new LayoutProcessor.LayoutProcessorResolver().find(formattingContext);
+        new LayoutProcessor.LayoutProcessorResolver().find(
+          formattingContext,
+          this.layoutContext,
+        );
       layoutProcessor.clearOverflownViewNodes(
         this,
         parent,
@@ -4853,6 +4902,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const copy = position;
     const layoutProcessor = new LayoutProcessor.LayoutProcessorResolver().find(
       position.formattingContext,
+      this.layoutContext,
     );
     const clonedPaddingBorder = this.calculateClonedPaddingBorder(copy);
     const bp = layoutProcessor.createEdgeBreakPosition(
@@ -5009,7 +5059,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             } else {
               this.overflown = true;
               const result = new VtreeImpl.ChunkPosition(
-                NodeContext.toNodePosition(positionAfter),
+                NodeContext.toNodePosition(
+                  positionAfter,
+                  this.layoutContext.continuationStore,
+                ),
               );
               frame.finish(result);
             }
@@ -5077,7 +5130,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let overflownNodeContext: Vtree.NodeContext | null = null;
 
     // ------ init backtracking list -----
-    BreakPosition.beginLayoutPass(this);
+    this.edgeOverflowStore = {
+      edgeOverflowByViewNode: new WeakMap(),
+    };
     this.breakPositions = [];
     this.nodeContextOverflowingDueToRepetitiveElements = null;
 
@@ -5292,7 +5347,10 @@ export class PseudoColumn {
   isLastAfterNodeContext(nodeContext: Vtree.NodeContext): boolean {
     return (
       VtreeImpl.isSameNodePosition(
-        NodeContext.toNodePosition(nodeContext),
+        NodeContext.toNodePosition(
+          nodeContext,
+          this.column.layoutContext.continuationStore,
+        ),
         this.column.lastAfterPosition,
       ) || this.isEffectivelyLastAfterNodeContext(nodeContext)
     );

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2779,8 +2779,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     const hooks: Plugin.PostLayoutBlockHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.POST_LAYOUT_BLOCK,
     );
-    hooks.forEach((hook) => {
-      hook(
+    for (let i = 0; i < hooks.length; i++) {
+      hooks[i](
         LegacyPluginSurface.asLegacyNodeContextOrNull(
           Plugin.HOOKS.POST_LAYOUT_BLOCK,
           nodeContext,
@@ -2789,9 +2789,9 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           Plugin.HOOKS.POST_LAYOUT_BLOCK,
           checkPoints,
         ),
-        this,
+        LegacyPluginSurface.asLegacyColumn(hooks[i], this),
       );
-    });
+    }
   }
 
   findEndOfLine(

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -769,8 +769,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               !this.layoutConstraint.allowLayout(position)
             ) {
               violateConstraint = true;
-              position = position.modify();
-              position.overflow = true;
+              position = NodeContext.withOverflow(position, true);
             }
             const floatNodeContext = this.asFloatNodeContext(position);
             if (
@@ -881,8 +880,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               return;
             }
             if (!this.layoutConstraint.allowLayout(position)) {
-              position = position.modify();
-              position.overflow = true;
+              position = NodeContext.withOverflow(position, true);
               if (this.stopAtOverflow) {
                 bodyFrame.breakLoop();
                 return;
@@ -1608,8 +1606,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       const topValue = Math.max(0, floatBox.y1 - offsets.top);
       Base.setCSSProperty(element, "top", `${topValue}px`);
       if (nodeContext.clearSpacer) {
-        nodeContext.clearSpacer.remove();
-        nodeContext.clearSpacer = null;
+        const clearSpacer = nodeContext.clearSpacer;
+        clearSpacer.remove();
+        NodeContext.setClearSpacer(nodeContext, null);
+        if (nodeContextAfter.clearSpacer === clearSpacer) {
+          NodeContext.setClearSpacer(nodeContextAfter, null);
+        }
       }
       const floatBoxEdge = this.vertical ? floatBox.x1 : floatBox.y2;
       const floatBoxTop = this.vertical ? floatBox.x2 : floatBox.y1;
@@ -1644,8 +1646,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         this.updateMaxReachedAfterEdge(floatBoxEdge);
         frame.finish(nodeContextAfter);
       } else {
-        nodeContext = nodeContext.modify();
-        nodeContext.overflow = true;
+        nodeContext = NodeContext.withOverflow(nodeContext, true);
         frame.finish(nodeContext);
       }
     });
@@ -2265,15 +2266,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     }
 
     nodeContext.viewNode.remove();
-    const nodeContextAfter = nodeContext.modify();
-    nodeContextAfter.after = true;
-    nodeContextAfter.viewNode = anchor;
-    // Issue #868: For footnote-call anchors, set display to inline so that
-    // text-spacing can look through this element to find adjacent text nodes
-    if (nodeContext.floatSide === "footnote") {
-      nodeContextAfter.display = "inline";
-    }
-    return nodeContextAfter;
+    return NodeContext.anchoredAfterOf(
+      nodeContext,
+      anchor,
+      // Issue #868: For footnote-call anchors, set display to inline so that
+      // text-spacing can look through this element to find adjacent text nodes
+      nodeContext.floatSide === "footnote",
+    );
   }
 
   resolveFloatReferenceFromColumnSpan(
@@ -2711,9 +2710,11 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           const lineFootnoteOverflowBreak =
             this.findLineFootnoteOverflowBreak(checkPoints);
           if (lineFootnoteOverflowBreak) {
-            const overflowNodeContext = lineFootnoteOverflowBreak.modify();
-            overflowNodeContext.overflow = true;
-            overflowNodeContext.pluginProps["lineFootnoteOverflow"] = 1;
+            const overflowNodeContext = NodeContext.setPluginProp(
+              NodeContext.withOverflow(lineFootnoteOverflowBreak, true),
+              "lineFootnoteOverflow",
+              1,
+            );
             this.breakPositions = [];
             this.saveEdgeBreakPosition(overflowNodeContext, null, true);
             this.lineFootnoteOverflowEdge = null;
@@ -2727,8 +2728,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
 
             // TODO: how to signal overflow in the last pagargaph???
             if (overflown && !this.isLoneImage(checkPoints) && nodeContext) {
-              nodeContext = nodeContext.modify();
-              nodeContext.overflow = true;
+              nodeContext = NodeContext.withOverflow(nodeContext, true);
             }
           }
           frame.finish(nodeContext);
@@ -3246,8 +3246,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       blockParent = blockParent.parent;
     } while (blockParent && blockParent.inline);
     if (blockParent) {
-      blockParent = blockParent.copy().modify();
-      blockParent.after = true;
+      blockParent = NodeContext.detachedAfterEdgeOf(blockParent);
       return LayoutHelper.calculateEdge(
         blockParent,
         this.clientLayout,
@@ -3283,7 +3282,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
   ): Vtree.NodeContext {
     this.computedBlockSize =
       bp.computedBlockSize + this.getOffsetByRepetitiveElements(bp);
-    bp.position.overflow = bp.overflows;
     return bp.position;
   }
 
@@ -3366,8 +3364,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         Logging.logger.warn("Could not find any page breaks?!!");
         this.skipTailEdges(overflownNodeContext).then((nodeContext) => {
           if (nodeContext) {
-            nodeContext = nodeContext.modify();
-            nodeContext.overflow = false;
+            nodeContext = NodeContext.withOverflow(nodeContext, false);
             this.finishBreak(nodeContext, forceRemoveSelf, true).then(() => {
               frame.finish(nodeContext);
             });
@@ -3748,7 +3745,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           spacer.style.marginBottom = `${hAdj}px`;
         }
       }
-      nodeContext.clearSpacer = spacer;
+      NodeContext.setClearSpacer(nodeContext, spacer);
       return true;
     }
   }
@@ -4060,12 +4057,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     breakAtTheEdge,
                   )
                 ) {
-                  nodeContext = (
+                  nodeContext = NodeContext.withOverflow(
                     this.stopAtOverflow
                       ? lastAfterNodeContext || nodeContext
-                      : nodeContext
-                  ).modify();
-                  nodeContext.overflow = true;
+                      : nodeContext,
+                    true,
+                  );
                 } else {
                   // When lastAfterNodeContext is null (no in-flow trailing
                   // edge before this content, e.g. after CSS floats
@@ -4091,8 +4088,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   if (breakAtTheEdge === "column" && nodeContext.viewNode) {
                     Break.unsuppressColumnBreakBefore(nodeContext.viewNode);
                   }
-                  nodeContext = nodeContext.modify();
-                  nodeContext.breakBefore = breakAtTheEdge;
+                  nodeContext = NodeContext.withBreakBefore(
+                    nodeContext,
+                    breakAtTheEdge,
+                  );
                 }
                 loopFrame.breakLoop();
                 return;
@@ -4190,12 +4189,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   !this.layoutConstraint.allowLayout(nodeContext)
                 ) {
                   // overflow
-                  nodeContext = (
+                  nodeContext = NodeContext.withOverflow(
                     this.stopAtOverflow
                       ? lastAfterNodeContext || nodeContext
-                      : nodeContext
-                  ).modify();
-                  nodeContext.overflow = true;
+                      : nodeContext,
+                    true,
+                  );
                 }
                 loopFrame.breakLoop();
                 return;
@@ -4341,8 +4340,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   !this.stopAtOverflow,
                   breakAtTheEdge,
                 );
-                nodeContext = nodeContext.modify();
-                nodeContext.overflow = true;
+                nodeContext = NodeContext.withOverflow(nodeContext, true);
                 if (this.stopAtOverflow) {
                   loopFrame.breakLoop();
                   return;
@@ -4363,12 +4361,12 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                   )
                 ) {
                   // overflow
-                  nodeContext = (
+                  nodeContext = NodeContext.withOverflow(
                     this.stopAtOverflow
                       ? lastAfterNodeContext || nodeContext
-                      : nodeContext
-                  ).modify();
-                  nodeContext.overflow = true;
+                      : nodeContext,
+                    true,
+                  );
                 }
                 loopFrame.breakLoop();
                 return;
@@ -4403,8 +4401,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           )
         ) {
           if (lastAfterNodeContext && this.stopAtOverflow) {
-            nodeContext = lastAfterNodeContext.modify();
-            nodeContext.overflow = true;
+            nodeContext = NodeContext.withOverflow(lastAfterNodeContext, true);
           } else {
             // TODO: what to return here??
           }
@@ -4573,10 +4570,8 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         generatingNodePosition &&
         nodeContext.sourceNode === generatingNodePosition.steps[0].node
       ) {
-        const nodeContextMod: Vtree.NodeContext = nodeContext.modify();
-        nodeContextMod.floatSide = null;
-        nodeContextMod.floatReference = PageFloats.FloatReference.INLINE;
-        nodeContextMod.clearSide = null;
+        const nodeContextMod: Vtree.NodeContext =
+          NodeContext.withoutFloat(nodeContext);
         if (this.isBreakable(nodeContextMod)) {
           return this.layoutBreakableBlock(nodeContextMod);
         } else {
@@ -4971,9 +4966,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 this.stopAtOverflow
               ) {
                 this.pageBreakType = null;
-                nodeContext =
-                  this.nodeContextOverflowingDueToRepetitiveElements;
-                nodeContext.overflow = true;
+                nodeContext = NodeContext.setOverflow(
+                  this.nodeContextOverflowingDueToRepetitiveElements,
+                  true,
+                );
               } else {
                 nodeContext = nodeContextParam;
               }
@@ -5134,11 +5130,11 @@ export class PseudoColumn {
       startNodeContext.overflow,
       0,
     );
-    bp.findAcceptableBreak(this.column, 0);
     // updates the column's overflow state, so it runs whether or not the
     // start position is the one taken
-    startNodeContext.overflow = bp.overflows;
-    return p ?? { breakPosition: bp, nodeContext: startNodeContext };
+    bp.findAcceptableBreak(this.column, 0);
+    this.startNodeContexts[0] = bp.position;
+    return p ?? { breakPosition: bp, nodeContext: bp.position };
   }
   /**
    * @return holing true
@@ -5237,8 +5233,7 @@ export class TextNodeBreaker implements Layout.TextNodeBreaker {
     force: boolean,
   ): Vtree.NodeContext {
     if (nodeContext.after) {
-      nodeContext = nodeContext.modify();
-      nodeContext.offsetInNode = textNode.length;
+      nodeContext = NodeContext.withOffsetInNode(nodeContext, textNode.length);
     } else {
       // Character with index low is the last one that fits.
       let viewIndex = low - nodeContext.boxOffset;
@@ -5319,10 +5314,7 @@ export class TextNodeBreaker implements Layout.TextNodeBreaker {
     viewIndex: number,
     textNode: Text,
   ): Vtree.NodeContext {
-    nodeContext = nodeContext.modify();
-    nodeContext.offsetInNode += viewIndex;
-    nodeContext.breakBefore = null;
-    return nodeContext;
+    return NodeContext.textBrokenAt(nodeContext, viewIndex);
   }
 
   static instance: TextNodeBreaker;

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2484,14 +2484,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     nodeContext: Vtree.NodeContext,
     resNodeContext: Vtree.NodeContext | null,
     checkPoints: Vtree.RenderedNodeContext[],
-  ): Task.Result<Vtree.NodeContext | null> {
-    const frame: Task.Frame<Vtree.NodeContext | null> =
+  ): Task.Result<Layout.LineStylingResult> {
+    const frame: Task.Frame<Layout.LineStylingResult> =
       Task.newFrame("processLineStyling");
     if (VIVLIOSTYLE_DEBUG) {
       validateCheckPoints(checkPoints);
     }
     let lastCheckPoints = checkPoints.concat([]); // make a copy
-    checkPoints.splice(0, checkPoints.length); // make empty
     let totalLineCount = 0;
     let firstPseudo = nodeContext.firstPseudo; // :first-letter is not processed here
     if (firstPseudo?.count === 0) {
@@ -2538,11 +2537,13 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         });
       })
       .then(() => {
-        Array.prototype.push.apply(checkPoints, lastCheckPoints);
         if (VIVLIOSTYLE_DEBUG) {
-          validateCheckPoints(checkPoints);
+          validateCheckPoints(lastCheckPoints);
         }
-        frame.finish(resNodeContext);
+        frame.finish({
+          nodeContext: resNodeContext,
+          checkPoints: lastCheckPoints,
+        });
       });
     return frame.result();
   }
@@ -2688,7 +2689,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
           edge += this.getTrailingMarginEdgeAdjustment(checkPoints);
         }
         this.updateMaxReachedAfterEdge(edge);
-        let lineCont: Task.Result<Vtree.NodeContext | null>;
+        let lineCont: Task.Result<Layout.LineStylingResult>;
         if (nodeContext.firstPseudo) {
           // possibly need to deal with :first-line and friends
           lineCont = this.processLineStyling(
@@ -2697,12 +2698,17 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
             checkPoints,
           );
         } else {
-          lineCont = Task.newResult(resNodeContext);
+          lineCont = Task.newResult({
+            nodeContext: resNodeContext,
+            checkPoints,
+          });
         }
-        lineCont.then((nodeContext) => {
+        lineCont.then((lineResult) => {
           // Text-spacing etc. must be done before calculating edge. (Issue #898)
           // this.postLayoutBlock(nodeContext, checkPoints);
 
+          let nodeContext = lineResult.nodeContext;
+          const checkPoints = lineResult.checkPoints;
           const lineFootnoteOverflowBreak =
             this.findLineFootnoteOverflowBreak(checkPoints);
           if (lineFootnoteOverflowBreak) {
@@ -4761,7 +4767,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       }
       penalty = block.breakPenalty;
     }
-    const bp = new BoxBreakPosition(checkPoints, penalty);
+    const bp = new BoxBreakPosition([...checkPoints], penalty);
     this.breakPositions.push(bp);
   }
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2791,6 +2791,14 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         ),
         LegacyPluginSurface.asLegacyColumn(hooks[i], this),
       );
+      LegacyPluginSurface.retagLegacyNodeContext(
+        Plugin.HOOKS.POST_LAYOUT_BLOCK,
+        nodeContext,
+      );
+      LegacyPluginSurface.retagLegacyNodeContexts(
+        Plugin.HOOKS.POST_LAYOUT_BLOCK,
+        checkPoints,
+      );
     }
   }
 
@@ -2951,18 +2959,10 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
         ? LegacyPluginSurface.adaptLegacyTextNodeBreaker(hook, breaker)
         : prev;
     }, TextNodeBreaker.instance);
-    if (
-      LegacyPluginSurface.legacySurfaceActive(
-        Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
-      )
-    ) {
-      LegacyPluginSurface.normalizeLegacyNodeContext(
-        LegacyPluginSurface.asLegacyNodeContext(
-          Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
-          nodeContext,
-        ),
-      );
-    }
+    LegacyPluginSurface.retagLegacyNodeContext(
+      Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
+      nodeContext,
+    );
     return resolved;
   }
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -2934,14 +2934,36 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     return nodeContext;
   }
 
-  resolveTextNodeBreaker(nodeContext: Vtree.NodeContext): TextNodeBreaker {
+  resolveTextNodeBreaker(
+    nodeContext: Vtree.NodeContext,
+  ): Layout.TextNodeBreaker {
     const hooks: Plugin.ResolveTextNodeBreakerHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
     );
-    return hooks.reduce(
-      (prev, hook) => hook(nodeContext) || prev,
-      TextNodeBreaker.instance,
-    );
+    const resolved = hooks.reduce((prev, hook) => {
+      const breaker = hook(
+        LegacyPluginSurface.asLegacyNodeContext(
+          Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
+          nodeContext,
+        ),
+      );
+      return breaker
+        ? LegacyPluginSurface.adaptLegacyTextNodeBreaker(hook, breaker)
+        : prev;
+    }, TextNodeBreaker.instance);
+    if (
+      LegacyPluginSurface.legacySurfaceActive(
+        Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
+      )
+    ) {
+      LegacyPluginSurface.normalizeLegacyNodeContext(
+        LegacyPluginSurface.asLegacyNodeContext(
+          Plugin.HOOKS.RESOLVE_TEXT_NODE_BREAKER,
+          nodeContext,
+        ),
+      );
+    }
+    return resolved;
   }
 
   /**

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -25,6 +25,7 @@
  * for, and an assignment to a projected member stays inside the view. Core code
  * must use `Vtree.NodeContext` and `node-context.ts`.
  */
+import * as Break from "./break";
 import * as Css from "./css";
 import * as Diff from "./diff";
 import * as NodeContext from "./node-context";
@@ -345,18 +346,179 @@ function isDecorated(nodeContext: Vtree.NodeContext): boolean {
 
 function decorate(nodeContext: Vtree.NodeContext): void {
   for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
+    reportSuppressedBreaks(nc);
     if (!isDecorated(nc)) {
       // The core builds node contexts as plain object literals, so the legacy
       // prototype cannot shadow any own field of the value.
       Object.setPrototypeOf(nc, legacyPrototype);
     }
-    if (nc.shadowSibling && !isDecorated(nc.shadowSibling)) {
-      decorate(nc.shadowSibling);
+    if (nc.shadowSibling) {
+      reportSuppressedBreaks(nc.shadowSibling);
+      if (!isDecorated(nc.shadowSibling)) {
+        decorate(nc.shadowSibling);
+      }
     }
     if (nc.blockContainer && !isDecorated(nc.blockContainer)) {
       decorate(nc.blockContainer);
     }
   }
+}
+
+function reportSuppressedBreaks(nodeContext: Vtree.NodeContext): void {
+  // Suppression used to null the field itself; the core now composes it with
+  // the registry, so writing the composed value back is a no-op for the core
+  // and restores what a plugin used to read.
+  const writable = nodeContext as unknown as {
+    breakBefore: string | null;
+    breakAfter: string | null;
+  };
+  writable.breakBefore = Break.reportEffectiveBreakBefore(nodeContext);
+  writable.breakAfter = Break.reportEffectiveBreakAfter(nodeContext);
+}
+
+let renderFields: readonly string[] | null = null;
+
+function renderFieldsOf(): readonly string[] {
+  if (!renderFields) {
+    renderFields = Object.keys(
+      NodeContext.elementRenderResultOf({} as unknown as Vtree.NodeContext),
+    );
+  }
+  return renderFields;
+}
+
+const CONTEXT_FIELDS: readonly string[] = [
+  "offsetInNode",
+  "after",
+  "shadowType",
+  "shadowContext",
+  "shadowSibling",
+  "overflow",
+  "viewNode",
+  "clearSpacer",
+  "preprocessedTextContent",
+  "pluginProps",
+  "fragmentIndex",
+  "sourceNode",
+  "parent",
+  "blockContainer",
+  "boxOffset",
+];
+
+type RenderFields = { [field: string]: unknown };
+
+export type LegacyContextWrites = { readonly [field: string]: unknown };
+
+const retainedWrites = new WeakSet<LegacyContextWrites>();
+
+/**
+ * @deprecated Hand out a node context whose rendered style is the draft the
+ * core has built so far, which is what the value carried when it was mutated
+ * in place. Falls back to the value the core hands today while no external
+ * hook is registered.
+ */
+export function asLegacyRenderContext(
+  hook: string,
+  nodeContext: Vtree.NodeContext,
+  progress: Vtree.NodeContext,
+  rendered: NodeContext.ElementRenderDraft,
+): LegacyNodeContext {
+  if (!legacySurfaceActive(hook)) {
+    return legacyViewOf(progress);
+  }
+  // Runtime fact outside the type system: the draft holds the rendered style
+  // of this very position, so overlaying it cannot contradict the variant.
+  const overlaid = {
+    ...progress,
+    ...rendered,
+  } as unknown as Vtree.NodeContext;
+  if (retained.has(nodeContext)) {
+    retained.add(overlaid);
+  }
+  return decorated(overlaid);
+}
+
+export function captureRenderFields(
+  hook: string,
+  nodeContext: LegacyNodeContext,
+): RenderFields | null {
+  if (!legacySurfaceActive(hook)) {
+    return null;
+  }
+  const source = nodeContext as unknown as RenderFields;
+  const snapshot: RenderFields = {};
+  for (const field of renderFieldsOf()) {
+    snapshot[field] = source[field];
+  }
+  for (const field of CONTEXT_FIELDS) {
+    snapshot[field] = source[field];
+  }
+  return snapshot;
+}
+
+export function applyLegacyRenderWrites(
+  before: RenderFields | null,
+  nodeContext: LegacyNodeContext,
+  rendered: NodeContext.ElementRenderDraft,
+): LegacyContextWrites {
+  if (!before) {
+    return {};
+  }
+  const source = nodeContext as unknown as RenderFields;
+  const draft = rendered as unknown as RenderFields;
+  for (const field of renderFieldsOf()) {
+    if (source[field] !== before[field]) {
+      draft[field] = source[field];
+    }
+  }
+  const written: RenderFields = {};
+  for (const field of CONTEXT_FIELDS) {
+    if (source[field] !== before[field]) {
+      written[field] = source[field];
+    }
+  }
+  if (retained.has(coreOf(nodeContext))) {
+    retainedWrites.add(written);
+  }
+  return written;
+}
+
+export function withLegacyContextWrites<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  writes: LegacyContextWrites,
+): T {
+  const claimed = retainedWrites.has(writes);
+  if (Object.keys(writes).length === 0) {
+    if (claimed) {
+      retained.add(nodeContext);
+    }
+    return nodeContext;
+  }
+  const composed = { ...nodeContext, ...writes } as unknown as T;
+  if (claimed) {
+    retained.add(composed);
+  }
+  if ("after" in writes || "viewNode" in writes) {
+    normalizeLegacyNodeContext(legacyViewOf(composed));
+  }
+  return composed;
+}
+
+function applyRenderedNodeContext(
+  nodeContext: Vtree.NodeContext,
+  rendered: Vtree.NodeContext,
+): void {
+  if (rendered !== nodeContext) {
+    const target = nodeContext as unknown as RenderFields;
+    const source = rendered as unknown as RenderFields;
+    for (const field of renderFieldsOf()) {
+      target[field] = source[field];
+    }
+    for (const field of CONTEXT_FIELDS) {
+      target[field] = source[field];
+    }
+  }
+  normalizeLegacyNodeContext(decorated(nodeContext));
 }
 
 function decorated(nodeContext: Vtree.NodeContext): LegacyNodeContext {
@@ -796,7 +958,10 @@ export function asLegacyLayoutContext(
       ) =>
         layoutContext
           .setCurrent(nodeContext, firstTime, atUnforcedBreak)
-          .thenAsync((result) => Task.newResult(result.processChildren)),
+          .thenAsync((result) => {
+            applyRenderedNodeContext(nodeContext, result.nodeContext);
+            return Task.newResult(result.processChildren);
+          }),
     clone: () => () => asLegacyLayoutContext(layoutContext.clone()),
     nextInTree:
       () => (nodeContext: Vtree.NodeContext, atUnforcedBreak?: boolean) =>

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -459,6 +459,7 @@ export function captureRenderFields(
 }
 
 export function applyLegacyRenderWrites(
+  hooks: readonly ((...p1) => any)[],
   before: RenderFields | null,
   nodeContext: LegacyNodeContext,
   rendered: NodeContext.ElementRenderDraft,
@@ -466,11 +467,16 @@ export function applyLegacyRenderWrites(
   if (!before) {
     return {};
   }
+  const adapts = hooks.some((hook) => !Plugin.isCoreHook(hook));
   const source = nodeContext as unknown as RenderFields;
   const draft = rendered as unknown as RenderFields;
   for (const field of renderFieldsOf()) {
     if (source[field] !== before[field]) {
-      draft[field] = source[field];
+      const written = source[field];
+      draft[field] =
+        field === "formattingContext" && written && adapts
+          ? adaptFormattingContext(written as Vtree.FormattingContext)
+          : written;
     }
   }
   const written: RenderFields = {};
@@ -1548,6 +1554,14 @@ export interface LegacyBreakPosition {
   checkPoints?: LegacyRenderedNodeContext[];
 }
 
+export interface LegacyFormattingContext extends Omit<
+  Vtree.FormattingContext,
+  "isFirstTime" | "getParent"
+> {
+  isFirstTime(nodeContext: LegacyNodeContext, firstTime: boolean): boolean;
+  getParent(): LegacyFormattingContext | null;
+}
+
 export interface LegacyLayoutProcessor {
   layout(
     nodeContext: LegacyNodeContext,
@@ -1751,6 +1765,88 @@ function adaptLegacyBreakPosition(
   adaptedBreakPositions.set(legacy, adapted);
   legacyOfAdaptedBreakPositions.set(adapted, legacy);
   return adapted;
+}
+
+const adaptedFormattingContexts = new WeakSet<Vtree.FormattingContext>();
+
+function acceptsFirstTimeReplacement(
+  formattingContext: Vtree.FormattingContext,
+): boolean {
+  const target = formattingContext as unknown as object;
+  for (
+    let owner: object | null = target;
+    owner;
+    owner = Object.getPrototypeOf(owner)
+  ) {
+    const descriptor = Object.getOwnPropertyDescriptor(owner, "isFirstTime");
+    if (!descriptor) {
+      continue;
+    }
+    if (descriptor.writable !== true) {
+      return false;
+    }
+    return owner === target || Object.isExtensible(target);
+  }
+  return Object.isExtensible(target);
+}
+
+function adaptFormattingContext(
+  formattingContext: Vtree.FormattingContext,
+): Vtree.FormattingContext {
+  if (
+    adaptedFormattingContexts.has(formattingContext) ||
+    !acceptsFirstTimeReplacement(formattingContext)
+  ) {
+    return formattingContext;
+  }
+  adaptedFormattingContexts.add(formattingContext);
+  const isFirstTime = formattingContext.isFirstTime;
+  formattingContext.isFirstTime = (
+    nodeContext: Vtree.NodeContext,
+    firstTime: boolean,
+  ): boolean => {
+    decorate(nodeContext);
+    return isFirstTime.call(formattingContext, nodeContext, firstTime);
+  };
+  return formattingContext;
+}
+
+export function adaptLegacyFormattingContext(
+  hook: (...p1) => any,
+  formattingContext: LegacyFormattingContext,
+): Vtree.FormattingContext {
+  const core = formattingContext as unknown as Vtree.FormattingContext;
+  return Plugin.isCoreHook(hook) ? core : adaptFormattingContext(core);
+}
+
+export function legacyFirstTime(
+  formattingContext: Vtree.FormattingContext,
+  nodeContext: Vtree.NodeContext,
+  rendered: NodeContext.ElementRenderDraft,
+  firstTime: boolean,
+): { firstTime: boolean; nodeContext: Vtree.NodeContext } {
+  const hook = Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT;
+  const legacy = asLegacyRenderContext(
+    hook,
+    nodeContext,
+    NodeContext.elementRenderProgress(nodeContext, rendered),
+    rendered,
+  );
+  const before = captureRenderFields(hook, legacy);
+  const resolved = formattingContext.isFirstTime(coreOf(legacy), firstTime);
+  normalizeLegacyNodeContext(legacy);
+  return {
+    firstTime: resolved,
+    nodeContext: withLegacyContextWrites(
+      nodeContext,
+      applyLegacyRenderWrites(
+        Plugin.getHooksForName(hook),
+        before,
+        legacy,
+        rendered,
+      ),
+    ),
+  };
 }
 
 const adaptedLayoutProcessors = new WeakMap<

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -1610,6 +1610,17 @@ function retagLegacyValue(nodeContext: LegacyNodeContext): void {
 
 const handedOut = new Set<Vtree.NodeContext>();
 
+function retagHandedOut(): void {
+  if (handedOut.size === 0) {
+    return;
+  }
+  const served = [...handedOut];
+  handedOut.clear();
+  for (const nodeContext of served) {
+    retagLegacyValue(legacyViewOf(nodeContext));
+  }
+}
+
 /**
  * @deprecated Give a value coming back from a legacy implementation the
  * discriminant its own fields imply, and hand it to the core as itself.
@@ -1617,11 +1628,35 @@ const handedOut = new Set<Vtree.NodeContext>();
 export function normalizeLegacyNodeContext(
   nodeContext: LegacyNodeContext | null | undefined,
 ): Vtree.NodeContext | null {
+  retagHandedOut();
   if (!nodeContext) {
     return null;
   }
   retagLegacyValue(nodeContext);
   return coreOf(nodeContext);
+}
+
+export function retagLegacyNodeContext(
+  hook: string,
+  nodeContext: Vtree.NodeContext | null,
+): void {
+  retagHandedOut();
+  if (nodeContext && legacySurfaceActive(hook)) {
+    retagLegacyValue(legacyViewOf(nodeContext));
+  }
+}
+
+export function retagLegacyNodeContexts(
+  hook: string,
+  checkPoints: Vtree.RenderedNodeContext[],
+): void {
+  retagHandedOut();
+  if (!legacySurfaceActive(hook)) {
+    return;
+  }
+  for (const checkPoint of checkPoints) {
+    retagLegacyValue(legacyViewOf(checkPoint));
+  }
 }
 
 const adaptedTextNodeBreakers = new WeakMap<

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -29,7 +29,7 @@ import * as Css from "./css";
 import * as Diff from "./diff";
 import * as NodeContext from "./node-context";
 import * as Plugin from "./plugin";
-import { PageFloats, Selectors, Vtree } from "./types";
+import { Layout, PageFloats, Selectors, Vtree } from "./types";
 
 /**
  * @deprecated Flat mutable view of a node context. Use `Vtree.NodeContext`.
@@ -383,6 +383,168 @@ export function asLegacyNodeContextOrNull(
 }
 
 /**
+ * @deprecated Base-compatible text node breaker contract. Implementations are
+ * handed to the core through `adaptLegacyTextNodeBreaker`.
+ */
+export interface LegacyTextNodeBreaker {
+  breakTextNode(
+    textNode: Text,
+    nodeContext: LegacyNodeContext,
+    low: number,
+    checkPoints: LegacyRenderedNodeContext[],
+    checkpointIndex: number,
+    force: boolean,
+  ): LegacyNodeContext;
+  breakAfterSoftHyphen(
+    textNode: Text,
+    text: string,
+    viewIndex: number,
+    nodeContext: LegacyNodeContext,
+  ): number;
+  breakAfterOtherCharacter(
+    textNode: Text,
+    text: string,
+    viewIndex: number,
+    nodeContext: LegacyNodeContext,
+  ): number;
+  updateNodeContext(
+    nodeContext: LegacyNodeContext,
+    viewIndex: number,
+    textNode: Text,
+  ): LegacyNodeContext;
+}
+
+function kindOfLegacy(nodeContext: LegacyNodeContext): Vtree.NodeContextKind {
+  const viewNode = nodeContext.viewNode;
+  if (viewNode === null) {
+    return nodeContext.after ? "after-none" : "open";
+  }
+  if (viewNode.nodeType === 1) {
+    return nodeContext.after ? "after-element" : "element";
+  }
+  return nodeContext.after ? "after-text" : "text";
+}
+
+/**
+ * @deprecated Give a value coming back from a legacy implementation the
+ * discriminant its own fields imply, and hand it to the core as itself.
+ */
+export function normalizeLegacyNodeContext(
+  nodeContext: LegacyNodeContext | null | undefined,
+): Vtree.NodeContext | null {
+  if (!nodeContext) {
+    return null;
+  }
+  setLegacyKind(nodeContext, kindOfLegacy(nodeContext));
+  return coreOf(nodeContext);
+}
+
+const adaptedTextNodeBreakers = new WeakMap<
+  LegacyTextNodeBreaker,
+  Layout.TextNodeBreaker
+>();
+
+/**
+ * @deprecated Serve a legacy text node breaker under the current contract.
+ */
+export function adaptLegacyTextNodeBreaker(
+  hook: (...p1) => any,
+  legacy: LegacyTextNodeBreaker,
+): Layout.TextNodeBreaker {
+  if (Plugin.isCoreHook(hook)) {
+    return legacy as unknown as Layout.TextNodeBreaker;
+  }
+  const cached = adaptedTextNodeBreakers.get(legacy);
+  if (cached) {
+    return cached;
+  }
+  const adapted: Layout.TextNodeBreaker = {
+    breakTextNode(
+      textNode: Text,
+      nodeContext: Vtree.NodeContext,
+      low: number,
+      checkPoints: Vtree.RenderedNodeContext[],
+      checkpointIndex: number,
+      force: boolean,
+    ): Vtree.NodeContext {
+      const legacyNodeContext = decorated(nodeContext);
+      const legacyCheckPoints = decoratedCheckPoints(checkPoints);
+      const broken = legacy.breakTextNode(
+        textNode,
+        legacyNodeContext,
+        low,
+        legacyCheckPoints,
+        checkpointIndex,
+        force,
+      );
+      normalizeLegacyNodeContext(legacyNodeContext);
+      for (const checkPoint of legacyCheckPoints) {
+        normalizeLegacyNodeContext(checkPoint);
+      }
+      return normalizeLegacyNodeContext(broken)!;
+    },
+    breakAfterSoftHyphen(
+      textNode: Text,
+      text: string,
+      viewIndex: number,
+      nodeContext: Vtree.NodeContext,
+    ): number {
+      const legacyNodeContext = decorated(nodeContext);
+      const broken = legacy.breakAfterSoftHyphen(
+        textNode,
+        text,
+        viewIndex,
+        legacyNodeContext,
+      );
+      normalizeLegacyNodeContext(legacyNodeContext);
+      return broken;
+    },
+    breakAfterOtherCharacter(
+      textNode: Text,
+      text: string,
+      viewIndex: number,
+      nodeContext: Vtree.NodeContext,
+    ): number {
+      const legacyNodeContext = decorated(nodeContext);
+      const broken = legacy.breakAfterOtherCharacter(
+        textNode,
+        text,
+        viewIndex,
+        legacyNodeContext,
+      );
+      normalizeLegacyNodeContext(legacyNodeContext);
+      return broken;
+    },
+    updateNodeContext(
+      nodeContext: Vtree.NodeContext,
+      viewIndex: number,
+      textNode: Text,
+    ): Vtree.NodeContext {
+      const legacyNodeContext = decorated(nodeContext);
+      const updated = legacy.updateNodeContext(
+        legacyNodeContext,
+        viewIndex,
+        textNode,
+      );
+      normalizeLegacyNodeContext(legacyNodeContext);
+      return normalizeLegacyNodeContext(updated)!;
+    },
+  };
+  adaptedTextNodeBreakers.set(legacy, adapted);
+  return adapted;
+}
+
+function decoratedCheckPoints(
+  checkPoints: Vtree.RenderedNodeContext[],
+): LegacyRenderedNodeContext[] {
+  for (const checkPoint of checkPoints) {
+    decorate(checkPoint);
+  }
+  // Same array, same elements: see coreOf.
+  return checkPoints as unknown as LegacyRenderedNodeContext[];
+}
+
+/**
  * @deprecated `asLegacyNodeContext` for checkpoint arrays. The array itself is
  * returned so that its identity and its elements' identities are preserved.
  */
@@ -390,11 +552,9 @@ export function asLegacyRenderedNodeContexts(
   hook: string,
   checkPoints: Vtree.RenderedNodeContext[],
 ): LegacyRenderedNodeContext[] {
-  if (legacySurfaceActive(hook)) {
-    for (const checkPoint of checkPoints) {
-      decorate(checkPoint);
-    }
+  if (!legacySurfaceActive(hook)) {
+    // Same array, same elements: see coreOf.
+    return checkPoints as unknown as LegacyRenderedNodeContext[];
   }
-  // Same array, same elements: see coreOf.
-  return checkPoints as unknown as LegacyRenderedNodeContext[];
+  return decoratedCheckPoints(checkPoints);
 }

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -29,7 +29,14 @@ import * as Css from "./css";
 import * as Diff from "./diff";
 import * as NodeContext from "./node-context";
 import * as Plugin from "./plugin";
-import { Layout, PageFloats, Selectors, Vtree } from "./types";
+import * as Task from "./task";
+import {
+  FragmentLayoutConstraintType,
+  Layout,
+  PageFloats,
+  Selectors,
+  Vtree,
+} from "./types";
 
 /**
  * @deprecated Flat mutable view of a node context. Use `Vtree.NodeContext`.
@@ -357,6 +364,15 @@ function decorated(nodeContext: Vtree.NodeContext): LegacyNodeContext {
   return legacyViewOf(nodeContext);
 }
 
+function decoratedAs<T>(nodeContext: Vtree.NodeContext): T {
+  decorate(nodeContext);
+  return nodeContext as unknown as T;
+}
+
+function decoratedOrNull<T>(nodeContext: Vtree.NodeContext | null): T | null {
+  return nodeContext === null ? null : decoratedAs<T>(nodeContext);
+}
+
 /**
  * @deprecated Hand a node context to an external hook under the legacy
  * declaration. The value itself is returned so that plugin writes reach the
@@ -380,6 +396,780 @@ export function asLegacyNodeContextOrNull(
   nodeContext: Vtree.NodeContext | null,
 ): LegacyNodeContext | null {
   return nodeContext === null ? null : asLegacyNodeContext(hook, nodeContext);
+}
+
+/**
+ * @deprecated Base-compatible layout context contract. `setCurrent` reported
+ * only whether children should be processed, and the caller kept using the
+ * node context it had passed in.
+ */
+export type LegacyLayoutContext = Omit<
+  Vtree.LayoutContext,
+  | "setCurrent"
+  | "clone"
+  | "nextInTree"
+  | "peelOff"
+  | "applyPseudoelementStyle"
+  | "processFragmentedBlockEdge"
+> & {
+  applyPseudoelementStyle(
+    nodeContext: LegacyNodeContext,
+    pseudoName: string,
+    target: Element,
+  ): void;
+  processFragmentedBlockEdge(nodeContext: LegacyNodeContext);
+  setCurrent(
+    nodeContext: LegacyNodeContext,
+    firstTime: boolean,
+    atUnforcedBreak?: boolean,
+  ): Task.Result<boolean>;
+  clone(): LegacyLayoutContext;
+  nextInTree(
+    nodeContext: LegacyNodeContext,
+    atUnforcedBreak?: boolean,
+  ): Task.Result<LegacyNodeContext | null>;
+  peelOff(
+    nodeContext: LegacyChildNodeContext,
+    nodeOffset: number,
+  ): Task.Result<LegacyNodeContext>;
+};
+
+export interface LegacyFragmentLayoutConstraint {
+  flagmentLayoutConstraintType: FragmentLayoutConstraintType;
+  allowLayout(
+    nodeContext: LegacyNodeContext | null,
+    overflownNodeContext: LegacyNodeContext | null,
+    column: LegacyColumn,
+  ): boolean;
+  nextCandidate(nodeContext: LegacyNodeContext | null): boolean;
+  postLayout(
+    allowed: boolean,
+    positionAfter: LegacyNodeContext | null,
+    initialPosition: LegacyNodeContext | null,
+    column: LegacyColumn,
+  );
+  finishBreak(
+    nodeContext: LegacyNodeContext | null,
+    column: LegacyColumn,
+  ): Task.Result<boolean>;
+  equalsTo(constraint: LegacyFragmentLayoutConstraint): boolean;
+  getPriorityOfFinishBreak(): number;
+}
+
+export interface LegacyElementsOffset {
+  calculateOffset(nodeContext: LegacyNodeContext | null): number;
+  calculateMinimumOffset(nodeContext: LegacyNodeContext | null): number;
+}
+
+/**
+ * @deprecated Base-compatible column contract. The members whose result type
+ * changed are served by a projection, so the view is not the column and an
+ * assignment to such a member stays inside the view.
+ */
+export type LegacyColumn = Omit<
+  Layout.Column,
+  | "checkOverflowAndSaveEdge"
+  | "applyClearance"
+  | "processLineStyling"
+  | "layoutContext"
+  | "nodeContextOverflowingDueToRepetitiveElements"
+  | "pseudoParent"
+  | "asFloatNodeContext"
+  | "openAllViews"
+  | "maybePeelOff"
+  | "buildViewToNextBlockEdge"
+  | "nextInTree"
+  | "buildDeepElementView"
+  | "layoutUnbreakable"
+  | "layoutFloat"
+  | "setFloatAnchorViewNode"
+  | "layoutPageFloat"
+  | "layoutBreakableBlock"
+  | "findEndOfLine"
+  | "findAcceptableBreakInside"
+  | "findBoxBreakPosition"
+  | "findFirstOverflowingEdgeAndCheckPoint"
+  | "findEdgeBreakPosition"
+  | "findAcceptableBreakPosition"
+  | "doFinishBreak"
+  | "skipEdges"
+  | "skipTailEdges"
+  | "layoutFloatOrFootnote"
+  | "layoutNext"
+  | "doLayout"
+  | "stopByOverflow"
+  | "calculateEdge"
+  | "resolveFloatReferenceFromColumnSpan"
+  | "isLoneImage"
+  | "getTrailingMarginEdgeAdjustment"
+  | "postLayoutBlock"
+  | "resolveTextNodeBreaker"
+  | "findLinePositions"
+  | "calculateClonedPaddingBorder"
+  | "getAfterEdgeOfBlockContainer"
+  | "finishBreak"
+  | "isBreakable"
+  | "checkOverflowAndSaveEdgeAndBreakPosition"
+  | "clearOverflownViewNodes"
+  | "saveEdgeBreakPosition"
+  | "saveBoxBreakPosition"
+  | "doFinishBreakOfFragmentLayoutConstraints"
+  | "fragmentLayoutConstraints"
+  | "collectElementsOffset"
+> & {
+  fragmentLayoutConstraints: LegacyFragmentLayoutConstraint[];
+  collectElementsOffset(): LegacyElementsOffset[];
+  stopByOverflow(nodeContext: LegacyNodeContext): boolean;
+  calculateEdge(
+    nodeContext: LegacyNodeContext | null,
+    checkPoints: LegacyRenderedNodeContext[],
+    index: number,
+    boxOffset: number,
+  ): number;
+  resolveFloatReferenceFromColumnSpan(
+    floatReference: PageFloats.FloatReference,
+    columnSpan: Css.Val | null,
+    nodeContext: LegacyNodeContext,
+  ): Task.Result<PageFloats.FloatReference>;
+  isLoneImage(checkPoints: LegacyRenderedNodeContext[]): boolean;
+  getTrailingMarginEdgeAdjustment(
+    trailingEdgeContexts: LegacyNodeContext[],
+  ): number;
+  postLayoutBlock(
+    nodeContext: LegacyNodeContext | null,
+    checkPoints: LegacyRenderedNodeContext[],
+  ): void;
+  resolveTextNodeBreaker(nodeContext: LegacyNodeContext): LegacyTextNodeBreaker;
+  findLinePositions(checkPoints: LegacyRenderedNodeContext[]): number[];
+  calculateClonedPaddingBorder(nodeContext: LegacyNodeContext): number;
+  getAfterEdgeOfBlockContainer(nodeContext: LegacyNodeContext): number;
+  finishBreak(
+    nodeContext: LegacyNodeContext,
+    forceRemoveSelf: boolean,
+    endOfColumn: boolean,
+  ): Task.Result<boolean>;
+  isBreakable(flowPosition: LegacyNodeContext): boolean;
+  checkOverflowAndSaveEdgeAndBreakPosition(
+    nodeContext: LegacyNodeContext | null,
+    trailingEdgeContexts: LegacyNodeContext[] | null,
+    saveEvenOverflown: boolean,
+    breakAtTheEdge: string | null,
+  ): boolean;
+  clearOverflownViewNodes(
+    nodeContext: LegacyNodeContext | null,
+    removeSelf: boolean,
+  ): void;
+  saveEdgeBreakPosition(
+    position: LegacyNodeContext,
+    breakAtEdge: string | null,
+    overflows: boolean,
+  ): void;
+  saveBoxBreakPosition(checkPoints: LegacyRenderedNodeContext[]): void;
+  doFinishBreakOfFragmentLayoutConstraints(
+    nodeContext: LegacyNodeContext,
+  ): Task.Result<boolean>;
+  checkOverflowAndSaveEdge(
+    nodeContext: LegacyNodeContext | null,
+    trailingEdgeContexts: LegacyNodeContext[] | null,
+  ): boolean;
+  applyClearance(nodeContext: LegacyRenderedNodeContext): boolean;
+  processLineStyling(
+    nodeContext: LegacyNodeContext,
+    resNodeContext: LegacyNodeContext | null,
+    checkPoints: LegacyRenderedNodeContext[],
+  ): Task.Result<LegacyNodeContext | null>;
+  layoutContext: LegacyLayoutContext;
+  nodeContextOverflowingDueToRepetitiveElements: LegacyNodeContext | null;
+  pseudoParent: LegacyColumn | null;
+  asFloatNodeContext(
+    nodeContext: LegacyNodeContext,
+  ): LegacyFloatNodeContext | null;
+  openAllViews(position: Vtree.NodePosition): Task.Result<LegacyNodeContext>;
+  maybePeelOff(
+    position: LegacyNodeContext,
+    count: number,
+  ): Task.Result<LegacyNodeContext>;
+  buildViewToNextBlockEdge(
+    position: LegacyNodeContext | null,
+    checkPoints: LegacyRenderedNodeContext[],
+  ): Task.Result<LegacyNodeContext | null>;
+  nextInTree(
+    position: LegacyNodeContext,
+    atUnforcedBreak?: boolean,
+  ): Task.Result<LegacyNodeContext | null>;
+  buildDeepElementView(
+    position: LegacyNodeContext | null,
+  ): Task.Result<LegacyNodeContext | null>;
+  layoutUnbreakable(
+    nodeContextIn: LegacyNodeContext,
+  ): Task.Result<LegacyNodeContext | null>;
+  layoutFloat(
+    nodeContext: LegacyRenderedNodeContext,
+  ): Task.Result<LegacyNodeContext | null>;
+  setFloatAnchorViewNode(
+    nodeContext: LegacyRenderedNodeContext,
+  ): LegacyRenderedNodeContext;
+  layoutPageFloat(
+    nodeContext: LegacyFloatNodeContext,
+  ): Task.Result<LegacyNodeContext | null>;
+  layoutBreakableBlock(
+    nodeContext: LegacyNodeContext,
+  ): Task.Result<LegacyNodeContext | null>;
+  findEndOfLine(
+    linePosition: number,
+    checkPoints: LegacyRenderedNodeContext[],
+    isUpdateMaxReachedAfterEdge: boolean,
+  ): {
+    nodeContext: LegacyRenderedNodeContext;
+    index: number;
+    checkPointIndex: number;
+  };
+  findAcceptableBreakInside(
+    checkPoints: LegacyRenderedNodeContext[],
+    edgePosition: number,
+    force: boolean,
+  ): LegacyNodeContext | null;
+  findBoxBreakPosition(
+    bp: Layout.BoxBreakPosition,
+    force: boolean,
+  ): LegacyNodeContext | null;
+  findFirstOverflowingEdgeAndCheckPoint(
+    checkPoints: LegacyRenderedNodeContext[],
+  ): {
+    edge: number;
+    checkPoint: LegacyRenderedNodeContext | null;
+  };
+  findEdgeBreakPosition(bp: Layout.EdgeBreakPosition): LegacyNodeContext;
+  findAcceptableBreakPosition(): {
+    breakPosition: Layout.BreakPosition;
+    nodeContext: LegacyNodeContext;
+  } | null;
+  doFinishBreak(
+    nodeContext: LegacyNodeContext | null,
+    overflownNodeContext: LegacyNodeContext | null,
+    initialNodeContext: LegacyNodeContext | null,
+    initialComputedBlockSize: number,
+  ): Task.Result<LegacyNodeContext | null>;
+  skipEdges(
+    nodeContext: LegacyNodeContext,
+    leadingEdge: boolean,
+    forcedBreakValue: string | null,
+  ): Task.Result<LegacyNodeContext | null>;
+  skipTailEdges(
+    nodeContext: LegacyNodeContext,
+  ): Task.Result<LegacyNodeContext | null>;
+  layoutFloatOrFootnote(
+    nodeContext: LegacyFloatNodeContext,
+  ): Task.Result<LegacyNodeContext | null>;
+  layoutNext(
+    nodeContext: LegacyNodeContext,
+    leadingEdge: boolean,
+    forcedBreakValue?: string | null,
+  ): Task.Result<LegacyNodeContext>;
+  doLayout(
+    nodeContext: LegacyNodeContext | null,
+    leadingEdge: boolean,
+    breakAfter?: string | null,
+  ): Task.Result<{
+    nodeContext: LegacyNodeContext | null;
+    overflownNodeContext: LegacyNodeContext | null;
+  }>;
+};
+
+type LegacyProjections = { [name: string]: () => unknown };
+
+function projectionsOf(members: LegacyProjections): LegacyProjections {
+  return Object.assign(Object.create(null) as LegacyProjections, members);
+}
+
+type LegacyMember = (...args: unknown[]) => unknown;
+
+function retagLegacyArgument(value: unknown): void {
+  if (
+    value &&
+    typeof value === "object" &&
+    Object.getPrototypeOf(value) === legacyPrototype
+  ) {
+    normalizeLegacyNodeContext(value as unknown as LegacyNodeContext);
+  }
+}
+
+function retagLegacyArguments(args: unknown[]): void {
+  for (const arg of args) {
+    retagLegacyArgument(arg);
+    if (Array.isArray(arg)) {
+      for (const item of arg) {
+        retagLegacyArgument(item);
+      }
+    }
+  }
+}
+
+function retaggingLegacyArguments(member: LegacyMember): LegacyMember {
+  return function (this: unknown, ...args: unknown[]): unknown {
+    retagLegacyArguments(args);
+    return member.apply(this, args);
+  };
+}
+
+function retaggingMemberOf(member: unknown): unknown {
+  return typeof member === "function"
+    ? retaggingLegacyArguments(member as LegacyMember)
+    : member;
+}
+
+function projectedMemberOf(
+  target: object,
+  bound: Map<string | symbol, unknown>,
+  overrides: Map<string | symbol, unknown>,
+  projections: LegacyProjections,
+  property: string | symbol,
+): unknown {
+  if (overrides.has(property)) {
+    return overrides.get(property);
+  }
+  const projection =
+    typeof property === "string" ? projections[property] : undefined;
+  if (projection) {
+    return retaggingMemberOf(projection());
+  }
+  const cached = bound.get(property);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const member = Reflect.get(target, property, target);
+  if (typeof member !== "function") {
+    return member;
+  }
+  // The view must not become the receiver of core methods: a core method that
+  // reaches another one through `this` would otherwise read the projection.
+  const boundMember = retaggingLegacyArguments(member.bind(target));
+  bound.set(property, boundMember);
+  return boundMember;
+}
+
+function legacyViewOfObject<T extends object>(
+  target: T,
+  members: LegacyProjections,
+): object {
+  const projections = projectionsOf(members);
+  const bound = new Map<string | symbol, unknown>();
+  const overrides = new Map<string | symbol, unknown>();
+  return new Proxy(target, {
+    get: (t, property) =>
+      projectedMemberOf(t, bound, overrides, projections, property),
+    set: (t, property, value) => {
+      bound.delete(property);
+      if (typeof property === "string" && projections[property]) {
+        overrides.set(property, value);
+        return true;
+      }
+      return Reflect.set(t, property, value, t);
+    },
+  });
+}
+
+const legacyLayoutContexts = new WeakMap<
+  Vtree.LayoutContext,
+  LegacyLayoutContext
+>();
+
+/**
+ * @deprecated Serve a layout context under the base contract. The members whose
+ * result type changed are served by a projection, so the view is not the layout
+ * context and an assignment to such a member stays inside the view.
+ */
+export function asLegacyLayoutContext(
+  layoutContext: Vtree.LayoutContext,
+): LegacyLayoutContext {
+  const cached = legacyLayoutContexts.get(layoutContext);
+  if (cached) {
+    return cached;
+  }
+  const projected = legacyViewOfObject(layoutContext, {
+    setCurrent:
+      () =>
+      (
+        nodeContext: Vtree.NodeContext,
+        firstTime: boolean,
+        atUnforcedBreak?: boolean,
+      ) =>
+        layoutContext
+          .setCurrent(nodeContext, firstTime, atUnforcedBreak)
+          .thenAsync((result) => Task.newResult(result.processChildren)),
+    clone: () => () => asLegacyLayoutContext(layoutContext.clone()),
+    nextInTree:
+      () => (nodeContext: Vtree.NodeContext, atUnforcedBreak?: boolean) =>
+        layoutContext
+          .nextInTree(nodeContext, atUnforcedBreak)
+          .thenAsync((result) =>
+            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          ),
+    peelOff: () => (nodeContext: Vtree.ChildNodeContext, nodeOffset: number) =>
+      layoutContext
+        .peelOff(nodeContext, nodeOffset)
+        .thenAsync((result) =>
+          Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+        ),
+  });
+  // Runtime fact outside the type system: the proxy answers every member of
+  // the base contract, projecting the ones whose result type changed.
+  const view = projected as LegacyLayoutContext;
+  legacyLayoutContexts.set(layoutContext, view);
+  return view;
+}
+
+const legacyColumns = new WeakMap<Layout.Column, LegacyColumn>();
+
+const legacyTextNodeBreakers = new WeakMap<
+  Layout.TextNodeBreaker,
+  LegacyTextNodeBreaker
+>();
+
+const coreTextNodeBreakers = new WeakMap<
+  LegacyTextNodeBreaker,
+  Layout.TextNodeBreaker
+>();
+
+const legacyOfAdaptedTextNodeBreakers = new WeakMap<
+  Layout.TextNodeBreaker,
+  LegacyTextNodeBreaker
+>();
+
+function legacyTextNodeBreakerViewOf(
+  breaker: Layout.TextNodeBreaker,
+): LegacyTextNodeBreaker {
+  const legacy = legacyOfAdaptedTextNodeBreakers.get(breaker);
+  if (legacy) {
+    return legacy;
+  }
+  const cached = legacyTextNodeBreakers.get(breaker);
+  if (cached) {
+    return cached;
+  }
+  const view: LegacyTextNodeBreaker = {
+    breakTextNode(
+      textNode: Text,
+      nodeContext: LegacyNodeContext,
+      low: number,
+      checkPoints: LegacyRenderedNodeContext[],
+      checkpointIndex: number,
+      force: boolean,
+    ): LegacyNodeContext {
+      retagLegacyArguments([nodeContext, checkPoints]);
+      return decoratedAs<LegacyNodeContext>(
+        breaker.breakTextNode(
+          textNode,
+          coreOf(nodeContext),
+          low,
+          checkPoints as unknown as Vtree.RenderedNodeContext[],
+          checkpointIndex,
+          force,
+        ),
+      );
+    },
+    breakAfterSoftHyphen(
+      textNode: Text,
+      text: string,
+      viewIndex: number,
+      nodeContext: LegacyNodeContext,
+    ): number {
+      retagLegacyArguments([nodeContext]);
+      return breaker.breakAfterSoftHyphen(
+        textNode,
+        text,
+        viewIndex,
+        coreOf(nodeContext),
+      );
+    },
+    breakAfterOtherCharacter(
+      textNode: Text,
+      text: string,
+      viewIndex: number,
+      nodeContext: LegacyNodeContext,
+    ): number {
+      retagLegacyArguments([nodeContext]);
+      return breaker.breakAfterOtherCharacter(
+        textNode,
+        text,
+        viewIndex,
+        coreOf(nodeContext),
+      );
+    },
+    updateNodeContext(
+      nodeContext: LegacyNodeContext,
+      viewIndex: number,
+      textNode: Text,
+    ): LegacyNodeContext {
+      retagLegacyArguments([nodeContext]);
+      return decoratedAs<LegacyNodeContext>(
+        breaker.updateNodeContext(coreOf(nodeContext), viewIndex, textNode),
+      );
+    },
+  };
+  legacyTextNodeBreakers.set(breaker, view);
+  coreTextNodeBreakers.set(view, breaker);
+  return view;
+}
+
+export function asLegacyColumn(
+  hook: (...p1) => any,
+  column: Layout.Column,
+): LegacyColumn {
+  if (Plugin.isCoreHook(hook)) {
+    return column as unknown as LegacyColumn;
+  }
+  const cached = legacyColumns.get(column);
+  if (cached) {
+    return cached;
+  }
+  const projected = legacyViewOfObject(column, {
+    checkOverflowAndSaveEdge:
+      () =>
+      (
+        nodeContext: Vtree.NodeContext | null,
+        trailingEdgeContexts: Vtree.NodeContext[] | null,
+      ) =>
+        column.checkOverflowAndSaveEdge(nodeContext, trailingEdgeContexts)
+          .overflown,
+    applyClearance: () => (nodeContext: Vtree.RenderedNodeContext) => {
+      const spacer = column.applyClearance(nodeContext);
+      if (spacer) {
+        (
+          nodeContext as unknown as { clearSpacer: Element | null }
+        ).clearSpacer = spacer;
+      }
+      return spacer !== null;
+    },
+    processLineStyling:
+      () =>
+      (
+        nodeContext: Vtree.NodeContext,
+        resNodeContext: Vtree.NodeContext | null,
+        checkPoints: Vtree.RenderedNodeContext[],
+      ) =>
+        column
+          .processLineStyling(nodeContext, resNodeContext, checkPoints)
+          .thenAsync((result) => {
+            checkPoints.splice(0, checkPoints.length, ...result.checkPoints);
+            decoratedCheckPoints(checkPoints);
+            return Task.newResult(
+              decoratedOrNull<LegacyNodeContext>(result.nodeContext),
+            );
+          }),
+    layoutContext: () => asLegacyLayoutContext(column.layoutContext),
+    resolveTextNodeBreaker: () => (nodeContext: Vtree.NodeContext) =>
+      legacyTextNodeBreakerViewOf(column.resolveTextNodeBreaker(nodeContext)),
+    nodeContextOverflowingDueToRepetitiveElements: () =>
+      decoratedOrNull<LegacyNodeContext>(
+        column.nodeContextOverflowingDueToRepetitiveElements,
+      ),
+    pseudoParent: () =>
+      column.pseudoParent === null
+        ? null
+        : asLegacyColumn(hook, column.pseudoParent),
+    asFloatNodeContext: () => (nodeContext: Vtree.NodeContext) =>
+      decoratedOrNull<LegacyFloatNodeContext>(
+        column.asFloatNodeContext(nodeContext),
+      ),
+    openAllViews: () => (position: Vtree.NodePosition) =>
+      column
+        .openAllViews(position)
+        .thenAsync((result) =>
+          Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+        ),
+    maybePeelOff: () => (position: Vtree.NodeContext, count: number) =>
+      column
+        .maybePeelOff(position, count)
+        .thenAsync((result) =>
+          Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+        ),
+    buildViewToNextBlockEdge:
+      () =>
+      (
+        position: Vtree.NodeContext | null,
+        checkPoints: Vtree.RenderedNodeContext[],
+      ) =>
+        column
+          .buildViewToNextBlockEdge(position, checkPoints)
+          .thenAsync((result) => {
+            decoratedCheckPoints(checkPoints);
+            return Task.newResult(decoratedOrNull<LegacyNodeContext>(result));
+          }),
+    nextInTree:
+      () => (position: Vtree.NodeContext, atUnforcedBreak?: boolean) =>
+        column
+          .nextInTree(position, atUnforcedBreak)
+          .thenAsync((result) =>
+            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          ),
+    buildDeepElementView: () => (position: Vtree.NodeContext | null) =>
+      column
+        .buildDeepElementView(position)
+        .thenAsync((result) =>
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+        ),
+    layoutUnbreakable: () => (nodeContextIn: Vtree.NodeContext) =>
+      column
+        .layoutUnbreakable(nodeContextIn)
+        .thenAsync((result) =>
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+        ),
+    layoutFloat: () => (nodeContext: Vtree.RenderedNodeContext) =>
+      column
+        .layoutFloat(nodeContext)
+        .thenAsync((result) =>
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+        ),
+    setFloatAnchorViewNode: () => (nodeContext: Vtree.RenderedNodeContext) =>
+      decoratedAs<LegacyRenderedNodeContext>(
+        column.setFloatAnchorViewNode(nodeContext),
+      ),
+    layoutPageFloat: () => (nodeContext: Vtree.FloatNodeContext) =>
+      column
+        .layoutPageFloat(nodeContext)
+        .thenAsync((result) =>
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+        ),
+    layoutBreakableBlock: () => (nodeContext: Vtree.NodeContext) =>
+      column
+        .layoutBreakableBlock(nodeContext)
+        .thenAsync((result) =>
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+        ),
+    findEndOfLine:
+      () =>
+      (
+        linePosition: number,
+        checkPoints: Vtree.RenderedNodeContext[],
+        isUpdateMaxReachedAfterEdge: boolean,
+      ) => {
+        const result = column.findEndOfLine(
+          linePosition,
+          checkPoints,
+          isUpdateMaxReachedAfterEdge,
+        );
+        return {
+          ...result,
+          nodeContext: decoratedAs<LegacyRenderedNodeContext>(
+            result.nodeContext,
+          ),
+        };
+      },
+    findAcceptableBreakInside:
+      () =>
+      (
+        checkPoints: Vtree.RenderedNodeContext[],
+        edgePosition: number,
+        force: boolean,
+      ) =>
+        decoratedOrNull<LegacyNodeContext>(
+          column.findAcceptableBreakInside(checkPoints, edgePosition, force),
+        ),
+    findBoxBreakPosition: () => (bp: Layout.BoxBreakPosition, force: boolean) =>
+      decoratedOrNull<LegacyNodeContext>(
+        column.findBoxBreakPosition(bp, force),
+      ),
+    findFirstOverflowingEdgeAndCheckPoint:
+      () => (checkPoints: Vtree.RenderedNodeContext[]) => {
+        const result =
+          column.findFirstOverflowingEdgeAndCheckPoint(checkPoints);
+        return {
+          ...result,
+          checkPoint: decoratedOrNull<LegacyRenderedNodeContext>(
+            result.checkPoint,
+          ),
+        };
+      },
+    findEdgeBreakPosition: () => (bp: Layout.EdgeBreakPosition) =>
+      decoratedAs<LegacyNodeContext>(column.findEdgeBreakPosition(bp)),
+    findAcceptableBreakPosition: () => () => {
+      const result = column.findAcceptableBreakPosition();
+      return result === null
+        ? null
+        : {
+            ...result,
+            nodeContext: decoratedAs<LegacyNodeContext>(result.nodeContext),
+          };
+    },
+    doFinishBreak:
+      () =>
+      (
+        nodeContext: Vtree.NodeContext | null,
+        overflownNodeContext: Vtree.NodeContext | null,
+        initialNodeContext: Vtree.NodeContext | null,
+        initialComputedBlockSize: number,
+      ) =>
+        column
+          .doFinishBreak(
+            nodeContext,
+            overflownNodeContext,
+            initialNodeContext,
+            initialComputedBlockSize,
+          )
+          .thenAsync((result) =>
+            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          ),
+    skipEdges:
+      () =>
+      (
+        nodeContext: Vtree.NodeContext,
+        leadingEdge: boolean,
+        forcedBreakValue: string | null,
+      ) =>
+        column
+          .skipEdges(nodeContext, leadingEdge, forcedBreakValue)
+          .thenAsync((result) =>
+            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          ),
+    skipTailEdges: () => (nodeContext: Vtree.NodeContext) =>
+      column
+        .skipTailEdges(nodeContext)
+        .thenAsync((result) =>
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+        ),
+    layoutFloatOrFootnote: () => (nodeContext: Vtree.FloatNodeContext) =>
+      column
+        .layoutFloatOrFootnote(nodeContext)
+        .thenAsync((result) =>
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+        ),
+    layoutNext:
+      () =>
+      (
+        nodeContext: Vtree.NodeContext,
+        leadingEdge: boolean,
+        forcedBreakValue?: string | null,
+      ) =>
+        column
+          .layoutNext(nodeContext, leadingEdge, forcedBreakValue)
+          .thenAsync((result) =>
+            Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+          ),
+    doLayout:
+      () =>
+      (
+        nodeContext: Vtree.NodeContext | null,
+        leadingEdge: boolean,
+        breakAfter?: string | null,
+      ) =>
+        column
+          .doLayout(nodeContext, leadingEdge, breakAfter)
+          .thenAsync((result) =>
+            Task.newResult({
+              nodeContext: decoratedOrNull<LegacyNodeContext>(
+                result.nodeContext,
+              ),
+              overflownNodeContext: decoratedOrNull<LegacyNodeContext>(
+                result.overflownNodeContext,
+              ),
+            }),
+          ),
+  });
+  // Runtime fact outside the type system: see asLegacyLayoutContext.
+  const view = projected as LegacyColumn;
+  legacyColumns.set(column, view);
+  return view;
 }
 
 /**
@@ -453,6 +1243,10 @@ export function adaptLegacyTextNodeBreaker(
 ): Layout.TextNodeBreaker {
   if (Plugin.isCoreHook(hook)) {
     return legacy as unknown as Layout.TextNodeBreaker;
+  }
+  const core = coreTextNodeBreakers.get(legacy);
+  if (core) {
+    return core;
   }
   const cached = adaptedTextNodeBreakers.get(legacy);
   if (cached) {
@@ -531,6 +1325,7 @@ export function adaptLegacyTextNodeBreaker(
     },
   };
   adaptedTextNodeBreakers.set(legacy, adapted);
+  legacyOfAdaptedTextNodeBreakers.set(adapted, legacy);
   return adapted;
 }
 

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -26,6 +26,7 @@
  * must use `Vtree.NodeContext` and `node-context.ts`.
  */
 import * as Break from "./break";
+import * as BreakPosition from "./break-position";
 import * as Css from "./css";
 import * as Diff from "./diff";
 import * as NodeContext from "./node-context";
@@ -38,6 +39,7 @@ import {
   Selectors,
   Vtree,
 } from "./types";
+import type { LayoutProcessor } from "./layout-processor";
 
 /**
  * @deprecated Flat mutable view of a node context. Use `Vtree.NodeContext`.
@@ -535,6 +537,15 @@ function decoratedOrNull<T>(nodeContext: Vtree.NodeContext | null): T | null {
   return nodeContext === null ? null : decoratedAs<T>(nodeContext);
 }
 
+function retaggedOrNull<T>(nodeContext: Vtree.NodeContext | null): T | null {
+  const legacy = decoratedOrNull<LegacyNodeContext>(nodeContext);
+  if (legacy) {
+    retagLegacyValue(legacy);
+    handedOut.add(nodeContext);
+  }
+  return legacy as T | null;
+}
+
 /**
  * @deprecated Hand a node context to an external hook under the legacy
  * declaration. The value itself is returned so that plugin writes reach the
@@ -676,9 +687,11 @@ export type LegacyColumn = Omit<
   | "saveEdgeBreakPosition"
   | "saveBoxBreakPosition"
   | "doFinishBreakOfFragmentLayoutConstraints"
+  | "breakPositions"
   | "fragmentLayoutConstraints"
   | "collectElementsOffset"
 > & {
+  breakPositions: LegacyBreakPosition[];
   fragmentLayoutConstraints: LegacyFragmentLayoutConstraint[];
   collectElementsOffset(): LegacyElementsOffset[];
   stopByOverflow(nodeContext: LegacyNodeContext): boolean;
@@ -803,7 +816,7 @@ export type LegacyColumn = Omit<
   };
   findEdgeBreakPosition(bp: Layout.EdgeBreakPosition): LegacyNodeContext;
   findAcceptableBreakPosition(): {
-    breakPosition: Layout.BreakPosition;
+    breakPosition: LegacyBreakPosition;
     nodeContext: LegacyNodeContext;
   } | null;
   doFinishBreak(
@@ -852,7 +865,7 @@ function retagLegacyArgument(value: unknown): void {
     typeof value === "object" &&
     Object.getPrototypeOf(value) === legacyPrototype
   ) {
-    normalizeLegacyNodeContext(value as unknown as LegacyNodeContext);
+    retagLegacyValue(value as unknown as LegacyNodeContext);
   }
 }
 
@@ -885,6 +898,7 @@ function projectedMemberOf(
   bound: Map<string | symbol, unknown>,
   overrides: Map<string | symbol, unknown>,
   projections: LegacyProjections,
+  fields: LegacyProjections,
   property: string | symbol,
 ): unknown {
   if (overrides.has(property)) {
@@ -894,6 +908,10 @@ function projectedMemberOf(
     typeof property === "string" ? projections[property] : undefined;
   if (projection) {
     return retaggingMemberOf(projection());
+  }
+  const field = typeof property === "string" ? fields[property] : undefined;
+  if (field) {
+    return field();
   }
   const cached = bound.get(property);
   if (cached !== undefined) {
@@ -913,13 +931,15 @@ function projectedMemberOf(
 function legacyViewOfObject<T extends object>(
   target: T,
   members: LegacyProjections,
+  decoratedFields?: LegacyProjections,
 ): object {
   const projections = projectionsOf(members);
+  const fields = projectionsOf(decoratedFields ?? {});
   const bound = new Map<string | symbol, unknown>();
   const overrides = new Map<string | symbol, unknown>();
   return new Proxy(target, {
     get: (t, property) =>
-      projectedMemberOf(t, bound, overrides, projections, property),
+      projectedMemberOf(t, bound, overrides, projections, fields, property),
     set: (t, property, value) => {
       bound.delete(property);
       if (typeof property === "string" && projections[property]) {
@@ -985,6 +1005,92 @@ export function asLegacyLayoutContext(
 }
 
 const legacyColumns = new WeakMap<Layout.Column, LegacyColumn>();
+
+const columnTargets = new WeakMap<object, Layout.Column>();
+
+function coreColumnOf(column: LegacyColumn): Layout.Column {
+  return columnTargets.get(column) ?? (column as unknown as Layout.Column);
+}
+
+const legacyBreakPositions = new WeakMap<
+  Layout.BreakPosition,
+  LegacyBreakPosition
+>();
+
+const coreBreakPositions = new WeakMap<
+  LegacyBreakPosition,
+  Layout.BreakPosition
+>();
+
+const legacyOfAdaptedBreakPositions = new WeakMap<
+  Layout.BreakPosition,
+  LegacyBreakPosition
+>();
+
+function legacyBreakPositionViewOf(
+  breakPosition: Layout.BreakPosition,
+): LegacyBreakPosition {
+  const legacy = legacyOfAdaptedBreakPositions.get(breakPosition);
+  if (legacy) {
+    return legacy;
+  }
+  const cached = legacyBreakPositions.get(breakPosition);
+  if (cached) {
+    return cached;
+  }
+  const projected = legacyViewOfObject(
+    breakPosition,
+    {
+      findAcceptableBreak: () => (column: LegacyColumn, penalty: number) =>
+        decoratedOrNull<LegacyNodeContext>(
+          breakPosition.findAcceptableBreak(coreColumnOf(column), penalty),
+        ),
+      calculateOffset: () => (column: LegacyColumn) =>
+        breakPosition.calculateOffset(coreColumnOf(column)),
+      breakPositionChosen: () => (column: LegacyColumn) =>
+        breakPosition.breakPositionChosen(coreColumnOf(column)),
+      getNodeContext: () => {
+        const getNodeContext = (
+          breakPosition as Partial<Layout.AbstractBreakPosition>
+        ).getNodeContext;
+        return getNodeContext
+          ? () =>
+              decoratedOrNull<LegacyNodeContext>(
+                getNodeContext.call(breakPosition),
+              )
+          : undefined;
+      },
+    },
+    {
+      position: () =>
+        retaggedOrNull<LegacyNodeContext>(
+          (breakPosition as Partial<Layout.EdgeBreakPosition>).position ?? null,
+        ),
+      breakNodeContext: () =>
+        retaggedOrNull<LegacyNodeContext>(
+          (breakPosition as Partial<Layout.BoxBreakPosition>)
+            .breakNodeContext ?? null,
+        ),
+      checkPoints: () => {
+        const checkPoints = (breakPosition as Partial<Layout.BoxBreakPosition>)
+          .checkPoints;
+        return checkPoints === undefined
+          ? undefined
+          : retaggedCheckPoints(checkPoints);
+      },
+    },
+  );
+  const view = projected as LegacyBreakPosition;
+  legacyBreakPositions.set(breakPosition, view);
+  coreBreakPositions.set(view, breakPosition);
+  return view;
+}
+
+function coreBreakPositionOf(
+  breakPosition: LegacyBreakPosition,
+): Layout.BreakPosition {
+  return adaptLegacyBreakPosition(breakPosition);
+}
 
 const legacyTextNodeBreakers = new WeakMap<
   Layout.TextNodeBreaker,
@@ -1077,6 +1183,52 @@ function legacyTextNodeBreakerViewOf(
   return view;
 }
 
+const legacyBreakPositionLists = new WeakMap<
+  Layout.BreakPosition[],
+  LegacyBreakPosition[]
+>();
+
+function arrayIndexOf(property: string | symbol): number | null {
+  if (typeof property !== "string") {
+    return null;
+  }
+  const index = Number(property);
+  return Number.isInteger(index) && index >= 0 && String(index) === property
+    ? index
+    : null;
+}
+
+function legacyBreakPositionsViewOf(
+  breakPositions: Layout.BreakPosition[],
+): LegacyBreakPosition[] {
+  const cached = legacyBreakPositionLists.get(breakPositions);
+  if (cached) {
+    return cached;
+  }
+  const projected = new Proxy(breakPositions, {
+    get: (target, property) => {
+      const index = arrayIndexOf(property);
+      if (index === null) {
+        return Reflect.get(target, property, target);
+      }
+      const breakPosition = target[index];
+      return breakPosition === undefined
+        ? breakPosition
+        : legacyBreakPositionViewOf(breakPosition);
+    },
+    set: (target, property, value) => {
+      const index = arrayIndexOf(property);
+      if (index === null || !value) {
+        return Reflect.set(target, property, value, target);
+      }
+      return Reflect.set(target, property, coreBreakPositionOf(value), target);
+    },
+  });
+  const view = projected as unknown as LegacyBreakPosition[];
+  legacyBreakPositionLists.set(breakPositions, view);
+  return view;
+}
+
 export function asLegacyColumn(
   hook: (...p1) => any,
   column: Layout.Column,
@@ -1084,6 +1236,10 @@ export function asLegacyColumn(
   if (Plugin.isCoreHook(hook)) {
     return column as unknown as LegacyColumn;
   }
+  return legacyColumnViewOf(column);
+}
+
+function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
   const cached = legacyColumns.get(column);
   if (cached) {
     return cached;
@@ -1123,16 +1279,17 @@ export function asLegacyColumn(
             );
           }),
     layoutContext: () => asLegacyLayoutContext(column.layoutContext),
+    breakPositions: () => legacyBreakPositionsViewOf(column.breakPositions),
     resolveTextNodeBreaker: () => (nodeContext: Vtree.NodeContext) =>
       legacyTextNodeBreakerViewOf(column.resolveTextNodeBreaker(nodeContext)),
     nodeContextOverflowingDueToRepetitiveElements: () =>
-      decoratedOrNull<LegacyNodeContext>(
+      retaggedOrNull<LegacyNodeContext>(
         column.nodeContextOverflowingDueToRepetitiveElements,
       ),
     pseudoParent: () =>
       column.pseudoParent === null
         ? null
-        : asLegacyColumn(hook, column.pseudoParent),
+        : legacyColumnViewOf(column.pseudoParent),
     asFloatNodeContext: () => (nodeContext: Vtree.NodeContext) =>
       decoratedOrNull<LegacyFloatNodeContext>(
         column.asFloatNodeContext(nodeContext),
@@ -1231,9 +1388,12 @@ export function asLegacyColumn(
         decoratedOrNull<LegacyNodeContext>(
           column.findAcceptableBreakInside(checkPoints, edgePosition, force),
         ),
-    findBoxBreakPosition: () => (bp: Layout.BoxBreakPosition, force: boolean) =>
+    findBoxBreakPosition: () => (bp: LegacyBreakPosition, force: boolean) =>
       decoratedOrNull<LegacyNodeContext>(
-        column.findBoxBreakPosition(bp, force),
+        column.findBoxBreakPosition(
+          coreBreakPositionOf(bp) as Layout.BoxBreakPosition,
+          force,
+        ),
       ),
     findFirstOverflowingEdgeAndCheckPoint:
       () => (checkPoints: Vtree.RenderedNodeContext[]) => {
@@ -1246,14 +1406,18 @@ export function asLegacyColumn(
           ),
         };
       },
-    findEdgeBreakPosition: () => (bp: Layout.EdgeBreakPosition) =>
-      decoratedAs<LegacyNodeContext>(column.findEdgeBreakPosition(bp)),
+    findEdgeBreakPosition: () => (bp: LegacyBreakPosition) =>
+      decoratedAs<LegacyNodeContext>(
+        column.findEdgeBreakPosition(
+          coreBreakPositionOf(bp) as Layout.EdgeBreakPosition,
+        ),
+      ),
     findAcceptableBreakPosition: () => () => {
       const result = column.findAcceptableBreakPosition();
       return result === null
         ? null
         : {
-            ...result,
+            breakPosition: legacyBreakPositionViewOf(result.breakPosition),
             nodeContext: decoratedAs<LegacyNodeContext>(result.nodeContext),
           };
     },
@@ -1334,6 +1498,7 @@ export function asLegacyColumn(
   // Runtime fact outside the type system: see asLegacyLayoutContext.
   const view = projected as LegacyColumn;
   legacyColumns.set(column, view);
+  columnTargets.set(view, column);
   return view;
 }
 
@@ -1369,6 +1534,51 @@ export interface LegacyTextNodeBreaker {
   ): LegacyNodeContext;
 }
 
+export interface LegacyBreakPosition {
+  findAcceptableBreak(
+    column: LegacyColumn,
+    penalty: number,
+  ): LegacyNodeContext | null;
+  getMinBreakPenalty(): number;
+  calculateOffset(column: LegacyColumn): { current: number; minimum: number };
+  breakPositionChosen(column: LegacyColumn): void;
+  getNodeContext?(): LegacyNodeContext | null;
+  position?: LegacyNodeContext;
+  breakNodeContext?: LegacyNodeContext | null;
+  checkPoints?: LegacyRenderedNodeContext[];
+}
+
+export interface LegacyLayoutProcessor {
+  layout(
+    nodeContext: LegacyNodeContext,
+    column: LegacyColumn,
+    leadingEdge: boolean,
+  ): Task.Result<LegacyNodeContext | null>;
+  createEdgeBreakPosition(
+    position: LegacyNodeContext,
+    breakOnEdge: string | null,
+    overflows: boolean,
+    columnBlockSize: number,
+  ): LegacyBreakPosition;
+  startNonInlineElementNode(nodeContext: LegacyNodeContext): boolean;
+  afterNonInlineElementNode(
+    nodeContext: LegacyNodeContext,
+    stopAtOverflow: boolean,
+  ): boolean;
+  finishBreak(
+    column: LegacyColumn,
+    nodeContext: LegacyNodeContext,
+    forceRemoveSelf: boolean,
+    endOfColumn: boolean,
+  ): Task.Result<boolean>;
+  clearOverflownViewNodes(
+    column: LegacyColumn,
+    parentNodeContext: LegacyNodeContext | null,
+    nodeContext: LegacyNodeContext,
+    removeSelf: boolean,
+  );
+}
+
 function kindOfLegacy(nodeContext: LegacyNodeContext): Vtree.NodeContextKind {
   const viewNode = nodeContext.viewNode;
   if (viewNode === null) {
@@ -1380,6 +1590,12 @@ function kindOfLegacy(nodeContext: LegacyNodeContext): Vtree.NodeContextKind {
   return nodeContext.after ? "after-text" : "text";
 }
 
+function retagLegacyValue(nodeContext: LegacyNodeContext): void {
+  setLegacyKind(nodeContext, kindOfLegacy(nodeContext));
+}
+
+const handedOut = new Set<Vtree.NodeContext>();
+
 /**
  * @deprecated Give a value coming back from a legacy implementation the
  * discriminant its own fields imply, and hand it to the core as itself.
@@ -1390,7 +1606,7 @@ export function normalizeLegacyNodeContext(
   if (!nodeContext) {
     return null;
   }
-  setLegacyKind(nodeContext, kindOfLegacy(nodeContext));
+  retagLegacyValue(nodeContext);
   return coreOf(nodeContext);
 }
 
@@ -1494,6 +1710,155 @@ export function adaptLegacyTextNodeBreaker(
   return adapted;
 }
 
+const adaptedBreakPositions = new WeakMap<
+  LegacyBreakPosition,
+  Layout.BreakPosition
+>();
+
+function adaptLegacyBreakPosition(
+  legacy: LegacyBreakPosition,
+): Layout.BreakPosition {
+  const core = coreBreakPositions.get(legacy);
+  if (core) {
+    return core;
+  }
+  const cached = adaptedBreakPositions.get(legacy);
+  if (cached) {
+    return cached;
+  }
+  const adapted: Layout.BreakPosition = {
+    findAcceptableBreak(
+      column: Layout.Column,
+      penalty: number,
+    ): Vtree.NodeContext | null {
+      return normalizeLegacyNodeContext(
+        legacy.findAcceptableBreak(legacyColumnViewOf(column), penalty),
+      );
+    },
+    getMinBreakPenalty(): number {
+      return legacy.getMinBreakPenalty();
+    },
+    calculateOffset(column: Layout.Column): {
+      current: number;
+      minimum: number;
+    } {
+      return legacy.calculateOffset(legacyColumnViewOf(column));
+    },
+    breakPositionChosen(column: Layout.Column): void {
+      legacy.breakPositionChosen(legacyColumnViewOf(column));
+    },
+  };
+  adaptedBreakPositions.set(legacy, adapted);
+  legacyOfAdaptedBreakPositions.set(adapted, legacy);
+  return adapted;
+}
+
+const adaptedLayoutProcessors = new WeakMap<
+  LegacyLayoutProcessor,
+  LayoutProcessor
+>();
+
+export function adaptLegacyLayoutProcessor(
+  hook: (...p1) => any,
+  legacy: LegacyLayoutProcessor,
+): LayoutProcessor {
+  if (Plugin.isCoreHook(hook)) {
+    return legacy as unknown as LayoutProcessor;
+  }
+  const cached = adaptedLayoutProcessors.get(legacy);
+  if (cached) {
+    return cached;
+  }
+  const adapted: LayoutProcessor = {
+    layout(
+      nodeContext: Vtree.NodeContext,
+      column: Layout.Column,
+      leadingEdge: boolean,
+    ): Task.Result<Vtree.NodeContext | null> {
+      const legacyNodeContext = decorated(nodeContext);
+      return legacy
+        .layout(legacyNodeContext, legacyColumnViewOf(column), leadingEdge)
+        .thenAsync((result) => {
+          normalizeLegacyNodeContext(legacyNodeContext);
+          return Task.newResult(normalizeLegacyNodeContext(result));
+        });
+    },
+    createEdgeBreakPosition(
+      position: Vtree.NodeContext,
+      breakOnEdge: string | null,
+      overflows: boolean,
+      columnBlockSize: number,
+    ): Layout.BreakPosition {
+      const legacyPosition = decorated(position);
+      const breakPosition = legacy.createEdgeBreakPosition(
+        legacyPosition,
+        breakOnEdge,
+        overflows,
+        columnBlockSize,
+      );
+      normalizeLegacyNodeContext(legacyPosition);
+      return adaptLegacyBreakPosition(breakPosition);
+    },
+    startNonInlineElementNode(nodeContext: Vtree.NodeContext): boolean {
+      const legacyNodeContext = decorated(nodeContext);
+      const skipped = legacy.startNonInlineElementNode(legacyNodeContext);
+      normalizeLegacyNodeContext(legacyNodeContext);
+      return skipped;
+    },
+    afterNonInlineElementNode(
+      nodeContext: Vtree.NodeContext,
+      stopAtOverflow: boolean,
+    ): boolean {
+      const legacyNodeContext = decorated(nodeContext);
+      const skipped = legacy.afterNonInlineElementNode(
+        legacyNodeContext,
+        stopAtOverflow,
+      );
+      normalizeLegacyNodeContext(legacyNodeContext);
+      return skipped;
+    },
+    finishBreak(
+      column: Layout.Column,
+      nodeContext: Vtree.NodeContext,
+      forceRemoveSelf: boolean,
+      endOfColumn: boolean,
+    ): Task.Result<boolean> {
+      const legacyNodeContext = decorated(nodeContext);
+      return legacy
+        .finishBreak(
+          legacyColumnViewOf(column),
+          legacyNodeContext,
+          forceRemoveSelf,
+          endOfColumn,
+        )
+        .thenAsync((result) => {
+          normalizeLegacyNodeContext(legacyNodeContext);
+          return Task.newResult(result);
+        });
+    },
+    clearOverflownViewNodes(
+      column: Layout.Column,
+      parentNodeContext: Vtree.NodeContext | null,
+      nodeContext: Vtree.NodeContext,
+      removeSelf: boolean,
+    ) {
+      const legacyParentNodeContext =
+        parentNodeContext === null ? null : decorated(parentNodeContext);
+      const legacyNodeContext = decorated(nodeContext);
+      legacy.clearOverflownViewNodes(
+        legacyColumnViewOf(column),
+        legacyParentNodeContext,
+        legacyNodeContext,
+        removeSelf,
+      );
+      normalizeLegacyNodeContext(legacyParentNodeContext);
+      normalizeLegacyNodeContext(legacyNodeContext);
+    },
+  };
+  adaptedLayoutProcessors.set(legacy, adapted);
+  return adapted;
+}
+
 function decoratedCheckPoints(
   checkPoints: Vtree.RenderedNodeContext[],
 ): LegacyRenderedNodeContext[] {
@@ -1502,6 +1867,17 @@ function decoratedCheckPoints(
   }
   // Same array, same elements: see coreOf.
   return checkPoints as unknown as LegacyRenderedNodeContext[];
+}
+
+function retaggedCheckPoints(
+  checkPoints: Vtree.RenderedNodeContext[],
+): LegacyRenderedNodeContext[] {
+  const legacy = decoratedCheckPoints(checkPoints);
+  for (const checkPoint of legacy) {
+    retagLegacyValue(checkPoint);
+    handedOut.add(coreOf(checkPoint));
+  }
+  return legacy;
 }
 
 /**

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -167,10 +167,31 @@ export function legacySurfaceActive(hook: string): boolean {
   return Plugin.getHooksForName(hook).some((fn) => !Plugin.isCoreHook(fn));
 }
 
-function coreOf(nodeContext: LegacyNodeContext): Vtree.NodeContext {
+const retained = new WeakSet<Vtree.NodeContext>();
+
+function markRetained(nodeContext: Vtree.NodeContext): void {
+  for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
+    if (retained.has(nc)) {
+      return;
+    }
+    retained.add(nc);
+  }
+}
+
+/**
+ * @deprecated Record, for the plugin boundary alone, that the core keeps this
+ * position, which is what `NodeContext.copy()` marked on the value and its
+ * ancestors. It states nothing in the type world: the core keeps its own
+ * bindings and this call yields no value.
+ */
+export function noteRetained(nodeContext: Vtree.NodeContext): void {
+  markRetained(nodeContext);
+}
+
+function coreOf(nodeContext: unknown): Vtree.NodeContext {
   // Runtime fact outside the type system: the legacy view is the core's own
   // node context value, handed out under a flat mutable declaration.
-  return nodeContext as unknown as Vtree.NodeContext;
+  return nodeContext as Vtree.NodeContext;
 }
 
 function legacyViewOf(nodeContext: Vtree.NodeContext): LegacyNodeContext {
@@ -207,12 +228,16 @@ function cloneCoreItem<T extends Vtree.NodeContext>(nodeContext: T): T {
 
 class LegacyNodeContextMethods {
   get shared(): boolean {
-    return true;
+    return retained.has(coreOf(this));
   }
 
-  set shared(ignored: boolean) {
-    // The value world has no copy-on-write bit; the boundary value is always
-    // the one the core has already handed to a holder.
+  set shared(value: boolean) {
+    const core = coreOf(this);
+    if (value) {
+      retained.add(core);
+    } else {
+      retained.delete(core);
+    }
   }
 
   resetView(this: LegacyNodeContext): void {
@@ -256,10 +281,12 @@ class LegacyNodeContextMethods {
   }
 
   modify(this: LegacyNodeContext): LegacyNodeContext {
-    return decorated(cloneCoreItem(coreOf(this)));
+    const core = coreOf(this);
+    return retained.has(core) ? decorated(cloneCoreItem(core)) : this;
   }
 
   copy(this: LegacyNodeContext): LegacyNodeContext {
+    markRetained(coreOf(this));
     return this;
   }
 

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -177,14 +177,62 @@ export function legacySurfaceActive(hook: string): boolean {
   return Plugin.getHooksForName(hook).some((fn) => !Plugin.isCoreHook(fn));
 }
 
-const retained = new WeakSet<Vtree.NodeContext>();
+type LegacyContextStores = Pick<
+  Vtree.LayoutContext,
+  "breakSuppressionStore" | "continuationStore"
+>;
+
+type LegacyContextMetadata = Readonly<{
+  retained?: true;
+  stores?: LegacyContextStores;
+}>;
+
+const legacyContextMetadata = new WeakMap<
+  Vtree.NodeContext,
+  LegacyContextMetadata
+>();
+
+function isRetained(nodeContext: Vtree.NodeContext): boolean {
+  return legacyContextMetadata.get(nodeContext)?.retained === true;
+}
+
+function setRetained(nodeContext: Vtree.NodeContext, retained: boolean): void {
+  const metadata = legacyContextMetadata.get(nodeContext);
+  if (!retained && !metadata?.stores) {
+    legacyContextMetadata.delete(nodeContext);
+    return;
+  }
+  legacyContextMetadata.set(nodeContext, {
+    ...metadata,
+    retained: retained ? true : undefined,
+  });
+}
+
+function associateContextStores(
+  nodeContext: Vtree.NodeContext,
+  stores: LegacyContextStores,
+): void {
+  legacyContextMetadata.set(nodeContext, {
+    ...legacyContextMetadata.get(nodeContext),
+    stores: {
+      breakSuppressionStore: stores.breakSuppressionStore,
+      continuationStore: stores.continuationStore,
+    },
+  });
+}
+
+function contextStoresOf(
+  nodeContext: Vtree.NodeContext,
+): LegacyContextStores | undefined {
+  return legacyContextMetadata.get(nodeContext)?.stores;
+}
 
 function markRetained(nodeContext: Vtree.NodeContext): void {
   for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
-    if (retained.has(nc)) {
+    if (isRetained(nc)) {
       return;
     }
-    retained.add(nc);
+    setRetained(nc, true);
   }
 }
 
@@ -238,15 +286,15 @@ function cloneCoreItem<T extends Vtree.NodeContext>(nodeContext: T): T {
 
 class LegacyNodeContextMethods {
   get shared(): boolean {
-    return retained.has(coreOf(this));
+    return isRetained(coreOf(this));
   }
 
   set shared(value: boolean) {
     const core = coreOf(this);
     if (value) {
-      retained.add(core);
+      setRetained(core, true);
     } else {
-      retained.delete(core);
+      setRetained(core, false);
     }
   }
 
@@ -292,7 +340,9 @@ class LegacyNodeContextMethods {
 
   modify(this: LegacyNodeContext): LegacyNodeContext {
     const core = coreOf(this);
-    return retained.has(core) ? decorated(cloneCoreItem(core)) : this;
+    return isRetained(core)
+      ? decorated(cloneCoreItem(core), contextStoresOf(core))
+      : this;
   }
 
   copy(this: LegacyNodeContext): LegacyNodeContext {
@@ -306,15 +356,23 @@ class LegacyNodeContextMethods {
       const writable = nc as unknown as { pluginProps: Vtree.PluginProps };
       writable.pluginProps = { ...nc.pluginProps };
     }
-    return decorated(chain);
+    return decorated(chain, contextStoresOf(coreOf(this)));
   }
 
   toNodePositionStep(this: LegacyNodeContext): Vtree.NodePositionStep {
-    return NodeContext.toNodePositionStep(coreOf(this));
+    const core = coreOf(this);
+    return NodeContext.toNodePositionStep(
+      core,
+      contextStoresOf(core)?.continuationStore,
+    );
   }
 
   toNodePosition(this: LegacyNodeContext): Vtree.NodePosition {
-    return NodeContext.toNodePosition(coreOf(this));
+    const core = coreOf(this);
+    return NodeContext.toNodePosition(
+      core,
+      contextStoresOf(core)?.continuationStore,
+    );
   }
 
   isInsideBFC(this: LegacyNodeContext): boolean {
@@ -328,7 +386,7 @@ class LegacyNodeContextMethods {
     if (!container) {
       return null;
     }
-    decorate(container);
+    decorate(container, contextStoresOf(coreOf(this)));
     return legacyElementViewOf(container);
   }
 
@@ -346,27 +404,39 @@ function isDecorated(nodeContext: Vtree.NodeContext): boolean {
   return Object.getPrototypeOf(nodeContext) === legacyPrototype;
 }
 
-function decorate(nodeContext: Vtree.NodeContext): void {
+function decorate(
+  nodeContext: Vtree.NodeContext,
+  stores?: LegacyContextStores,
+  visited: WeakSet<Vtree.NodeContext> = new WeakSet(),
+): void {
   for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
-    reportSuppressedBreaks(nc);
+    if (visited.has(nc)) {
+      continue;
+    }
+    visited.add(nc);
+    const associatedStores = stores ?? contextStoresOf(nc);
+    if (associatedStores) {
+      associateContextStores(nc, associatedStores);
+      reportSuppressedBreaks(associatedStores.breakSuppressionStore, nc);
+    }
     if (!isDecorated(nc)) {
       // The core builds node contexts as plain object literals, so the legacy
       // prototype cannot shadow any own field of the value.
       Object.setPrototypeOf(nc, legacyPrototype);
     }
     if (nc.shadowSibling) {
-      reportSuppressedBreaks(nc.shadowSibling);
-      if (!isDecorated(nc.shadowSibling)) {
-        decorate(nc.shadowSibling);
-      }
+      decorate(nc.shadowSibling, associatedStores, visited);
     }
-    if (nc.blockContainer && !isDecorated(nc.blockContainer)) {
-      decorate(nc.blockContainer);
+    if (nc.blockContainer) {
+      decorate(nc.blockContainer, associatedStores, visited);
     }
   }
 }
 
-function reportSuppressedBreaks(nodeContext: Vtree.NodeContext): void {
+function reportSuppressedBreaks(
+  breakSuppressionStore: Break.BreakSuppressionStore,
+  nodeContext: Vtree.NodeContext,
+): void {
   // Suppression used to null the field itself; the core now composes it with
   // the registry, so writing the composed value back is a no-op for the core
   // and restores what a plugin used to read.
@@ -374,8 +444,14 @@ function reportSuppressedBreaks(nodeContext: Vtree.NodeContext): void {
     breakBefore: string | null;
     breakAfter: string | null;
   };
-  writable.breakBefore = Break.reportEffectiveBreakBefore(nodeContext);
-  writable.breakAfter = Break.reportEffectiveBreakAfter(nodeContext);
+  writable.breakBefore = Break.reportEffectiveBreakBefore(
+    breakSuppressionStore,
+    nodeContext,
+  );
+  writable.breakAfter = Break.reportEffectiveBreakAfter(
+    breakSuppressionStore,
+    nodeContext,
+  );
 }
 
 let renderFields: readonly string[] | null = null;
@@ -407,11 +483,69 @@ const CONTEXT_FIELDS: readonly string[] = [
   "boxOffset",
 ];
 
-type RenderFields = { [field: string]: unknown };
+const formattingContextsSnapshot = Symbol();
+
+type FormattingContextSnapshot = Readonly<{
+  formattingContext: Vtree.FormattingContext;
+  isFirstTime: Vtree.FormattingContext["isFirstTime"];
+}>;
+
+type RenderFields = {
+  [field: string]: unknown;
+  [formattingContextsSnapshot]?: ReadonlyMap<
+    Vtree.NodeContext,
+    FormattingContextSnapshot
+  >;
+};
+
+function formattingContextSnapshotsByNodeOf(
+  nodeContext: Vtree.NodeContext,
+): ReadonlyMap<Vtree.NodeContext, FormattingContextSnapshot> {
+  const contexts = new Map<Vtree.NodeContext, FormattingContextSnapshot>();
+  const pending = [nodeContext];
+  const visited = new WeakSet<Vtree.NodeContext>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    contexts.set(current, {
+      formattingContext: current.formattingContext,
+      isFirstTime: current.formattingContext.isFirstTime,
+    });
+    if (current.parent) {
+      pending.push(current.parent);
+    }
+    if (current.shadowSibling) {
+      pending.push(current.shadowSibling);
+    }
+    if (current.blockContainer) {
+      pending.push(current.blockContainer);
+    }
+  }
+  return contexts;
+}
 
 export type LegacyContextWrites = { readonly [field: string]: unknown };
 
 const retainedWrites = new WeakSet<LegacyContextWrites>();
+
+function legacyRenderContext(
+  stores: LegacyContextStores,
+  nodeContext: Vtree.NodeContext,
+  progress: Vtree.NodeContext,
+  rendered: NodeContext.ElementRenderDraft,
+): LegacyNodeContext {
+  const overlaid = {
+    ...progress,
+    ...rendered,
+  } as unknown as Vtree.NodeContext;
+  if (isRetained(nodeContext)) {
+    setRetained(overlaid, true);
+  }
+  return decorated(overlaid, stores);
+}
 
 /**
  * @deprecated Hand out a node context whose rendered style is the draft the
@@ -421,6 +555,7 @@ const retainedWrites = new WeakSet<LegacyContextWrites>();
  */
 export function asLegacyRenderContext(
   hook: string,
+  stores: LegacyContextStores,
   nodeContext: Vtree.NodeContext,
   progress: Vtree.NodeContext,
   rendered: NodeContext.ElementRenderDraft,
@@ -428,16 +563,60 @@ export function asLegacyRenderContext(
   if (!legacySurfaceActive(hook)) {
     return legacyViewOf(progress);
   }
-  // Runtime fact outside the type system: the draft holds the rendered style
-  // of this very position, so overlaying it cannot contradict the variant.
-  const overlaid = {
-    ...progress,
-    ...rendered,
-  } as unknown as Vtree.NodeContext;
-  if (retained.has(nodeContext)) {
-    retained.add(overlaid);
+  return legacyRenderContext(stores, nodeContext, progress, rendered);
+}
+
+function snapshotRenderFields(nodeContext: LegacyNodeContext): RenderFields {
+  const source = nodeContext as unknown as RenderFields;
+  const snapshot: RenderFields = {};
+  for (const field of renderFieldsOf()) {
+    snapshot[field] = source[field];
   }
-  return decorated(overlaid);
+  for (const field of CONTEXT_FIELDS) {
+    snapshot[field] = source[field];
+  }
+  snapshot[formattingContextsSnapshot] = formattingContextSnapshotsByNodeOf(
+    coreOf(nodeContext),
+  );
+  return snapshot;
+}
+
+function adaptWrittenFormattingContexts(
+  before: RenderFields,
+  nodeContext: Vtree.NodeContext,
+): void {
+  const previous = before[formattingContextsSnapshot] ?? new Map();
+  const current = formattingContextSnapshotsByNodeOf(nodeContext);
+  const checked = new WeakSet<Vtree.NodeContext>();
+  for (const [contextNode, snapshot] of previous) {
+    checked.add(contextNode);
+    if (
+      contextNode.formattingContext !== snapshot.formattingContext ||
+      contextNode.formattingContext.isFirstTime !== snapshot.isFirstTime
+    ) {
+      (
+        contextNode as unknown as {
+          formattingContext: Vtree.FormattingContext;
+        }
+      ).formattingContext = adaptFormattingContext(
+        contextNode.formattingContext,
+      );
+    }
+  }
+  for (const [contextNode, snapshot] of current) {
+    const previousSnapshot = previous.get(contextNode);
+    if (
+      !checked.has(contextNode) ||
+      previousSnapshot?.formattingContext !== snapshot.formattingContext ||
+      previousSnapshot.isFirstTime !== snapshot.isFirstTime
+    ) {
+      (
+        contextNode as unknown as {
+          formattingContext: Vtree.FormattingContext;
+        }
+      ).formattingContext = adaptFormattingContext(snapshot.formattingContext);
+    }
+  }
 }
 
 export function captureRenderFields(
@@ -447,15 +626,7 @@ export function captureRenderFields(
   if (!legacySurfaceActive(hook)) {
     return null;
   }
-  const source = nodeContext as unknown as RenderFields;
-  const snapshot: RenderFields = {};
-  for (const field of renderFieldsOf()) {
-    snapshot[field] = source[field];
-  }
-  for (const field of CONTEXT_FIELDS) {
-    snapshot[field] = source[field];
-  }
-  return snapshot;
+  return snapshotRenderFields(nodeContext);
 }
 
 export function applyLegacyRenderWrites(
@@ -463,13 +634,19 @@ export function applyLegacyRenderWrites(
   before: RenderFields | null,
   nodeContext: LegacyNodeContext,
   rendered: NodeContext.ElementRenderDraft,
+  adaptsFormattingContextWrites: boolean = false,
 ): LegacyContextWrites {
   if (!before) {
     return {};
   }
-  const adapts = hooks.some((hook) => !Plugin.isCoreHook(hook));
+  const adapts =
+    adaptsFormattingContextWrites ||
+    hooks.some((hook) => !Plugin.isCoreHook(hook));
   const source = nodeContext as unknown as RenderFields;
   const draft = rendered as unknown as RenderFields;
+  if (adapts) {
+    adaptWrittenFormattingContexts(before, coreOf(nodeContext));
+  }
   for (const field of renderFieldsOf()) {
     if (source[field] !== before[field]) {
       const written = source[field];
@@ -485,7 +662,7 @@ export function applyLegacyRenderWrites(
       written[field] = source[field];
     }
   }
-  if (retained.has(coreOf(nodeContext))) {
+  if (isRetained(coreOf(nodeContext))) {
     retainedWrites.add(written);
   }
   return written;
@@ -498,13 +675,17 @@ export function withLegacyContextWrites<T extends Vtree.NodeContext>(
   const claimed = retainedWrites.has(writes);
   if (Object.keys(writes).length === 0) {
     if (claimed) {
-      retained.add(nodeContext);
+      setRetained(nodeContext, true);
     }
     return nodeContext;
   }
   const composed = { ...nodeContext, ...writes } as unknown as T;
+  const stores = contextStoresOf(nodeContext);
+  if (stores) {
+    associateContextStores(composed, stores);
+  }
   if (claimed) {
-    retained.add(composed);
+    setRetained(composed, true);
   }
   if ("after" in writes || "viewNode" in writes) {
     normalizeLegacyNodeContext(legacyViewOf(composed));
@@ -513,6 +694,7 @@ export function withLegacyContextWrites<T extends Vtree.NodeContext>(
 }
 
 function applyRenderedNodeContext(
+  stores: LegacyContextStores,
   nodeContext: Vtree.NodeContext,
   rendered: Vtree.NodeContext,
 ): void {
@@ -526,25 +708,37 @@ function applyRenderedNodeContext(
       target[field] = source[field];
     }
   }
-  normalizeLegacyNodeContext(decorated(nodeContext));
+  normalizeLegacyNodeContext(decorated(nodeContext, stores));
 }
 
-function decorated(nodeContext: Vtree.NodeContext): LegacyNodeContext {
-  decorate(nodeContext);
+function decorated(
+  nodeContext: Vtree.NodeContext,
+  stores?: LegacyContextStores,
+): LegacyNodeContext {
+  decorate(nodeContext, stores);
   return legacyViewOf(nodeContext);
 }
 
-function decoratedAs<T>(nodeContext: Vtree.NodeContext): T {
-  decorate(nodeContext);
+function decoratedAs<T>(
+  nodeContext: Vtree.NodeContext,
+  stores?: LegacyContextStores,
+): T {
+  decorate(nodeContext, stores);
   return nodeContext as unknown as T;
 }
 
-function decoratedOrNull<T>(nodeContext: Vtree.NodeContext | null): T | null {
-  return nodeContext === null ? null : decoratedAs<T>(nodeContext);
+function decoratedOrNull<T>(
+  nodeContext: Vtree.NodeContext | null,
+  stores?: LegacyContextStores,
+): T | null {
+  return nodeContext === null ? null : decoratedAs<T>(nodeContext, stores);
 }
 
-function retaggedOrNull<T>(nodeContext: Vtree.NodeContext | null): T | null {
-  const legacy = decoratedOrNull<LegacyNodeContext>(nodeContext);
+function retaggedOrNull<T>(
+  nodeContext: Vtree.NodeContext | null,
+  stores?: LegacyContextStores,
+): T | null {
+  const legacy = decoratedOrNull<LegacyNodeContext>(nodeContext, stores);
   if (legacy) {
     retagLegacyValue(legacy);
     handedOut.add(nodeContext);
@@ -559,10 +753,11 @@ function retaggedOrNull<T>(nodeContext: Vtree.NodeContext | null): T | null {
  */
 export function asLegacyNodeContext(
   hook: string,
+  stores: LegacyContextStores,
   nodeContext: Vtree.NodeContext,
 ): LegacyNodeContext {
   if (legacySurfaceActive(hook)) {
-    decorate(nodeContext);
+    decorate(nodeContext, stores);
   }
   return legacyViewOf(nodeContext);
 }
@@ -572,9 +767,12 @@ export function asLegacyNodeContext(
  */
 export function asLegacyNodeContextOrNull(
   hook: string,
+  stores: LegacyContextStores,
   nodeContext: Vtree.NodeContext | null,
 ): LegacyNodeContext | null {
-  return nodeContext === null ? null : asLegacyNodeContext(hook, nodeContext);
+  return nodeContext === null
+    ? null
+    : asLegacyNodeContext(hook, stores, nodeContext);
 }
 
 /**
@@ -985,7 +1183,11 @@ export function asLegacyLayoutContext(
         layoutContext
           .setCurrent(nodeContext, firstTime, atUnforcedBreak)
           .thenAsync((result) => {
-            applyRenderedNodeContext(nodeContext, result.nodeContext);
+            applyRenderedNodeContext(
+              layoutContext,
+              nodeContext,
+              result.nodeContext,
+            );
             return Task.newResult(result.processChildren);
           }),
     clone: () => () => asLegacyLayoutContext(layoutContext.clone()),
@@ -994,13 +1196,15 @@ export function asLegacyLayoutContext(
         layoutContext
           .nextInTree(nodeContext, atUnforcedBreak)
           .thenAsync((result) =>
-            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+            Task.newResult(
+              decoratedOrNull<LegacyNodeContext>(result, layoutContext),
+            ),
           ),
     peelOff: () => (nodeContext: Vtree.ChildNodeContext, nodeOffset: number) =>
       layoutContext
         .peelOff(nodeContext, nodeOffset)
         .thenAsync((result) =>
-          Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+          Task.newResult(decoratedAs<LegacyNodeContext>(result, layoutContext)),
         ),
   });
   // Runtime fact outside the type system: the proxy answers every member of
@@ -1035,6 +1239,7 @@ const legacyOfAdaptedBreakPositions = new WeakMap<
 
 function legacyBreakPositionViewOf(
   breakPosition: Layout.BreakPosition,
+  stores: LegacyContextStores,
 ): LegacyBreakPosition {
   const legacy = legacyOfAdaptedBreakPositions.get(breakPosition);
   if (legacy) {
@@ -1050,6 +1255,7 @@ function legacyBreakPositionViewOf(
       findAcceptableBreak: () => (column: LegacyColumn, penalty: number) =>
         decoratedOrNull<LegacyNodeContext>(
           breakPosition.findAcceptableBreak(coreColumnOf(column), penalty),
+          stores,
         ),
       calculateOffset: () => (column: LegacyColumn) =>
         breakPosition.calculateOffset(coreColumnOf(column)),
@@ -1063,6 +1269,7 @@ function legacyBreakPositionViewOf(
           ? () =>
               decoratedOrNull<LegacyNodeContext>(
                 getNodeContext.call(breakPosition),
+                stores,
               )
           : undefined;
       },
@@ -1071,18 +1278,20 @@ function legacyBreakPositionViewOf(
       position: () =>
         retaggedOrNull<LegacyNodeContext>(
           (breakPosition as Partial<Layout.EdgeBreakPosition>).position ?? null,
+          stores,
         ),
       breakNodeContext: () =>
         retaggedOrNull<LegacyNodeContext>(
           (breakPosition as Partial<Layout.BoxBreakPosition>)
             .breakNodeContext ?? null,
+          stores,
         ),
       checkPoints: () => {
         const checkPoints = (breakPosition as Partial<Layout.BoxBreakPosition>)
           .checkPoints;
         return checkPoints === undefined
           ? undefined
-          : retaggedCheckPoints(checkPoints);
+          : retaggedCheckPoints(checkPoints, stores);
       },
     },
   );
@@ -1143,6 +1352,7 @@ function legacyTextNodeBreakerViewOf(
           checkpointIndex,
           force,
         ),
+        contextStoresOf(coreOf(nodeContext)),
       );
     },
     breakAfterSoftHyphen(
@@ -1181,6 +1391,7 @@ function legacyTextNodeBreakerViewOf(
       retagLegacyArguments([nodeContext]);
       return decoratedAs<LegacyNodeContext>(
         breaker.updateNodeContext(coreOf(nodeContext), viewIndex, textNode),
+        contextStoresOf(coreOf(nodeContext)),
       );
     },
   };
@@ -1206,6 +1417,7 @@ function arrayIndexOf(property: string | symbol): number | null {
 
 function legacyBreakPositionsViewOf(
   breakPositions: Layout.BreakPosition[],
+  stores: LegacyContextStores,
 ): LegacyBreakPosition[] {
   const cached = legacyBreakPositionLists.get(breakPositions);
   if (cached) {
@@ -1220,7 +1432,7 @@ function legacyBreakPositionsViewOf(
       const breakPosition = target[index];
       return breakPosition === undefined
         ? breakPosition
-        : legacyBreakPositionViewOf(breakPosition);
+        : legacyBreakPositionViewOf(breakPosition, stores);
     },
     set: (target, property, value) => {
       const index = arrayIndexOf(property);
@@ -1250,6 +1462,7 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
   if (cached) {
     return cached;
   }
+  const stores = column.layoutContext;
   const projected = legacyViewOfObject(column, {
     checkOverflowAndSaveEdge:
       () =>
@@ -1279,18 +1492,24 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
           .processLineStyling(nodeContext, resNodeContext, checkPoints)
           .thenAsync((result) => {
             checkPoints.splice(0, checkPoints.length, ...result.checkPoints);
-            decoratedCheckPoints(checkPoints);
+            decoratedCheckPoints(checkPoints, stores);
             return Task.newResult(
-              decoratedOrNull<LegacyNodeContext>(result.nodeContext),
+              decoratedOrNull<LegacyNodeContext>(result.nodeContext, stores),
             );
           }),
     layoutContext: () => asLegacyLayoutContext(column.layoutContext),
-    breakPositions: () => legacyBreakPositionsViewOf(column.breakPositions),
-    resolveTextNodeBreaker: () => (nodeContext: Vtree.NodeContext) =>
-      legacyTextNodeBreakerViewOf(column.resolveTextNodeBreaker(nodeContext)),
+    breakPositions: () =>
+      legacyBreakPositionsViewOf(column.breakPositions, stores),
+    resolveTextNodeBreaker: () => (nodeContext: Vtree.NodeContext) => {
+      decorate(nodeContext, stores);
+      return legacyTextNodeBreakerViewOf(
+        column.resolveTextNodeBreaker(nodeContext),
+      );
+    },
     nodeContextOverflowingDueToRepetitiveElements: () =>
       retaggedOrNull<LegacyNodeContext>(
         column.nodeContextOverflowingDueToRepetitiveElements,
+        stores,
       ),
     pseudoParent: () =>
       column.pseudoParent === null
@@ -1299,18 +1518,19 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
     asFloatNodeContext: () => (nodeContext: Vtree.NodeContext) =>
       decoratedOrNull<LegacyFloatNodeContext>(
         column.asFloatNodeContext(nodeContext),
+        stores,
       ),
     openAllViews: () => (position: Vtree.NodePosition) =>
       column
         .openAllViews(position)
         .thenAsync((result) =>
-          Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+          Task.newResult(decoratedAs<LegacyNodeContext>(result, stores)),
         ),
     maybePeelOff: () => (position: Vtree.NodeContext, count: number) =>
       column
         .maybePeelOff(position, count)
         .thenAsync((result) =>
-          Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+          Task.newResult(decoratedAs<LegacyNodeContext>(result, stores)),
         ),
     buildViewToNextBlockEdge:
       () =>
@@ -1321,49 +1541,52 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
         column
           .buildViewToNextBlockEdge(position, checkPoints)
           .thenAsync((result) => {
-            decoratedCheckPoints(checkPoints);
-            return Task.newResult(decoratedOrNull<LegacyNodeContext>(result));
+            decoratedCheckPoints(checkPoints, stores);
+            return Task.newResult(
+              decoratedOrNull<LegacyNodeContext>(result, stores),
+            );
           }),
     nextInTree:
       () => (position: Vtree.NodeContext, atUnforcedBreak?: boolean) =>
         column
           .nextInTree(position, atUnforcedBreak)
           .thenAsync((result) =>
-            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+            Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
           ),
     buildDeepElementView: () => (position: Vtree.NodeContext | null) =>
       column
         .buildDeepElementView(position)
         .thenAsync((result) =>
-          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
         ),
     layoutUnbreakable: () => (nodeContextIn: Vtree.NodeContext) =>
       column
         .layoutUnbreakable(nodeContextIn)
         .thenAsync((result) =>
-          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
         ),
     layoutFloat: () => (nodeContext: Vtree.RenderedNodeContext) =>
       column
         .layoutFloat(nodeContext)
         .thenAsync((result) =>
-          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
         ),
     setFloatAnchorViewNode: () => (nodeContext: Vtree.RenderedNodeContext) =>
       decoratedAs<LegacyRenderedNodeContext>(
         column.setFloatAnchorViewNode(nodeContext),
+        stores,
       ),
     layoutPageFloat: () => (nodeContext: Vtree.FloatNodeContext) =>
       column
         .layoutPageFloat(nodeContext)
         .thenAsync((result) =>
-          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
         ),
     layoutBreakableBlock: () => (nodeContext: Vtree.NodeContext) =>
       column
         .layoutBreakableBlock(nodeContext)
         .thenAsync((result) =>
-          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
         ),
     findEndOfLine:
       () =>
@@ -1381,6 +1604,7 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
           ...result,
           nodeContext: decoratedAs<LegacyRenderedNodeContext>(
             result.nodeContext,
+            stores,
           ),
         };
       },
@@ -1393,6 +1617,7 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
       ) =>
         decoratedOrNull<LegacyNodeContext>(
           column.findAcceptableBreakInside(checkPoints, edgePosition, force),
+          stores,
         ),
     findBoxBreakPosition: () => (bp: LegacyBreakPosition, force: boolean) =>
       decoratedOrNull<LegacyNodeContext>(
@@ -1400,6 +1625,7 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
           coreBreakPositionOf(bp) as Layout.BoxBreakPosition,
           force,
         ),
+        stores,
       ),
     findFirstOverflowingEdgeAndCheckPoint:
       () => (checkPoints: Vtree.RenderedNodeContext[]) => {
@@ -1409,6 +1635,7 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
           ...result,
           checkPoint: decoratedOrNull<LegacyRenderedNodeContext>(
             result.checkPoint,
+            stores,
           ),
         };
       },
@@ -1417,14 +1644,21 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
         column.findEdgeBreakPosition(
           coreBreakPositionOf(bp) as Layout.EdgeBreakPosition,
         ),
+        stores,
       ),
     findAcceptableBreakPosition: () => () => {
       const result = column.findAcceptableBreakPosition();
       return result === null
         ? null
         : {
-            breakPosition: legacyBreakPositionViewOf(result.breakPosition),
-            nodeContext: decoratedAs<LegacyNodeContext>(result.nodeContext),
+            breakPosition: legacyBreakPositionViewOf(
+              result.breakPosition,
+              stores,
+            ),
+            nodeContext: decoratedAs<LegacyNodeContext>(
+              result.nodeContext,
+              stores,
+            ),
           };
     },
     doFinishBreak:
@@ -1443,7 +1677,7 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
             initialComputedBlockSize,
           )
           .thenAsync((result) =>
-            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+            Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
           ),
     skipEdges:
       () =>
@@ -1455,19 +1689,19 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
         column
           .skipEdges(nodeContext, leadingEdge, forcedBreakValue)
           .thenAsync((result) =>
-            Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+            Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
           ),
     skipTailEdges: () => (nodeContext: Vtree.NodeContext) =>
       column
         .skipTailEdges(nodeContext)
         .thenAsync((result) =>
-          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
         ),
     layoutFloatOrFootnote: () => (nodeContext: Vtree.FloatNodeContext) =>
       column
         .layoutFloatOrFootnote(nodeContext)
         .thenAsync((result) =>
-          Task.newResult(decoratedOrNull<LegacyNodeContext>(result)),
+          Task.newResult(decoratedOrNull<LegacyNodeContext>(result, stores)),
         ),
     layoutNext:
       () =>
@@ -1479,7 +1713,7 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
         column
           .layoutNext(nodeContext, leadingEdge, forcedBreakValue)
           .thenAsync((result) =>
-            Task.newResult(decoratedAs<LegacyNodeContext>(result)),
+            Task.newResult(decoratedAs<LegacyNodeContext>(result, stores)),
           ),
     doLayout:
       () =>
@@ -1494,9 +1728,11 @@ function legacyColumnViewOf(column: Layout.Column): LegacyColumn {
             Task.newResult({
               nodeContext: decoratedOrNull<LegacyNodeContext>(
                 result.nodeContext,
+                stores,
               ),
               overflownNodeContext: decoratedOrNull<LegacyNodeContext>(
                 result.overflownNodeContext,
+                stores,
               ),
             }),
           ),
@@ -1605,6 +1841,11 @@ function kindOfLegacy(nodeContext: LegacyNodeContext): Vtree.NodeContextKind {
 }
 
 function retagLegacyValue(nodeContext: LegacyNodeContext): void {
+  for (const { formattingContext } of formattingContextSnapshotsByNodeOf(
+    coreOf(nodeContext),
+  ).values()) {
+    adaptFormattingContext(formattingContext);
+  }
   setLegacyKind(nodeContext, kindOfLegacy(nodeContext));
 }
 
@@ -1661,7 +1902,7 @@ export function retagLegacyNodeContexts(
 
 const adaptedTextNodeBreakers = new WeakMap<
   LegacyTextNodeBreaker,
-  Layout.TextNodeBreaker
+  WeakMap<LegacyContextStores, Layout.TextNodeBreaker>
 >();
 
 /**
@@ -1670,6 +1911,7 @@ const adaptedTextNodeBreakers = new WeakMap<
 export function adaptLegacyTextNodeBreaker(
   hook: (...p1) => any,
   legacy: LegacyTextNodeBreaker,
+  stores: LegacyContextStores,
 ): Layout.TextNodeBreaker {
   if (Plugin.isCoreHook(hook)) {
     return legacy as unknown as Layout.TextNodeBreaker;
@@ -1678,7 +1920,12 @@ export function adaptLegacyTextNodeBreaker(
   if (core) {
     return core;
   }
-  const cached = adaptedTextNodeBreakers.get(legacy);
+  let adapters = adaptedTextNodeBreakers.get(legacy);
+  if (!adapters) {
+    adapters = new WeakMap();
+    adaptedTextNodeBreakers.set(legacy, adapters);
+  }
+  const cached = adapters.get(stores);
   if (cached) {
     return cached;
   }
@@ -1691,8 +1938,8 @@ export function adaptLegacyTextNodeBreaker(
       checkpointIndex: number,
       force: boolean,
     ): Vtree.NodeContext {
-      const legacyNodeContext = decorated(nodeContext);
-      const legacyCheckPoints = decoratedCheckPoints(checkPoints);
+      const legacyNodeContext = decorated(nodeContext, stores);
+      const legacyCheckPoints = decoratedCheckPoints(checkPoints, stores);
       const broken = legacy.breakTextNode(
         textNode,
         legacyNodeContext,
@@ -1713,7 +1960,7 @@ export function adaptLegacyTextNodeBreaker(
       viewIndex: number,
       nodeContext: Vtree.NodeContext,
     ): number {
-      const legacyNodeContext = decorated(nodeContext);
+      const legacyNodeContext = decorated(nodeContext, stores);
       const broken = legacy.breakAfterSoftHyphen(
         textNode,
         text,
@@ -1729,7 +1976,7 @@ export function adaptLegacyTextNodeBreaker(
       viewIndex: number,
       nodeContext: Vtree.NodeContext,
     ): number {
-      const legacyNodeContext = decorated(nodeContext);
+      const legacyNodeContext = decorated(nodeContext, stores);
       const broken = legacy.breakAfterOtherCharacter(
         textNode,
         text,
@@ -1744,7 +1991,7 @@ export function adaptLegacyTextNodeBreaker(
       viewIndex: number,
       textNode: Text,
     ): Vtree.NodeContext {
-      const legacyNodeContext = decorated(nodeContext);
+      const legacyNodeContext = decorated(nodeContext, stores);
       const updated = legacy.updateNodeContext(
         legacyNodeContext,
         viewIndex,
@@ -1754,7 +2001,7 @@ export function adaptLegacyTextNodeBreaker(
       return normalizeLegacyNodeContext(updated)!;
     },
   };
-  adaptedTextNodeBreakers.set(legacy, adapted);
+  adapters.set(stores, adapted);
   legacyOfAdaptedTextNodeBreakers.set(adapted, legacy);
   return adapted;
 }
@@ -1802,7 +2049,7 @@ function adaptLegacyBreakPosition(
   return adapted;
 }
 
-const adaptedFormattingContexts = new WeakSet<Vtree.FormattingContext>();
+const legacyFormattingContexts = new WeakSet<Vtree.FormattingContext>();
 
 function acceptsFirstTimeReplacement(
   formattingContext: Vtree.FormattingContext,
@@ -1828,13 +2075,13 @@ function acceptsFirstTimeReplacement(
 function adaptFormattingContext(
   formattingContext: Vtree.FormattingContext,
 ): Vtree.FormattingContext {
-  if (
-    adaptedFormattingContexts.has(formattingContext) ||
-    !acceptsFirstTimeReplacement(formattingContext)
-  ) {
+  if (legacyFormattingContexts.has(formattingContext)) {
     return formattingContext;
   }
-  adaptedFormattingContexts.add(formattingContext);
+  legacyFormattingContexts.add(formattingContext);
+  if (!acceptsFirstTimeReplacement(formattingContext)) {
+    return formattingContext;
+  }
   const isFirstTime = formattingContext.isFirstTime;
   formattingContext.isFirstTime = (
     nodeContext: Vtree.NodeContext,
@@ -1855,19 +2102,22 @@ export function adaptLegacyFormattingContext(
 }
 
 export function legacyFirstTime(
+  stores: LegacyContextStores,
   formattingContext: Vtree.FormattingContext,
   nodeContext: Vtree.NodeContext,
   rendered: NodeContext.ElementRenderDraft,
   firstTime: boolean,
 ): { firstTime: boolean; nodeContext: Vtree.NodeContext } {
   const hook = Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT;
-  const legacy = asLegacyRenderContext(
-    hook,
-    nodeContext,
-    NodeContext.elementRenderProgress(nodeContext, rendered),
-    rendered,
-  );
-  const before = captureRenderFields(hook, legacy);
+  const progress = NodeContext.elementRenderProgress(nodeContext, rendered);
+  const legacyFormattingContext =
+    legacyFormattingContexts.has(formattingContext);
+  const legacy = legacyFormattingContext
+    ? legacyRenderContext(stores, nodeContext, progress, rendered)
+    : asLegacyRenderContext(hook, stores, nodeContext, progress, rendered);
+  const before = legacyFormattingContext
+    ? snapshotRenderFields(legacy)
+    : captureRenderFields(hook, legacy);
   const resolved = formattingContext.isFirstTime(coreOf(legacy), firstTime);
   normalizeLegacyNodeContext(legacy);
   return {
@@ -1879,6 +2129,7 @@ export function legacyFirstTime(
         before,
         legacy,
         rendered,
+        legacyFormattingContext,
       ),
     ),
   };
@@ -1886,17 +2137,23 @@ export function legacyFirstTime(
 
 const adaptedLayoutProcessors = new WeakMap<
   LegacyLayoutProcessor,
-  LayoutProcessor
+  WeakMap<LegacyContextStores, LayoutProcessor>
 >();
 
 export function adaptLegacyLayoutProcessor(
   hook: (...p1) => any,
   legacy: LegacyLayoutProcessor,
+  stores: LegacyContextStores,
 ): LayoutProcessor {
   if (Plugin.isCoreHook(hook)) {
     return legacy as unknown as LayoutProcessor;
   }
-  const cached = adaptedLayoutProcessors.get(legacy);
+  let adapters = adaptedLayoutProcessors.get(legacy);
+  if (!adapters) {
+    adapters = new WeakMap();
+    adaptedLayoutProcessors.set(legacy, adapters);
+  }
+  const cached = adapters.get(stores);
   if (cached) {
     return cached;
   }
@@ -1906,7 +2163,7 @@ export function adaptLegacyLayoutProcessor(
       column: Layout.Column,
       leadingEdge: boolean,
     ): Task.Result<Vtree.NodeContext | null> {
-      const legacyNodeContext = decorated(nodeContext);
+      const legacyNodeContext = decorated(nodeContext, stores);
       return legacy
         .layout(legacyNodeContext, legacyColumnViewOf(column), leadingEdge)
         .thenAsync((result) => {
@@ -1920,7 +2177,7 @@ export function adaptLegacyLayoutProcessor(
       overflows: boolean,
       columnBlockSize: number,
     ): Layout.BreakPosition {
-      const legacyPosition = decorated(position);
+      const legacyPosition = decorated(position, stores);
       const breakPosition = legacy.createEdgeBreakPosition(
         legacyPosition,
         breakOnEdge,
@@ -1931,7 +2188,7 @@ export function adaptLegacyLayoutProcessor(
       return adaptLegacyBreakPosition(breakPosition);
     },
     startNonInlineElementNode(nodeContext: Vtree.NodeContext): boolean {
-      const legacyNodeContext = decorated(nodeContext);
+      const legacyNodeContext = decorated(nodeContext, stores);
       const skipped = legacy.startNonInlineElementNode(legacyNodeContext);
       normalizeLegacyNodeContext(legacyNodeContext);
       return skipped;
@@ -1940,7 +2197,7 @@ export function adaptLegacyLayoutProcessor(
       nodeContext: Vtree.NodeContext,
       stopAtOverflow: boolean,
     ): boolean {
-      const legacyNodeContext = decorated(nodeContext);
+      const legacyNodeContext = decorated(nodeContext, stores);
       const skipped = legacy.afterNonInlineElementNode(
         legacyNodeContext,
         stopAtOverflow,
@@ -1954,7 +2211,7 @@ export function adaptLegacyLayoutProcessor(
       forceRemoveSelf: boolean,
       endOfColumn: boolean,
     ): Task.Result<boolean> {
-      const legacyNodeContext = decorated(nodeContext);
+      const legacyNodeContext = decorated(nodeContext, stores);
       return legacy
         .finishBreak(
           legacyColumnViewOf(column),
@@ -1974,8 +2231,10 @@ export function adaptLegacyLayoutProcessor(
       removeSelf: boolean,
     ) {
       const legacyParentNodeContext =
-        parentNodeContext === null ? null : decorated(parentNodeContext);
-      const legacyNodeContext = decorated(nodeContext);
+        parentNodeContext === null
+          ? null
+          : decorated(parentNodeContext, stores);
+      const legacyNodeContext = decorated(nodeContext, stores);
       legacy.clearOverflownViewNodes(
         legacyColumnViewOf(column),
         legacyParentNodeContext,
@@ -1986,15 +2245,16 @@ export function adaptLegacyLayoutProcessor(
       normalizeLegacyNodeContext(legacyNodeContext);
     },
   };
-  adaptedLayoutProcessors.set(legacy, adapted);
+  adapters.set(stores, adapted);
   return adapted;
 }
 
 function decoratedCheckPoints(
   checkPoints: Vtree.RenderedNodeContext[],
+  stores?: LegacyContextStores,
 ): LegacyRenderedNodeContext[] {
   for (const checkPoint of checkPoints) {
-    decorate(checkPoint);
+    decorate(checkPoint, stores);
   }
   // Same array, same elements: see coreOf.
   return checkPoints as unknown as LegacyRenderedNodeContext[];
@@ -2002,8 +2262,9 @@ function decoratedCheckPoints(
 
 function retaggedCheckPoints(
   checkPoints: Vtree.RenderedNodeContext[],
+  stores?: LegacyContextStores,
 ): LegacyRenderedNodeContext[] {
-  const legacy = decoratedCheckPoints(checkPoints);
+  const legacy = decoratedCheckPoints(checkPoints, stores);
   for (const checkPoint of legacy) {
     retagLegacyValue(checkPoint);
     handedOut.add(coreOf(checkPoint));
@@ -2017,11 +2278,12 @@ function retaggedCheckPoints(
  */
 export function asLegacyRenderedNodeContexts(
   hook: string,
+  stores: LegacyContextStores,
   checkPoints: Vtree.RenderedNodeContext[],
 ): LegacyRenderedNodeContext[] {
   if (!legacySurfaceActive(hook)) {
     // Same array, same elements: see coreOf.
     return checkPoints as unknown as LegacyRenderedNodeContext[];
   }
-  return decoratedCheckPoints(checkPoints);
+  return decoratedCheckPoints(checkPoints, stores);
 }

--- a/packages/core/src/vivliostyle/legacy-plugin-surface.ts
+++ b/packages/core/src/vivliostyle/legacy-plugin-surface.ts
@@ -1,0 +1,373 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @fileoverview LegacyPluginSurface - Compatibility view of the node context
+ * contract for externally registered plugin hooks.
+ *
+ * @deprecated Everything in this module exists so that plugin code written
+ * against the mutable class-based `Vtree.NodeContext` keeps compiling, and
+ * keeps behaving as it did over the payloads a hook is handed and over the
+ * members the projections and the adapters serve. Two things it does not keep,
+ * both fixed by the spec: a projected object is not the core object it stands
+ * for, and an assignment to a projected member stays inside the view. Core code
+ * must use `Vtree.NodeContext` and `node-context.ts`.
+ */
+import * as Css from "./css";
+import * as Diff from "./diff";
+import * as NodeContext from "./node-context";
+import * as Plugin from "./plugin";
+import { PageFloats, Selectors, Vtree } from "./types";
+
+/**
+ * @deprecated Flat mutable view of a node context. Use `Vtree.NodeContext`.
+ */
+export interface LegacyNodeContext {
+  offsetInNode: number;
+  after: boolean;
+  shadowType: Vtree.ShadowType;
+  shadowContext: Vtree.ShadowContext | null;
+  nodeShadow: Vtree.ShadowContext | null;
+  shadowSibling: LegacyNodeContext | null;
+  shared: boolean;
+  inline: boolean;
+  overflow: boolean;
+  breakPenalty: number;
+  display: string | null;
+  floatReference: PageFloats.FloatReference;
+  floatSide: string | null;
+  clearSide: string | null;
+  floatMinWrapBlock: Css.Numeric | null;
+  columnSpan: Css.Val | null;
+  captionSide: string;
+  inlineBorderSpacing: number;
+  blockBorderSpacing: number;
+  flexContainer: boolean;
+  whitespace: Vtree.Whitespace;
+  hyphenateCharacter: string | null;
+  breakWord: boolean;
+  establishesBFC: boolean;
+  containingBlockForAbsolute: boolean;
+  breakBefore: string | null;
+  breakAfter: string | null;
+  viewNode: Element | Text | null;
+  clearSpacer: Element | null;
+  inheritedProps: { [key: string]: number | string | Css.Val | undefined };
+  vertical: boolean;
+  direction: string;
+  firstPseudo: Vtree.FirstPseudo | null;
+  lang: string | null;
+  preprocessedTextContent: Diff.Change[] | null;
+  formattingContext: Vtree.FormattingContext;
+  repeatOnBreak: string | null;
+  pluginProps: {
+    [key: string]: string | number | undefined | null | (number | null)[];
+  };
+  fragmentIndex: number;
+  afterIfContinues: Selectors.AfterIfContinues | null;
+  footnotePolicy: Css.Ident | null;
+  pageType: string | null;
+
+  sourceNode: Node;
+  parent: LegacyNodeContext | null;
+  blockContainer: LegacyElementNodeContext | null;
+  boxOffset: number;
+
+  resetView(): void;
+  modify(): this;
+  copy(): this;
+  clone(): this;
+  toNodePositionStep(): Vtree.NodePositionStep;
+  toNodePosition(): Vtree.NodePosition;
+  isInsideBFC(): boolean;
+  getContainingBlockForAbsolute(): LegacyElementNodeContext | null;
+  belongsTo(formattingContext: Vtree.FormattingContext): boolean;
+}
+
+/**
+ * @deprecated Use `Vtree.ChildNodeContext`.
+ */
+export interface LegacyChildNodeContext extends LegacyNodeContext {
+  parent: LegacyNodeContext;
+}
+
+/**
+ * @deprecated Use `Vtree.RootNodeContext`.
+ */
+export interface LegacyRootNodeContext extends LegacyNodeContext {
+  parent: null;
+  shadowSibling: null;
+}
+
+/**
+ * @deprecated Use `Vtree.TextNodeContext`.
+ */
+export interface LegacyTextNodeContext extends LegacyChildNodeContext {
+  viewNode: Text;
+}
+
+/**
+ * @deprecated Use `Vtree.ElementNodeContext`.
+ */
+export interface LegacyElementNodeContext extends LegacyNodeContext {
+  viewNode: Element;
+}
+
+/**
+ * @deprecated Use `Vtree.RenderedNodeContext`.
+ */
+export type LegacyRenderedNodeContext =
+  LegacyElementNodeContext | LegacyTextNodeContext;
+
+/**
+ * @deprecated Use `Vtree.ContainedElementNodeContext`.
+ */
+export interface LegacyContainedElementNodeContext extends LegacyElementNodeContext {
+  blockContainer: LegacyElementNodeContext;
+}
+
+/**
+ * @deprecated Use `Vtree.FloatNodeContext`.
+ */
+export interface LegacyFloatNodeContext extends LegacyElementNodeContext {
+  floatSide: string;
+}
+
+/**
+ * @deprecated Use `Vtree.ClearNodeContext`.
+ */
+export interface LegacyClearNodeContext extends LegacyElementNodeContext {
+  clearSide: string;
+}
+
+/**
+ * @deprecated Use `Vtree.AfterIfContinuesNodeContext`.
+ */
+export interface LegacyAfterIfContinuesNodeContext extends LegacyElementNodeContext {
+  afterIfContinues: Selectors.AfterIfContinues;
+}
+
+/**
+ * @deprecated True when the named hook carries registrations the core did not
+ * make. The legacy view is built only then.
+ */
+export function legacySurfaceActive(hook: string): boolean {
+  return Plugin.getHooksForName(hook).some((fn) => !Plugin.isCoreHook(fn));
+}
+
+function coreOf(nodeContext: LegacyNodeContext): Vtree.NodeContext {
+  // Runtime fact outside the type system: the legacy view is the core's own
+  // node context value, handed out under a flat mutable declaration.
+  return nodeContext as unknown as Vtree.NodeContext;
+}
+
+function legacyViewOf(nodeContext: Vtree.NodeContext): LegacyNodeContext {
+  // Same value, opposite direction: see coreOf.
+  return nodeContext as unknown as LegacyNodeContext;
+}
+
+function legacyElementViewOf(
+  nodeContext: Vtree.ElementNodeContext,
+): LegacyElementNodeContext {
+  // Same value as coreOf; the element variant carries a non-null Element view.
+  return nodeContext as unknown as LegacyElementNodeContext;
+}
+
+function setLegacyKind(
+  nodeContext: LegacyNodeContext,
+  kind: Vtree.NodeContextKind,
+): void {
+  // resetView clears the fields the discriminant classifies, so the core value
+  // would otherwise be left tagged as a variant it no longer satisfies.
+  (nodeContext as unknown as { kind: Vtree.NodeContextKind }).kind = kind;
+}
+
+function cloneCoreItem<T extends Vtree.NodeContext>(nodeContext: T): T {
+  const parent = nodeContext.parent;
+  return {
+    ...nodeContext,
+    lang: null,
+    direction: parent ? parent.direction : "ltr",
+    inheritedProps: parent ? parent.inheritedProps : {},
+    pluginProps: { ...nodeContext.pluginProps },
+  };
+}
+
+class LegacyNodeContextMethods {
+  get shared(): boolean {
+    return true;
+  }
+
+  set shared(ignored: boolean) {
+    // The value world has no copy-on-write bit; the boundary value is always
+    // the one the core has already handed to a holder.
+  }
+
+  resetView(this: LegacyNodeContext): void {
+    this.inline = true;
+    this.breakPenalty = this.parent ? this.parent.breakPenalty : 0;
+    this.viewNode = null;
+    this.clearSpacer = null;
+    this.offsetInNode = 0;
+    this.after = false;
+    this.display = null;
+    this.floatReference = PageFloats.FloatReference.INLINE;
+    this.floatSide = null;
+    this.clearSide = null;
+    this.floatMinWrapBlock = null;
+    this.columnSpan = null;
+    this.flexContainer = false;
+    this.whitespace = this.parent
+      ? this.parent.whitespace
+      : Vtree.Whitespace.IGNORE;
+    this.hyphenateCharacter = this.parent
+      ? this.parent.hyphenateCharacter
+      : null;
+    this.breakWord = this.parent ? this.parent.breakWord : false;
+    this.breakBefore = null;
+    this.breakAfter = null;
+    this.nodeShadow = null;
+    this.establishesBFC = false;
+    this.containingBlockForAbsolute = false;
+    this.vertical = this.parent ? this.parent.vertical : false;
+    this.preprocessedTextContent = null;
+    if (this.parent) {
+      this.formattingContext = this.parent.formattingContext;
+    }
+    this.repeatOnBreak = null;
+    this.pluginProps = {};
+    this.fragmentIndex = 1;
+    this.afterIfContinues = null;
+    this.footnotePolicy = null;
+    this.pageType = this.parent ? this.parent.pageType : null;
+    setLegacyKind(this, "open");
+  }
+
+  modify(this: LegacyNodeContext): LegacyNodeContext {
+    return decorated(cloneCoreItem(coreOf(this)));
+  }
+
+  copy(this: LegacyNodeContext): LegacyNodeContext {
+    return this;
+  }
+
+  clone(this: LegacyNodeContext): LegacyNodeContext {
+    const chain = NodeContext.positionChainOf(coreOf(this));
+    for (let nc: Vtree.NodeContext | null = chain; nc; nc = nc.parent) {
+      const writable = nc as unknown as { pluginProps: Vtree.PluginProps };
+      writable.pluginProps = { ...nc.pluginProps };
+    }
+    return decorated(chain);
+  }
+
+  toNodePositionStep(this: LegacyNodeContext): Vtree.NodePositionStep {
+    return NodeContext.toNodePositionStep(coreOf(this));
+  }
+
+  toNodePosition(this: LegacyNodeContext): Vtree.NodePosition {
+    return NodeContext.toNodePosition(coreOf(this));
+  }
+
+  isInsideBFC(this: LegacyNodeContext): boolean {
+    return NodeContext.isInsideBFC(coreOf(this));
+  }
+
+  getContainingBlockForAbsolute(
+    this: LegacyNodeContext,
+  ): LegacyElementNodeContext | null {
+    const container = NodeContext.containingBlockForAbsoluteOf(coreOf(this));
+    if (!container) {
+      return null;
+    }
+    decorate(container);
+    return legacyElementViewOf(container);
+  }
+
+  belongsTo(
+    this: LegacyNodeContext,
+    formattingContext: Vtree.FormattingContext,
+  ): boolean {
+    return NodeContext.belongsTo(coreOf(this), formattingContext);
+  }
+}
+
+const legacyPrototype = LegacyNodeContextMethods.prototype;
+
+function isDecorated(nodeContext: Vtree.NodeContext): boolean {
+  return Object.getPrototypeOf(nodeContext) === legacyPrototype;
+}
+
+function decorate(nodeContext: Vtree.NodeContext): void {
+  for (let nc: Vtree.NodeContext | null = nodeContext; nc; nc = nc.parent) {
+    if (!isDecorated(nc)) {
+      // The core builds node contexts as plain object literals, so the legacy
+      // prototype cannot shadow any own field of the value.
+      Object.setPrototypeOf(nc, legacyPrototype);
+    }
+    if (nc.shadowSibling && !isDecorated(nc.shadowSibling)) {
+      decorate(nc.shadowSibling);
+    }
+    if (nc.blockContainer && !isDecorated(nc.blockContainer)) {
+      decorate(nc.blockContainer);
+    }
+  }
+}
+
+function decorated(nodeContext: Vtree.NodeContext): LegacyNodeContext {
+  decorate(nodeContext);
+  return legacyViewOf(nodeContext);
+}
+
+/**
+ * @deprecated Hand a node context to an external hook under the legacy
+ * declaration. The value itself is returned so that plugin writes reach the
+ * core, as they did when node contexts were mutable class instances.
+ */
+export function asLegacyNodeContext(
+  hook: string,
+  nodeContext: Vtree.NodeContext,
+): LegacyNodeContext {
+  if (legacySurfaceActive(hook)) {
+    decorate(nodeContext);
+  }
+  return legacyViewOf(nodeContext);
+}
+
+/**
+ * @deprecated `asLegacyNodeContext` for hook payloads that admit null.
+ */
+export function asLegacyNodeContextOrNull(
+  hook: string,
+  nodeContext: Vtree.NodeContext | null,
+): LegacyNodeContext | null {
+  return nodeContext === null ? null : asLegacyNodeContext(hook, nodeContext);
+}
+
+/**
+ * @deprecated `asLegacyNodeContext` for checkpoint arrays. The array itself is
+ * returned so that its identity and its elements' identities are preserved.
+ */
+export function asLegacyRenderedNodeContexts(
+  hook: string,
+  checkPoints: Vtree.RenderedNodeContext[],
+): LegacyRenderedNodeContext[] {
+  if (legacySurfaceActive(hook)) {
+    for (const checkPoint of checkPoints) {
+      decorate(checkPoint);
+    }
+  }
+  // Same array, same elements: see coreOf.
+  return checkPoints as unknown as LegacyRenderedNodeContext[];
+}

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -101,6 +101,19 @@ export function openSiblingOf(
   return nodeContext;
 }
 
+export function openNextSiblingOf<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  sourceNode: Node,
+  boxOffset?: number,
+): T {
+  if (boxOffset !== undefined) {
+    nodeContext.boxOffset = boxOffset;
+  }
+  nodeContext.sourceNode = sourceNode;
+  nodeContext.resetView();
+  return nodeContext;
+}
+
 export function openAt(
   sourceNode: Node,
   parent: VtreeImpl.NodeContext | null,

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -32,7 +32,6 @@ export type PositionHead = {
   offsetInNode: number;
   after: boolean;
   preprocessedTextContent?: Diff.Change[] | null;
-  fragmentIndex?: number;
 };
 
 const unstyled: Vtree.UnstyledFields = {
@@ -61,7 +60,7 @@ function derivedFromParent(parent: Vtree.ParentNodeContext | null): Pick<
   };
 }
 
-function derived<T extends Vtree.NodeContext>(nodeContext: T): T {
+export function derived<T extends Vtree.NodeContext>(nodeContext: T): T {
   return { ...nodeContext, ...derivedFromParent(nodeContext.parent) };
 }
 
@@ -134,10 +133,6 @@ function withPositionHead(
     ...nodeContext,
     offsetInNode: head.offsetInNode,
     preprocessedTextContent: head.preprocessedTextContent ?? null,
-    fragmentIndex:
-      head.fragmentIndex === undefined
-        ? nodeContext.fragmentIndex
-        : head.fragmentIndex,
   };
   return head.after
     ? { ...positioned, kind: "after-none", after: true }
@@ -559,13 +554,7 @@ export function afterEdgeAt(
   return { ...moved, kind: "after-text", after: true };
 }
 
-export function detachedAfterEdgeOf(
-  nodeContext: Vtree.NodeContext,
-): Vtree.AfterEdgeNodeContext {
-  return afterEdgeOf(nodeContext);
-}
-
-export function detachedBeforeEdgeOf(
+export function beforeEdgeOf(
   nodeContext: Vtree.NodeContext,
 ): Vtree.BeforeEdgeNodeContext {
   const moved = derived(nodeContext);
@@ -602,25 +591,11 @@ export function anchoredAfterOf(
   };
 }
 
-export function withOverflow<T extends Vtree.NodeContext>(
-  nodeContext: T,
-  overflow: boolean,
-): T {
-  return { ...derived(nodeContext), overflow };
-}
-
 export function setOverflow<T extends Vtree.NodeContext>(
   nodeContext: T,
   overflow: boolean,
 ): T {
   return { ...nodeContext, overflow };
-}
-
-export function withBoxOffset<T extends Vtree.NodeContext>(
-  nodeContext: T,
-  boxOffset: number,
-): T {
-  return { ...derived(nodeContext), boxOffset };
 }
 
 export function setBoxOffset<T extends Vtree.NodeContext>(
@@ -630,11 +605,11 @@ export function setBoxOffset<T extends Vtree.NodeContext>(
   return { ...nodeContext, boxOffset };
 }
 
-export function withOffsetInNode<T extends Vtree.NodeContext>(
+export function setOffsetInNode<T extends Vtree.NodeContext>(
   nodeContext: T,
   offsetInNode: number,
 ): T {
-  return { ...derived(nodeContext), offsetInNode };
+  return { ...nodeContext, offsetInNode };
 }
 
 export function textBrokenAt<T extends Vtree.NodeContext>(
@@ -646,13 +621,6 @@ export function textBrokenAt<T extends Vtree.NodeContext>(
     offsetInNode: nodeContext.offsetInNode + viewIndex,
     breakBefore: null,
   };
-}
-
-export function withBreakBefore<T extends Vtree.NodeContext>(
-  nodeContext: T,
-  breakBefore: string | null,
-): T {
-  return { ...derived(nodeContext), breakBefore };
 }
 
 export function setBreakBefore<T extends Vtree.NodeContext>(
@@ -787,7 +755,7 @@ export function positionChainOf<T extends Vtree.NodeContext>(
   };
 }
 
-export function toNodePositionStep(
+function toNodePositionStep(
   nodeContext: Vtree.NodeContext,
 ): Vtree.NodePositionStep {
   return {
@@ -807,7 +775,7 @@ export function toNodePositionStep(
   };
 }
 
-export function toRootNodePositionStep(
+function toRootNodePositionStep(
   root: Vtree.RootNodeContext,
 ): Vtree.RootNodePositionStep {
   return {

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -177,3 +177,84 @@ export function afterHeadFromPosition(
     preprocessedTextContent: position.preprocessedTextContent,
   };
 }
+
+export type ElementRenderResult = Pick<
+  Vtree.NodeContext,
+  | "nodeShadow"
+  | "containingBlockForAbsolute"
+  | "flexContainer"
+  | "inline"
+  | "breakPenalty"
+  | "clearSide"
+  | "floatReference"
+  | "floatMinWrapBlock"
+  | "columnSpan"
+  | "breakAfter"
+  | "pageType"
+  | "captionSide"
+  | "inlineBorderSpacing"
+  | "blockBorderSpacing"
+  | "footnotePolicy"
+  | "firstPseudo"
+  | "afterIfContinues"
+  | "whitespace"
+  | "hyphenateCharacter"
+  | "breakWord"
+  | "repeatOnBreak"
+>;
+
+export function elementRenderResultOf(
+  nodeContext: Vtree.NodeContext,
+): ElementRenderResult {
+  return {
+    nodeShadow: nodeContext.nodeShadow,
+    containingBlockForAbsolute: nodeContext.containingBlockForAbsolute,
+    flexContainer: nodeContext.flexContainer,
+    inline: nodeContext.inline,
+    breakPenalty: nodeContext.breakPenalty,
+    clearSide: nodeContext.clearSide,
+    floatReference: nodeContext.floatReference,
+    floatMinWrapBlock: nodeContext.floatMinWrapBlock,
+    columnSpan: nodeContext.columnSpan,
+    breakAfter: nodeContext.breakAfter,
+    pageType: nodeContext.pageType,
+    captionSide: nodeContext.captionSide,
+    inlineBorderSpacing: nodeContext.inlineBorderSpacing,
+    blockBorderSpacing: nodeContext.blockBorderSpacing,
+    footnotePolicy: nodeContext.footnotePolicy,
+    firstPseudo: nodeContext.firstPseudo,
+    afterIfContinues: nodeContext.afterIfContinues,
+    whitespace: nodeContext.whitespace,
+    hyphenateCharacter: nodeContext.hyphenateCharacter,
+    breakWord: nodeContext.breakWord,
+    repeatOnBreak: nodeContext.repeatOnBreak,
+  };
+}
+
+export function renderedElement(
+  nodeContext: VtreeImpl.NodeContext,
+  result: ElementRenderResult,
+): VtreeImpl.NodeContext {
+  nodeContext.nodeShadow = result.nodeShadow;
+  nodeContext.containingBlockForAbsolute = result.containingBlockForAbsolute;
+  nodeContext.flexContainer = result.flexContainer;
+  nodeContext.inline = result.inline;
+  nodeContext.breakPenalty = result.breakPenalty;
+  nodeContext.clearSide = result.clearSide;
+  nodeContext.floatReference = result.floatReference;
+  nodeContext.floatMinWrapBlock = result.floatMinWrapBlock;
+  nodeContext.columnSpan = result.columnSpan;
+  nodeContext.breakAfter = result.breakAfter;
+  nodeContext.pageType = result.pageType;
+  nodeContext.captionSide = result.captionSide;
+  nodeContext.inlineBorderSpacing = result.inlineBorderSpacing;
+  nodeContext.blockBorderSpacing = result.blockBorderSpacing;
+  nodeContext.footnotePolicy = result.footnotePolicy;
+  nodeContext.firstPseudo = result.firstPseudo;
+  nodeContext.afterIfContinues = result.afterIfContinues;
+  nodeContext.whitespace = result.whitespace;
+  nodeContext.hyphenateCharacter = result.hyphenateCharacter;
+  nodeContext.breakWord = result.breakWord;
+  nodeContext.repeatOnBreak = result.repeatOnBreak;
+  return nodeContext;
+}

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -62,7 +62,7 @@ function derivedFromParent(parent: Vtree.ParentNodeContext | null): Pick<
 }
 
 export function derived<T extends Vtree.NodeContext>(nodeContext: T): T {
-  return { ...nodeContext, ...derivedFromParent(nodeContext.parent) };
+  return { ...nodeContext };
 }
 
 function openCore<P extends Vtree.ParentNodeContext | null>(
@@ -192,6 +192,7 @@ export function openNextSiblingOf<T extends Vtree.NodeContext>(
   const parent = nodeContext.parent;
   return {
     ...nodeContext,
+    ...derivedFromParent(parent),
     ...unstyled,
     kind: "open",
     after: false,

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -464,3 +464,44 @@ export function setShadowSibling<T extends Vtree.NodeContext>(
   nodeContext.shadowSibling = shadowSibling;
   return nodeContext;
 }
+
+export function toNodePosition(
+  nodeContext: Vtree.NodeContext,
+): Vtree.NodePosition {
+  return nodeContext.toNodePosition();
+}
+
+export function isInsideBFC(nodeContext: Vtree.NodeContext): boolean {
+  let parent = nodeContext.parent;
+  while (parent) {
+    if (parent.establishesBFC) {
+      return true;
+    }
+    parent = parent.parent;
+  }
+  return false;
+}
+
+export function containingBlockForAbsoluteOf(
+  nodeContext: Vtree.NodeContext,
+): Vtree.ElementNodeContext | null {
+  let parent = nodeContext.parent;
+  while (parent) {
+    if (parent.containingBlockForAbsolute) {
+      return VtreeImpl.asElementNodeContext(parent);
+    }
+    parent = parent.parent;
+  }
+  return null;
+}
+
+export function belongsTo(
+  nodeContext: Vtree.NodeContext,
+  formattingContext: Vtree.FormattingContext,
+): boolean {
+  return (
+    nodeContext.formattingContext === formattingContext &&
+    !!nodeContext.parent &&
+    nodeContext.parent.formattingContext === formattingContext
+  );
+}

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -712,7 +712,7 @@ export function positionChainOf<T extends Vtree.NodeContext>(
   };
 }
 
-function toNodePositionStep(
+export function toNodePositionStep(
   nodeContext: Vtree.NodeContext,
 ): Vtree.NodePositionStep {
   return {

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -22,6 +22,11 @@ import * as PseudoElement from "./pseudo-element";
 import * as VtreeImpl from "./vtree";
 import { PageFloats, Vtree } from "./types";
 
+export type ContinuationStore = Readonly<{
+  continuationOfSlot: WeakMap<Vtree.NodeContext, Vtree.NodeContext>;
+  slotOfContinuation: WeakMap<Vtree.NodeContext, Vtree.NodeContext>;
+}>;
+
 export type ShadowPlacement = {
   shadowType: Vtree.ShadowType;
   shadowContext: Vtree.ShadowContext | null;
@@ -665,45 +670,38 @@ export function setPreprocessedTextContent<T extends Vtree.NodeContext>(
   return { ...nodeContext, preprocessedTextContent };
 }
 
-type ContinuationHolder = { current: Vtree.NodeContext };
-
-const continuationOfSlot = new WeakMap<Vtree.NodeContext, ContinuationHolder>();
-const continuationAtValue = new WeakMap<
-  Vtree.NodeContext,
-  ContinuationHolder
->();
-
-export function latestContinuation(slot: Vtree.NodeContext): Vtree.NodeContext {
-  return continuationOfSlot.get(slot)?.current ?? slot;
+export function latestContinuation(
+  store: ContinuationStore,
+  slot: Vtree.NodeContext,
+): Vtree.NodeContext {
+  return store.continuationOfSlot.get(slot) ?? slot;
 }
 
 export function resumeContinuation(
+  store: ContinuationStore,
   slot: Vtree.NodeContext,
   resumed: Vtree.NodeContext,
 ): void {
-  const holder = continuationOfSlot.get(slot);
-  if (holder) {
-    continuationAtValue.delete(holder.current);
-    holder.current = resumed;
-    continuationAtValue.set(resumed, holder);
-    return;
+  const current = store.continuationOfSlot.get(slot);
+  if (current) {
+    store.slotOfContinuation.delete(current);
   }
-  const started = { current: resumed };
-  continuationOfSlot.set(slot, started);
-  continuationAtValue.set(resumed, started);
+  store.continuationOfSlot.set(slot, resumed);
+  store.slotOfContinuation.set(resumed, slot);
 }
 
 export function followContinuation(
+  store: ContinuationStore,
   previous: Vtree.NodeContext,
   next: Vtree.NodeContext,
 ): void {
-  const holder = continuationAtValue.get(previous);
-  if (!holder) {
+  const slot = store.slotOfContinuation.get(previous);
+  if (!slot) {
     return;
   }
-  continuationAtValue.delete(previous);
-  holder.current = next;
-  continuationAtValue.set(next, holder);
+  store.slotOfContinuation.delete(previous);
+  store.continuationOfSlot.set(slot, next);
+  store.slotOfContinuation.set(next, slot);
 }
 
 export function positionChainOf<T extends Vtree.NodeContext>(
@@ -723,6 +721,7 @@ export function positionChainOf<T extends Vtree.NodeContext>(
 
 export function toNodePositionStep(
   nodeContext: Vtree.NodeContext,
+  continuationStore?: ContinuationStore,
 ): Vtree.NodePositionStep {
   return {
     node: nodeContext.sourceNode,
@@ -730,7 +729,12 @@ export function toNodePositionStep(
     shadowContext: nodeContext.shadowContext,
     nodeShadow: nodeContext.nodeShadow,
     shadowSibling: nodeContext.shadowSibling
-      ? toNodePositionStep(latestContinuation(nodeContext.shadowSibling))
+      ? toNodePositionStep(
+          continuationStore
+            ? latestContinuation(continuationStore, nodeContext.shadowSibling)
+            : nodeContext.shadowSibling,
+          continuationStore,
+        )
       : null,
     formattingContext: nodeContext.formattingContext,
 
@@ -743,15 +747,17 @@ export function toNodePositionStep(
 
 function toRootNodePositionStep(
   root: Vtree.RootNodeContext,
+  continuationStore?: ContinuationStore,
 ): Vtree.RootNodePositionStep {
   return {
-    ...toNodePositionStep(root),
+    ...toNodePositionStep(root, continuationStore),
     shadowSibling: root.shadowSibling,
   };
 }
 
 export function toNodePosition(
   nodeContext: Vtree.NodeContext,
+  continuationStore?: ContinuationStore,
 ): Vtree.NodePosition {
   // Fix for issue #703
   // A float or footnote context inside a pseudo-element shadow is always a
@@ -774,7 +780,7 @@ export function toNodePosition(
     // We need fully "peeled" path, so don't record first-XXX pseudoelement
     // containers
     if (!nc.firstPseudo || parent.firstPseudo === nc.firstPseudo) {
-      steps.push(toNodePositionStep(nc));
+      steps.push(toNodePositionStep(nc, continuationStore));
     }
     nc = parent;
   }
@@ -785,7 +791,13 @@ export function toNodePosition(
       )
     : nodeContext.offsetInNode;
   return {
-    steps: [...steps, toRootNodePositionStep(VtreeImpl.asRootNodeContext(nc))],
+    steps: [
+      ...steps,
+      toRootNodePositionStep(
+        VtreeImpl.asRootNodeContext(nc),
+        continuationStore,
+      ),
+    ],
     offsetInNode: actualOffsetInNode,
     after: nodeContext.after,
     preprocessedTextContent: nodeContext.preprocessedTextContent,

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -17,6 +17,7 @@
  * @fileoverview NodeContext - Construction of node contexts.
  */
 import * as Diff from "./diff";
+import * as LegacyPluginSurface from "./legacy-plugin-surface";
 import * as PseudoElement from "./pseudo-element";
 import * as VtreeImpl from "./vtree";
 import { PageFloats, Vtree } from "./types";
@@ -239,6 +240,13 @@ export function openAt(
   return withShadowPlacement(positioned, placement);
 }
 
+function retainedParent(
+  parent: Vtree.ParentNodeContext,
+): Vtree.ParentNodeContext {
+  LegacyPluginSurface.noteRetained(parent);
+  return parent;
+}
+
 export function openFromStep(
   step: Vtree.NodePositionStep,
   parent: Vtree.ParentNodeContext,
@@ -266,7 +274,7 @@ export function openFromStep( // eslint-disable-line no-redeclare
   const chained: Vtree.OpenNodeContext = {
     ...opened,
     shadowSibling: step.shadowSibling
-      ? openFromStep(step.shadowSibling, parent)
+      ? openFromStep(step.shadowSibling, retainedParent(parent))
       : null,
   };
   return head ? withPositionHead(chained, head) : chained;

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -17,6 +17,7 @@
  * @fileoverview NodeContext - Construction of node contexts.
  */
 import * as Diff from "./diff";
+import * as PseudoElement from "./pseudo-element";
 import * as VtreeImpl from "./vtree";
 import { PageFloats, Vtree } from "./types";
 
@@ -24,7 +25,7 @@ export type ShadowPlacement = {
   shadowType: Vtree.ShadowType;
   shadowContext: Vtree.ShadowContext | null;
   nodeShadow?: Vtree.ShadowContext | null;
-  shadowSibling?: VtreeImpl.NodeContext | null;
+  shadowSibling?: Vtree.NodeContext | null;
 };
 
 export type PositionHead = {
@@ -34,150 +35,277 @@ export type PositionHead = {
   fragmentIndex?: number;
 };
 
-function applyShadowPlacement(
-  nodeContext: VtreeImpl.NodeContext,
+const unstyled: Vtree.UnstyledFields = {
+  floatReference: PageFloats.FloatReference.INLINE,
+  clearSide: null,
+  floatMinWrapBlock: null,
+  columnSpan: null,
+  flexContainer: false,
+  containingBlockForAbsolute: false,
+  breakAfter: null,
+  repeatOnBreak: null,
+  afterIfContinues: null,
+  footnotePolicy: null,
+};
+
+function derivedFromParent(parent: Vtree.ParentNodeContext | null): Pick<
+  Vtree.NodeContextCore,
+  "direction" | "inheritedProps"
+> & {
+  lang: null;
+} {
+  return {
+    lang: null,
+    direction: parent ? parent.direction : "ltr",
+    inheritedProps: parent ? parent.inheritedProps : {},
+  };
+}
+
+function derived<T extends Vtree.NodeContext>(nodeContext: T): T {
+  return { ...nodeContext, ...derivedFromParent(nodeContext.parent) };
+}
+
+function openCore<P extends Vtree.ParentNodeContext | null>(
+  sourceNode: Node,
+  parent: P,
+  boxOffset: number,
+  formattingContext: Vtree.FormattingContext,
+  blockContainer: Vtree.ElementNodeContext | null,
+): Omit<Vtree.OpenNodeContext, "parent"> & { readonly parent: P } {
+  return {
+    kind: "open",
+    after: false,
+    viewNode: null,
+    preprocessedTextContent: null,
+    sourceNode,
+    parent,
+    boxOffset,
+    formattingContext,
+    blockContainer,
+    offsetInNode: 0,
+    shadowType: Vtree.ShadowType.NONE,
+    shadowContext: parent ? parent.shadowContext : null,
+    nodeShadow: null,
+    shadowSibling: null,
+    fragmentIndex: 1,
+    inline: true,
+    overflow: false,
+    breakBefore: null,
+    breakPenalty: parent ? parent.breakPenalty : 0,
+    whitespace: parent ? parent.whitespace : Vtree.Whitespace.IGNORE,
+    hyphenateCharacter: parent ? parent.hyphenateCharacter : null,
+    breakWord: parent ? parent.breakWord : false,
+    firstPseudo: parent ? parent.firstPseudo : null,
+    pageType: parent ? parent.pageType : null,
+    vertical: parent ? parent.vertical : false,
+    direction: parent ? parent.direction : "ltr",
+    lang: null,
+    inheritedProps: parent ? parent.inheritedProps : {},
+    pluginProps: {},
+    clearSpacer: null,
+    display: null,
+    floatSide: null,
+    establishesBFC: false,
+    captionSide: "top",
+    inlineBorderSpacing: 0,
+    blockBorderSpacing: 0,
+    ...unstyled,
+  };
+}
+
+function withShadowPlacement<T extends Vtree.NodeContext>(
+  nodeContext: T,
   placement: ShadowPlacement,
-): void {
-  nodeContext.shadowType = placement.shadowType;
-  nodeContext.shadowContext = placement.shadowContext;
-  nodeContext.nodeShadow = placement.nodeShadow ?? null;
-  nodeContext.shadowSibling = placement.shadowSibling ?? null;
+): T {
+  return {
+    ...nodeContext,
+    shadowType: placement.shadowType,
+    shadowContext: placement.shadowContext,
+    nodeShadow: placement.nodeShadow ?? null,
+    shadowSibling: placement.shadowSibling ?? null,
+  };
 }
 
-function applyPositionHead(
-  nodeContext: VtreeImpl.NodeContext,
+function withPositionHead(
+  nodeContext: Vtree.OpenNodeContext,
   head: PositionHead,
-): void {
-  nodeContext.offsetInNode = head.offsetInNode;
-  nodeContext.after = head.after;
-  nodeContext.preprocessedTextContent = head.preprocessedTextContent ?? null;
-  if (head.fragmentIndex !== undefined) {
-    nodeContext.fragmentIndex = head.fragmentIndex;
-  }
+): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext {
+  const positioned = {
+    ...nodeContext,
+    offsetInNode: head.offsetInNode,
+    preprocessedTextContent: head.preprocessedTextContent ?? null,
+    fragmentIndex:
+      head.fragmentIndex === undefined
+        ? nodeContext.fragmentIndex
+        : head.fragmentIndex,
+  };
+  return head.after
+    ? { ...positioned, kind: "after-none", after: true }
+    : positioned;
 }
 
-function applyNodePositionStep(
-  nodeContext: VtreeImpl.NodeContext,
+function withNodePositionStep(
+  nodeContext: Vtree.OpenNodeContext,
   step: Vtree.NodePositionStep,
-): void {
-  nodeContext.shadowType = step.shadowType;
-  nodeContext.shadowContext = step.shadowContext;
-  nodeContext.nodeShadow = step.nodeShadow;
-  nodeContext.fragmentIndex = step.fragmentIndex + 1;
+): Vtree.OpenNodeContext {
+  return {
+    ...nodeContext,
+    shadowType: step.shadowType,
+    shadowContext: step.shadowContext,
+    nodeShadow: step.nodeShadow,
+    fragmentIndex: step.fragmentIndex + 1,
+  };
 }
 
 export function openChildOf(
   sourceNode: Node,
-  parent: VtreeImpl.NodeContext,
+  parent: Vtree.ParentNodeContext,
   boxOffset: number,
   placement?: ShadowPlacement,
-): VtreeImpl.ChildNodeContext {
-  const nodeContext = new VtreeImpl.NodeContext(
+): Vtree.OpenNodeContext & Vtree.ChildNodeContext {
+  const nodeContext = openCore(
     sourceNode,
     parent,
     boxOffset,
     parent.formattingContext,
+    VtreeImpl.blockContainerForChildrenOf(parent),
   );
-  nodeContext.blockContainer = VtreeImpl.blockContainerForChildrenOf(parent);
-  if (placement) {
-    applyShadowPlacement(nodeContext, placement);
-  }
-  return nodeContext as VtreeImpl.ChildNodeContext;
+  return placement ? withShadowPlacement(nodeContext, placement) : nodeContext;
 }
 
 export function openSiblingOf(
   sourceNode: Node,
-  sibling: VtreeImpl.NodeContext,
+  sibling: Vtree.NodeContext,
   boxOffset: number,
-): VtreeImpl.NodeContext {
+): Vtree.OpenNodeContext {
   const parent = sibling.parent;
-  const nodeContext = new VtreeImpl.NodeContext(
+  return openCore(
     sourceNode,
     parent,
     boxOffset,
     (parent ?? sibling).formattingContext,
+    sibling.blockContainer,
   );
-  nodeContext.blockContainer = sibling.blockContainer;
-  return nodeContext;
 }
 
 export function openNextSiblingOf<T extends Vtree.NodeContext>(
   nodeContext: T,
   sourceNode: Node,
   boxOffset?: number,
-): T {
-  if (boxOffset !== undefined) {
-    nodeContext.boxOffset = boxOffset;
-  }
-  nodeContext.sourceNode = sourceNode;
-  nodeContext.resetView();
-  return nodeContext;
+): Omit<Vtree.OpenNodeContext, "parent"> & { readonly parent: T["parent"] } {
+  const parent = nodeContext.parent;
+  return {
+    ...nodeContext,
+    ...unstyled,
+    kind: "open",
+    after: false,
+    viewNode: null,
+    sourceNode,
+    boxOffset: boxOffset === undefined ? nodeContext.boxOffset : boxOffset,
+    inline: true,
+    breakPenalty: parent ? parent.breakPenalty : 0,
+    clearSpacer: null,
+    display: null,
+    floatSide: null,
+    establishesBFC: false,
+    offsetInNode: 0,
+    whitespace: parent ? parent.whitespace : Vtree.Whitespace.IGNORE,
+    hyphenateCharacter: parent ? parent.hyphenateCharacter : null,
+    breakWord: parent ? parent.breakWord : false,
+    breakBefore: null,
+    nodeShadow: null,
+    vertical: parent ? parent.vertical : false,
+    preprocessedTextContent: null,
+    formattingContext: parent
+      ? parent.formattingContext
+      : nodeContext.formattingContext,
+    pluginProps: {},
+    fragmentIndex: 1,
+    pageType: parent ? parent.pageType : null,
+  };
 }
 
 export function openAt(
   sourceNode: Node,
-  parent: VtreeImpl.NodeContext | null,
+  parent: Vtree.ParentNodeContext | null,
   boxOffset: number,
   formattingContext: Vtree.FormattingContext,
   placement: ShadowPlacement,
   head?: PositionHead,
-): VtreeImpl.NodeContext {
-  const nodeContext = new VtreeImpl.NodeContext(
+): Vtree.NodeContext {
+  const nodeContext = openCore(
     sourceNode,
     parent,
     boxOffset,
     formattingContext,
+    parent && VtreeImpl.blockContainerForChildrenOf(parent),
   );
-  nodeContext.blockContainer =
-    parent && VtreeImpl.blockContainerForChildrenOf(parent);
-  if (head) {
-    applyPositionHead(nodeContext, head);
-  }
-  applyShadowPlacement(nodeContext, placement);
-  return nodeContext;
+  const positioned = head ? withPositionHead(nodeContext, head) : nodeContext;
+  return withShadowPlacement(positioned, placement);
 }
 
 export function openFromStep(
   step: Vtree.NodePositionStep,
-  parent: Vtree.NodeContext,
+  parent: Vtree.ParentNodeContext,
+): Vtree.OpenNodeContext;
+export function openFromStep( // eslint-disable-line no-redeclare
+  step: Vtree.NodePositionStep,
+  parent: Vtree.ParentNodeContext,
   head?: PositionHead,
-): VtreeImpl.NodeContext {
-  const parentContext = parent as VtreeImpl.NodeContext;
-  const nodeContext = new VtreeImpl.NodeContext(
-    step.node,
-    parentContext,
-    0,
-    step.formattingContext ?? parentContext.formattingContext,
+): Vtree.NodeContext;
+export function openFromStep( // eslint-disable-line no-redeclare
+  step: Vtree.NodePositionStep,
+  parent: Vtree.ParentNodeContext,
+  head?: PositionHead,
+): Vtree.NodeContext {
+  const opened = withNodePositionStep(
+    openCore(
+      step.node,
+      parent,
+      0,
+      step.formattingContext ?? parent.formattingContext,
+      VtreeImpl.blockContainerForChildrenOf(parent),
+    ),
+    step,
   );
-  nodeContext.blockContainer =
-    VtreeImpl.blockContainerForChildrenOf(parentContext);
-  applyNodePositionStep(nodeContext, step);
-  nodeContext.shadowSibling = step.shadowSibling
-    ? openFromStep(step.shadowSibling, parent.copy())
-    : null;
-  if (head) {
-    applyPositionHead(nodeContext, head);
-  }
-  return nodeContext;
+  const chained: Vtree.OpenNodeContext = {
+    ...opened,
+    shadowSibling: step.shadowSibling
+      ? openFromStep(step.shadowSibling, parent)
+      : null,
+  };
+  return head ? withPositionHead(chained, head) : chained;
 }
 
 export function openRootFromStep(
   step: Vtree.RootNodePositionStep,
   flowRootFormattingContext: Vtree.FormattingContext,
+): Vtree.OpenNodeContext;
+export function openRootFromStep( // eslint-disable-line no-redeclare
+  step: Vtree.RootNodePositionStep,
+  flowRootFormattingContext: Vtree.FormattingContext,
   head?: PositionHead,
-): VtreeImpl.NodeContext {
-  const nodeContext = new VtreeImpl.NodeContext(
-    step.node,
-    null,
-    0,
-    step.formattingContext ?? flowRootFormattingContext,
+): Vtree.NodeContext;
+export function openRootFromStep( // eslint-disable-line no-redeclare
+  step: Vtree.RootNodePositionStep,
+  flowRootFormattingContext: Vtree.FormattingContext,
+  head?: PositionHead,
+): Vtree.NodeContext {
+  const opened = withNodePositionStep(
+    openCore(
+      step.node,
+      null,
+      0,
+      step.formattingContext ?? flowRootFormattingContext,
+      null,
+    ),
+    step,
   );
-  applyNodePositionStep(nodeContext, step);
-  nodeContext.shadowSibling = step.shadowSibling;
-  if (head) {
-    applyPositionHead(nodeContext, head);
-  }
-  return nodeContext;
+  const chained: Vtree.OpenNodeContext = {
+    ...opened,
+    shadowSibling: step.shadowSibling,
+  };
+  return head ? withPositionHead(chained, head) : chained;
 }
 
 export function afterHeadFromPosition(
@@ -192,7 +320,7 @@ export function afterHeadFromPosition(
 }
 
 export type ElementRenderResult = Pick<
-  Vtree.NodeContext,
+  Vtree.BeforeElementNodeContext,
   | "nodeShadow"
   | "containingBlockForAbsolute"
   | "flexContainer"
@@ -214,11 +342,24 @@ export type ElementRenderResult = Pick<
   | "hyphenateCharacter"
   | "breakWord"
   | "repeatOnBreak"
+  | "lang"
+  | "vertical"
+  | "direction"
+  | "inheritedProps"
+  | "establishesBFC"
+  | "display"
+  | "floatSide"
+  | "breakBefore"
+  | "formattingContext"
 >;
+
+export type ElementRenderDraft = {
+  -readonly [K in keyof ElementRenderResult]: ElementRenderResult[K];
+};
 
 export function elementRenderResultOf(
   nodeContext: Vtree.NodeContext,
-): ElementRenderResult {
+): ElementRenderDraft {
   return {
     nodeShadow: nodeContext.nodeShadow,
     containingBlockForAbsolute: nodeContext.containingBlockForAbsolute,
@@ -241,247 +382,480 @@ export function elementRenderResultOf(
     hyphenateCharacter: nodeContext.hyphenateCharacter,
     breakWord: nodeContext.breakWord,
     repeatOnBreak: nodeContext.repeatOnBreak,
+    lang: nodeContext.lang,
+    vertical: nodeContext.vertical,
+    direction: nodeContext.direction,
+    inheritedProps: nodeContext.inheritedProps,
+    establishesBFC: nodeContext.establishesBFC,
+    display: nodeContext.display,
+    floatSide: nodeContext.floatSide,
+    breakBefore: nodeContext.breakBefore,
+    formattingContext: nodeContext.formattingContext,
   };
 }
 
-export function renderedElement(
-  nodeContext: VtreeImpl.NodeContext,
-  result: ElementRenderResult,
-): VtreeImpl.NodeContext {
-  nodeContext.nodeShadow = result.nodeShadow;
-  nodeContext.containingBlockForAbsolute = result.containingBlockForAbsolute;
-  nodeContext.flexContainer = result.flexContainer;
-  nodeContext.inline = result.inline;
-  nodeContext.breakPenalty = result.breakPenalty;
-  nodeContext.clearSide = result.clearSide;
-  nodeContext.floatReference = result.floatReference;
-  nodeContext.floatMinWrapBlock = result.floatMinWrapBlock;
-  nodeContext.columnSpan = result.columnSpan;
-  nodeContext.breakAfter = result.breakAfter;
-  nodeContext.pageType = result.pageType;
-  nodeContext.captionSide = result.captionSide;
-  nodeContext.inlineBorderSpacing = result.inlineBorderSpacing;
-  nodeContext.blockBorderSpacing = result.blockBorderSpacing;
-  nodeContext.footnotePolicy = result.footnotePolicy;
-  nodeContext.firstPseudo = result.firstPseudo;
-  nodeContext.afterIfContinues = result.afterIfContinues;
-  nodeContext.whitespace = result.whitespace;
-  nodeContext.hyphenateCharacter = result.hyphenateCharacter;
-  nodeContext.breakWord = result.breakWord;
-  nodeContext.repeatOnBreak = result.repeatOnBreak;
-  return nodeContext;
-}
+export type ViewlessChildNodeContext = (
+  Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext
+) &
+  Vtree.ChildNodeContext;
 
-export function afterEdgeOf<T extends Vtree.NodeContext>(nodeContext: T): T {
-  const afterEdge = nodeContext.modify();
-  afterEdge.after = true;
-  return afterEdge;
-}
+export type ElementRenderProgress = Pick<
+  ElementRenderResult,
+  | "lang"
+  | "vertical"
+  | "direction"
+  | "inheritedProps"
+  | "establishesBFC"
+  | "display"
+  | "floatSide"
+  | "breakBefore"
+  | "formattingContext"
+>;
 
-export function afterEdgeAt<T extends Vtree.NodeContext>(
+export function elementRenderProgress<T extends Vtree.NodeContext>(
   nodeContext: T,
-  boxOffset: number,
+  progress: ElementRenderProgress,
 ): T {
-  const afterEdge = nodeContext.modify();
-  afterEdge.boxOffset = boxOffset;
-  afterEdge.after = true;
-  return afterEdge;
+  return {
+    ...nodeContext,
+    lang: progress.lang,
+    vertical: progress.vertical,
+    direction: progress.direction,
+    inheritedProps: progress.inheritedProps,
+    establishesBFC: progress.establishesBFC,
+    display: progress.display,
+    floatSide: progress.floatSide,
+    breakBefore: progress.breakBefore,
+    formattingContext: progress.formattingContext,
+  };
 }
 
-export function detachedAfterEdgeOf<T extends Vtree.NodeContext>(
-  nodeContext: T,
-): T {
-  const afterEdge = nodeContext.copy().modify();
-  afterEdge.after = true;
-  return afterEdge;
-}
-
-export function detachedBeforeEdgeOf<T extends Vtree.NodeContext>(
-  nodeContext: T,
-): T {
-  const beforeEdge = nodeContext.copy().modify();
-  beforeEdge.after = false;
-  return beforeEdge;
-}
-
-export function skippedAfterOf<T extends Vtree.NodeContext>(nodeContext: T): T {
-  const skipped = nodeContext.modify();
-  skipped.after = true;
-  if (!skipped.viewNode) {
-    skipped.inline = true;
+export function viewless(
+  nodeContext: Vtree.BeforeEdgeNodeContext,
+): Vtree.OpenNodeContext;
+export function viewless( // eslint-disable-line no-redeclare
+  nodeContext: Vtree.NodeContext,
+): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext;
+export function viewless( // eslint-disable-line no-redeclare
+  nodeContext: Vtree.NodeContext,
+): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext {
+  switch (nodeContext.kind) {
+    case "open":
+    case "after-none":
+      return nodeContext;
+    case "element":
+    case "text":
+      return {
+        ...nodeContext,
+        ...unstyled,
+        kind: "open",
+        after: false,
+        viewNode: null,
+      };
   }
-  return skipped;
+  return {
+    ...nodeContext,
+    ...unstyled,
+    kind: "after-none",
+    after: true,
+    viewNode: null,
+  };
 }
 
-export function anchoredAfterOf<T extends Vtree.NodeContext>(
-  nodeContext: T,
+export function viewlessRender(
+  nodeContext: Vtree.BeforeEdgeNodeContext,
+  result: ElementRenderResult,
+): Vtree.OpenNodeContext;
+export function viewlessRender( // eslint-disable-line no-redeclare
+  nodeContext: Vtree.NodeContext,
+  result: ElementRenderResult,
+): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext;
+export function viewlessRender( // eslint-disable-line no-redeclare
+  nodeContext: Vtree.NodeContext,
+  result: ElementRenderResult,
+): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext {
+  return viewless({
+    ...elementRenderProgress(nodeContext, result),
+    nodeShadow: result.nodeShadow,
+    inline: result.inline,
+    breakPenalty: result.breakPenalty,
+    pageType: result.pageType,
+    captionSide: result.captionSide,
+    inlineBorderSpacing: result.inlineBorderSpacing,
+    blockBorderSpacing: result.blockBorderSpacing,
+    firstPseudo: result.firstPseudo,
+    whitespace: result.whitespace,
+    hyphenateCharacter: result.hyphenateCharacter,
+    breakWord: result.breakWord,
+  });
+}
+
+export function renderedElement(
+  nodeContext: Vtree.BeforeEdgeNodeContext,
+  viewNode: Element,
+  result: ElementRenderResult,
+): Vtree.BeforeElementNodeContext;
+export function renderedElement( // eslint-disable-line no-redeclare
+  nodeContext: Vtree.NodeContext,
+  viewNode: Element,
+  result: ElementRenderResult,
+): Vtree.ElementNodeContext;
+export function renderedElement( // eslint-disable-line no-redeclare
+  nodeContext: Vtree.NodeContext,
+  viewNode: Element,
+  result: ElementRenderResult,
+): Vtree.ElementNodeContext {
+  const rendered = { ...nodeContext, ...result, viewNode };
+  return nodeContext.after
+    ? { ...rendered, kind: "after-element", after: true }
+    : { ...rendered, kind: "element", after: false };
+}
+
+export function renderedText(
+  nodeContext: Vtree.OpenNodeContext & Vtree.ChildNodeContext,
+  viewNode: Text,
+  preprocessedTextContent: Diff.Change[],
+): Vtree.BeforeTextNodeContext;
+export function renderedText( // eslint-disable-line no-redeclare
+  nodeContext: ViewlessChildNodeContext,
+  viewNode: Text,
+  preprocessedTextContent: Diff.Change[],
+): Vtree.TextNodeContext;
+export function renderedText( // eslint-disable-line no-redeclare
+  nodeContext: ViewlessChildNodeContext,
+  viewNode: Text,
+  preprocessedTextContent: Diff.Change[],
+): Vtree.TextNodeContext {
+  const rendered = {
+    ...nodeContext,
+    viewNode,
+    preprocessedTextContent,
+    parent: nodeContext.parent,
+  };
+  return nodeContext.after
+    ? { ...rendered, kind: "after-text", after: true }
+    : { ...rendered, kind: "text", after: false };
+}
+
+export function afterEdgeOf(
+  nodeContext: Vtree.NodeContext,
+): Vtree.AfterEdgeNodeContext {
+  return afterEdgeAt(nodeContext, nodeContext.boxOffset);
+}
+
+export function afterEdgeAt(
+  nodeContext: Vtree.NodeContext,
+  boxOffset: number,
+): Vtree.AfterEdgeNodeContext {
+  const moved = { ...derived(nodeContext), boxOffset };
+  switch (moved.kind) {
+    case "open":
+    case "after-none":
+      return { ...moved, kind: "after-none", after: true };
+    case "element":
+    case "after-element":
+      return { ...moved, kind: "after-element", after: true };
+  }
+  return { ...moved, kind: "after-text", after: true };
+}
+
+export function detachedAfterEdgeOf(
+  nodeContext: Vtree.NodeContext,
+): Vtree.AfterEdgeNodeContext {
+  return afterEdgeOf(nodeContext);
+}
+
+export function detachedBeforeEdgeOf(
+  nodeContext: Vtree.NodeContext,
+): Vtree.BeforeEdgeNodeContext {
+  const moved = derived(nodeContext);
+  switch (moved.kind) {
+    case "open":
+    case "after-none":
+      return { ...moved, kind: "open", after: false };
+    case "element":
+    case "after-element":
+      return { ...moved, kind: "element", after: false };
+  }
+  return { ...moved, kind: "text", after: false };
+}
+
+export function skippedAfterOf(
+  nodeContext: Vtree.NodeContext,
+): Vtree.AfterEdgeNodeContext {
+  const after = afterEdgeOf(nodeContext);
+  return after.viewNode ? after : { ...after, inline: true };
+}
+
+export function anchoredAfterOf(
+  nodeContext: Vtree.NodeContext,
   anchor: Element,
   asInline: boolean,
-): T {
-  const anchored = nodeContext.modify();
-  anchored.after = true;
-  anchored.viewNode = anchor;
-  if (asInline) {
-    anchored.display = "inline";
-  }
-  return anchored;
+): Vtree.AfterElementNodeContext {
+  const moved = derived(nodeContext);
+  return {
+    ...moved,
+    kind: "after-element",
+    after: true,
+    viewNode: anchor,
+    display: asInline ? "inline" : moved.display,
+  };
 }
 
 export function withOverflow<T extends Vtree.NodeContext>(
   nodeContext: T,
   overflow: boolean,
 ): T {
-  const modified = nodeContext.modify();
-  modified.overflow = overflow;
-  return modified;
+  return { ...derived(nodeContext), overflow };
 }
 
 export function setOverflow<T extends Vtree.NodeContext>(
   nodeContext: T,
   overflow: boolean,
 ): T {
-  nodeContext.overflow = overflow;
-  return nodeContext;
+  return { ...nodeContext, overflow };
 }
 
 export function withBoxOffset<T extends Vtree.NodeContext>(
   nodeContext: T,
   boxOffset: number,
 ): T {
-  const modified = nodeContext.modify();
-  modified.boxOffset = boxOffset;
-  return modified;
+  return { ...derived(nodeContext), boxOffset };
 }
 
 export function setBoxOffset<T extends Vtree.NodeContext>(
   nodeContext: T,
   boxOffset: number,
 ): T {
-  nodeContext.boxOffset = boxOffset;
-  return nodeContext;
+  return { ...nodeContext, boxOffset };
 }
 
 export function withOffsetInNode<T extends Vtree.NodeContext>(
   nodeContext: T,
   offsetInNode: number,
 ): T {
-  const modified = nodeContext.modify();
-  modified.offsetInNode = offsetInNode;
-  return modified;
+  return { ...derived(nodeContext), offsetInNode };
 }
 
 export function textBrokenAt<T extends Vtree.NodeContext>(
   nodeContext: T,
   viewIndex: number,
 ): T {
-  const modified = nodeContext.modify();
-  modified.offsetInNode += viewIndex;
-  modified.breakBefore = null;
-  return modified;
+  return {
+    ...derived(nodeContext),
+    offsetInNode: nodeContext.offsetInNode + viewIndex,
+    breakBefore: null,
+  };
 }
 
 export function withBreakBefore<T extends Vtree.NodeContext>(
   nodeContext: T,
   breakBefore: string | null,
 ): T {
-  const modified = nodeContext.modify();
-  modified.breakBefore = breakBefore;
-  return modified;
+  return { ...derived(nodeContext), breakBefore };
 }
 
 export function setBreakBefore<T extends Vtree.NodeContext>(
   nodeContext: T,
   breakBefore: string | null,
 ): T {
-  nodeContext.breakBefore = breakBefore;
-  return nodeContext;
+  return { ...nodeContext, breakBefore };
 }
 
 export function withoutFloat<T extends Vtree.NodeContext>(nodeContext: T): T {
-  const modified = nodeContext.modify();
-  modified.floatSide = null;
-  modified.floatReference = PageFloats.FloatReference.INLINE;
-  modified.clearSide = null;
-  return modified;
+  return {
+    ...derived(nodeContext),
+    floatSide: null,
+    floatReference: PageFloats.FloatReference.INLINE,
+    clearSide: null,
+  };
 }
 
 export function setClearSpacer<T extends Vtree.NodeContext>(
   nodeContext: T,
   clearSpacer: Element | null,
 ): T {
-  nodeContext.clearSpacer = clearSpacer;
-  return nodeContext;
+  return { ...nodeContext, clearSpacer };
 }
 
-export function setRepeatOnBreak<T extends Vtree.NodeContext>(
-  nodeContext: T,
+export function setRepeatOnBreak(
+  nodeContext: Vtree.ElementNodeContext,
   repeatOnBreak: string | null,
-): T {
-  nodeContext.repeatOnBreak = repeatOnBreak;
-  return nodeContext;
+): Vtree.ElementNodeContext {
+  return { ...nodeContext, repeatOnBreak };
 }
 
 export function setFragmentIndex<T extends Vtree.NodeContext>(
   nodeContext: T,
   fragmentIndex: number,
 ): T {
-  nodeContext.fragmentIndex = fragmentIndex;
-  return nodeContext;
+  return { ...nodeContext, fragmentIndex };
 }
 
 export function setPluginProp<T extends Vtree.NodeContext>(
   nodeContext: T,
   name: string,
-  value: Vtree.NodeContext["pluginProps"][string],
+  value: Vtree.PluginProps[string],
 ): T {
-  nodeContext.pluginProps[name] = value;
-  return nodeContext;
-}
-
-export function setViewNode<T extends Vtree.NodeContext>(
-  nodeContext: T,
-  viewNode: Element | Text | null,
-): T {
-  nodeContext.viewNode = viewNode;
-  return nodeContext;
-}
-
-export function setPreprocessedTextContent<T extends Vtree.NodeContext>(
-  nodeContext: T,
-  preprocessedTextContent: Diff.Change[],
-): T {
-  nodeContext.preprocessedTextContent = preprocessedTextContent;
-  return nodeContext;
+  return {
+    ...nodeContext,
+    pluginProps: { ...nodeContext.pluginProps, [name]: value },
+  };
 }
 
 export function setInline<T extends Vtree.NodeContext>(
   nodeContext: T,
   inline: boolean,
 ): T {
-  nodeContext.inline = inline;
-  return nodeContext;
+  return { ...nodeContext, inline };
 }
 
 export function setShadowContext<T extends Vtree.NodeContext>(
   nodeContext: T,
   shadowContext: Vtree.ShadowContext | null,
 ): T {
-  nodeContext.shadowContext = shadowContext;
-  return nodeContext;
+  return { ...nodeContext, shadowContext };
 }
 
 export function setShadowSibling<T extends Vtree.NodeContext>(
   nodeContext: T,
   shadowSibling: Vtree.NodeContext | null,
 ): T {
-  nodeContext.shadowSibling = shadowSibling;
-  return nodeContext;
+  return { ...nodeContext, shadowSibling };
+}
+
+export function setPreprocessedTextContent<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  preprocessedTextContent: Diff.Change[],
+): T {
+  return { ...nodeContext, preprocessedTextContent };
+}
+
+type ContinuationHolder = { current: Vtree.NodeContext };
+
+const continuationOfSlot = new WeakMap<Vtree.NodeContext, ContinuationHolder>();
+const continuationAtValue = new WeakMap<
+  Vtree.NodeContext,
+  ContinuationHolder
+>();
+
+export function latestContinuation(slot: Vtree.NodeContext): Vtree.NodeContext {
+  return continuationOfSlot.get(slot)?.current ?? slot;
+}
+
+export function resumeContinuation(
+  slot: Vtree.NodeContext,
+  resumed: Vtree.NodeContext,
+): void {
+  const holder = continuationOfSlot.get(slot);
+  if (holder) {
+    continuationAtValue.delete(holder.current);
+    holder.current = resumed;
+    continuationAtValue.set(resumed, holder);
+    return;
+  }
+  const started = { current: resumed };
+  continuationOfSlot.set(slot, started);
+  continuationAtValue.set(resumed, started);
+}
+
+export function followContinuation(
+  previous: Vtree.NodeContext,
+  next: Vtree.NodeContext,
+): void {
+  const holder = continuationAtValue.get(previous);
+  if (!holder) {
+    return;
+  }
+  continuationAtValue.delete(previous);
+  holder.current = next;
+  continuationAtValue.set(next, holder);
+}
+
+export function positionChainOf<T extends Vtree.NodeContext>(
+  nodeContext: T,
+): T {
+  const parent = nodeContext.parent;
+  if (!parent) {
+    return derived(nodeContext);
+  }
+  const chainedParent = positionChainOf(parent);
+  return {
+    ...derived(nodeContext),
+    parent: chainedParent,
+    blockContainer: VtreeImpl.blockContainerForChildrenOf(chainedParent),
+  };
+}
+
+export function toNodePositionStep(
+  nodeContext: Vtree.NodeContext,
+): Vtree.NodePositionStep {
+  return {
+    node: nodeContext.sourceNode,
+    shadowType: nodeContext.shadowType,
+    shadowContext: nodeContext.shadowContext,
+    nodeShadow: nodeContext.nodeShadow,
+    shadowSibling: nodeContext.shadowSibling
+      ? toNodePositionStep(latestContinuation(nodeContext.shadowSibling))
+      : null,
+    formattingContext: nodeContext.formattingContext,
+
+    // fragmentIndex needs to be reset to 0 if this viewNode has been removed
+    // from the view tree by forced break processing. (Issue #1557)
+    fragmentIndex:
+      nodeContext.viewNode?.parentNode === null ? 0 : nodeContext.fragmentIndex,
+  };
+}
+
+export function toRootNodePositionStep(
+  root: Vtree.RootNodeContext,
+): Vtree.RootNodePositionStep {
+  return {
+    ...toNodePositionStep(root),
+    shadowSibling: root.shadowSibling,
+  };
 }
 
 export function toNodePosition(
   nodeContext: Vtree.NodeContext,
 ): Vtree.NodePosition {
-  return nodeContext.toNodePosition();
+  // Fix for issue #703
+  // A float or footnote context inside a pseudo-element shadow is always a
+  // descended one: restored heads keep the constructor's default float
+  // fields and live roots carry no shadow context.
+  const floatInPseudoContent =
+    nodeContext.shadowType === Vtree.ShadowType.ROOTLESS &&
+    (nodeContext.floatReference !== PageFloats.FloatReference.INLINE ||
+      nodeContext.floatSide === "footnote") &&
+    (nodeContext.shadowContext?.styler as PseudoElement.PseudoelementStyler)
+      ?.style?.["_pseudos"]
+      ? VtreeImpl.asChildNodeContext(nodeContext)
+      : null;
+  const steps: Vtree.NodePositionStep[] = [];
+  let nc: Vtree.NodeContext = floatInPseudoContent
+    ? floatInPseudoContent.parent
+    : nodeContext;
+  let parent: Vtree.ParentNodeContext | null;
+  while ((parent = nc.parent) !== null) {
+    // We need fully "peeled" path, so don't record first-XXX pseudoelement
+    // containers
+    if (!nc.firstPseudo || parent.firstPseudo === nc.firstPseudo) {
+      steps.push(toNodePositionStep(nc));
+    }
+    nc = parent;
+  }
+  const actualOffsetInNode = nodeContext.preprocessedTextContent
+    ? Diff.resolveOriginalIndex(
+        nodeContext.preprocessedTextContent,
+        nodeContext.offsetInNode,
+      )
+    : nodeContext.offsetInNode;
+  return {
+    steps: [...steps, toRootNodePositionStep(VtreeImpl.asRootNodeContext(nc))],
+    offsetInNode: actualOffsetInNode,
+    after: nodeContext.after,
+    preprocessedTextContent: nodeContext.preprocessedTextContent,
+  };
 }
 
 export function isInsideBFC(nodeContext: Vtree.NodeContext): boolean {

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -18,7 +18,7 @@
  */
 import * as Diff from "./diff";
 import * as VtreeImpl from "./vtree";
-import { Vtree } from "./types";
+import { PageFloats, Vtree } from "./types";
 
 export type ShadowPlacement = {
   shadowType: Vtree.ShadowType;
@@ -256,5 +256,211 @@ export function renderedElement(
   nodeContext.hyphenateCharacter = result.hyphenateCharacter;
   nodeContext.breakWord = result.breakWord;
   nodeContext.repeatOnBreak = result.repeatOnBreak;
+  return nodeContext;
+}
+
+export function afterEdgeOf<T extends Vtree.NodeContext>(nodeContext: T): T {
+  const afterEdge = nodeContext.modify();
+  afterEdge.after = true;
+  return afterEdge;
+}
+
+export function afterEdgeAt<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  boxOffset: number,
+): T {
+  const afterEdge = nodeContext.modify();
+  afterEdge.boxOffset = boxOffset;
+  afterEdge.after = true;
+  return afterEdge;
+}
+
+export function detachedAfterEdgeOf<T extends Vtree.NodeContext>(
+  nodeContext: T,
+): T {
+  const afterEdge = nodeContext.copy().modify();
+  afterEdge.after = true;
+  return afterEdge;
+}
+
+export function detachedBeforeEdgeOf<T extends Vtree.NodeContext>(
+  nodeContext: T,
+): T {
+  const beforeEdge = nodeContext.copy().modify();
+  beforeEdge.after = false;
+  return beforeEdge;
+}
+
+export function skippedAfterOf<T extends Vtree.NodeContext>(nodeContext: T): T {
+  const skipped = nodeContext.modify();
+  skipped.after = true;
+  if (!skipped.viewNode) {
+    skipped.inline = true;
+  }
+  return skipped;
+}
+
+export function anchoredAfterOf<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  anchor: Element,
+  asInline: boolean,
+): T {
+  const anchored = nodeContext.modify();
+  anchored.after = true;
+  anchored.viewNode = anchor;
+  if (asInline) {
+    anchored.display = "inline";
+  }
+  return anchored;
+}
+
+export function withOverflow<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  overflow: boolean,
+): T {
+  const modified = nodeContext.modify();
+  modified.overflow = overflow;
+  return modified;
+}
+
+export function setOverflow<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  overflow: boolean,
+): T {
+  nodeContext.overflow = overflow;
+  return nodeContext;
+}
+
+export function withBoxOffset<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  boxOffset: number,
+): T {
+  const modified = nodeContext.modify();
+  modified.boxOffset = boxOffset;
+  return modified;
+}
+
+export function setBoxOffset<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  boxOffset: number,
+): T {
+  nodeContext.boxOffset = boxOffset;
+  return nodeContext;
+}
+
+export function withOffsetInNode<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  offsetInNode: number,
+): T {
+  const modified = nodeContext.modify();
+  modified.offsetInNode = offsetInNode;
+  return modified;
+}
+
+export function textBrokenAt<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  viewIndex: number,
+): T {
+  const modified = nodeContext.modify();
+  modified.offsetInNode += viewIndex;
+  modified.breakBefore = null;
+  return modified;
+}
+
+export function withBreakBefore<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  breakBefore: string | null,
+): T {
+  const modified = nodeContext.modify();
+  modified.breakBefore = breakBefore;
+  return modified;
+}
+
+export function setBreakBefore<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  breakBefore: string | null,
+): T {
+  nodeContext.breakBefore = breakBefore;
+  return nodeContext;
+}
+
+export function withoutFloat<T extends Vtree.NodeContext>(nodeContext: T): T {
+  const modified = nodeContext.modify();
+  modified.floatSide = null;
+  modified.floatReference = PageFloats.FloatReference.INLINE;
+  modified.clearSide = null;
+  return modified;
+}
+
+export function setClearSpacer<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  clearSpacer: Element | null,
+): T {
+  nodeContext.clearSpacer = clearSpacer;
+  return nodeContext;
+}
+
+export function setRepeatOnBreak<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  repeatOnBreak: string | null,
+): T {
+  nodeContext.repeatOnBreak = repeatOnBreak;
+  return nodeContext;
+}
+
+export function setFragmentIndex<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  fragmentIndex: number,
+): T {
+  nodeContext.fragmentIndex = fragmentIndex;
+  return nodeContext;
+}
+
+export function setPluginProp<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  name: string,
+  value: Vtree.NodeContext["pluginProps"][string],
+): T {
+  nodeContext.pluginProps[name] = value;
+  return nodeContext;
+}
+
+export function setViewNode<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  viewNode: Element | Text | null,
+): T {
+  nodeContext.viewNode = viewNode;
+  return nodeContext;
+}
+
+export function setPreprocessedTextContent<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  preprocessedTextContent: Diff.Change[],
+): T {
+  nodeContext.preprocessedTextContent = preprocessedTextContent;
+  return nodeContext;
+}
+
+export function setInline<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  inline: boolean,
+): T {
+  nodeContext.inline = inline;
+  return nodeContext;
+}
+
+export function setShadowContext<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  shadowContext: Vtree.ShadowContext | null,
+): T {
+  nodeContext.shadowContext = shadowContext;
+  return nodeContext;
+}
+
+export function setShadowSibling<T extends Vtree.NodeContext>(
+  nodeContext: T,
+  shadowSibling: Vtree.NodeContext | null,
+): T {
+  nodeContext.shadowSibling = shadowSibling;
   return nodeContext;
 }

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2019 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @fileoverview NodeContext - Construction of node contexts.
+ */
+import * as Diff from "./diff";
+import * as VtreeImpl from "./vtree";
+import { Vtree } from "./types";
+
+export type ShadowPlacement = {
+  shadowType: Vtree.ShadowType;
+  shadowContext: Vtree.ShadowContext | null;
+  nodeShadow?: Vtree.ShadowContext | null;
+  shadowSibling?: VtreeImpl.NodeContext | null;
+};
+
+export type PositionHead = {
+  offsetInNode: number;
+  after: boolean;
+  preprocessedTextContent?: Diff.Change[] | null;
+  fragmentIndex?: number;
+};
+
+function applyShadowPlacement(
+  nodeContext: VtreeImpl.NodeContext,
+  placement: ShadowPlacement,
+): void {
+  nodeContext.shadowType = placement.shadowType;
+  nodeContext.shadowContext = placement.shadowContext;
+  nodeContext.nodeShadow = placement.nodeShadow ?? null;
+  nodeContext.shadowSibling = placement.shadowSibling ?? null;
+}
+
+function applyPositionHead(
+  nodeContext: VtreeImpl.NodeContext,
+  head: PositionHead,
+): void {
+  nodeContext.offsetInNode = head.offsetInNode;
+  nodeContext.after = head.after;
+  nodeContext.preprocessedTextContent = head.preprocessedTextContent ?? null;
+  if (head.fragmentIndex !== undefined) {
+    nodeContext.fragmentIndex = head.fragmentIndex;
+  }
+}
+
+function applyNodePositionStep(
+  nodeContext: VtreeImpl.NodeContext,
+  step: Vtree.NodePositionStep,
+): void {
+  nodeContext.shadowType = step.shadowType;
+  nodeContext.shadowContext = step.shadowContext;
+  nodeContext.nodeShadow = step.nodeShadow;
+  nodeContext.fragmentIndex = step.fragmentIndex + 1;
+}
+
+export function openChildOf(
+  sourceNode: Node,
+  parent: VtreeImpl.NodeContext,
+  boxOffset: number,
+  placement?: ShadowPlacement,
+): VtreeImpl.ChildNodeContext {
+  const nodeContext = new VtreeImpl.NodeContext(
+    sourceNode,
+    parent,
+    boxOffset,
+    parent.formattingContext,
+  );
+  nodeContext.blockContainer = VtreeImpl.blockContainerForChildrenOf(parent);
+  if (placement) {
+    applyShadowPlacement(nodeContext, placement);
+  }
+  return nodeContext as VtreeImpl.ChildNodeContext;
+}
+
+export function openSiblingOf(
+  sourceNode: Node,
+  sibling: VtreeImpl.NodeContext,
+  boxOffset: number,
+): VtreeImpl.NodeContext {
+  const parent = sibling.parent;
+  const nodeContext = new VtreeImpl.NodeContext(
+    sourceNode,
+    parent,
+    boxOffset,
+    (parent ?? sibling).formattingContext,
+  );
+  nodeContext.blockContainer = sibling.blockContainer;
+  return nodeContext;
+}
+
+export function openAt(
+  sourceNode: Node,
+  parent: VtreeImpl.NodeContext | null,
+  boxOffset: number,
+  formattingContext: Vtree.FormattingContext,
+  placement: ShadowPlacement,
+  head?: PositionHead,
+): VtreeImpl.NodeContext {
+  const nodeContext = new VtreeImpl.NodeContext(
+    sourceNode,
+    parent,
+    boxOffset,
+    formattingContext,
+  );
+  nodeContext.blockContainer =
+    parent && VtreeImpl.blockContainerForChildrenOf(parent);
+  if (head) {
+    applyPositionHead(nodeContext, head);
+  }
+  applyShadowPlacement(nodeContext, placement);
+  return nodeContext;
+}
+
+export function openFromStep(
+  step: Vtree.NodePositionStep,
+  parent: Vtree.NodeContext,
+  head?: PositionHead,
+): VtreeImpl.NodeContext {
+  const parentContext = parent as VtreeImpl.NodeContext;
+  const nodeContext = new VtreeImpl.NodeContext(
+    step.node,
+    parentContext,
+    0,
+    step.formattingContext ?? parentContext.formattingContext,
+  );
+  nodeContext.blockContainer =
+    VtreeImpl.blockContainerForChildrenOf(parentContext);
+  applyNodePositionStep(nodeContext, step);
+  nodeContext.shadowSibling = step.shadowSibling
+    ? openFromStep(step.shadowSibling, parent.copy())
+    : null;
+  if (head) {
+    applyPositionHead(nodeContext, head);
+  }
+  return nodeContext;
+}
+
+export function openRootFromStep(
+  step: Vtree.RootNodePositionStep,
+  flowRootFormattingContext: Vtree.FormattingContext,
+  head?: PositionHead,
+): VtreeImpl.NodeContext {
+  const nodeContext = new VtreeImpl.NodeContext(
+    step.node,
+    null,
+    0,
+    step.formattingContext ?? flowRootFormattingContext,
+  );
+  applyNodePositionStep(nodeContext, step);
+  nodeContext.shadowSibling = step.shadowSibling;
+  if (head) {
+    applyPositionHead(nodeContext, head);
+  }
+  return nodeContext;
+}
+
+export function afterHeadFromPosition(
+  position: Vtree.NodePosition,
+  offsetInNode: number,
+): PositionHead {
+  return {
+    offsetInNode,
+    after: position.after,
+    preprocessedTextContent: position.preprocessedTextContent,
+  };
+}

--- a/packages/core/src/vivliostyle/node-context.ts
+++ b/packages/core/src/vivliostyle/node-context.ts
@@ -275,17 +275,8 @@ export function openFromStep( // eslint-disable-line no-redeclare
 export function openRootFromStep(
   step: Vtree.RootNodePositionStep,
   flowRootFormattingContext: Vtree.FormattingContext,
-): Vtree.OpenNodeContext;
-export function openRootFromStep( // eslint-disable-line no-redeclare
-  step: Vtree.RootNodePositionStep,
-  flowRootFormattingContext: Vtree.FormattingContext,
   head?: PositionHead,
-): Vtree.NodeContext;
-export function openRootFromStep( // eslint-disable-line no-redeclare
-  step: Vtree.RootNodePositionStep,
-  flowRootFormattingContext: Vtree.FormattingContext,
-  head?: PositionHead,
-): Vtree.NodeContext {
+): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext {
   const opened = withNodePositionStep(
     openCore(
       step.node,
@@ -426,12 +417,6 @@ export function elementRenderProgress<T extends Vtree.NodeContext>(
 }
 
 export function viewless(
-  nodeContext: Vtree.BeforeEdgeNodeContext,
-): Vtree.OpenNodeContext;
-export function viewless( // eslint-disable-line no-redeclare
-  nodeContext: Vtree.NodeContext,
-): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext;
-export function viewless( // eslint-disable-line no-redeclare
   nodeContext: Vtree.NodeContext,
 ): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext {
   switch (nodeContext.kind) {
@@ -458,14 +443,6 @@ export function viewless( // eslint-disable-line no-redeclare
 }
 
 export function viewlessRender(
-  nodeContext: Vtree.BeforeEdgeNodeContext,
-  result: ElementRenderResult,
-): Vtree.OpenNodeContext;
-export function viewlessRender( // eslint-disable-line no-redeclare
-  nodeContext: Vtree.NodeContext,
-  result: ElementRenderResult,
-): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext;
-export function viewlessRender( // eslint-disable-line no-redeclare
   nodeContext: Vtree.NodeContext,
   result: ElementRenderResult,
 ): Vtree.OpenNodeContext | Vtree.AfterNoneNodeContext {
@@ -486,16 +463,6 @@ export function viewlessRender( // eslint-disable-line no-redeclare
 }
 
 export function renderedElement(
-  nodeContext: Vtree.BeforeEdgeNodeContext,
-  viewNode: Element,
-  result: ElementRenderResult,
-): Vtree.BeforeElementNodeContext;
-export function renderedElement( // eslint-disable-line no-redeclare
-  nodeContext: Vtree.NodeContext,
-  viewNode: Element,
-  result: ElementRenderResult,
-): Vtree.ElementNodeContext;
-export function renderedElement( // eslint-disable-line no-redeclare
   nodeContext: Vtree.NodeContext,
   viewNode: Element,
   result: ElementRenderResult,
@@ -507,16 +474,6 @@ export function renderedElement( // eslint-disable-line no-redeclare
 }
 
 export function renderedText(
-  nodeContext: Vtree.OpenNodeContext & Vtree.ChildNodeContext,
-  viewNode: Text,
-  preprocessedTextContent: Diff.Change[],
-): Vtree.BeforeTextNodeContext;
-export function renderedText( // eslint-disable-line no-redeclare
-  nodeContext: ViewlessChildNodeContext,
-  viewNode: Text,
-  preprocessedTextContent: Diff.Change[],
-): Vtree.TextNodeContext;
-export function renderedText( // eslint-disable-line no-redeclare
   nodeContext: ViewlessChildNodeContext,
   viewNode: Text,
   preprocessedTextContent: Diff.Change[],

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -45,6 +45,7 @@ import * as Layout from "./layout";
 import * as LayoutProcessor from "./layout-processor";
 import * as Logging from "./logging";
 import * as Net from "./net";
+import * as NodeContext from "./node-context";
 import * as PageFloats from "./page-floats";
 import * as CssPage from "./css-page";
 import * as Plugin from "./plugin";
@@ -286,6 +287,13 @@ export class StyleInstance
     PageMaster.InstanceHolder,
     Vgen.StylerProducer
 {
+  public readonly breakSuppressionStore: Break.BreakSuppressionStore = {
+    breakSuppressionByViewNode: new WeakMap(),
+  };
+  public readonly continuationStore: NodeContext.ContinuationStore = {
+    continuationOfSlot: new WeakMap(),
+    slotOfContinuation: new WeakMap(),
+  };
   lang: string | null;
   primaryFlows = { body: true } as { [key: string]: boolean };
   rootPageBoxInstance: PageMaster.RootPageBoxInstance;
@@ -2364,6 +2372,8 @@ export class StyleInstance
     );
     const layoutContext = new Vgen.ViewFactory(
       flowNameStr,
+      this.breakSuppressionStore,
+      this.continuationStore,
       this,
       this.viewport,
       this.styler,

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -2760,7 +2760,10 @@ export class NormalPageFloatLayoutStrategy implements PageFloatLayoutStrategy {
   ): Task.Result<PageFloat> {
     let floatReference = nodeContext.floatReference;
     const floatSide = nodeContext.floatSide;
-    const nodePosition = NodeContext.toNodePosition(nodeContext);
+    const nodePosition = NodeContext.toNodePosition(
+      nodeContext,
+      column.layoutContext.continuationStore,
+    );
     const insidePageFloat = !!pageFloatLayoutContext.generatingNodePosition;
     return column
       .resolveFloatReferenceFromColumnSpan(

--- a/packages/core/src/vivliostyle/page-floats.ts
+++ b/packages/core/src/vivliostyle/page-floats.ts
@@ -22,6 +22,7 @@ import * as Css from "./css";
 import * as Constants from "./constants";
 import * as GeometryUtil from "./geometry-util";
 import * as LayoutHelper from "./layout-helper";
+import * as NodeContext from "./node-context";
 import * as Logging from "./logging";
 import * as CssLogicalUtil from "./css-logical-util";
 import * as Sizing from "./sizing";
@@ -2759,7 +2760,7 @@ export class NormalPageFloatLayoutStrategy implements PageFloatLayoutStrategy {
   ): Task.Result<PageFloat> {
     let floatReference = nodeContext.floatReference;
     const floatSide = nodeContext.floatSide;
-    const nodePosition = nodeContext.toNodePosition();
+    const nodePosition = NodeContext.toNodePosition(nodeContext);
     const insidePageFloat = !!pageFloatLayoutContext.generatingNodePosition;
     return column
       .resolveFloatReferenceFromColumnSpan(

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -206,6 +206,8 @@ export type PaginationProgressHook = (p1: {
 
 const hooks = {};
 
+const noRegisteredHooks = Object.freeze([]) as ((...p1) => any)[];
+
 /**
  * Register a function to a hook with the specified name.
  * The registered function is called at appropriate timings by the core code.
@@ -278,7 +280,7 @@ export function removeHook(name: string, fn: (...p1) => any): void {
  */
 export function getHooksForName(name: string): ((...p1) => any)[] {
   const hooksForName = hooks[name];
-  return hooksForName || [];
+  return hooksForName || noRegisteredHooks;
 }
 
 /**

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -24,6 +24,7 @@ import * as Task from "./task";
 import { Layout, Vtree } from "./types";
 import type {
   LegacyColumn,
+  LegacyFormattingContext,
   LegacyLayoutProcessor,
   LegacyNodeContext,
   LegacyRenderedNodeContext,
@@ -185,7 +186,7 @@ export type ResolveFormattingContextHook = (
   p4: Css.Ident | null | undefined,
   p5: Css.Val | null | undefined,
   p6: boolean,
-) => Vtree.FormattingContext;
+) => LegacyFormattingContext;
 
 export type ResolveLayoutProcessorHook = (
   p1: Vtree.FormattingContext,

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -19,12 +19,12 @@
  */
 import * as Base from "./base";
 import * as Css from "./css";
-import * as LayoutProcessor from "./layout-processor";
 import * as Logging from "./logging";
 import * as Task from "./task";
 import { Layout, Vtree } from "./types";
 import type {
   LegacyColumn,
+  LegacyLayoutProcessor,
   LegacyNodeContext,
   LegacyRenderedNodeContext,
   LegacyTextNodeBreaker,
@@ -189,7 +189,7 @@ export type ResolveFormattingContextHook = (
 
 export type ResolveLayoutProcessorHook = (
   p1: Vtree.FormattingContext,
-) => LayoutProcessor.LayoutProcessor;
+) => LegacyLayoutProcessor;
 
 export type PostLayoutBlockHook = (
   p1: LegacyNodeContext | null,

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -23,6 +23,10 @@ import * as LayoutProcessor from "./layout-processor";
 import * as Logging from "./logging";
 import * as Task from "./task";
 import { Layout, Vtree } from "./types";
+import type {
+  LegacyNodeContext,
+  LegacyRenderedNodeContext,
+} from "./legacy-plugin-surface";
 
 /**
  * Type of implemented hooks.
@@ -152,12 +156,12 @@ export enum HOOKS {
 export type PreProcessSingleDocumentHook = (p1: Document) => any;
 
 export type PreProcessTextContentHook = (
-  p1: Vtree.NodeContext,
+  p1: LegacyNodeContext,
   p2: string,
 ) => Task.Result<string>;
 
 export type PreProcessElementStyleHook = (
-  p1: Vtree.NodeContext,
+  p1: LegacyNodeContext,
   p2: object,
 ) => void;
 
@@ -173,7 +177,7 @@ export type ResolveTextNodeBreakerHook = (
 ) => Layout.TextNodeBreaker;
 
 export type ResolveFormattingContextHook = (
-  p1: Vtree.NodeContext,
+  p1: LegacyNodeContext,
   p2: boolean,
   p3: Css.Val | null | undefined,
   p4: Css.Ident | null | undefined,
@@ -186,8 +190,8 @@ export type ResolveLayoutProcessorHook = (
 ) => LayoutProcessor.LayoutProcessor;
 
 export type PostLayoutBlockHook = (
-  p1: Vtree.NodeContext | null,
-  p2: Vtree.RenderedNodeContext[],
+  p1: LegacyNodeContext | null,
+  p2: LegacyRenderedNodeContext[],
   p3: Layout.Column,
 ) => void;
 
@@ -227,6 +231,21 @@ export function registerHook(
       hooksForName.push(fn);
     }
   }
+}
+
+const coreHooks = new WeakSet<(...p1) => any>();
+
+export function registerCoreHook(
+  name: string,
+  fn: (...p1) => any,
+  atFirst?: boolean,
+): void {
+  coreHooks.add(fn);
+  registerHook(name, fn, atFirst);
+}
+
+export function isCoreHook(fn: (...p1) => any): boolean {
+  return coreHooks.has(fn);
 }
 
 /**

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -24,6 +24,7 @@ import * as Logging from "./logging";
 import * as Task from "./task";
 import { Layout, Vtree } from "./types";
 import type {
+  LegacyColumn,
   LegacyNodeContext,
   LegacyRenderedNodeContext,
   LegacyTextNodeBreaker,
@@ -193,7 +194,7 @@ export type ResolveLayoutProcessorHook = (
 export type PostLayoutBlockHook = (
   p1: LegacyNodeContext | null,
   p2: LegacyRenderedNodeContext[],
-  p3: Layout.Column,
+  p3: LegacyColumn,
 ) => void;
 
 export type PaginationProgressHook = (p1: {

--- a/packages/core/src/vivliostyle/plugin.ts
+++ b/packages/core/src/vivliostyle/plugin.ts
@@ -26,6 +26,7 @@ import { Layout, Vtree } from "./types";
 import type {
   LegacyNodeContext,
   LegacyRenderedNodeContext,
+  LegacyTextNodeBreaker,
 } from "./legacy-plugin-surface";
 
 /**
@@ -173,8 +174,8 @@ export type ConfigurationHook = (p1: Base.JSON) => {
 };
 
 export type ResolveTextNodeBreakerHook = (
-  p1: Vtree.NodeContext,
-) => Layout.TextNodeBreaker;
+  p1: LegacyNodeContext,
+) => LegacyTextNodeBreaker;
 
 export type ResolveFormattingContextHook = (
   p1: LegacyNodeContext,

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -745,7 +745,7 @@ export class EntireBlockLayoutStrategy extends LayoutUtil.EdgeSkipper {
     public readonly formattingContext: RepetitiveElement.RepetitiveElementsOwnerFormattingContext,
     public readonly column: LayoutType.Column,
   ) {
-    super();
+    super(column.layoutContext.breakSuppressionStore);
   }
 
   override startNonInlineElementNode(
@@ -823,7 +823,7 @@ export class FragmentedBlockLayoutStrategy extends LayoutUtil.EdgeSkipper {
     public readonly formattingContext: RepetitiveElementsOwnerFormattingContext,
     public readonly column: LayoutType.Column,
   ) {
-    super();
+    super(column.layoutContext.breakSuppressionStore);
   }
 }
 

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -1129,7 +1129,7 @@ function getRepetitiveElementsOwnerFormattingContext(
 
 const repetitiveLayoutProcessor = new RepetitiveElementsOwnerLayoutProcessor();
 
-Plugin.registerHook(
+Plugin.registerCoreHook(
   Plugin.HOOKS.RESOLVE_LAYOUT_PROCESSOR,
   (formattingContext) => {
     if (

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -749,7 +749,7 @@ export class EntireBlockLayoutStrategy extends LayoutUtil.EdgeSkipper {
   }
 
   override startNonInlineElementNode(
-    state: LayoutUtil.RenderedActiveLayoutIteratorState,
+    state: LayoutUtil.ElementActiveLayoutIteratorState,
   ): void | Task.Result<boolean> {
     const formattingContext = this.formattingContext;
     const nodeContext = state.nodeContext;
@@ -764,7 +764,10 @@ export class EntireBlockLayoutStrategy extends LayoutUtil.EdgeSkipper {
             repetitiveElements.setHeaderNodeContext(nodeContext);
             return Task.newResult(true);
           } else {
-            NodeContext.setRepeatOnBreak(nodeContext, "none");
+            state.nodeContext = NodeContext.setRepeatOnBreak(
+              nodeContext,
+              "none",
+            );
           }
           break;
         case "footer":
@@ -772,7 +775,10 @@ export class EntireBlockLayoutStrategy extends LayoutUtil.EdgeSkipper {
             repetitiveElements.setFooterNodeContext(nodeContext);
             return Task.newResult(true);
           } else {
-            NodeContext.setRepeatOnBreak(nodeContext, "none");
+            state.nodeContext = NodeContext.setRepeatOnBreak(
+              nodeContext,
+              "none",
+            );
           }
           break;
       }

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -23,6 +23,7 @@ import * as LayoutHelper from "./layout-helper";
 import * as LayoutProcessor from "./layout-processor";
 import * as LayoutRetryers from "./layout-retryers";
 import * as LayoutUtil from "./layout-util";
+import * as NodeContext from "./node-context";
 import * as Plugin from "./plugin";
 import * as Shared from "./shared";
 import * as Task from "./task";
@@ -757,7 +758,7 @@ export class EntireBlockLayoutStrategy extends LayoutUtil.EdgeSkipper {
             repetitiveElements.setHeaderNodeContext(nodeContext);
             return Task.newResult(true);
           } else {
-            nodeContext.repeatOnBreak = "none";
+            NodeContext.setRepeatOnBreak(nodeContext, "none");
           }
           break;
         case "footer":
@@ -765,7 +766,7 @@ export class EntireBlockLayoutStrategy extends LayoutUtil.EdgeSkipper {
             repetitiveElements.setFooterNodeContext(nodeContext);
             return Task.newResult(true);
           } else {
-            nodeContext.repeatOnBreak = "none";
+            NodeContext.setRepeatOnBreak(nodeContext, "none");
           }
           break;
       }

--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -77,7 +77,10 @@ export class RepetitiveElementsOwnerFormattingContext
   getRootNodeContext(nodeContext: Vtree.NodeContext): Vtree.NodeContext | null {
     let nc: Vtree.NodeContext | null = nodeContext;
     do {
-      if (!nc.belongsTo(this) && nc.sourceNode === this.rootSourceNode) {
+      if (
+        !NodeContext.belongsTo(nc, this) &&
+        nc.sourceNode === this.rootSourceNode
+      ) {
         return nc;
       }
     } while ((nc = nc.parent));
@@ -556,7 +559,10 @@ export class LayoutFragmentedOwnerBlock extends LayoutFragmentedBlock {
     nodeContext: Vtree.NodeContext,
     column: LayoutType.Column,
   ): Task.Result<Vtree.NodeContext | null> {
-    if (!nodeContext.belongsTo(this.formattingContext) && !nodeContext.after) {
+    if (
+      !NodeContext.belongsTo(nodeContext, this.formattingContext) &&
+      !nodeContext.after
+    ) {
       column.fragmentLayoutConstraints.unshift(
         new RepetitiveElementsOwnerLayoutConstraint(nodeContext),
       );
@@ -713,13 +719,13 @@ export class RepetitiveElementsOwnerLayoutRetryer
   ): LayoutType.LayoutMode {
     const repetitiveElements = this.formattingContext.getRepetitiveElements();
     if (
-      !nodeContext.belongsTo(this.formattingContext) &&
+      !NodeContext.belongsTo(nodeContext, this.formattingContext) &&
       !repetitiveElements.doneInitialLayout
     ) {
       return new LayoutEntireOwnerBlock(this.formattingContext, this.processor);
     } else {
       if (
-        !nodeContext.belongsTo(this.formattingContext) &&
+        !NodeContext.belongsTo(nodeContext, this.formattingContext) &&
         !nodeContext.after
       ) {
         if (repetitiveElements) {
@@ -838,7 +844,7 @@ export class RepetitiveElementsOwnerLayoutProcessor
       if (leadingEdge) {
         appendHeaderToAncestors(nodeContext.parent, column);
       }
-      if (!nodeContext.belongsTo(formattingContext)) {
+      if (!NodeContext.belongsTo(nodeContext, formattingContext)) {
         return new RepetitiveElementsOwnerLayoutRetryer(
           formattingContext,
           this,
@@ -1006,7 +1012,7 @@ function eachAncestorNodeContext(
     const formattingContext = nc.formattingContext;
     if (
       formattingContext instanceof RepetitiveElementsOwnerFormattingContext &&
-      !nc.belongsTo(formattingContext)
+      !NodeContext.belongsTo(nc, formattingContext)
     ) {
       callback(formattingContext, nc);
     }

--- a/packages/core/src/vivliostyle/semantic-footnote.ts
+++ b/packages/core/src/vivliostyle/semantic-footnote.ts
@@ -425,7 +425,7 @@ function markReferencedFootnoteElements(document: Document): void {
   }
 }
 
-Plugin.registerHook(
+Plugin.registerCoreHook(
   Plugin.HOOKS.PREPROCESS_SINGLE_DOCUMENT,
   markReferencedFootnoteElements,
 );

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -2090,9 +2090,10 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
             const breakNodeContext =
               cellFragment.findAcceptableBreakPosition().nodeContext;
             const cellNodeContext = cellFragment.cellNodeContext;
-            const cellNodePosition = cellNodeContext.toNodePosition();
+            const cellNodePosition =
+              NodeContext.toNodePosition(cellNodeContext);
             const breakChunkPosition = new VtreeImpl.ChunkPosition(
-              breakNodeContext.toNodePosition(),
+              NodeContext.toNodePosition(breakNodeContext),
             );
             formattingContext.cellBreakPositions.push({
               cellNodePosition,

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -280,8 +280,9 @@ export class InsideTableRowBreakPosition
         );
       },
     );
-    this.beforeNodeContext.overflow = acceptableCellBreakPositions.some(
-      (bp) => bp.nodeContext.overflow,
+    NodeContext.setOverflow(
+      this.beforeNodeContext,
+      acceptableCellBreakPositions.some((bp) => bp.nodeContext.overflow),
     );
     if (foundBreakInsideCell) {
       return this.beforeNodeContext;
@@ -1346,7 +1347,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
           ).length === 0
         ) {
           this.resetColumn();
-          nodeContext.overflow = true;
+          NodeContext.setOverflow(nodeContext, true);
           state.break = true;
         }
         return Task.newResult(true);
@@ -1398,8 +1399,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       state.break = true;
       return Task.newResult(true);
     }
-    const afterNodeContext = nodeContext.copy().modify();
-    afterNodeContext.after = true;
+    const afterNodeContext = NodeContext.detachedAfterEdgeOf(nodeContext);
     state.nodeContext = afterNodeContext;
     const frame = Task.newFrame<boolean>("startTableCell");
     let cont: Task.Result<Vtree.ChunkPosition>;
@@ -1414,8 +1414,10 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       // subsequent rows are not affected by stale entries.
       // (Old code used cellBreakPositions.shift() which consumed entries.)
       this.formattingContext.cellBreakPositions.splice(brokenCell.index, 1);
-      nodeContext.fragmentIndex =
-        cellBreakPosition.cellNodePosition.steps[0].fragmentIndex + 1;
+      NodeContext.setFragmentIndex(
+        nodeContext,
+        cellBreakPosition.cellNodePosition.steps[0].fragmentIndex + 1,
+      );
       cont = Task.newResult(cellBreakPosition.breakChunkPosition);
     } else {
       cont = this.column
@@ -1488,8 +1490,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     if (display === "table-row") {
       this.inRow = false;
       if (!this.inHeader && !this.inFooter) {
-        const beforeNodeContext = nodeContext.copy().modify();
-        beforeNodeContext.after = false;
+        const beforeNodeContext = NodeContext.detachedBeforeEdgeOf(nodeContext);
         const bp = new InsideTableRowBreakPosition(
           this.currentRowIndex,
           beforeNodeContext,
@@ -1543,10 +1544,10 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     } else if (
       nodeContext.sourceNode === this.formattingContext.tableSourceNode
     ) {
-      nodeContext.overflow = this.column.checkOverflowAndSaveEdge(
+      NodeContext.setOverflow(
         nodeContext,
-        null,
-      ).overflown;
+        this.column.checkOverflowAndSaveEdge(nodeContext, null).overflown,
+      );
       this.resetColumn();
       state.break = true;
     } else if (display === "table-row" && !this.inHeader && !this.inFooter) {
@@ -1577,7 +1578,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
               ).length === 0
             ) {
               this.resetColumn();
-              nodeContext.overflow = true;
+              NodeContext.setOverflow(nodeContext, true);
               state.break = true;
             }
           }

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -327,7 +327,7 @@ export class InsideTableRowBreakPosition
         const overflows = cellFragments[i].column.checkOverflowAndSaveEdge(
           bp.nodeContext,
           null,
-        );
+        ).overflown;
         if (!overflows) {
           penalty1 -= 3;
         }
@@ -1542,7 +1542,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       nodeContext.overflow = this.column.checkOverflowAndSaveEdge(
         nodeContext,
         null,
-      );
+      ).overflown;
       this.resetColumn();
       state.break = true;
     } else if (display === "table-row" && !this.inHeader && !this.inFooter) {
@@ -1550,24 +1550,19 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       const pending = cont && cont.isPending() ? cont : Task.newResult(true);
       return pending.thenAsync(() => {
         if (!state.break) {
-          const overflown = this.column.checkOverflowAndSaveEdge(
-            nodeContext,
-            null,
-          );
+          const { overflown, recordedRepetitiveOverflow } =
+            this.column.checkOverflowAndSaveEdge(nodeContext, null);
           const repetitiveElements =
             this.formattingContext.getRepetitiveElements();
-          const overflownDueToRepetitiveElements =
-            this.column.nodeContextOverflowingDueToRepetitiveElements ===
-            nodeContext;
           // Keep this guard broad. During repetitive-element retry passes the
           // footer may already be marked skipped in the current state even
           // though footer dropping is still the mechanism that resolves the
           // overflow for this table fragment.
           const canResolveByDroppingFooter =
             !overflown &&
-            overflownDueToRepetitiveElements &&
+            recordedRepetitiveOverflow &&
             !!repetitiveElements?.isFooterRegistered();
-          if (overflown || overflownDueToRepetitiveElements) {
+          if (overflown || recordedRepetitiveOverflow) {
             // Catch row overflow as soon as the row finishes; otherwise the
             // next row start detects it one row too late and content can drift
             // into the page margin before the break is taken. (Issue #1902)

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -280,12 +280,12 @@ export class InsideTableRowBreakPosition
         );
       },
     );
-    NodeContext.setOverflow(
+    const beforeNodeContext = NodeContext.setOverflow(
       this.beforeNodeContext,
       acceptableCellBreakPositions.some((bp) => bp.nodeContext.overflow),
     );
     if (foundBreakInsideCell) {
-      return this.beforeNodeContext;
+      return beforeNodeContext;
     } else {
       return null;
     }
@@ -1015,7 +1015,7 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
   registerCheckPoint(state: LayoutUtil.RenderedActiveLayoutIteratorState) {
     const nodeContext = state.nodeContext;
     if (!LayoutHelper.isSpecialNodeContext(nodeContext)) {
-      this.checkPoints.push(nodeContext.clone());
+      this.checkPoints.push(NodeContext.positionChainOf(nodeContext));
     }
   }
 
@@ -1196,76 +1196,79 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
           rowCellBreakPositions[0].cellNodePosition.steps[1],
           (currentRow as Vtree.ChildNodeContext).parent,
         );
-        return layoutContext.setCurrent(rowNodeContext, false).thenAsync(() => {
-          // the row was rendered in the previous fragment and re-renders here
-          const rowElementContext =
-            VtreeImpl.asElementNodeContext(rowNodeContext);
-          Asserts.assert(rowElementContext);
-          const rowViewNode = rowElementContext.viewNode;
-          let cont1 = Task.newResult(true);
-          let columnIndex = 0;
+        return layoutContext
+          .setCurrent(rowNodeContext, false)
+          .thenAsync(({ nodeContext: renderedRow }) => {
+            // the row was rendered in the previous fragment and re-renders here
+            const rowElementContext =
+              VtreeImpl.asElementNodeContext(renderedRow);
+            Asserts.assert(rowElementContext);
+            const rowViewNode = rowElementContext.viewNode;
+            let cont1 = Task.newResult(true);
+            let columnIndex = 0;
 
-          function addDummyCellUntil(upperColumnIndex) {
-            while (columnIndex < upperColumnIndex) {
-              if (!occupiedSlotIndices.includes(columnIndex)) {
-                const dummy = rowViewNode.ownerDocument.createElement("td");
-                Base.setCSSProperty(dummy, "padding", "0");
-                rowViewNode.appendChild(dummy);
+            function addDummyCellUntil(upperColumnIndex) {
+              while (columnIndex < upperColumnIndex) {
+                if (!occupiedSlotIndices.includes(columnIndex)) {
+                  const dummy = rowViewNode.ownerDocument.createElement("td");
+                  Base.setCSSProperty(dummy, "padding", "0");
+                  rowViewNode.appendChild(dummy);
+                }
+                columnIndex++;
               }
-              columnIndex++;
             }
-          }
-          rowCellBreakPositions.forEach((cellBreakPosition) => {
-            cont1 = cont1.thenAsync(() => {
-              const cell = cellBreakPosition.cell;
-              addDummyCellUntil(cell.anchorColumnIndex);
-              const cellNodePosition = cellBreakPosition.cellNodePosition;
-              const cellNodeContext = NodeContext.openFromStep(
-                cellNodePosition.steps[0],
-                rowNodeContext,
-                {
-                  offsetInNode: cellNodePosition.offsetInNode,
-                  after: cellNodePosition.after,
-                  fragmentIndex: cellNodePosition.steps[0].fragmentIndex + 1,
-                },
-              );
-              return layoutContext
-                .setCurrent(cellNodeContext, false)
-                .thenAsync(() => {
-                  const breakChunkPosition =
-                    cellBreakPosition.breakChunkPosition;
-                  for (let i = 0; i < cell.colSpan; i++) {
-                    occupiedSlotIndices.push(columnIndex + i);
-                  }
-                  columnIndex += cell.colSpan;
-                  return this.layoutCell(
-                    cell,
-                    cellNodeContext,
-                    breakChunkPosition,
-                  ).thenAsync(() => {
-                    (cellNodeContext.viewNode as HTMLTableCellElement).rowSpan =
-                      cell.rowIndex +
-                      cell.rowSpan -
-                      this.currentRowIndex +
-                      rowCount -
-                      spanningCellRowIndex;
-                    return Task.newResult(true);
+            rowCellBreakPositions.forEach((cellBreakPosition) => {
+              cont1 = cont1.thenAsync(() => {
+                const cell = cellBreakPosition.cell;
+                addDummyCellUntil(cell.anchorColumnIndex);
+                const cellNodePosition = cellBreakPosition.cellNodePosition;
+                const cellNodeContext = NodeContext.openFromStep(
+                  cellNodePosition.steps[0],
+                  renderedRow,
+                  {
+                    offsetInNode: cellNodePosition.offsetInNode,
+                    after: cellNodePosition.after,
+                    fragmentIndex: cellNodePosition.steps[0].fragmentIndex + 1,
+                  },
+                );
+                return layoutContext
+                  .setCurrent(cellNodeContext, false)
+                  .thenAsync(({ nodeContext: renderedCell }) => {
+                    const breakChunkPosition =
+                      cellBreakPosition.breakChunkPosition;
+                    for (let i = 0; i < cell.colSpan; i++) {
+                      occupiedSlotIndices.push(columnIndex + i);
+                    }
+                    columnIndex += cell.colSpan;
+                    return this.layoutCell(
+                      cell,
+                      renderedCell,
+                      breakChunkPosition,
+                    ).thenAsync(() => {
+                      (renderedCell.viewNode as HTMLTableCellElement).rowSpan =
+                        cell.rowIndex +
+                        cell.rowSpan -
+                        this.currentRowIndex +
+                        rowCount -
+                        spanningCellRowIndex;
+                      return Task.newResult(true);
+                    });
                   });
-                });
+              });
+            });
+            return cont1.thenAsync(() => {
+              addDummyCellUntil(formattingContext.getColumnCount());
+              spanningCellRowIndex++;
+              return Task.newResult(true);
             });
           });
-          return cont1.thenAsync(() => {
-            addDummyCellUntil(formattingContext.getColumnCount());
-            spanningCellRowIndex++;
-            return Task.newResult(true);
-          });
-        });
       });
     });
     cont.then(() => {
       layoutContext
         .setCurrent(currentRow, true, state.atUnforcedBreak)
-        .then(() => {
+        .then(({ nodeContext: renderedRow }) => {
+          state.nodeContext = renderedRow;
           frame.finish(true);
         });
     });
@@ -1291,6 +1294,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     this.inRow = true;
     return this.layoutRowSpanningCellsFromPreviousFragment(state).thenAsync(
       () => {
+        const rowNodeContext = state.nodeContext;
         this.registerCellFragmentIndex();
 
         // Merge pre-collected cell/row break values with state.breakAtTheEdge
@@ -1320,7 +1324,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             true,
             breakAtEdge,
           );
-          nodeContext.viewNode?.remove();
+          rowNodeContext.viewNode?.remove();
           // Set block-end box-break flags on the table and its ancestors
           // since doFinishBreak skips finishBreak when pageBreakType is set
           if (state.lastAfterNodeContext) {
@@ -1347,7 +1351,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
           ).length === 0
         ) {
           this.resetColumn();
-          NodeContext.setOverflow(nodeContext, true);
+          state.nodeContext = NodeContext.setOverflow(rowNodeContext, true);
           state.break = true;
         }
         return Task.newResult(true);
@@ -1382,7 +1386,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     if (this.inHeader || this.inFooter) {
       return Task.newResult(true);
     }
-    const nodeContext = state.nodeContext;
+    let nodeContext = state.nodeContext;
     if (!this.inRow) {
       if (this.currentRowIndex < 0) {
         this.currentRowIndex = 0;
@@ -1414,7 +1418,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       // subsequent rows are not affected by stale entries.
       // (Old code used cellBreakPositions.shift() which consumed entries.)
       this.formattingContext.cellBreakPositions.splice(brokenCell.index, 1);
-      NodeContext.setFragmentIndex(
+      nodeContext = NodeContext.setFragmentIndex(
         nodeContext,
         cellBreakPosition.cellNodePosition.steps[0].fragmentIndex + 1,
       );
@@ -1544,7 +1548,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     } else if (
       nodeContext.sourceNode === this.formattingContext.tableSourceNode
     ) {
-      NodeContext.setOverflow(
+      state.nodeContext = NodeContext.setOverflow(
         nodeContext,
         this.column.checkOverflowAndSaveEdge(nodeContext, null).overflown,
       );
@@ -1578,7 +1582,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
               ).length === 0
             ) {
               this.resetColumn();
-              NodeContext.setOverflow(nodeContext, true);
+              state.nodeContext = NodeContext.setOverflow(nodeContext, true);
               state.break = true;
             }
           }
@@ -1793,7 +1797,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     const frame = Task.newFrame<Vtree.NodeContext | null>(
       "TableLayoutProcessor.doInitialLayout",
     );
-    const initialNodeContext = nodeContext.copy();
+    const initialNodeContext = nodeContext;
     this.layoutEntireTable(nodeContext, column).then((nodeContextAfter) => {
       const tableElement = nodeContextAfter.viewNode as Element;
 

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -893,9 +893,9 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             new TableRow(this.rowIndex, nodeContext.sourceNode),
           );
           // Capture row's own breakBefore for forced break detection
-          if (nodeContext.breakBefore) {
-            formattingContext.rows[this.rowIndex].breakBefore =
-              nodeContext.breakBefore;
+          const rowBreakBefore = Break.effectiveBreakBefore(nodeContext);
+          if (rowBreakBefore) {
+            formattingContext.rows[this.rowIndex].breakBefore = rowBreakBefore;
           }
           if (!repetitiveElements.firstContentSourceNode) {
             repetitiveElements.firstContentSourceNode =
@@ -941,10 +941,11 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             this.inRow = false;
             // Capture row's own breakAfter for forced break detection
             const row = formattingContext.rows[this.rowIndex];
-            if (row && nodeContext.breakAfter) {
+            const rowBreakAfter = Break.effectiveBreakAfter(nodeContext);
+            if (row && rowBreakAfter) {
               row.breakAfter = Break.resolveEffectiveBreakValue(
                 row.breakAfter,
-                nodeContext.breakAfter,
+                rowBreakAfter,
               );
             }
           }
@@ -963,16 +964,18 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             // Propagate cell break values to the row for forced break detection
             const cellRow = formattingContext.rows[this.rowIndex];
             if (cellRow) {
-              if (nodeContext.breakBefore) {
+              const cellBreakBefore = Break.effectiveBreakBefore(nodeContext);
+              if (cellBreakBefore) {
                 cellRow.breakBefore = Break.resolveEffectiveBreakValue(
                   cellRow.breakBefore,
-                  nodeContext.breakBefore,
+                  cellBreakBefore,
                 );
               }
-              if (nodeContext.breakAfter) {
+              const cellBreakAfter = Break.effectiveBreakAfter(nodeContext);
+              if (cellBreakAfter) {
                 cellRow.breakAfter = Break.resolveEffectiveBreakValue(
                   cellRow.breakAfter,
-                  nodeContext.breakAfter,
+                  cellBreakAfter,
                 );
               }
             }

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -23,6 +23,7 @@ import * as Break from "./break";
 import * as BreakPosition from "./break-position";
 import * as Css from "./css";
 import * as LayoutHelper from "./layout-helper";
+import * as LegacyPluginSurface from "./legacy-plugin-surface";
 import * as LayoutProcessor from "./layout-processor";
 import * as LayoutRetryers from "./layout-retryers";
 import * as LayoutUtil from "./layout-util";
@@ -1402,6 +1403,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       state.break = true;
       return Task.newResult(true);
     }
+    LegacyPluginSurface.noteRetained(nodeContext);
     const afterNodeContext = NodeContext.afterEdgeOf(nodeContext);
     state.nodeContext = afterNodeContext;
     const frame = Task.newFrame<boolean>("startTableCell");
@@ -1493,6 +1495,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     if (display === "table-row") {
       this.inRow = false;
       if (!this.inHeader && !this.inFooter) {
+        LegacyPluginSurface.noteRetained(nodeContext);
         const beforeNodeContext = NodeContext.beforeEdgeOf(nodeContext);
         const bp = new InsideTableRowBreakPosition(
           this.currentRowIndex,
@@ -1796,6 +1799,7 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
     const frame = Task.newFrame<Vtree.NodeContext | null>(
       "TableLayoutProcessor.doInitialLayout",
     );
+    LegacyPluginSurface.noteRetained(nodeContext);
     const initialNodeContext = nodeContext;
     this.layoutEntireTable(nodeContext, column).then((nodeContextAfter) => {
       const tableElement = nodeContextAfter.viewNode as Element;

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -26,6 +26,7 @@ import * as LayoutHelper from "./layout-helper";
 import * as LayoutProcessor from "./layout-processor";
 import * as LayoutRetryers from "./layout-retryers";
 import * as LayoutUtil from "./layout-util";
+import * as NodeContext from "./node-context";
 import * as PageFloats from "./page-floats";
 import * as Plugin from "./plugin";
 import * as RepetitiveElementImpl from "./repetitive-element";
@@ -1190,7 +1191,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       cont = cont.thenAsync(() => {
         // Is it always correct to assume steps[1] to be the row?
         // A table row under layout always sits below its table element context.
-        const rowNodeContext = VtreeImpl.makeNodeContextFromNodePositionStep(
+        const rowNodeContext = NodeContext.openFromStep(
           rowCellBreakPositions[0].cellNodePosition.steps[1],
           (currentRow as Vtree.ChildNodeContext).parent,
         );
@@ -1218,15 +1219,15 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
               const cell = cellBreakPosition.cell;
               addDummyCellUntil(cell.anchorColumnIndex);
               const cellNodePosition = cellBreakPosition.cellNodePosition;
-              const cellNodeContext =
-                VtreeImpl.makeNodeContextFromNodePositionStep(
-                  cellNodePosition.steps[0],
-                  rowNodeContext,
-                );
-              cellNodeContext.offsetInNode = cellNodePosition.offsetInNode;
-              cellNodeContext.after = cellNodePosition.after;
-              cellNodeContext.fragmentIndex =
-                cellNodePosition.steps[0].fragmentIndex + 1;
+              const cellNodeContext = NodeContext.openFromStep(
+                cellNodePosition.steps[0],
+                rowNodeContext,
+                {
+                  offsetInNode: cellNodePosition.offsetInNode,
+                  after: cellNodePosition.after,
+                  fragmentIndex: cellNodePosition.steps[0].fragmentIndex + 1,
+                },
+              );
               return layoutContext
                 .setCurrent(cellNodeContext, false)
                 .thenAsync(() => {

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -1228,7 +1228,6 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
                   {
                     offsetInNode: cellNodePosition.offsetInNode,
                     after: cellNodePosition.after,
-                    fragmentIndex: cellNodePosition.steps[0].fragmentIndex + 1,
                   },
                 );
                 return layoutContext
@@ -1403,7 +1402,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
       state.break = true;
       return Task.newResult(true);
     }
-    const afterNodeContext = NodeContext.detachedAfterEdgeOf(nodeContext);
+    const afterNodeContext = NodeContext.afterEdgeOf(nodeContext);
     state.nodeContext = afterNodeContext;
     const frame = Task.newFrame<boolean>("startTableCell");
     let cont: Task.Result<Vtree.ChunkPosition>;
@@ -1494,7 +1493,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     if (display === "table-row") {
       this.inRow = false;
       if (!this.inHeader && !this.inFooter) {
-        const beforeNodeContext = NodeContext.detachedBeforeEdgeOf(nodeContext);
+        const beforeNodeContext = NodeContext.beforeEdgeOf(nodeContext);
         const bp = new InsideTableRowBreakPosition(
           this.currentRowIndex,
           beforeNodeContext,

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -843,7 +843,7 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     public readonly formattingContext: TableFormattingContext,
     public readonly column: Layout.Column,
   ) {
-    super();
+    super(column.layoutContext.breakSuppressionStore);
   }
 
   override startNonInlineElementNode(
@@ -896,7 +896,10 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             new TableRow(this.rowIndex, nodeContext.sourceNode),
           );
           // Capture row's own breakBefore for forced break detection
-          const rowBreakBefore = Break.effectiveBreakBefore(nodeContext);
+          const rowBreakBefore = Break.effectiveBreakBefore(
+            this.column.layoutContext.breakSuppressionStore,
+            nodeContext,
+          );
           if (rowBreakBefore) {
             formattingContext.rows[this.rowIndex].breakBefore = rowBreakBefore;
           }
@@ -944,7 +947,10 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             this.inRow = false;
             // Capture row's own breakAfter for forced break detection
             const row = formattingContext.rows[this.rowIndex];
-            const rowBreakAfter = Break.effectiveBreakAfter(nodeContext);
+            const rowBreakAfter = Break.effectiveBreakAfter(
+              this.column.layoutContext.breakSuppressionStore,
+              nodeContext,
+            );
             if (row && rowBreakAfter) {
               row.breakAfter = Break.resolveEffectiveBreakValue(
                 row.breakAfter,
@@ -967,14 +973,20 @@ export class EntireTableLayoutStrategy extends LayoutUtil.EdgeSkipper {
             // Propagate cell break values to the row for forced break detection
             const cellRow = formattingContext.rows[this.rowIndex];
             if (cellRow) {
-              const cellBreakBefore = Break.effectiveBreakBefore(nodeContext);
+              const cellBreakBefore = Break.effectiveBreakBefore(
+                this.column.layoutContext.breakSuppressionStore,
+                nodeContext,
+              );
               if (cellBreakBefore) {
                 cellRow.breakBefore = Break.resolveEffectiveBreakValue(
                   cellRow.breakBefore,
                   cellBreakBefore,
                 );
               }
-              const cellBreakAfter = Break.effectiveBreakAfter(nodeContext);
+              const cellBreakAfter = Break.effectiveBreakAfter(
+                this.column.layoutContext.breakSuppressionStore,
+                nodeContext,
+              );
               if (cellBreakAfter) {
                 cellRow.breakAfter = Break.resolveEffectiveBreakValue(
                   cellRow.breakAfter,
@@ -1046,7 +1058,7 @@ export class TableLayoutStrategy extends LayoutUtil.EdgeSkipper {
     public readonly formattingContext: TableFormattingContext,
     public readonly column: Layout.Column,
   ) {
-    super(true);
+    super(column.layoutContext.breakSuppressionStore, true);
     this.originalStopAtOverflow = column.stopAtOverflow;
     column.stopAtOverflow = false;
   }
@@ -2097,10 +2109,15 @@ export class TableLayoutProcessor implements LayoutProcessor.LayoutProcessor {
             const breakNodeContext =
               cellFragment.findAcceptableBreakPosition().nodeContext;
             const cellNodeContext = cellFragment.cellNodeContext;
-            const cellNodePosition =
-              NodeContext.toNodePosition(cellNodeContext);
+            const cellNodePosition = NodeContext.toNodePosition(
+              cellNodeContext,
+              column.layoutContext.continuationStore,
+            );
             const breakChunkPosition = new VtreeImpl.ChunkPosition(
-              NodeContext.toNodePosition(breakNodeContext),
+              NodeContext.toNodePosition(
+                breakNodeContext,
+                column.layoutContext.continuationStore,
+              ),
             );
             formattingContext.cellBreakPositions.push({
               cellNodePosition,

--- a/packages/core/src/vivliostyle/table.ts
+++ b/packages/core/src/vivliostyle/table.ts
@@ -2774,12 +2774,12 @@ function resolveLayoutProcessor(
   return null;
 }
 
-Plugin.registerHook(
+Plugin.registerCoreHook(
   Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
   resolveFormattingContextHook,
 );
 
-Plugin.registerHook(
+Plugin.registerCoreHook(
   Plugin.HOOKS.RESOLVE_LAYOUT_PROCESSOR,
   resolveLayoutProcessor,
 );

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -1191,15 +1191,15 @@ class TextSpacingPolyfill {
   }
 
   registerHooks() {
-    Plugin.registerHook(
+    Plugin.registerCoreHook(
       Plugin.HOOKS.POLYFILLED_INHERITED_PROPS,
       this.getPolyfilledInheritedProps.bind(this),
     );
-    Plugin.registerHook(
+    Plugin.registerCoreHook(
       Plugin.HOOKS.PREPROCESS_SINGLE_DOCUMENT,
       this.preprocessSingleDocument.bind(this),
     );
-    Plugin.registerHook(
+    Plugin.registerCoreHook(
       Plugin.HOOKS.POST_LAYOUT_BLOCK,
       this.postLayoutBlock.bind(this),
       true, // text-spacing must be processed before others (Issue #1105)

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -124,6 +124,11 @@ export namespace Layout {
     nodeContext: Vtree.NodeContext;
   };
 
+  export type OverflowCheckResult = {
+    overflown: boolean;
+    recordedRepetitiveOverflow: boolean;
+  };
+
   /**
    * Potential breaking position inside CSS box (between lines).
    * @param checkPoints array of breaking points for
@@ -430,13 +435,10 @@ export namespace Layout {
      * Determines if a page break is acceptable at this position
      */
     isBreakable(flowPosition: Vtree.NodeContext): boolean;
-    /**
-     * @return true if overflows
-     */
     checkOverflowAndSaveEdge(
       nodeContext: Vtree.NodeContext | null,
       trailingEdgeContexts: Vtree.NodeContext[] | null,
-    ): boolean;
+    ): OverflowCheckResult;
     /**
      * Save a possible page break position on a CSS block edge. Check if it
      * overflows.

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -129,6 +129,11 @@ export namespace Layout {
     recordedRepetitiveOverflow: boolean;
   };
 
+  export type LineStylingResult = {
+    nodeContext: Vtree.NodeContext | null;
+    checkPoints: Vtree.RenderedNodeContext[];
+  };
+
   /**
    * Potential breaking position inside CSS box (between lines).
    * @param checkPoints array of breaking points for
@@ -359,7 +364,7 @@ export namespace Layout {
       nodeContext: Vtree.NodeContext,
       resNodeContext: Vtree.NodeContext | null,
       checkPoints: Vtree.RenderedNodeContext[],
-    ): Task.Result<Vtree.NodeContext | null>;
+    ): Task.Result<LineStylingResult>;
     isLoneImage(checkPoints: Vtree.RenderedNodeContext[]): boolean;
     getTrailingMarginEdgeAdjustment(
       trailingEdgeContexts: Vtree.NodeContext[],

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -150,7 +150,7 @@ export namespace Layout {
    */
   export interface EdgeBreakPosition extends AbstractBreakPosition {
     overflowIfRepetitiveElementsDropped: boolean;
-    readonly position: Vtree.NodeContext;
+    position: Vtree.NodeContext;
     readonly breakOnEdge: string | null;
     overflows: boolean;
     readonly computedBlockSize: number;

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -1377,9 +1377,6 @@ export namespace Vtree {
     clone(): this;
     toNodePositionStep(): NodePositionStep;
     toNodePosition(): NodePosition;
-    isInsideBFC(): boolean;
-    getContainingBlockForAbsolute(): ElementNodeContext | null;
-    belongsTo(formattingContext: FormattingContext): boolean;
   }
 
   export interface ChildNodeContext extends NodeContext {

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -23,6 +23,9 @@ import * as Exprs from "./exprs";
 import * as GeometryUtil from "./geometry-util";
 import * as Task from "./task";
 import * as TaskUtil from "./task-util";
+import type { BreakSuppressionStore } from "./break";
+import type { EdgeOverflowStore } from "./break-position";
+import type { ContinuationStore } from "./node-context";
 
 export type FormattingContextType =
   "Block" | "RepetitiveElementsOwner" | "Table";
@@ -196,6 +199,7 @@ export namespace Layout {
     blockDistanceToBlockEndFloats: number;
     lastLineStride: number;
     computedBlockSize: number;
+    edgeOverflowStore: EdgeOverflowStore;
 
     layoutContext: Vtree.LayoutContext;
     clientLayout: Vtree.ClientLayout;
@@ -1072,6 +1076,8 @@ export namespace Vtree {
    * Styling, creating a single node's view, etc.
    */
   export interface LayoutContext {
+    readonly breakSuppressionStore: BreakSuppressionStore;
+    readonly continuationStore: ContinuationStore;
     /**
      * Creates a functionally equivalent, but uninitialized layout context,
      * suitable for building a separate column.

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -455,7 +455,7 @@ export namespace Layout {
       saveEvenOverflown: boolean,
       breakAtTheEdge: string | null,
     ): boolean;
-    applyClearance(nodeContext: Vtree.RenderedNodeContext): boolean;
+    applyClearance(nodeContext: Vtree.RenderedNodeContext): Element | null;
     isBFC(formattingContext: Vtree.FormattingContext): boolean;
     /**
      * Skips positions until either the start of unbreakable block or inline
@@ -1081,13 +1081,19 @@ export namespace Vtree {
      * Set the current source node and create a view. Parameter firstTime
      * is true (and possibly offsetInNode > 0) if node was broken on
      * the previous page.
-     * @return true if children should be processed as well
+     * @return the rendered node context and whether children should be
+     *     processed as well
      */
+    setCurrent(
+      nodeContext: BeforeEdgeNodeContext,
+      firstTime: boolean,
+      atUnforcedBreak?: boolean,
+    ): Task.Result<RenderResult<BeforeEdgeNodeContext>>;
     setCurrent(
       nodeContext: NodeContext,
       firstTime: boolean,
       atUnforcedBreak?: boolean,
-    ): Task.Result<boolean>;
+    ): Task.Result<RenderResult<NodeContext>>;
     /**
      * Set the container element that holds view elements produced from the
      * source.
@@ -1310,6 +1316,131 @@ export namespace Vtree {
     readonly count: number;
   }
 
+  export type NodeContextKind =
+    "open" | "element" | "text" | "after-element" | "after-text" | "after-none";
+
+  export type PluginProps = {
+    readonly [key: string]:
+      string | number | undefined | null | (number | null)[];
+  };
+
+  export interface NodeContextCore {
+    readonly kind: NodeContextKind;
+
+    // position itself
+    readonly offsetInNode: number;
+    readonly shadowType: ShadowType; // parent's shadow type
+    readonly shadowContext: Vtree.ShadowContext | null;
+    readonly nodeShadow: Vtree.ShadowContext | null;
+    readonly shadowSibling: NodeContext | null; // next "sibling" in the shadow tree
+    // other stuff
+    readonly inline: boolean;
+    readonly overflow: boolean;
+    readonly breakPenalty: number;
+    readonly whitespace: Whitespace;
+    readonly hyphenateCharacter: string | null;
+    readonly breakWord: boolean;
+    readonly breakBefore: string | null;
+    readonly clearSpacer: Element | null;
+    readonly display: string | null;
+    readonly floatSide: string | null;
+    readonly establishesBFC: boolean;
+    readonly captionSide: string;
+    readonly inlineBorderSpacing: number;
+    readonly blockBorderSpacing: number;
+    readonly inheritedProps: {
+      [key: string]: number | string | Css.Val | undefined;
+    };
+    readonly vertical: boolean;
+    readonly direction: string;
+    readonly firstPseudo: FirstPseudo | null;
+    readonly lang: string | null;
+    readonly formattingContext: FormattingContext;
+    readonly pluginProps: PluginProps;
+    readonly fragmentIndex: number;
+    readonly pageType: string | null;
+
+    readonly sourceNode: Node;
+    readonly parent: ParentNodeContext | null;
+    readonly blockContainer: ElementNodeContext | null;
+    readonly boxOffset: number;
+  }
+
+  export interface ElementStyleFields {
+    readonly floatReference: PageFloats.FloatReference;
+    readonly clearSide: string | null;
+    readonly floatMinWrapBlock: Css.Numeric | null;
+    readonly columnSpan: Css.Val | null;
+    readonly flexContainer: boolean;
+    readonly containingBlockForAbsolute: boolean;
+    readonly breakAfter: string | null;
+    readonly repeatOnBreak: string | null;
+    readonly afterIfContinues: Selectors.AfterIfContinues | null;
+    readonly footnotePolicy: Css.Ident | null;
+  }
+
+  export interface UnstyledFields {
+    readonly floatReference: PageFloats.FloatReference.INLINE;
+    readonly clearSide: null;
+    readonly floatMinWrapBlock: null;
+    readonly columnSpan: null;
+    readonly flexContainer: false;
+    readonly containingBlockForAbsolute: false;
+    readonly breakAfter: null;
+    readonly repeatOnBreak: null;
+    readonly afterIfContinues: null;
+    readonly footnotePolicy: null;
+  }
+
+  export interface OpenNodeContext extends NodeContextCore, UnstyledFields {
+    readonly kind: "open";
+    readonly after: false;
+    readonly viewNode: null;
+    readonly preprocessedTextContent: Diff.Change[] | null;
+  }
+
+  export interface BeforeElementNodeContext
+    extends NodeContextCore, ElementStyleFields {
+    readonly kind: "element";
+    readonly after: false;
+    readonly viewNode: Element;
+    readonly preprocessedTextContent: Diff.Change[] | null;
+  }
+
+  export interface BeforeTextNodeContext
+    extends NodeContextCore, UnstyledFields {
+    readonly kind: "text";
+    readonly after: false;
+    readonly viewNode: Text;
+    readonly parent: ParentNodeContext;
+    readonly preprocessedTextContent: Diff.Change[];
+  }
+
+  export interface AfterElementNodeContext
+    extends NodeContextCore, ElementStyleFields {
+    readonly kind: "after-element";
+    readonly after: true;
+    readonly viewNode: Element;
+    readonly preprocessedTextContent: Diff.Change[] | null;
+  }
+
+  export interface AfterTextNodeContext
+    extends NodeContextCore, UnstyledFields {
+    readonly kind: "after-text";
+    readonly after: true;
+    readonly viewNode: Text;
+    readonly parent: ParentNodeContext;
+    readonly preprocessedTextContent: Diff.Change[];
+  }
+
+  export interface AfterNoneNodeContext
+    extends NodeContextCore, UnstyledFields {
+    readonly kind: "after-none";
+    readonly after: true;
+    readonly viewNode: null;
+    readonly preprocessedTextContent: Diff.Change[] | null;
+  }
+
   /**
    * NodeContext represents a position in the document + layout-related
    * information attached to it. When after=false and offsetInNode=0, the
@@ -1318,101 +1449,58 @@ export namespace Vtree {
    * node. When after=true it represents position right after the last child
    * of the node. boxOffset is incremented by 1 for any valid node position.
    */
-  export interface NodeContext {
-    // position itself
-    offsetInNode: number;
-    after: boolean;
-    shadowType: ShadowType; // parent's shadow type
-    shadowContext: Vtree.ShadowContext | null;
-    nodeShadow: Vtree.ShadowContext | null;
-    shadowSibling: NodeContext | null; // next "sibling" in the shadow tree
-    // other stuff
-    shared: boolean;
-    inline: boolean;
-    overflow: boolean;
-    breakPenalty: number;
-    display: string | null;
-    floatReference: PageFloats.FloatReference;
-    floatSide: string | null;
-    clearSide: string | null;
-    floatMinWrapBlock: Css.Numeric | null;
-    columnSpan: Css.Val | null;
-    captionSide: string;
-    inlineBorderSpacing: number;
-    blockBorderSpacing: number;
-    flexContainer: boolean;
-    whitespace: Whitespace;
-    hyphenateCharacter: string | null;
-    breakWord: boolean;
-    establishesBFC: boolean;
-    containingBlockForAbsolute: boolean;
-    breakBefore: string | null;
-    breakAfter: string | null;
-    viewNode: Element | Text | null;
-    clearSpacer: Element | null;
-    inheritedProps: { [key: string]: number | string | Css.Val | undefined };
-    vertical: boolean;
-    direction: string;
-    firstPseudo: FirstPseudo | null;
-    lang: string | null;
-    preprocessedTextContent: Diff.Change[] | null;
-    formattingContext: FormattingContext;
-    repeatOnBreak: string | null;
-    pluginProps: {
-      [key: string]: string | number | undefined | null | (number | null)[];
-    };
-    fragmentIndex: number;
-    afterIfContinues: Selectors.AfterIfContinues | null;
-    footnotePolicy: Css.Ident | null;
-    pageType: string | null;
+  export type NodeContext =
+    | OpenNodeContext
+    | BeforeElementNodeContext
+    | BeforeTextNodeContext
+    | AfterElementNodeContext
+    | AfterTextNodeContext
+    | AfterNoneNodeContext;
 
-    sourceNode: Node;
-    parent: NodeContext | null;
-    blockContainer: ElementNodeContext | null;
-    boxOffset: number;
+  export type BeforeEdgeNodeContext =
+    OpenNodeContext | BeforeElementNodeContext | BeforeTextNodeContext;
 
-    resetView(): void;
-    modify(): this;
-    copy(): this;
-    clone(): this;
-    toNodePositionStep(): NodePositionStep;
-    toNodePosition(): NodePosition;
-  }
+  export type AfterEdgeNodeContext =
+    AfterElementNodeContext | AfterTextNodeContext | AfterNoneNodeContext;
 
-  export interface ChildNodeContext extends NodeContext {
-    parent: NodeContext;
-  }
+  export type ParentNodeContext = BeforeEdgeNodeContext;
 
-  export interface RootNodeContext extends NodeContext {
-    parent: null;
-    shadowSibling: null;
-  }
+  export type RenderResult<T extends NodeContext> = {
+    readonly nodeContext: T;
+    readonly processChildren: boolean;
+  };
 
-  export interface TextNodeContext extends ChildNodeContext {
-    viewNode: Text;
-  }
+  export type ChildNodeContext = NodeContext & {
+    readonly parent: ParentNodeContext;
+  };
 
-  export interface ElementNodeContext extends NodeContext {
-    viewNode: Element;
-  }
+  export type RootNodeContext = NodeContext & {
+    readonly parent: null;
+    readonly shadowSibling: null;
+  };
+
+  export type TextNodeContext = BeforeTextNodeContext | AfterTextNodeContext;
+
+  export type ElementNodeContext =
+    BeforeElementNodeContext | AfterElementNodeContext;
 
   export type RenderedNodeContext = ElementNodeContext | TextNodeContext;
 
-  export interface ContainedElementNodeContext extends ElementNodeContext {
-    blockContainer: ElementNodeContext;
-  }
+  export type ContainedElementNodeContext = ElementNodeContext & {
+    readonly blockContainer: ElementNodeContext;
+  };
 
-  export interface FloatNodeContext extends ElementNodeContext {
-    floatSide: string;
-  }
+  export type FloatNodeContext = ElementNodeContext & {
+    readonly floatSide: string;
+  };
 
-  export interface ClearNodeContext extends ElementNodeContext {
-    clearSide: string;
-  }
+  export type ClearNodeContext = ElementNodeContext & {
+    readonly clearSide: string;
+  };
 
-  export interface AfterIfContinuesNodeContext extends ElementNodeContext {
-    afterIfContinues: Selectors.AfterIfContinues;
-  }
+  export type AfterIfContinuesNodeContext = ElementNodeContext & {
+    readonly afterIfContinues: Selectors.AfterIfContinues;
+  };
 
   export interface ChunkPosition {
     floats: NodePosition[] | null;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1443,7 +1443,7 @@ export class ViewFactory
       rendered.containingBlockForAbsolute =
         Display.establishesCBForAbsolute(position);
       if (
-        nodeContext.isInsideBFC() &&
+        NodeContext.isInsideBFC(nodeContext) &&
         floatSide !== Css.ident.footnote &&
         !(floatReference && PageFloats.isPageFloat(floatReference))
       ) {
@@ -2764,7 +2764,7 @@ export class ViewFactory
       if (
         nodeContext.formattingContext instanceof
           RepetitiveElement.RepetitiveElementsOwnerFormattingContext &&
-        !nodeContext.belongsTo(nodeContext.formattingContext)
+        !NodeContext.belongsTo(nodeContext, nodeContext.formattingContext)
       ) {
         return;
       }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -3115,7 +3115,10 @@ export class ViewFactory
         // our next position is the element after shadow:content in the parent
         // shadow tree
         const resumed = NodeContext.latestContinuation(cur.shadowSibling);
-        const advanced = NodeContext.withBoxOffset(resumed, boxOffset);
+        const advanced = NodeContext.setBoxOffset(
+          NodeContext.derived(resumed),
+          boxOffset,
+        );
         NodeContext.resumeContinuation(cur.shadowSibling, advanced);
         return advanced;
       }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -371,9 +371,9 @@ export class ViewFactory
       return;
     }
     if (!Break.isSpreadBreakValue(nodeContext.breakBefore)) {
-      nodeContext.breakBefore = Break.resolveEffectiveBreakValue(
-        nodeContext.breakBefore,
-        "page",
+      NodeContext.setBreakBefore(
+        nodeContext,
+        Break.resolveEffectiveBreakValue(nodeContext.breakBefore, "page"),
       );
     }
     if (pageType !== this.styler.cascade.previousPageType) {
@@ -2848,7 +2848,10 @@ export class ViewFactory
       })
       .then(() => {
         const preprocessedTextContent = Diff.diffChars(originl, textContent);
-        nodeContext.preprocessedTextContent = preprocessedTextContent;
+        NodeContext.setPreprocessedTextContent(
+          nodeContext,
+          preprocessedTextContent,
+        );
         frame.finish(preprocessedTextContent);
       });
     return frame.result();
@@ -2877,7 +2880,7 @@ export class ViewFactory
     }
     result.then((processChildren) => {
       needToProcessChildren = processChildren;
-      nodeContext.viewNode = this.viewNode;
+      NodeContext.setViewNode(nodeContext, this.viewNode);
       if (this.viewNode) {
         const isPseudo = (node: Node | null, name: string): boolean =>
           node?.nodeType === 1 &&
@@ -2981,11 +2984,9 @@ export class ViewFactory
       return this.processShadowContent(r);
     }
     if (nextPos === null) {
-      nextPos = pos.parent.modify();
-      nextPos.after = true;
+      nextPos = NodeContext.afterEdgeOf(pos.parent);
     }
-    nextPos.boxOffset = boxOffset;
-    return nextPos;
+    return NodeContext.setBoxOffset(nextPos, boxOffset);
   }
 
   private nextPositionInTree(
@@ -3019,16 +3020,11 @@ export class ViewFactory
       if (cur.shadowSibling) {
         // our next position is the element after shadow:content in the parent
         // shadow tree
-        const sibling = cur.shadowSibling.modify();
-        sibling.boxOffset = boxOffset;
-        return sibling;
+        return NodeContext.withBoxOffset(cur.shadowSibling, boxOffset);
       }
 
       // if not rootless shadow, move to the "after" position for the parent
-      const afterParent = cur.parent.modify();
-      afterParent.boxOffset = boxOffset;
-      afterParent.after = true;
-      return afterParent;
+      return NodeContext.afterEdgeAt(cur.parent, boxOffset);
     } else {
       // any shadow trees?
       if (pos.nodeShadow) {
@@ -3058,10 +3054,7 @@ export class ViewFactory
         const content = Diff.restoreNewText(preprocessedTextContent);
         boxOffset += content.length - 1 - pos.offsetInNode;
       }
-      pos = pos.modify();
-      pos.boxOffset = boxOffset;
-      pos.after = true;
-      return pos;
+      return NodeContext.afterEdgeAt(pos, boxOffset);
     }
   }
 
@@ -3146,7 +3139,7 @@ export class ViewFactory
     );
 
     // Set up properties for inline element
-    footnoteCallContext.inline = true;
+    NodeContext.setInline(footnoteCallContext, true);
 
     // Create shadow context for footnote-call styling
     // Use the footnote element's styler to get ::footnote-call styles
@@ -3157,22 +3150,27 @@ export class ViewFactory
       this.context,
       this.exprContentListener,
     );
-    footnoteCallContext.shadowContext = new Vtree.ShadowContext(
-      footnoteNodeContext.sourceNode as Element,
-      footnoteCallSourceNode, // Use the span directly as root, not a shadow:root
-      null,
-      footnoteNodeContext.parent?.shadowContext || null,
-      null,
-      Vtree.ShadowType.ROOTLESS,
-      shadowStyler,
+    NodeContext.setShadowContext(
+      footnoteCallContext,
+      new Vtree.ShadowContext(
+        footnoteNodeContext.sourceNode as Element,
+        footnoteCallSourceNode, // Use the span directly as root, not a shadow:root
+        null,
+        footnoteNodeContext.parent?.shadowContext || null,
+        null,
+        Vtree.ShadowType.ROOTLESS,
+        shadowStyler,
+      ),
     );
 
     // Set up shadow sibling to return to footnote after footnote-call is done
-    footnoteCallContext.shadowSibling =
-      footnoteNodeContext as Vtree.NodeContext;
+    NodeContext.setShadowSibling(footnoteCallContext, footnoteNodeContext);
 
     // Increment footnote's boxOffset since footnote-call takes one position
-    (footnoteNodeContext as Vtree.NodeContext).boxOffset++;
+    NodeContext.setBoxOffset(
+      footnoteNodeContext,
+      footnoteNodeContext.boxOffset + 1,
+    );
 
     // Remove the footnote element's viewNode from DOM if it was already created
     // (setCurrent was called before we detected this is a footnote)
@@ -3193,12 +3191,7 @@ export class ViewFactory
           frame.finish(footnoteCallContext);
         } else {
           // No children to process, mark as done
-          const modified = footnoteCallContext.modify();
-          modified.after = true;
-          if (!footnoteCallContext.viewNode) {
-            modified.inline = true;
-          }
-          frame.finish(modified);
+          frame.finish(NodeContext.skippedAfterOf(footnoteCallContext));
         }
       },
     );
@@ -3243,11 +3236,7 @@ export class ViewFactory
     this.setCurrent(nodeContext, true, atUnforcedBreak).then(
       (processChildren) => {
         if (!nodeContext.viewNode || !processChildren) {
-          nodeContext = nodeContext.modify();
-          nodeContext.after = true; // skip
-          if (!nodeContext.viewNode) {
-            nodeContext.inline = true;
-          }
+          nodeContext = NodeContext.skippedAfterOf(nodeContext); // skip
         }
 
         // Issue #868: Insert footnote-call before footnote element
@@ -3272,10 +3261,10 @@ export class ViewFactory
           if (this.isFootnote && nodeContext.parent) {
             // Detach nested footnote content into footnote area while keeping
             // the call marker in the parent footnote text. (Issue #1352)
-            nodeContext.pluginProps["nestedFootnoteDetached"] = 1;
+            NodeContext.setPluginProp(nodeContext, "nestedFootnoteDetached", 1);
           }
           // Mark as processed to avoid infinite loop when returning via shadowSibling
-          nodeContext.pluginProps["footnoteCallProcessed"] = 1;
+          NodeContext.setPluginProp(nodeContext, "footnoteCallProcessed", 1);
           // Return footnote-call first, footnote will be processed via shadowSibling
           this.insertFootnoteCall(nodeContext).then((footnoteCallContext) => {
             this.dispatchEvent({

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2967,9 +2967,7 @@ export class ViewFactory
     const nextSibling = pos.sourceNode.nextSibling;
     let nextPos: Vtree.NodeContext | null;
     if (nextSibling) {
-      pos.sourceNode = nextSibling;
-      pos.resetView();
-      nextPos = pos;
+      nextPos = NodeContext.openNextSiblingOf(pos, nextSibling);
     } else if (pos.shadowSibling) {
       nextPos = pos.shadowSibling;
     } else {
@@ -3006,12 +3004,8 @@ export class ViewFactory
       if (cur.shadowType != Vtree.ShadowType.ROOTED) {
         const next = cur.sourceNode.nextSibling;
         if (next) {
-          cur = cur.modify();
-
           // keep shadowType
-          cur.boxOffset = boxOffset;
-          cur.sourceNode = next;
-          cur.resetView();
+          cur = NodeContext.openNextSiblingOf(cur.modify(), next, boxOffset);
           return this.processShadowContent(cur);
         }
       }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2465,8 +2465,9 @@ export class ViewFactory
       nc && !nc.after;
       nc = nc.parent
     ) {
-      if (Break.isForcedBreakValue(nc.breakBefore)) {
-        return nc.breakBefore; // forced break
+      const breakBefore = Break.effectiveBreakBefore(nc);
+      if (Break.isForcedBreakValue(breakBefore)) {
+        return breakBefore; // forced break
       }
       const parent = nc.parent;
       if (nc.fragmentIndex === 1 && !parent) {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1207,17 +1207,24 @@ export class ViewFactory
     position: Css.Ident | null | undefined,
     float: Css.Val | null | undefined,
     isRoot: boolean,
-  ) {
+  ): Vtree.NodeContext {
     const hooks: Plugin.ResolveFormattingContextHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
     );
     const inProgress = NodeContext.elementRenderProgress(nodeContext, rendered);
+    const legacyInProgress = LegacyPluginSurface.asLegacyRenderContext(
+      Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
+      nodeContext,
+      inProgress,
+      rendered,
+    );
+    const beforeHooks = LegacyPluginSurface.captureRenderFields(
+      Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
+      legacyInProgress,
+    );
     for (let i = 0; i < hooks.length; i++) {
       const formattingContext = hooks[i](
-        LegacyPluginSurface.asLegacyNodeContext(
-          Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
-          inProgress,
-        ),
+        legacyInProgress,
         firstTime,
         display,
         position,
@@ -1225,10 +1232,24 @@ export class ViewFactory
         isRoot,
       );
       if (formattingContext) {
+        const resolvedWrites = LegacyPluginSurface.applyLegacyRenderWrites(
+          beforeHooks,
+          legacyInProgress,
+          rendered,
+        );
         rendered.formattingContext = formattingContext;
-        return;
+        return LegacyPluginSurface.withLegacyContextWrites(
+          nodeContext,
+          resolvedWrites,
+        );
       }
     }
+    const writes = LegacyPluginSurface.applyLegacyRenderWrites(
+      beforeHooks,
+      legacyInProgress,
+      rendered,
+    );
+    return LegacyPluginSurface.withLegacyContextWrites(nodeContext, writes);
   }
 
   /**
@@ -1833,7 +1854,7 @@ export class ViewFactory
       }
 
       // Resolve formatting context
-      this.resolveFormattingContext(
+      nodeContext = this.resolveFormattingContext(
         nodeContext,
         rendered,
         firstTime,
@@ -2363,9 +2384,10 @@ export class ViewFactory
           this.page.fetchers.push(Net.loadElement(result));
         }
 
-        this.preprocessElementStyle(
-          NodeContext.elementRenderProgress(nodeContext, rendered),
+        nodeContext = this.preprocessElementStyle(
+          nodeContext,
           computedStyle,
+          rendered,
         );
         this.applyComputedStyles(result, computedStyle);
 
@@ -2773,19 +2795,30 @@ export class ViewFactory
   private preprocessElementStyle(
     nodeContext: Vtree.NodeContext,
     computedStyle: { [key: string]: Css.Val },
-  ) {
+    rendered: NodeContext.ElementRenderDraft,
+  ): Vtree.NodeContext {
     const hooks: Plugin.PreProcessElementStyleHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
     );
+    const legacyNodeContext = LegacyPluginSurface.asLegacyRenderContext(
+      Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
+      nodeContext,
+      NodeContext.elementRenderProgress(nodeContext, rendered),
+      rendered,
+    );
+    const beforeHooks = LegacyPluginSurface.captureRenderFields(
+      Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
+      legacyNodeContext,
+    );
     hooks.forEach((hook) => {
-      hook(
-        LegacyPluginSurface.asLegacyNodeContext(
-          Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
-          nodeContext,
-        ),
-        computedStyle,
-      );
+      hook(legacyNodeContext, computedStyle);
     });
+    const writes = LegacyPluginSurface.applyLegacyRenderWrites(
+      beforeHooks,
+      legacyNodeContext,
+      rendered,
+    );
+    return LegacyPluginSurface.withLegacyContextWrites(nodeContext, writes);
   }
 
   private findAndProcessRepeatingElements(

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -3865,8 +3865,7 @@ export class ViewFactory
       return;
     }
     const computedStyle: { [key: string]: Css.Val } = {};
-    const writable = nodeContext as unknown as { vertical: boolean };
-    writable.vertical = this.computeStyle(
+    this.computeStyle(
       nodeContext.vertical,
       nodeContext.direction === "rtl",
       elementStyle,

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -36,6 +36,7 @@ import * as LayoutHelper from "./layout-helper";
 import * as Logging from "./logging";
 import * as Matchers from "./matchers";
 import * as Net from "./net";
+import * as NodeContext from "./node-context";
 import * as PageFloats from "./page-floats";
 import * as Plugin from "./plugin";
 import * as PseudoElement from "./pseudo-element";
@@ -2968,10 +2969,11 @@ export class ViewFactory
       nextPos = null;
     }
     if (contentNode) {
-      const r = Vtree.NodeContext.childOf(contentNode, pos.parent, boxOffset);
-      r.shadowContext = contentShadow;
-      r.shadowType = contentShadowType;
-      r.shadowSibling = nextPos;
+      const r = NodeContext.openChildOf(contentNode, pos.parent, boxOffset, {
+        shadowType: contentShadowType,
+        shadowContext: contentShadow,
+        shadowSibling: nextPos,
+      });
       return this.processShadowContent(r);
     }
     if (nextPos === null) {
@@ -3031,9 +3033,10 @@ export class ViewFactory
           shadowNode = shadowNode.firstChild;
         }
         if (shadowNode) {
-          const sr = Vtree.NodeContext.childOf(shadowNode, pos, boxOffset);
-          sr.shadowContext = pos.nodeShadow;
-          sr.shadowType = pos.nodeShadow.type;
+          const sr = NodeContext.openChildOf(shadowNode, pos, boxOffset, {
+            shadowType: pos.nodeShadow.type,
+            shadowContext: pos.nodeShadow,
+          });
           return this.processShadowContent(sr);
         }
       }
@@ -3042,7 +3045,7 @@ export class ViewFactory
       const child = pos.sourceNode.firstChild;
       if (child) {
         return this.processShadowContent(
-          Vtree.NodeContext.childOf(child, pos, boxOffset),
+          NodeContext.openChildOf(child, pos, boxOffset),
         );
       }
 
@@ -3132,7 +3135,7 @@ export class ViewFactory
     );
 
     // Create NodeContext for footnote-call with the same parent as footnote
-    const footnoteCallContext = Vtree.NodeContext.siblingOf(
+    const footnoteCallContext = NodeContext.openSiblingOf(
       footnoteCallSourceNode,
       footnoteNodeContext,
       footnoteNodeContext.boxOffset,
@@ -3734,24 +3737,19 @@ export class ViewFactory
         while (i >= 0) {
           const pn = arr[i];
           const parentContext = rebuilt ?? container.parent;
-          const child = new Vtree.NodeContext(
+          const child = NodeContext.openAt(
             pn.sourceNode,
             parentContext,
             boxOffset,
             (parentContext ?? container).formattingContext,
+            {
+              shadowType: pn.shadowType,
+              shadowContext: pn.shadowContext,
+              nodeShadow: pn.nodeShadow,
+              shadowSibling: pn.shadowSibling ?? shadowSibling,
+            },
+            i == 0 ? { offsetInNode, after } : undefined,
           );
-          child.blockContainer =
-            parentContext && Vtree.blockContainerForChildrenOf(parentContext);
-          if (i == 0) {
-            child.offsetInNode = offsetInNode;
-            child.after = after;
-          }
-          child.shadowType = pn.shadowType;
-          child.shadowContext = pn.shadowContext;
-          child.nodeShadow = pn.nodeShadow;
-          child.shadowSibling = pn.shadowSibling
-            ? pn.shadowSibling
-            : shadowSibling;
           shadowSibling = null;
           rebuilt = child;
           i--;

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -33,6 +33,7 @@ import * as Display from "./display";
 import * as Exprs from "./exprs";
 import * as Font from "./font";
 import * as LayoutHelper from "./layout-helper";
+import * as LegacyPluginSurface from "./legacy-plugin-surface";
 import * as Logging from "./logging";
 import * as Matchers from "./matchers";
 import * as Net from "./net";
@@ -1213,7 +1214,10 @@ export class ViewFactory
     const inProgress = NodeContext.elementRenderProgress(nodeContext, rendered);
     for (let i = 0; i < hooks.length; i++) {
       const formattingContext = hooks[i](
-        inProgress,
+        LegacyPluginSurface.asLegacyNodeContext(
+          Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
+          inProgress,
+        ),
         firstTime,
         display,
         position,
@@ -2774,7 +2778,13 @@ export class ViewFactory
       Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
     );
     hooks.forEach((hook) => {
-      hook(nodeContext, computedStyle);
+      hook(
+        LegacyPluginSurface.asLegacyNodeContext(
+          Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
+          nodeContext,
+        ),
+        computedStyle,
+      );
     });
   }
 
@@ -2893,12 +2903,16 @@ export class ViewFactory
         if (index >= hooks.length) {
           return Task.newResult(false);
         }
-        return hooks[index++](nodeContext, textContent).thenAsync(
-          (processedText) => {
-            textContent = processedText;
-            return Task.newResult(true);
-          },
-        );
+        return hooks[index++](
+          LegacyPluginSurface.asLegacyNodeContext(
+            Plugin.HOOKS.PREPROCESS_TEXT_CONTENT,
+            nodeContext,
+          ),
+          textContent,
+        ).thenAsync((processedText) => {
+          textContent = processedText;
+          return Task.newResult(true);
+        });
       })
       .then(() => {
         frame.finish(Diff.diffChars(originl, textContent));

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -206,6 +206,8 @@ export class ViewFactory
 
   constructor(
     public readonly flowName: string,
+    public readonly breakSuppressionStore: Break.BreakSuppressionStore,
+    public readonly continuationStore: NodeContext.ContinuationStore,
     public readonly context: Exprs.Context,
     public readonly viewport: Viewport,
     public readonly styler: CssStyler.Styler,
@@ -237,6 +239,8 @@ export class ViewFactory
   clone(): Vtree.LayoutContext {
     return new ViewFactory(
       this.flowName,
+      this.breakSuppressionStore,
+      this.continuationStore,
       this.context,
       this.viewport,
       this.styler,
@@ -1214,6 +1218,7 @@ export class ViewFactory
     const inProgress = NodeContext.elementRenderProgress(nodeContext, rendered);
     const legacyInProgress = LegacyPluginSurface.asLegacyRenderContext(
       Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
+      this,
       nodeContext,
       inProgress,
       rendered,
@@ -1871,6 +1876,7 @@ export class ViewFactory
       );
       if (nodeContext.parent) {
         const resolved = LegacyPluginSurface.legacyFirstTime(
+          this,
           nodeContext.parent.formattingContext,
           nodeContext,
           rendered,
@@ -2550,7 +2556,10 @@ export class ViewFactory
       nc && !nc.after;
       nc = nc.parent
     ) {
-      const breakBefore = Break.effectiveBreakBefore(nc);
+      const breakBefore = Break.effectiveBreakBefore(
+        this.breakSuppressionStore,
+        nc,
+      );
       if (Break.isForcedBreakValue(breakBefore)) {
         return breakBefore; // forced break
       }
@@ -2815,6 +2824,7 @@ export class ViewFactory
     }
     const legacyNodeContext = LegacyPluginSurface.asLegacyRenderContext(
       Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
+      this,
       nodeContext,
       NodeContext.elementRenderProgress(nodeContext, rendered),
       rendered,
@@ -2953,6 +2963,7 @@ export class ViewFactory
         return hooks[index++](
           LegacyPluginSurface.asLegacyNodeContext(
             Plugin.HOOKS.PREPROCESS_TEXT_CONTENT,
+            this,
             nodeContext,
           ),
           textContent,
@@ -3126,10 +3137,12 @@ export class ViewFactory
     if (nextPos === null) {
       nextPos = NodeContext.afterEdgeOf(pos.parent);
     }
-    const resumed = slot ? NodeContext.latestContinuation(slot) : nextPos;
+    const resumed = slot
+      ? NodeContext.latestContinuation(this.continuationStore, slot)
+      : nextPos;
     const positioned = NodeContext.setBoxOffset(resumed, boxOffset);
     if (slot) {
-      NodeContext.resumeContinuation(slot, positioned);
+      NodeContext.resumeContinuation(this.continuationStore, slot, positioned);
     }
     this.replaceWalkedContext(resumed, positioned);
     return positioned;
@@ -3141,7 +3154,11 @@ export class ViewFactory
     cursorAdvance = false,
   ): void {
     if (!cursorAdvance) {
-      NodeContext.followContinuation(previousNodeContext, nodeContext);
+      NodeContext.followContinuation(
+        this.continuationStore,
+        previousNodeContext,
+        nodeContext,
+      );
     }
     this.dispatchEvent({
       type: "replaceWalkedContext",
@@ -3179,12 +3196,19 @@ export class ViewFactory
       if (cur.shadowSibling) {
         // our next position is the element after shadow:content in the parent
         // shadow tree
-        const resumed = NodeContext.latestContinuation(cur.shadowSibling);
+        const resumed = NodeContext.latestContinuation(
+          this.continuationStore,
+          cur.shadowSibling,
+        );
         const advanced = NodeContext.setBoxOffset(
           NodeContext.derived(resumed),
           boxOffset,
         );
-        NodeContext.resumeContinuation(cur.shadowSibling, advanced);
+        NodeContext.resumeContinuation(
+          this.continuationStore,
+          cur.shadowSibling,
+          advanced,
+        );
         return advanced;
       }
 

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -358,29 +358,32 @@ export class ViewFactory
     return effectivePageType;
   }
 
-  private syncTextNodePageTypeBoundary(nodeContext: Vtree.NodeContext): void {
+  private syncTextNodePageTypeBoundary<T extends Vtree.NodeContext>(
+    nodeContext: T,
+  ): T {
     if (
       nodeContext.sourceNode.nodeType !== Node.TEXT_NODE ||
       Vtree.canIgnore(nodeContext.sourceNode) ||
       nodeContext.fragmentIndex !== 1
     ) {
-      return;
+      return nodeContext;
     }
     const pageType = nodeContext.pageType;
     if (this.styler.cascade.currentPageType === pageType) {
-      return;
+      return nodeContext;
     }
-    if (!Break.isSpreadBreakValue(nodeContext.breakBefore)) {
-      NodeContext.setBreakBefore(
-        nodeContext,
-        Break.resolveEffectiveBreakValue(nodeContext.breakBefore, "page"),
-      );
-    }
+    const synced = Break.isSpreadBreakValue(nodeContext.breakBefore)
+      ? nodeContext
+      : NodeContext.setBreakBefore(
+          nodeContext,
+          Break.resolveEffectiveBreakValue(nodeContext.breakBefore, "page"),
+        );
     if (pageType !== this.styler.cascade.previousPageType) {
       this.styler.cascade.previousPageType =
         this.styler.cascade.currentPageType;
     }
     this.styler.cascade.currentPageType = pageType;
+    return synced;
   }
 
   private syncSemanticFootnoteCounterToTarget(element: Element): void {
@@ -1131,15 +1134,19 @@ export class ViewFactory
     return this.fallbackMap[url] || url;
   }
 
-  inheritLangAttribute(nodeContext: Vtree.NodeContext) {
-    nodeContext.lang =
+  inheritLangAttribute(
+    nodeContext: Vtree.NodeContext,
+    rendered: NodeContext.ElementRenderDraft,
+  ) {
+    rendered.lang =
       Base.getLangAttribute(nodeContext.sourceNode as Element) ||
       (nodeContext.parent && nodeContext.parent.lang) ||
-      nodeContext.lang;
+      rendered.lang;
   }
 
   transferPolyfilledInheritedProps(
     nodeContext: Vtree.NodeContext,
+    rendered: NodeContext.ElementRenderDraft,
     computedStyle: { [key: string]: Css.Val },
   ) {
     const polyfilledInheritedProps =
@@ -1147,9 +1154,9 @@ export class ViewFactory
         (name) => computedStyle[name],
       );
     if (polyfilledInheritedProps.length) {
-      let props = nodeContext.inheritedProps;
+      let props = rendered.inheritedProps;
       if (nodeContext.parent) {
-        props = nodeContext.inheritedProps = {};
+        props = rendered.inheritedProps = {};
         for (const n in nodeContext.parent.inheritedProps) {
           props[n] = nodeContext.parent.inheritedProps[n];
         }
@@ -1193,6 +1200,7 @@ export class ViewFactory
 
   resolveFormattingContext(
     nodeContext: Vtree.NodeContext,
+    rendered: NodeContext.ElementRenderDraft,
     firstTime: boolean,
     display: Css.Val | null | undefined,
     position: Css.Ident | null | undefined,
@@ -1202,9 +1210,10 @@ export class ViewFactory
     const hooks: Plugin.ResolveFormattingContextHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.RESOLVE_FORMATTING_CONTEXT,
     );
+    const inProgress = NodeContext.elementRenderProgress(nodeContext, rendered);
     for (let i = 0; i < hooks.length; i++) {
       const formattingContext = hooks[i](
-        nodeContext,
+        inProgress,
         firstTime,
         display,
         position,
@@ -1212,7 +1221,7 @@ export class ViewFactory
         isRoot,
       );
       if (formattingContext) {
-        nodeContext.formattingContext = formattingContext;
+        rendered.formattingContext = formattingContext;
         return;
       }
     }
@@ -1225,9 +1234,11 @@ export class ViewFactory
     nodeContext: Vtree.NodeContext,
     firstTime: boolean,
     atUnforcedBreak: boolean,
-  ): Task.Result<boolean> {
+  ): Task.Result<Vtree.RenderResult<Vtree.NodeContext>> {
     let needToProcessChildren = true;
-    const frame: Task.Frame<boolean> = Task.newFrame("createElementView");
+    const frame: Task.Frame<Vtree.RenderResult<Vtree.NodeContext>> =
+      Task.newFrame("createElementView");
+    const rendered = NodeContext.elementRenderResultOf(nodeContext);
 
     // Figure out element's styles
     let element = this.sourceNode as Element;
@@ -1272,7 +1283,7 @@ export class ViewFactory
         elementStyle,
       );
       elementStyle = inheritedValues.elementStyle;
-      nodeContext.lang = inheritedValues.lang;
+      rendered.lang = inheritedValues.lang;
     }
     const positionCV: CssCascade.CascadeValue = elementStyle["position"];
     const floatCV: CssCascade.CascadeValue = elementStyle["float"];
@@ -1303,7 +1314,7 @@ export class ViewFactory
         elementStyle,
       );
       elementStyle = inheritedValues.elementStyle;
-      nodeContext.lang = inheritedValues.lang;
+      rendered.lang = inheritedValues.lang;
     }
     elementStyle = SemanticFootnote.mergeSemanticFootnoteIncludeStyle(
       element,
@@ -1321,9 +1332,9 @@ export class ViewFactory
       this.context,
       semanticFootnoteStyleAccess,
     );
-    nodeContext.vertical = this.computeStyle(
-      nodeContext.vertical,
-      nodeContext.direction === "rtl",
+    rendered.vertical = this.computeStyle(
+      rendered.vertical,
+      rendered.direction === "rtl",
       elementStyle,
       computedStyle,
     );
@@ -1336,17 +1347,22 @@ export class ViewFactory
       computedStyle["display"] = Css.ident.flow_root;
     }
     styler.processContent(element, computedStyle, nodeContext);
-    this.transferPolyfilledInheritedProps(nodeContext, computedStyle);
-    this.inheritLangAttribute(nodeContext);
+    this.transferPolyfilledInheritedProps(nodeContext, rendered, computedStyle);
+    this.inheritLangAttribute(nodeContext, rendered);
     if (computedStyle["direction"]) {
-      nodeContext.direction = computedStyle["direction"].toString();
+      rendered.direction = computedStyle["direction"].toString();
     }
 
     // Sort out the properties
     const flow = computedStyle["flow-into"];
     if (flow && flow.toString() != this.flowName) {
       // foreign flow, don't create a view
-      frame.finish(false);
+      frame.finish({
+        nodeContext: NodeContext.viewless(
+          NodeContext.elementRenderProgress(nodeContext, rendered),
+        ),
+        processChildren: false,
+      });
       return frame.result();
     }
     if (
@@ -1354,10 +1370,15 @@ export class ViewFactory
       element.localName === "script" &&
       element.namespaceURI === Base.NS.XHTML
     ) {
+      const scriptContext = NodeContext.viewless(
+        NodeContext.elementRenderProgress(nodeContext, rendered),
+      );
       Scripts.loadScript(
         element as HTMLScriptElement,
         this.viewport.window,
-      ).thenFinish(frame);
+      ).then((processChildren) => {
+        frame.finish({ nodeContext: scriptContext, processChildren });
+      });
       return frame.result();
     }
 
@@ -1384,11 +1405,16 @@ export class ViewFactory
     }
     if (display === Css.ident.none) {
       // no content
-      frame.finish(false);
+      frame.finish({
+        nodeContext: NodeContext.viewless(
+          NodeContext.elementRenderProgress(nodeContext, rendered),
+        ),
+        processChildren: false,
+      });
       return frame.result();
     }
     const isRoot = nodeContext.parent == null;
-    const blockSize = computedStyle[nodeContext.vertical ? "width" : "height"];
+    const blockSize = computedStyle[rendered.vertical ? "width" : "height"];
     // Issue #1999: fixed-size grid boxes used as synthetic page references
     // must stay whole. Once fragmented, continuation fragments lose the block
     // size and later reference pages collapse.
@@ -1396,7 +1422,6 @@ export class ViewFactory
       (display === Css.ident.grid || display === Css.ident.inline_grid) &&
       !!blockSize &&
       !(blockSize === Css.ident.auto || Css.isDefaultingValue(blockSize));
-    const rendered = NodeContext.elementRenderResultOf(nodeContext);
     rendered.flexContainer =
       display === Css.ident.flex || isFixedSizeGridContainer;
     this.createShadows(
@@ -1413,7 +1438,7 @@ export class ViewFactory
       const position = computedStyle["position"] as Css.Ident;
       let floatSide: Css.Val | null = computedStyle["float"];
       let clearSide: Css.Ident | null = computedStyle["clear"] as Css.Ident;
-      const writingMode = nodeContext.vertical
+      const writingMode = rendered.vertical
         ? Css.ident.vertical_rl
         : Css.ident.horizontal_tb;
       const parentWritingMode = nodeContext.parent
@@ -1431,7 +1456,7 @@ export class ViewFactory
         (columnWidth &&
           columnWidth !== Css.ident.auto &&
           !Css.isDefaultingValue(columnWidth));
-      nodeContext.establishesBFC = Display.establishesBFC(
+      rendered.establishesBFC = Display.establishesBFC(
         display,
         position,
         floatSide,
@@ -1607,8 +1632,8 @@ export class ViewFactory
         (!floating && !display) ||
         Display.isInlineLevel(display) ||
         Display.isRubyInternalDisplay(display);
-      nodeContext.display = display ? display.toString() : "inline";
-      nodeContext.floatSide = floating ? floatSideName : null;
+      rendered.display = display ? display.toString() : "inline";
+      rendered.floatSide = floating ? floatSideName : null;
       rendered.floatReference =
         floatReference || PageFloats.FloatReference.INLINE;
       const floatMinWrapBlock = computedStyle["float-min-wrap-block"];
@@ -1649,8 +1674,8 @@ export class ViewFactory
           !Css.isDefaultingValue(breakBefore) &&
           !(insideNonRootMultiColumn && breakBefore === Css.ident.column)
         ) {
-          nodeContext.breakBefore = breakBefore.toString();
-          if (Break.forcedBreakValues[nodeContext.breakBefore]) {
+          rendered.breakBefore = breakBefore.toString();
+          if (Break.forcedBreakValues[rendered.breakBefore]) {
             if (this.isAtStartOfPage()) {
               delete computedStyle["break-before"];
             } else {
@@ -1659,7 +1684,7 @@ export class ViewFactory
             }
           }
           if (nodeContext.fragmentIndex !== 1) {
-            nodeContext.breakBefore = null;
+            rendered.breakBefore = null;
           }
         }
         // Named page type
@@ -1703,9 +1728,9 @@ export class ViewFactory
         ) {
           if (
             nodeContext.fragmentIndex === 1 &&
-            !Break.isSpreadBreakValue(nodeContext.breakBefore)
+            !Break.isSpreadBreakValue(rendered.breakBefore)
           ) {
-            nodeContext.breakBefore = "page";
+            rendered.breakBefore = "page";
           }
           // Fix for issue #1309
           if (effectivePageType !== this.styler.cascade.previousPageType) {
@@ -1806,6 +1831,7 @@ export class ViewFactory
       // Resolve formatting context
       this.resolveFormattingContext(
         nodeContext,
+        rendered,
         firstTime,
         display,
         position,
@@ -1814,18 +1840,22 @@ export class ViewFactory
       );
       if (nodeContext.parent) {
         firstTime = nodeContext.parent.formattingContext.isFirstTime(
-          nodeContext,
+          NodeContext.elementRenderProgress(nodeContext, rendered),
           firstTime,
         );
       }
       if (!rendered.inline) {
         rendered.repeatOnBreak = this.processRepeatOnBreak(computedStyle);
-        this.findAndProcessRepeatingElements(nodeContext, element, styler);
+        this.findAndProcessRepeatingElements(
+          nodeContext,
+          rendered,
+          element,
+          styler,
+        );
       }
 
       // Create the view element
       let custom = false;
-      let inner: Element | null = null;
       const fetchers: TaskUtil.Fetcher<string>[] = [];
       let ns = element.namespaceURI;
       let tag = element.localName;
@@ -1917,8 +1947,10 @@ export class ViewFactory
         } else if (computedStyle["display"] === Css.ident.none) {
           // No element should be created if display:none is set.
           // (Fix issue #924)
-          NodeContext.renderedElement(nodeContext, rendered);
-          frame.finish(false);
+          frame.finish({
+            nodeContext: NodeContext.viewlessRender(nodeContext, rendered),
+            processChildren: false,
+          });
           return;
         } else {
           result = this.createElement(ns, tag);
@@ -1929,7 +1961,7 @@ export class ViewFactory
           isMultiColumn &&
           computedStyle["column-fill"] === Css.ident.auto
         ) {
-          const blockSize = nodeContext.vertical
+          const blockSize = rendered.vertical
             ? computedStyle["width"]
             : computedStyle["height"];
           if (
@@ -1954,19 +1986,14 @@ export class ViewFactory
         if (tag == "a") {
           result.addEventListener("click", this.page.hrefHandler, false);
         }
-        if (inner) {
-          this.applyPseudoelementStyle(nodeContext, "inner", inner);
-          result.appendChild(inner);
-        }
         if (
           result.localName == "iframe" &&
           result.namespaceURI == Base.NS.XHTML
         ) {
           initIFrame(result as HTMLIFrameElement);
         }
-        const imageResolution = nodeContext.inheritedProps[
-          "image-resolution"
-        ] as number | undefined;
+        const imageResolution = rendered.inheritedProps["image-resolution"] as
+          number | undefined;
         const images: {
           image: HTMLElement;
           element: HTMLElement;
@@ -2238,7 +2265,7 @@ export class ViewFactory
           const hasPercentBlockSize = (): boolean => {
             // Check if the image has percentage block size, which is usually same as auto,
             // which means the size is not determined until the image is loaded.
-            const blockSize = nodeContext.vertical ? cssWidth : cssHeight;
+            const blockSize = rendered.vertical ? cssWidth : cssHeight;
             return blockSize instanceof Css.Numeric && blockSize.unit === "%";
           };
           if (
@@ -2332,7 +2359,10 @@ export class ViewFactory
           this.page.fetchers.push(Net.loadElement(result));
         }
 
-        this.preprocessElementStyle(nodeContext, computedStyle);
+        this.preprocessElementStyle(
+          NodeContext.elementRenderProgress(nodeContext, rendered),
+          computedStyle,
+        );
         this.applyComputedStyles(result, computedStyle);
 
         if (rendered.inline) {
@@ -2344,7 +2374,7 @@ export class ViewFactory
           }
         } else {
           if (!firstTime) {
-            const blockSizeP = nodeContext.vertical ? "width" : "height";
+            const blockSizeP = rendered.vertical ? "width" : "height";
             if (Base.getCSSProperty(result, blockSizeP)) {
               // When a box with a specified block size is fragmented,
               // the fragmented box should not have the block size.
@@ -2355,7 +2385,7 @@ export class ViewFactory
               Base.setCSSProperty(
                 result,
                 blockSizeP,
-                nodeContext.display === "table-row" ? "0.01px" : "",
+                rendered.display === "table-row" ? "0.01px" : "",
               );
             }
             Break.setBoxBreakFlag(result, "block-start");
@@ -2371,14 +2401,16 @@ export class ViewFactory
             // Detect forced or unforced break at this point
             // to handle margin-break properly.
             // Note: Do not use `atUnforcedBreak` which may be inaccurate.
-            const breakType = this.getBreakTypeAt(nodeContext);
+            const breakType = this.getBreakTypeAt(
+              NodeContext.elementRenderProgress(nodeContext, rendered),
+            );
             const anyBreak = breakType !== null;
             const unforcedBreak = breakType === "auto";
             if (
               (marginBreak === Css.ident.discard && anyBreak) ||
               (marginBreak !== Css.ident.keep &&
                 unforcedBreak &&
-                !nodeContext.floatSide)
+                !rendered.floatSide)
             ) {
               Break.setMarginDiscardFlag(result, "block-start");
             }
@@ -2393,7 +2425,11 @@ export class ViewFactory
           }
         }
 
-        NodeContext.renderedElement(nodeContext, rendered);
+        const elementContext = NodeContext.renderedElement(
+          nodeContext,
+          result,
+          rendered,
+        );
         this.viewNode = result;
         if (fetchers.length) {
           TaskUtil.waitForFetchers(fetchers).then(() => {
@@ -2402,14 +2438,20 @@ export class ViewFactory
                 images,
                 imageResolution,
                 computedStyle,
-                nodeContext.vertical,
+                rendered.vertical,
               );
             }
-            frame.finish(needToProcessChildren);
+            frame.finish({
+              nodeContext: elementContext,
+              processChildren: needToProcessChildren,
+            });
           });
         } else {
           frame.timeSlice().then(() => {
-            frame.finish(needToProcessChildren);
+            frame.finish({
+              nodeContext: elementContext,
+              processChildren: needToProcessChildren,
+            });
           });
         }
       });
@@ -2738,6 +2780,7 @@ export class ViewFactory
 
   private findAndProcessRepeatingElements(
     nodeContext: Vtree.NodeContext,
+    rendered: NodeContext.ElementRenderDraft,
     element: Element,
     styler: CssStyler.AbstractStyler,
   ) {
@@ -2752,8 +2795,8 @@ export class ViewFactory
       const computedStyle: { [key: string]: Css.Val } = {};
       const elementStyle = styler.getStyle(child as Element, false);
       this.computeStyle(
-        nodeContext.vertical,
-        nodeContext.direction === "rtl",
+        rendered.vertical,
+        rendered.direction === "rtl",
         elementStyle,
         computedStyle,
       );
@@ -2762,22 +2805,24 @@ export class ViewFactory
         continue;
       }
       if (
-        nodeContext.formattingContext instanceof
+        rendered.formattingContext instanceof
           RepetitiveElement.RepetitiveElementsOwnerFormattingContext &&
-        !NodeContext.belongsTo(nodeContext, nodeContext.formattingContext)
+        !NodeContext.belongsTo(
+          NodeContext.elementRenderProgress(nodeContext, rendered),
+          rendered.formattingContext,
+        )
       ) {
         return;
       }
       const parent = nodeContext.parent;
       const parentFormattingContext = parent ? parent.formattingContext : null;
-      nodeContext.formattingContext =
+      const formattingContext =
         new RepetitiveElement.RepetitiveElementsOwnerFormattingContext(
           parentFormattingContext,
           nodeContext.sourceNode as Element,
         );
-      (
-        nodeContext.formattingContext as RepetitiveElement.RepetitiveElementsOwnerFormattingContext
-      ).initializeRepetitiveElements(nodeContext.vertical);
+      rendered.formattingContext = formattingContext;
+      formattingContext.initializeRepetitiveElements(rendered.vertical);
       return;
     }
   }
@@ -2806,15 +2851,24 @@ export class ViewFactory
 
   private createTextNodeView(
     nodeContext: Vtree.NodeContext,
-  ): Task.Result<boolean> {
-    const frame: Task.Frame<boolean> = Task.newFrame("createTextNodeView");
+  ): Task.Result<Vtree.RenderResult<Vtree.TextNodeContext>> {
+    const frame: Task.Frame<Vtree.RenderResult<Vtree.TextNodeContext>> =
+      Task.newFrame("createTextNodeView");
     this.preprocessTextContent(nodeContext).then((preprocessedTextContent) => {
       const offsetInNode = this.offsetInNode || 0;
       const textContent = Diff.restoreNewText(preprocessedTextContent).substr(
         offsetInNode,
       );
-      this.viewNode = document.createTextNode(textContent);
-      frame.finish(true);
+      const textView = document.createTextNode(textContent);
+      this.viewNode = textView;
+      frame.finish({
+        nodeContext: NodeContext.renderedText(
+          NodeContext.viewless(nodeContext),
+          textView,
+          preprocessedTextContent,
+        ),
+        processChildren: true,
+      });
     });
     return frame.result();
   }
@@ -2847,12 +2901,7 @@ export class ViewFactory
         );
       })
       .then(() => {
-        const preprocessedTextContent = Diff.diffChars(originl, textContent);
-        NodeContext.setPreprocessedTextContent(
-          nodeContext,
-          preprocessedTextContent,
-        );
-        frame.finish(preprocessedTextContent);
+        frame.finish(Diff.diffChars(originl, textContent));
       });
     return frame.result();
   }
@@ -2864,23 +2913,26 @@ export class ViewFactory
     nodeContext: Vtree.NodeContext,
     firstTime: boolean,
     atUnforcedBreak: boolean,
-  ): Task.Result<boolean> {
-    const frame: Task.Frame<boolean> = Task.newFrame("createNodeView");
-    let result: Task.Result<boolean>;
-    let needToProcessChildren = true;
+  ): Task.Result<Vtree.RenderResult<Vtree.NodeContext>> {
+    const frame: Task.Frame<Vtree.RenderResult<Vtree.NodeContext>> =
+      Task.newFrame("createNodeView");
+    let result: Task.Result<Vtree.RenderResult<Vtree.NodeContext>>;
     if (nodeContext.sourceNode.nodeType == 1) {
       result = this.createElementView(nodeContext, firstTime, atUnforcedBreak);
     } else {
       if (nodeContext.sourceNode.nodeType == 8) {
         this.viewNode = null; // comment node
-        result = Task.newResult(true);
+        result = Task.newResult({
+          nodeContext: NodeContext.viewless(nodeContext),
+          processChildren: true,
+        });
       } else {
         result = this.createTextNodeView(nodeContext);
       }
     }
-    result.then((processChildren) => {
-      needToProcessChildren = processChildren;
-      NodeContext.setViewNode(nodeContext, this.viewNode);
+    result.then((rendered) => {
+      this.replaceWalkedContext(nodeContext, rendered.nodeContext);
+      nodeContext = rendered.nodeContext;
       if (this.viewNode) {
         const isPseudo = (node: Node | null, name: string): boolean =>
           node?.nodeType === 1 &&
@@ -2919,22 +2971,44 @@ export class ViewFactory
           LayoutHelper.fixOverflowAtForcedColumnBreak(this.viewNode);
         }
       }
-      frame.finish(needToProcessChildren);
+      frame.finish(rendered);
     });
     return frame.result();
   }
+
+  setCurrent(
+    nodeContext: Vtree.BeforeEdgeNodeContext,
+    firstTime: boolean,
+    atUnforcedBreak?: boolean,
+  ): Task.Result<Vtree.RenderResult<Vtree.BeforeEdgeNodeContext>>;
+  setCurrent(
+    nodeContext: Vtree.NodeContext,
+    firstTime: boolean,
+    atUnforcedBreak?: boolean,
+  ): Task.Result<Vtree.RenderResult<Vtree.NodeContext>>;
 
   /** @override */
   setCurrent(
     nodeContext: Vtree.NodeContext,
     firstTime: boolean,
     atUnforcedBreak?: boolean,
-  ): Task.Result<boolean> {
+  ): Task.Result<Vtree.RenderResult<Vtree.NodeContext>> {
     this.nodeContext = nodeContext;
     this.sourceNode = nodeContext.sourceNode;
     this.offsetInNode = nodeContext.offsetInNode;
     this.viewNode = null;
-    return this.createNodeView(nodeContext, firstTime, !!atUnforcedBreak);
+    const rendering = this.createNodeView(
+      nodeContext,
+      firstTime,
+      !!atUnforcedBreak,
+    );
+    return rendering.thenAsync((result) => {
+      if (VIVLIOSTYLE_DEBUG) {
+        Asserts.assert(nodeContext.after || !result.nodeContext.after);
+      }
+      this.nodeContext = result.nodeContext;
+      return Task.newResult(result);
+    });
   }
 
   processShadowContent(pos: Vtree.ChildNodeContext): Vtree.NodeContext {
@@ -2966,10 +3040,13 @@ export class ViewFactory
     }
     const nextSibling = pos.sourceNode.nextSibling;
     let nextPos: Vtree.NodeContext | null;
+    let slot: Vtree.NodeContext | null = null;
     if (nextSibling) {
       nextPos = NodeContext.openNextSiblingOf(pos, nextSibling);
+      this.replaceWalkedContext(pos, nextPos);
     } else if (pos.shadowSibling) {
-      nextPos = pos.shadowSibling;
+      slot = pos.shadowSibling;
+      nextPos = slot;
     } else {
       nextPos = null;
     }
@@ -2984,7 +3061,29 @@ export class ViewFactory
     if (nextPos === null) {
       nextPos = NodeContext.afterEdgeOf(pos.parent);
     }
-    return NodeContext.setBoxOffset(nextPos, boxOffset);
+    const resumed = slot ? NodeContext.latestContinuation(slot) : nextPos;
+    const positioned = NodeContext.setBoxOffset(resumed, boxOffset);
+    if (slot) {
+      NodeContext.resumeContinuation(slot, positioned);
+    }
+    this.replaceWalkedContext(resumed, positioned);
+    return positioned;
+  }
+
+  private replaceWalkedContext(
+    previousNodeContext: Vtree.NodeContext,
+    nodeContext: Vtree.NodeContext,
+    cursorAdvance = false,
+  ): void {
+    if (!cursorAdvance) {
+      NodeContext.followContinuation(previousNodeContext, nodeContext);
+    }
+    this.dispatchEvent({
+      type: "replaceWalkedContext",
+      previousNodeContext,
+      nodeContext,
+      cursorAdvance,
+    });
   }
 
   private nextPositionInTree(
@@ -2992,7 +3091,7 @@ export class ViewFactory
     preprocessedTextContent: Diff.Change[] | null,
   ): Vtree.NodeContext | null {
     let boxOffset = pos.boxOffset + 1; // offset for the next position
-    if (pos.after) {
+    if (pos.after === true) {
       // root, that was the last possible position
       let cur = Vtree.asChildNodeContext(pos);
       if (!cur) {
@@ -3005,8 +3104,9 @@ export class ViewFactory
         const next = cur.sourceNode.nextSibling;
         if (next) {
           // keep shadowType
-          cur = NodeContext.openNextSiblingOf(cur.modify(), next, boxOffset);
-          return this.processShadowContent(cur);
+          const advanced = NodeContext.openNextSiblingOf(cur, next, boxOffset);
+          this.replaceWalkedContext(cur, advanced, true);
+          return this.processShadowContent(advanced);
         }
       }
 
@@ -3014,7 +3114,10 @@ export class ViewFactory
       if (cur.shadowSibling) {
         // our next position is the element after shadow:content in the parent
         // shadow tree
-        return NodeContext.withBoxOffset(cur.shadowSibling, boxOffset);
+        const resumed = NodeContext.latestContinuation(cur.shadowSibling);
+        const advanced = NodeContext.withBoxOffset(resumed, boxOffset);
+        NodeContext.resumeContinuation(cur.shadowSibling, advanced);
+        return advanced;
       }
 
       // if not rootless shadow, move to the "after" position for the parent
@@ -3048,7 +3151,9 @@ export class ViewFactory
         const content = Diff.restoreNewText(preprocessedTextContent);
         boxOffset += content.length - 1 - pos.offsetInNode;
       }
-      return NodeContext.afterEdgeAt(pos, boxOffset);
+      const afterEdge = NodeContext.afterEdgeAt(pos, boxOffset);
+      this.replaceWalkedContext(pos, afterEdge, true);
+      return afterEdge;
     }
   }
 
@@ -3126,14 +3231,14 @@ export class ViewFactory
     );
 
     // Create NodeContext for footnote-call with the same parent as footnote
-    const footnoteCallContext = NodeContext.openSiblingOf(
+    const openedCallContext = NodeContext.openSiblingOf(
       footnoteCallSourceNode,
       footnoteNodeContext,
       footnoteNodeContext.boxOffset,
     );
 
     // Set up properties for inline element
-    NodeContext.setInline(footnoteCallContext, true);
+    const inlineCallContext = NodeContext.setInline(openedCallContext, true);
 
     // Create shadow context for footnote-call styling
     // Use the footnote element's styler to get ::footnote-call styles
@@ -3144,8 +3249,8 @@ export class ViewFactory
       this.context,
       this.exprContentListener,
     );
-    NodeContext.setShadowContext(
-      footnoteCallContext,
+    const shadowedCallContext = NodeContext.setShadowContext(
+      inlineCallContext,
       new Vtree.ShadowContext(
         footnoteNodeContext.sourceNode as Element,
         footnoteCallSourceNode, // Use the span directly as root, not a shadow:root
@@ -3157,13 +3262,16 @@ export class ViewFactory
       ),
     );
 
-    // Set up shadow sibling to return to footnote after footnote-call is done
-    NodeContext.setShadowSibling(footnoteCallContext, footnoteNodeContext);
-
     // Increment footnote's boxOffset since footnote-call takes one position
-    NodeContext.setBoxOffset(
+    const bumpedFootnoteContext = NodeContext.setBoxOffset(
       footnoteNodeContext,
       footnoteNodeContext.boxOffset + 1,
+    );
+
+    // Set up shadow sibling to return to footnote after footnote-call is done
+    const footnoteCallContext = NodeContext.setShadowSibling(
+      shadowedCallContext,
+      bumpedFootnoteContext,
     );
 
     // Remove the footnote element's viewNode from DOM if it was already created
@@ -3176,16 +3284,16 @@ export class ViewFactory
 
     // Now create the view for footnote-call
     this.setCurrent(footnoteCallContext, true, false).then(
-      (processChildren) => {
+      ({ nodeContext: renderedCallContext, processChildren }) => {
         // If processChildren is true and the source node has children (generated content),
         // let the normal layout flow process them by NOT setting after=true.
         // This ensures text-spacing polyfill is applied via postLayoutBlock.
         if (processChildren && footnoteCallSourceNode.hasChildNodes()) {
           // Return the footnote-call context as-is to process children
-          frame.finish(footnoteCallContext);
+          frame.finish(renderedCallContext);
         } else {
           // No children to process, mark as done
-          frame.finish(NodeContext.skippedAfterOf(footnoteCallContext));
+          frame.finish(NodeContext.skippedAfterOf(renderedCallContext));
         }
       },
     );
@@ -3202,13 +3310,21 @@ export class ViewFactory
       !position.after && position.sourceNode.nodeType != 1
         ? this.preprocessTextContent(position)
         : Task.newResult<Diff.Change[] | null>(null);
-    return preprocessResult.thenAsync((preprocessedTextContent) =>
-      this.nextInTreeWithPreprocessedText(
-        position,
+    return preprocessResult.thenAsync((preprocessedTextContent) => {
+      let preprocessed = position;
+      if (preprocessedTextContent) {
+        preprocessed = NodeContext.setPreprocessedTextContent(
+          position,
+          preprocessedTextContent,
+        );
+        this.replaceWalkedContext(position, preprocessed);
+      }
+      return this.nextInTreeWithPreprocessedText(
+        preprocessed,
         preprocessedTextContent,
         atUnforcedBreak,
-      ),
-    );
+      );
+    });
   }
 
   private nextInTreeWithPreprocessedText(
@@ -3223,14 +3339,18 @@ export class ViewFactory
     if (!nextPosition || nextPosition.after) {
       return Task.newResult<Vtree.NodeContext | null>(nextPosition);
     }
-    this.syncTextNodePageTypeBoundary(nextPosition);
-    let nodeContext = nextPosition;
+    let nodeContext: Vtree.NodeContext =
+      this.syncTextNodePageTypeBoundary(nextPosition);
+    this.replaceWalkedContext(nextPosition, nodeContext);
     const frame: Task.Frame<Vtree.NodeContext | null> =
       Task.newFrame("nextInTree");
     this.setCurrent(nodeContext, true, atUnforcedBreak).then(
-      (processChildren) => {
+      ({ nodeContext: renderedContext, processChildren }) => {
+        nodeContext = renderedContext;
         if (!nodeContext.viewNode || !processChildren) {
-          nodeContext = NodeContext.skippedAfterOf(nodeContext); // skip
+          const skipped = NodeContext.skippedAfterOf(nodeContext); // skip
+          this.replaceWalkedContext(nodeContext, skipped, true);
+          nodeContext = skipped;
         }
 
         // Issue #868: Insert footnote-call before footnote element
@@ -3255,22 +3375,34 @@ export class ViewFactory
           if (this.isFootnote && nodeContext.parent) {
             // Detach nested footnote content into footnote area while keeping
             // the call marker in the parent footnote text. (Issue #1352)
-            NodeContext.setPluginProp(nodeContext, "nestedFootnoteDetached", 1);
+            const detached = NodeContext.setPluginProp(
+              nodeContext,
+              "nestedFootnoteDetached",
+              1,
+            );
+            this.replaceWalkedContext(nodeContext, detached);
+            nodeContext = detached;
           }
           // Mark as processed to avoid infinite loop when returning via shadowSibling
-          NodeContext.setPluginProp(nodeContext, "footnoteCallProcessed", 1);
+          const processed = NodeContext.setPluginProp(
+            nodeContext,
+            "footnoteCallProcessed",
+            1,
+          );
+          this.replaceWalkedContext(nodeContext, processed);
+          nodeContext = processed;
           // Return footnote-call first, footnote will be processed via shadowSibling
           this.insertFootnoteCall(nodeContext).then((footnoteCallContext) => {
             this.dispatchEvent({
               type: "nextInTree",
               nodeContext: footnoteCallContext,
-            } as any);
+            });
             frame.finish(footnoteCallContext);
           });
           return;
         }
 
-        this.dispatchEvent({ type: "nextInTree", nodeContext } as any);
+        this.dispatchEvent({ type: "nextInTree", nodeContext });
         frame.finish(nodeContext);
       },
     );
@@ -3665,7 +3797,8 @@ export class ViewFactory
       return;
     }
     const computedStyle: { [key: string]: Css.Val } = {};
-    nodeContext.vertical = this.computeStyle(
+    const writable = nodeContext as unknown as { vertical: boolean };
+    writable.vertical = this.computeStyle(
       nodeContext.vertical,
       nodeContext.direction === "rtl",
       elementStyle,
@@ -3719,11 +3852,12 @@ export class ViewFactory
     let shadowSibling = container.shadowSibling;
     let i = arr.length - 1;
     let rebuilt: Vtree.NodeContext | null = null;
+    let openParent: Vtree.ParentNodeContext | null = null;
     frame
       .loop(() => {
         while (i >= 0) {
           const pn = arr[i];
-          const parentContext = rebuilt ?? container.parent;
+          const parentContext = openParent ?? container.parent;
           const child = NodeContext.openAt(
             pn.sourceNode,
             parentContext,
@@ -3740,7 +3874,15 @@ export class ViewFactory
           shadowSibling = null;
           rebuilt = child;
           i--;
-          const result = this.setCurrent(child, false);
+          const result = this.setCurrent(child, false).thenAsync(
+            ({ nodeContext: renderedChild, processChildren }) => {
+              rebuilt = renderedChild;
+              if (renderedChild.after === false) {
+                openParent = renderedChild;
+              }
+              return Task.newResult(processChildren);
+            },
+          );
           if (result.isPending()) {
             return result;
           }

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2959,6 +2959,10 @@ export class ViewFactory
         });
       })
       .then(() => {
+        LegacyPluginSurface.retagLegacyNodeContext(
+          Plugin.HOOKS.PREPROCESS_TEXT_CONTENT,
+          nodeContext,
+        );
         frame.finish(Diff.diffChars(originl, textContent));
       });
     return frame.result();

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1233,11 +1233,16 @@ export class ViewFactory
       );
       if (formattingContext) {
         const resolvedWrites = LegacyPluginSurface.applyLegacyRenderWrites(
+          hooks.slice(0, i + 1),
           beforeHooks,
           legacyInProgress,
           rendered,
         );
-        rendered.formattingContext = formattingContext;
+        rendered.formattingContext =
+          LegacyPluginSurface.adaptLegacyFormattingContext(
+            hooks[i],
+            formattingContext,
+          );
         return LegacyPluginSurface.withLegacyContextWrites(
           nodeContext,
           resolvedWrites,
@@ -1245,6 +1250,7 @@ export class ViewFactory
       }
     }
     const writes = LegacyPluginSurface.applyLegacyRenderWrites(
+      hooks,
       beforeHooks,
       legacyInProgress,
       rendered,
@@ -1864,10 +1870,14 @@ export class ViewFactory
         isRoot,
       );
       if (nodeContext.parent) {
-        firstTime = nodeContext.parent.formattingContext.isFirstTime(
-          NodeContext.elementRenderProgress(nodeContext, rendered),
+        const resolved = LegacyPluginSurface.legacyFirstTime(
+          nodeContext.parent.formattingContext,
+          nodeContext,
+          rendered,
           firstTime,
         );
+        firstTime = resolved.firstTime;
+        nodeContext = resolved.nodeContext;
       }
       if (!rendered.inline) {
         rendered.repeatOnBreak = this.processRepeatOnBreak(computedStyle);
@@ -2814,6 +2824,7 @@ export class ViewFactory
       hook(legacyNodeContext, computedStyle);
     });
     const writes = LegacyPluginSurface.applyLegacyRenderWrites(
+      hooks,
       beforeHooks,
       legacyNodeContext,
       rendered,

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1396,7 +1396,8 @@ export class ViewFactory
       (display === Css.ident.grid || display === Css.ident.inline_grid) &&
       !!blockSize &&
       !(blockSize === Css.ident.auto || Css.isDefaultingValue(blockSize));
-    nodeContext.flexContainer =
+    const rendered = NodeContext.elementRenderResultOf(nodeContext);
+    rendered.flexContainer =
       display === Css.ident.flex || isFixedSizeGridContainer;
     this.createShadows(
       nodeContext,
@@ -1408,7 +1409,7 @@ export class ViewFactory
       this.context,
       nodeContext.shadowContext,
     ).then((shadowParam) => {
-      nodeContext.nodeShadow = shadowParam;
+      rendered.nodeShadow = shadowParam;
       const position = computedStyle["position"] as Css.Ident;
       let floatSide: Css.Val | null = computedStyle["float"];
       let clearSide: Css.Ident | null = computedStyle["clear"] as Css.Ident;
@@ -1439,7 +1440,7 @@ export class ViewFactory
         parentWritingMode,
         isMultiColumn || isFlowRoot,
       );
-      nodeContext.containingBlockForAbsolute =
+      rendered.containingBlockForAbsolute =
         Display.establishesCBForAbsolute(position);
       if (
         nodeContext.isInsideBFC() &&
@@ -1575,7 +1576,7 @@ export class ViewFactory
             (computedStyle["display"] &&
               computedStyle["display"] != Css.ident.inline)
           ) {
-            nodeContext.clearSide = clearSide.toString();
+            rendered.clearSide = clearSide.toString();
           }
         }
       }
@@ -1592,7 +1593,7 @@ export class ViewFactory
           !Css.isDefaultingValue(breakInside) &&
           breakInside !== Css.ident.auto)
       ) {
-        nodeContext.breakPenalty++;
+        rendered.breakPenalty++;
       }
       if (
         display &&
@@ -1600,18 +1601,18 @@ export class ViewFactory
         Display.isInlineLevel(display)
       ) {
         // Don't break inside ruby, inline-block, etc.
-        nodeContext.breakPenalty++;
+        rendered.breakPenalty++;
       }
-      nodeContext.inline =
+      rendered.inline =
         (!floating && !display) ||
         Display.isInlineLevel(display) ||
         Display.isRubyInternalDisplay(display);
       nodeContext.display = display ? display.toString() : "inline";
       nodeContext.floatSide = floating ? floatSideName : null;
-      nodeContext.floatReference =
+      rendered.floatReference =
         floatReference || PageFloats.FloatReference.INLINE;
       const floatMinWrapBlock = computedStyle["float-min-wrap-block"];
-      nodeContext.floatMinWrapBlock =
+      rendered.floatMinWrapBlock =
         floatMinWrapBlock && !Css.isDefaultingValue(floatMinWrapBlock)
           ? (floatMinWrapBlock as Css.Numeric)
           : null;
@@ -1621,21 +1622,21 @@ export class ViewFactory
         this.isInsideNonRootMultiColumn(nodeContext);
 
       const columnSpan = computedStyle["column-span"];
-      nodeContext.columnSpan =
+      rendered.columnSpan =
         !insideNonRootMultiColumn &&
         columnSpan &&
         !Css.isDefaultingValue(columnSpan)
           ? columnSpan
           : null;
-      if (!nodeContext.inline) {
+      if (!rendered.inline) {
         const breakAfter = computedStyle["break-after"];
         if (
           breakAfter &&
           !Css.isDefaultingValue(breakAfter) &&
           !(insideNonRootMultiColumn && breakAfter === Css.ident.column)
         ) {
-          nodeContext.breakAfter = breakAfter.toString();
-          if (Break.forcedBreakValues[nodeContext.breakAfter]) {
+          rendered.breakAfter = breakAfter.toString();
+          if (Break.forcedBreakValues[rendered.breakAfter]) {
             // delete computedStyle["break-after"];
 
             // Instead of deleting, set to "column" so that the browser can handle it.
@@ -1679,9 +1680,9 @@ export class ViewFactory
           pageType = this.styler.cascade.currentPageType;
         }
         if (!pageType || pageType.toLowerCase() === "auto") {
-          pageType = nodeContext.pageType;
+          pageType = rendered.pageType;
         } else {
-          nodeContext.pageType = pageType;
+          rendered.pageType = pageType;
         }
         const hasExplicitPageType =
           specifiedPageType != null &&
@@ -1714,7 +1715,7 @@ export class ViewFactory
           this.styler.cascade.currentPageType = effectivePageType;
         }
       }
-      nodeContext.captionSide =
+      rendered.captionSide =
         (computedStyle["caption-side"] &&
           computedStyle["caption-side"].toString()) ||
         "top";
@@ -1731,13 +1732,13 @@ export class ViewFactory
             inlineBorderSpacing = blockBorderSpacing = borderSpacing;
           }
           if (inlineBorderSpacing.isNumeric()) {
-            nodeContext.inlineBorderSpacing = Css.toNumber(
+            rendered.inlineBorderSpacing = Css.toNumber(
               inlineBorderSpacing,
               this.context,
             );
           }
           if (blockBorderSpacing.isNumeric()) {
-            nodeContext.blockBorderSpacing = Css.toNumber(
+            rendered.blockBorderSpacing = Css.toNumber(
               blockBorderSpacing,
               this.context,
             );
@@ -1750,7 +1751,7 @@ export class ViewFactory
       if (footnotePolicy && !Css.isDefaultingValue(footnotePolicy)) {
         computedStyle["--viv-footnote-policy"] = footnotePolicy;
       }
-      nodeContext.footnotePolicy =
+      rendered.footnotePolicy =
         footnotePolicy && !Css.isDefaultingValue(footnotePolicy)
           ? footnotePolicy
           : null;
@@ -1759,20 +1760,23 @@ export class ViewFactory
         const outerPseudo = nodeContext.parent
           ? nodeContext.parent.firstPseudo
           : null;
-        nodeContext.firstPseudo = new Vtree.FirstPseudo(
+        rendered.firstPseudo = new Vtree.FirstPseudo(
           outerPseudo,
           /** Css.Int */
           firstPseudo.num,
         );
       }
-      if (!nodeContext.inline) {
-        this.processAfterIfcontinues(
+      if (!rendered.inline) {
+        const afterIfContinues = this.resolveAfterIfContinues(
           nodeContext,
           element,
           elementStyle,
           styler,
           this.context,
         );
+        if (afterIfContinues) {
+          rendered.afterIfContinues = afterIfContinues;
+        }
       }
       const whitespace = computedStyle["white-space"];
       if (whitespace) {
@@ -1780,12 +1784,12 @@ export class ViewFactory
           whitespace.toString(),
         );
         if (whitespaceValue !== null) {
-          nodeContext.whitespace = whitespaceValue;
+          rendered.whitespace = whitespaceValue;
         }
       }
       const hyphenateCharacter = computedStyle["hyphenate-character"];
       if (hyphenateCharacter && hyphenateCharacter instanceof Css.Str) {
-        nodeContext.hyphenateCharacter = hyphenateCharacter.str;
+        rendered.hyphenateCharacter = hyphenateCharacter.str;
       }
       const wordBreak = computedStyle["word-break"];
       const lineBreak = computedStyle["line-break"];
@@ -1796,7 +1800,7 @@ export class ViewFactory
         overflowWrap === Css.ident.break_word ||
         overflowWrap === Css.ident.anywhere
       ) {
-        nodeContext.breakWord = true;
+        rendered.breakWord = true;
       }
 
       // Resolve formatting context
@@ -1814,8 +1818,8 @@ export class ViewFactory
           firstTime,
         );
       }
-      if (!nodeContext.inline) {
-        nodeContext.repeatOnBreak = this.processRepeatOnBreak(computedStyle);
+      if (!rendered.inline) {
+        rendered.repeatOnBreak = this.processRepeatOnBreak(computedStyle);
         this.findAndProcessRepeatingElements(nodeContext, element, styler);
       }
 
@@ -1848,7 +1852,7 @@ export class ViewFactory
         ns = Base.NS.XHTML;
       } else if (ns == Base.NS.SHADOW) {
         ns = Base.NS.XHTML;
-        tag = nodeContext.inline ? "span" : "div";
+        tag = rendered.inline ? "span" : "div";
       } else {
         custom = true;
       }
@@ -1913,6 +1917,7 @@ export class ViewFactory
         } else if (computedStyle["display"] === Css.ident.none) {
           // No element should be created if display:none is set.
           // (Fix issue #924)
+          NodeContext.renderedElement(nodeContext, rendered);
           frame.finish(false);
           return;
         } else {
@@ -2330,7 +2335,7 @@ export class ViewFactory
         this.preprocessElementStyle(nodeContext, computedStyle);
         this.applyComputedStyles(result, computedStyle);
 
-        if (nodeContext.inline) {
+        if (rendered.inline) {
           if (!firstTime) {
             Break.setBoxBreakFlag(result, "inline-start");
             if (Break.isCloneBoxDecorationBreak(result)) {
@@ -2388,6 +2393,7 @@ export class ViewFactory
           }
         }
 
+        NodeContext.renderedElement(nodeContext, rendered);
         this.viewNode = result;
         if (fetchers.length) {
           TaskUtil.waitForFetchers(fetchers).then(() => {
@@ -2539,13 +2545,13 @@ export class ViewFactory
     return false;
   }
 
-  private processAfterIfcontinues(
+  private resolveAfterIfContinues(
     nodeContext: Vtree.NodeContext,
     element: Element,
     cascStyle: CssCascade.ElementStyle,
     styler: CssStyler.AbstractStyler,
     context: Exprs.Context,
-  ) {
+  ): Layout.AfterIfContinues | null {
     const pseudoMap = this.getPseudoMap(
       cascStyle,
       this.regionIds,
@@ -2554,7 +2560,7 @@ export class ViewFactory
       context,
     );
     if (!pseudoMap) {
-      return;
+      return null;
     }
     if (
       pseudoMap["after-if-continues"] &&
@@ -2567,11 +2573,9 @@ export class ViewFactory
         context,
         this.exprContentListener,
       );
-      nodeContext.afterIfContinues = new Layout.AfterIfContinues(
-        element,
-        shadowStyler,
-      );
+      return new Layout.AfterIfContinues(element, shadowStyler);
     }
+    return null;
   }
 
   isSVGUrlAttribute(attributeName: string): boolean {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -2810,6 +2810,9 @@ export class ViewFactory
     const hooks: Plugin.PreProcessElementStyleHook[] = Plugin.getHooksForName(
       Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
     );
+    if (hooks.length === 0) {
+      return nodeContext;
+    }
     const legacyNodeContext = LegacyPluginSurface.asLegacyRenderContext(
       Plugin.HOOKS.PREPROCESS_ELEMENT_STYLE,
       nodeContext,

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -23,19 +23,11 @@ import * as Break from "./break";
 import * as Constants from "./constants";
 import * as Css from "./css";
 import * as CssProp from "./css-prop";
-import * as Diff from "./diff";
 import * as Exprs from "./exprs";
 import * as GeometryUtil from "./geometry-util";
 import * as TaskUtil from "./task-util";
 import { assert } from "./asserts";
-import {
-  CssStyler,
-  PageFloats,
-  PseudoElement,
-  Selectors,
-  Vtree,
-  XmlDoc,
-} from "./types";
+import { CssStyler, PageFloats, Vtree, XmlDoc } from "./types";
 
 export const delayedProps = {
   transform: true,

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -781,7 +781,7 @@ export class NodeContext implements Vtree.NodeContext {
     np.overflow = this.overflow;
     np.preprocessedTextContent = this.preprocessedTextContent;
     np.repeatOnBreak = this.repeatOnBreak;
-    np.pluginProps = Object.create(this.pluginProps);
+    np.pluginProps = { ...this.pluginProps };
     np.fragmentIndex = this.fragmentIndex;
     np.afterIfContinues = this.afterIfContinues;
     np.footnotePolicy = this.footnotePolicy;

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -807,36 +807,6 @@ export class NodeContext implements Vtree.NodeContext {
       preprocessedTextContent: this.preprocessedTextContent,
     };
   }
-
-  isInsideBFC(): boolean {
-    let parent = this.parent;
-    while (parent) {
-      if (parent.establishesBFC) {
-        return true;
-      }
-      parent = parent.parent;
-    }
-    return false;
-  }
-
-  getContainingBlockForAbsolute(): Vtree.ElementNodeContext | null {
-    let parent = this.parent;
-    while (parent) {
-      if (parent.containingBlockForAbsolute) {
-        return asElementNodeContext(parent);
-      }
-      parent = parent.parent;
-    }
-    return null;
-  }
-
-  belongsTo(formattingContext: FormattingContext): boolean {
-    return (
-      this.formattingContext === formattingContext &&
-      !!this.parent &&
-      this.parent.formattingContext === formattingContext
-    );
-  }
 }
 
 export type ChildNodeContext = NodeContext & Vtree.ChildNodeContext;

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -549,267 +549,20 @@ export class FirstPseudo implements Vtree.FirstPseudo {
   ) {}
 }
 
-/**
- * NodeContext represents a position in the document + layout-related
- * information attached to it. When after=false and offsetInNode=0, the
- * position is inside the element (node), but just before its first child.
- * When offsetInNode>0 it represents offset in the textual content of the
- * node. When after=true it represents position right after the last child
- * of the node. boxOffset is incremented by 1 for any valid node position.
- */
-export class NodeContext implements Vtree.NodeContext {
-  // position itself
-  offsetInNode: number = 0;
-  after: boolean = false;
-  shadowType: ShadowType;
-
-  // parent's shadow type
-  shadowContext: Vtree.ShadowContext | null;
-  nodeShadow: Vtree.ShadowContext | null = null;
-  shadowSibling: NodeContext | null = null;
-
-  // next "sibling" in the shadow tree
-  // other stuff
-  shared: boolean = false;
-  inline: boolean = true;
-  overflow: boolean = false;
-  breakPenalty: number;
-  display: string | null = null;
-  floatReference: PageFloats.FloatReference;
-  floatSide: string | null = null;
-  clearSide: string | null = null;
-  floatMinWrapBlock: Css.Numeric | null = null;
-  columnSpan: Css.Val | null = null;
-  captionSide: string = "top";
-  inlineBorderSpacing: number = 0;
-  blockBorderSpacing: number = 0;
-  flexContainer: boolean = false;
-  whitespace: Whitespace;
-  hyphenateCharacter: string | null;
-  breakWord: boolean;
-  establishesBFC: boolean = false;
-  containingBlockForAbsolute: boolean = false;
-  breakBefore: string | null = null;
-  breakAfter: string | null = null;
-  viewNode: Element | Text | null = null;
-  clearSpacer: Element | null = null;
-  inheritedProps: { [key: string]: number | string | Css.Val | undefined };
-  vertical: boolean;
-  direction: string;
-  firstPseudo: FirstPseudo | null;
-  lang: string | null = null;
-  preprocessedTextContent: Diff.Change[] | null = null;
-  repeatOnBreak: string | null = null;
-  pluginProps: {
-    [key: string]: string | number | undefined | null | (number | null)[];
-  } = {};
-  fragmentIndex: number = 1;
-  afterIfContinues: Selectors.AfterIfContinues | null = null;
-  footnotePolicy: Css.Ident | null = null;
-  pageType: string | null;
-  blockContainer: ElementNodeContext | null = null;
-
-  constructor(
-    public sourceNode: Node,
-    public parent: NodeContext | null,
-    public boxOffset: number,
-    public formattingContext: FormattingContext,
-  ) {
-    this.shadowType = ShadowType.NONE;
-    this.shadowContext = parent ? parent.shadowContext : null;
-    this.breakPenalty = parent ? parent.breakPenalty : 0;
-    this.floatReference = PageFloats.FloatReference.INLINE;
-    this.whitespace = parent ? parent.whitespace : Whitespace.IGNORE;
-    this.hyphenateCharacter = parent ? parent.hyphenateCharacter : null;
-    this.breakWord = parent ? parent.breakWord : false;
-    this.inheritedProps = parent ? parent.inheritedProps : {};
-    this.vertical = parent ? parent.vertical : false;
-    this.direction = parent ? parent.direction : "ltr";
-    this.firstPseudo = parent ? parent.firstPseudo : null;
-    this.pageType = parent ? parent.pageType : null;
-  }
-
-  resetView(): void {
-    this.inline = true;
-    this.breakPenalty = this.parent ? this.parent.breakPenalty : 0;
-    this.viewNode = null;
-    this.clearSpacer = null;
-    this.offsetInNode = 0;
-    this.after = false;
-    this.display = null;
-    this.floatReference = PageFloats.FloatReference.INLINE;
-    this.floatSide = null;
-    this.clearSide = null;
-    this.floatMinWrapBlock = null;
-    this.columnSpan = null;
-    this.flexContainer = false;
-    this.whitespace = this.parent ? this.parent.whitespace : Whitespace.IGNORE;
-    this.hyphenateCharacter = this.parent
-      ? this.parent.hyphenateCharacter
-      : null;
-    this.breakWord = this.parent ? this.parent.breakWord : false;
-    this.breakBefore = null;
-    this.breakAfter = null;
-    this.nodeShadow = null;
-    this.establishesBFC = false;
-    this.containingBlockForAbsolute = false;
-    this.vertical = this.parent ? this.parent.vertical : false;
-    this.nodeShadow = null;
-    this.preprocessedTextContent = null;
-    if (this.parent) {
-      this.formattingContext = this.parent.formattingContext;
-    }
-    this.repeatOnBreak = null;
-    this.pluginProps = {};
-    this.fragmentIndex = 1;
-    this.afterIfContinues = null;
-    this.footnotePolicy = null;
-    this.pageType = this.parent ? this.parent.pageType : null;
-  }
-
-  private cloneItem(): this {
-    const np = new NodeContext(
-      this.sourceNode,
-      this.parent,
-      this.boxOffset,
-      this.formattingContext,
-    ) as this;
-    np.offsetInNode = this.offsetInNode;
-    np.after = this.after;
-    np.nodeShadow = this.nodeShadow;
-    np.shadowType = this.shadowType;
-    np.shadowContext = this.shadowContext;
-    np.shadowSibling = this.shadowSibling;
-    np.inline = this.inline;
-    np.breakPenalty = this.breakPenalty;
-    np.display = this.display;
-    np.floatReference = this.floatReference;
-    np.floatSide = this.floatSide;
-    np.clearSide = this.clearSide;
-    np.floatMinWrapBlock = this.floatMinWrapBlock;
-    np.columnSpan = this.columnSpan;
-    np.captionSide = this.captionSide;
-    np.inlineBorderSpacing = this.inlineBorderSpacing;
-    np.blockBorderSpacing = this.blockBorderSpacing;
-    np.establishesBFC = this.establishesBFC;
-    np.containingBlockForAbsolute = this.containingBlockForAbsolute;
-    np.flexContainer = this.flexContainer;
-    np.whitespace = this.whitespace;
-    np.hyphenateCharacter = this.hyphenateCharacter;
-    np.breakWord = this.breakWord;
-    np.breakBefore = this.breakBefore;
-    np.breakAfter = this.breakAfter;
-    np.viewNode = this.viewNode;
-    np.clearSpacer = this.clearSpacer;
-    np.firstPseudo = this.firstPseudo;
-    np.vertical = this.vertical;
-    np.overflow = this.overflow;
-    np.preprocessedTextContent = this.preprocessedTextContent;
-    np.repeatOnBreak = this.repeatOnBreak;
-    np.pluginProps = { ...this.pluginProps };
-    np.fragmentIndex = this.fragmentIndex;
-    np.afterIfContinues = this.afterIfContinues;
-    np.footnotePolicy = this.footnotePolicy;
-    np.pageType = this.pageType;
-    np.blockContainer = this.blockContainer;
-    return np;
-  }
-
-  modify(): this {
-    if (!this.shared) {
-      return this;
-    }
-    return this.cloneItem();
-  }
-
-  copy(): this {
-    let np: NodeContext | null = this;
-    do {
-      if (np.shared) {
-        break;
-      }
-      np.shared = true;
-      np = np.parent;
-    } while (np);
-    return this;
-  }
-
-  clone(): this {
-    const np = this.cloneItem();
-    const chain: NodeContext[] = [np];
-    let npc: NodeContext = np;
-    let npp: NodeContext | null;
-    while ((npp = npc.parent) != null) {
-      npp = npp.cloneItem();
-      npc.parent = npp;
-      npc = npp;
-      chain.push(npp);
-    }
-    for (let i = chain.length - 2; i >= 0; i--) {
-      chain[i].blockContainer = blockContainerForChildrenOf(chain[i + 1]);
-    }
-    return np;
-  }
-
-  toNodePositionStep(): NodePositionStep {
-    return {
-      node: this.sourceNode,
-      shadowType: this.shadowType,
-      shadowContext: this.shadowContext,
-      nodeShadow: this.nodeShadow,
-      shadowSibling: this.shadowSibling
-        ? this.shadowSibling.toNodePositionStep()
-        : null,
-      formattingContext: this.formattingContext,
-
-      // fragmentIndex needs to be reset to 0 if this viewNode has been removed
-      // from the view tree by forced break processing. (Issue #1557)
-      fragmentIndex:
-        this.viewNode?.parentNode === null ? 0 : this.fragmentIndex,
-    };
-  }
-
-  toNodePosition(): NodePosition {
-    // Fix for issue #703
-    // A float or footnote context inside a pseudo-element shadow is always a
-    // descended one: restored heads keep the constructor's default float
-    // fields and live roots carry no shadow context.
-    const floatInPseudoContent =
-      this.shadowType === Vtree.ShadowType.ROOTLESS &&
-      (this.floatReference !== PageFloats.FloatReference.INLINE ||
-        this.floatSide === "footnote") &&
-      (this.shadowContext?.styler as PseudoElement.PseudoelementStyler)
-        ?.style?.["_pseudos"]
-        ? (this as ChildNodeContext)
-        : null;
-    const steps: NodePositionStep[] = [];
-    let nc = classifyNodeContext(
-      floatInPseudoContent ? floatInPseudoContent.parent : this,
-    );
-    while (hasParent(nc)) {
-      // We need fully "peeled" path, so don't record first-XXX pseudoelement
-      // containers
-      if (!nc.firstPseudo || nc.parent.firstPseudo === nc.firstPseudo) {
-        steps.push(nc.toNodePositionStep());
-      }
-      nc = classifyNodeContext(nc.parent);
-    }
-    const actualOffsetInNode = this.preprocessedTextContent
-      ? Diff.resolveOriginalIndex(
-          this.preprocessedTextContent,
-          this.offsetInNode,
-        )
-      : this.offsetInNode;
-    return {
-      steps: [...steps, toRootNodePositionStep(nc)],
-      offsetInNode: actualOffsetInNode,
-      after: this.after,
-      preprocessedTextContent: this.preprocessedTextContent,
-    };
-  }
-}
-
-export type ChildNodeContext = NodeContext & Vtree.ChildNodeContext;
+export type NodeContext = Vtree.NodeContext;
+export type BeforeEdgeNodeContext = Vtree.BeforeEdgeNodeContext;
+export type AfterEdgeNodeContext = Vtree.AfterEdgeNodeContext;
+export type RenderResult<T extends Vtree.NodeContext> = Vtree.RenderResult<T>;
+export type ParentNodeContext = Vtree.ParentNodeContext;
+export type ChildNodeContext = Vtree.ChildNodeContext;
+export type RootNodeContext = Vtree.RootNodeContext;
+export type TextNodeContext = Vtree.TextNodeContext;
+export type ElementNodeContext = Vtree.ElementNodeContext;
+export type RenderedNodeContext = Vtree.RenderedNodeContext;
+export type FloatNodeContext = Vtree.FloatNodeContext;
+export type ClearNodeContext = Vtree.ClearNodeContext;
+export type AfterIfContinuesNodeContext = Vtree.AfterIfContinuesNodeContext;
+export type ContainedElementNodeContext = Vtree.ContainedElementNodeContext;
 
 export function asChildNodeContext(
   nc: Vtree.NodeContext,
@@ -817,74 +570,54 @@ export function asChildNodeContext(
   return nc.parent !== null ? (nc as ChildNodeContext) : null;
 }
 
-export type RootNodeContext = NodeContext & Vtree.RootNodeContext;
-
-export function classifyNodeContext(
-  nc: Vtree.NodeContext,
-): ChildNodeContext | RootNodeContext {
-  return nc.parent !== null
-    ? (nc as ChildNodeContext)
-    : (nc as RootNodeContext);
+export function asRootNodeContext(nc: Vtree.NodeContext): RootNodeContext {
+  assert(nc.parent === null);
+  return nc as RootNodeContext;
 }
-
-export function hasParent(
-  nc: ChildNodeContext | RootNodeContext,
-): nc is ChildNodeContext {
-  return nc.parent !== null;
-}
-
-export function toRootNodePositionStep(
-  root: RootNodeContext,
-): RootNodePositionStep {
-  return { ...root.toNodePositionStep(), shadowSibling: root.shadowSibling };
-}
-
-export type TextNodeContext = NodeContext & Vtree.TextNodeContext;
 
 export function asTextNodeContext(
   nc: Vtree.NodeContext,
 ): TextNodeContext | null {
-  return nc.parent !== null && nc.viewNode?.nodeType === 3
-    ? (nc as TextNodeContext)
+  return (nc.kind === "text" || nc.kind === "after-text") &&
+    nc.viewNode?.nodeType === 3 &&
+    nc.parent !== null
+    ? nc
     : null;
 }
-
-export type RenderedNodeContext = NodeContext & Vtree.RenderedNodeContext;
-export type ElementNodeContext = NodeContext & Vtree.ElementNodeContext;
-export type FloatNodeContext = NodeContext & Vtree.FloatNodeContext;
-export type ClearNodeContext = NodeContext & Vtree.ClearNodeContext;
-export type AfterIfContinuesNodeContext = NodeContext &
-  Vtree.AfterIfContinuesNodeContext;
 
 export function asElementNodeContext(
   nc: Vtree.NodeContext,
 ): ElementNodeContext | null {
-  return nc.viewNode !== null && nc.viewNode.nodeType === 1
-    ? (nc as ElementNodeContext)
+  return (nc.kind === "element" || nc.kind === "after-element") &&
+    nc.viewNode?.nodeType === 1
+    ? nc
     : null;
 }
 
 export function asFloatNodeContext(
   nc: Vtree.NodeContext,
 ): FloatNodeContext | null {
-  return nc.floatSide !== null && nc.viewNode?.nodeType === 1
-    ? (nc as FloatNodeContext)
+  const element = asElementNodeContext(nc);
+  return element !== null && element.floatSide !== null
+    ? (element as FloatNodeContext)
     : null;
 }
 
 export function asClearNodeContext(
   nc: Vtree.NodeContext,
 ): ClearNodeContext | null {
-  return nc.clearSide !== null && nc.viewNode?.nodeType === 1
-    ? (nc as ClearNodeContext)
+  const element = asElementNodeContext(nc);
+  return element !== null && element.clearSide !== null
+    ? (element as ClearNodeContext)
     : null;
 }
 
 export function asAfterIfContinuesNodeContext(
   nc: Vtree.NodeContext,
 ): AfterIfContinuesNodeContext | null {
-  return nc.afterIfContinues !== null && nc.viewNode?.nodeType === 1
-    ? (nc as AfterIfContinuesNodeContext)
+  const element = asElementNodeContext(nc);
+  return element !== null && element.afterIfContinues !== null
+    ? (element as AfterIfContinuesNodeContext)
     : null;
 }
 
@@ -894,11 +627,8 @@ export function asRenderedNodeContext(
   return asElementNodeContext(nc) ?? asTextNodeContext(nc);
 }
 
-export type ContainedElementNodeContext = NodeContext &
-  Vtree.ContainedElementNodeContext;
-
 export function blockContainerForChildrenOf(
-  parent: NodeContext,
+  parent: Vtree.NodeContext,
 ): ElementNodeContext | null {
   const element = asElementNodeContext(parent);
   return element && !(parent.inline && parent.blockContainer)

--- a/packages/core/src/vivliostyle/vtree.ts
+++ b/packages/core/src/vivliostyle/vtree.ts
@@ -489,50 +489,6 @@ export function newNodePositionFromNodeContext(
   };
 }
 
-export function makeNodeContextFromNodePositionStep(
-  step: NodePositionStep,
-  parent: Vtree.NodeContext,
-): NodeContext {
-  const parentContext = parent as NodeContext;
-  const nodeContext = new NodeContext(
-    step.node,
-    parentContext,
-    0,
-    step.formattingContext ?? parentContext.formattingContext,
-  );
-  nodeContext.blockContainer = blockContainerForChildrenOf(parentContext);
-  applyNodePositionStep(nodeContext, step);
-  nodeContext.shadowSibling = step.shadowSibling
-    ? makeNodeContextFromNodePositionStep(step.shadowSibling, parent.copy())
-    : null;
-  return nodeContext;
-}
-
-export function makeRootNodeContextFromNodePositionStep(
-  step: RootNodePositionStep,
-  flowRootFormattingContext: FormattingContext,
-): NodeContext {
-  const nodeContext = new NodeContext(
-    step.node,
-    null,
-    0,
-    step.formattingContext ?? flowRootFormattingContext,
-  );
-  applyNodePositionStep(nodeContext, step);
-  nodeContext.shadowSibling = step.shadowSibling;
-  return nodeContext;
-}
-
-function applyNodePositionStep(
-  nodeContext: NodeContext,
-  step: NodePositionStep,
-): void {
-  nodeContext.shadowType = step.shadowType;
-  nodeContext.shadowContext = step.shadowContext;
-  nodeContext.nodeShadow = step.nodeShadow;
-  nodeContext.fragmentIndex = step.fragmentIndex + 1;
-}
-
 export function rootStepOfNodePosition(
   position: Vtree.NodePosition,
 ): RootNodePositionStep {
@@ -652,37 +608,6 @@ export class NodeContext implements Vtree.NodeContext {
   footnotePolicy: Css.Ident | null = null;
   pageType: string | null;
   blockContainer: ElementNodeContext | null = null;
-
-  static childOf(
-    sourceNode: Node,
-    parent: NodeContext,
-    boxOffset: number,
-  ): ChildNodeContext {
-    const nodeContext = new NodeContext(
-      sourceNode,
-      parent,
-      boxOffset,
-      parent.formattingContext,
-    );
-    nodeContext.blockContainer = blockContainerForChildrenOf(parent);
-    return nodeContext as ChildNodeContext;
-  }
-
-  static siblingOf(
-    sourceNode: Node,
-    sibling: NodeContext,
-    boxOffset: number,
-  ): NodeContext {
-    const parent = sibling.parent;
-    const nodeContext = new NodeContext(
-      sourceNode,
-      parent,
-      boxOffset,
-      (parent ?? sibling).formattingContext,
-    );
-    nodeContext.blockContainer = sibling.blockContainer;
-    return nodeContext;
-  }
 
   constructor(
     public sourceNode: Node,

--- a/packages/core/test/spec/vivliostyle/break-position-spec.js
+++ b/packages/core/test/spec/vivliostyle/break-position-spec.js
@@ -63,6 +63,9 @@ describe("break-position", function () {
 
   function stubColumn() {
     return {
+      edgeOverflowStore: {
+        edgeOverflowByViewNode: new WeakMap(),
+      },
       overflows: false,
       vertical: false,
       isOverflown: function () {
@@ -74,6 +77,12 @@ describe("break-position", function () {
       findEdgeBreakPosition: function (breakPosition) {
         return breakPosition.position;
       },
+    };
+  }
+
+  function beginLayoutPass(target) {
+    target.edgeOverflowStore = {
+      edgeOverflowByViewNode: new WeakMap(),
     };
   }
 
@@ -170,7 +179,7 @@ describe("break-position", function () {
       expect(
         vivliostyle_break_position.effectiveOverflow(column, position),
       ).toBe(true);
-      vivliostyle_break_position.beginLayoutPass(column);
+      beginLayoutPass(column);
       expect(
         vivliostyle_break_position.effectiveOverflow(column, position),
       ).toBe(false);
@@ -181,7 +190,7 @@ describe("break-position", function () {
         beforeEdgeOf(document.createElement("div")),
         true,
       );
-      vivliostyle_break_position.beginLayoutPass(column);
+      beginLayoutPass(column);
       expect(
         vivliostyle_break_position.effectiveOverflow(column, position),
       ).toBe(true);
@@ -191,7 +200,7 @@ describe("break-position", function () {
       var viewNode = document.createElement("div");
       var position = beforeEdgeOf(viewNode);
       edgeBreakPosition(position).findAcceptableBreak(overflowing(), 10);
-      vivliostyle_break_position.beginLayoutPass(column);
+      beginLayoutPass(column);
       var reached = beforeEdgeOf(viewNode);
       edgeBreakPosition(reached).findAcceptableBreak(overflowing(), 10);
       expect(
@@ -255,7 +264,7 @@ describe("break-position", function () {
     it("keeps the record a nested column's layout pass leaves alone", function () {
       var position = beforeEdgeOf(document.createElement("div"));
       edgeBreakPosition(position).findAcceptableBreak(overflowing(), 10);
-      vivliostyle_break_position.beginLayoutPass(Object.create(column));
+      beginLayoutPass(Object.create(column));
       expect(
         vivliostyle_break_position.effectiveOverflow(column, position),
       ).toBe(true);

--- a/packages/core/test/spec/vivliostyle/break-position-spec.js
+++ b/packages/core/test/spec/vivliostyle/break-position-spec.js
@@ -1,0 +1,264 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as vivliostyle_break_position from "../../../src/vivliostyle/break-position";
+import * as vivliostyle_layout_processor from "../../../src/vivliostyle/layout-processor";
+import * as vivliostyle_node_context from "../../../src/vivliostyle/node-context";
+import * as vivliostyle_vtree from "../../../src/vivliostyle/vtree";
+
+describe("break-position", function () {
+  "use strict";
+
+  var column;
+
+  beforeEach(function () {
+    column = stubColumn();
+  });
+
+  function beforeEdgeOf(viewNode) {
+    var opened = vivliostyle_node_context.openAt(
+      document.createElement("div"),
+      null,
+      0,
+      new vivliostyle_layout_processor.BlockFormattingContext(null),
+      {
+        shadowType: vivliostyle_vtree.ShadowType.NONE,
+        shadowContext: null,
+      },
+      { offsetInNode: 0, after: false },
+    );
+    return vivliostyle_node_context.renderedElement(
+      opened,
+      viewNode,
+      vivliostyle_node_context.elementRenderResultOf(opened),
+    );
+  }
+
+  function afterEdgeOf(viewNode) {
+    return vivliostyle_node_context.afterEdgeOf(beforeEdgeOf(viewNode));
+  }
+
+  function textPositionAt(viewNode, boxOffset) {
+    var child = vivliostyle_node_context.openChildOf(
+      viewNode,
+      beforeEdgeOf(document.createElement("div")),
+      boxOffset,
+    );
+    return vivliostyle_node_context.renderedText(child, viewNode, []);
+  }
+
+  function stubColumn() {
+    return {
+      overflows: false,
+      vertical: false,
+      isOverflown: function () {
+        return this.overflows;
+      },
+      collectElementsOffset: function () {
+        return [];
+      },
+      findEdgeBreakPosition: function (breakPosition) {
+        return breakPosition.position;
+      },
+    };
+  }
+
+  function edgeBreakPosition(position) {
+    var breakPosition = new vivliostyle_break_position.EdgeBreakPosition(
+      position,
+      null,
+      false,
+      0,
+    );
+    breakPosition.isEdgeUpdated = true;
+    return breakPosition;
+  }
+
+  function overflowing() {
+    column.overflows = true;
+    return column;
+  }
+
+  function fitting() {
+    column.overflows = false;
+    return column;
+  }
+
+  describe("effectiveOverflow", function () {
+    it("reports the overflow the value carries while no edge is recorded", function () {
+      var fits = beforeEdgeOf(document.createElement("div"));
+      var overflows = vivliostyle_node_context.setOverflow(
+        beforeEdgeOf(document.createElement("div")),
+        true,
+      );
+      expect(vivliostyle_break_position.effectiveOverflow(column, fits)).toBe(
+        false,
+      );
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, overflows),
+      ).toBe(true);
+    });
+
+    it("prefers the verdict recorded for the same edge", function () {
+      var position = vivliostyle_node_context.setOverflow(
+        beforeEdgeOf(document.createElement("div")),
+        false,
+      );
+      edgeBreakPosition(position).findAcceptableBreak(overflowing(), 10);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(true);
+    });
+
+    it("takes back the record when the edge no longer overflows", function () {
+      var position = beforeEdgeOf(document.createElement("div"));
+      var breakPosition = edgeBreakPosition(position);
+      breakPosition.findAcceptableBreak(overflowing(), 10);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(true);
+      breakPosition.findAcceptableBreak(fitting(), 10);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(false);
+    });
+
+    it("keeps the overflow the value carries once the edge fits", function () {
+      var position = vivliostyle_node_context.setOverflow(
+        beforeEdgeOf(document.createElement("div")),
+        true,
+      );
+      edgeBreakPosition(position).findAcceptableBreak(fitting(), 10);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(true);
+    });
+
+    it("keeps the overflow another value carries at the same edge", function () {
+      var viewNode = document.createElement("div");
+      var probe = beforeEdgeOf(viewNode);
+      var carrier = vivliostyle_node_context.setOverflow(
+        beforeEdgeOf(viewNode),
+        true,
+      );
+      edgeBreakPosition(probe).findAcceptableBreak(fitting(), 10);
+      expect(vivliostyle_break_position.effectiveOverflow(column, probe)).toBe(
+        false,
+      );
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, carrier),
+      ).toBe(true);
+    });
+
+    it("drops the record a previous layout pass left", function () {
+      var position = beforeEdgeOf(document.createElement("div"));
+      edgeBreakPosition(position).findAcceptableBreak(overflowing(), 10);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(true);
+      vivliostyle_break_position.beginLayoutPass(column);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(false);
+    });
+
+    it("keeps the overflow the value carries across a layout pass", function () {
+      var position = vivliostyle_node_context.setOverflow(
+        beforeEdgeOf(document.createElement("div")),
+        true,
+      );
+      vivliostyle_break_position.beginLayoutPass(column);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(true);
+    });
+
+    it("records again on the edge a previous layout pass recorded", function () {
+      var viewNode = document.createElement("div");
+      var position = beforeEdgeOf(viewNode);
+      edgeBreakPosition(position).findAcceptableBreak(overflowing(), 10);
+      vivliostyle_break_position.beginLayoutPass(column);
+      var reached = beforeEdgeOf(viewNode);
+      edgeBreakPosition(reached).findAcceptableBreak(overflowing(), 10);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, reached),
+      ).toBe(true);
+    });
+
+    it("keeps the two edges of one view node apart", function () {
+      var viewNode = document.createElement("div");
+      var before = beforeEdgeOf(viewNode);
+      var after = afterEdgeOf(viewNode);
+      edgeBreakPosition(after).findAcceptableBreak(overflowing(), 10);
+      expect(vivliostyle_break_position.effectiveOverflow(column, after)).toBe(
+        true,
+      );
+      expect(vivliostyle_break_position.effectiveOverflow(column, before)).toBe(
+        false,
+      );
+      edgeBreakPosition(before).findAcceptableBreak(overflowing(), 10);
+      edgeBreakPosition(after).findAcceptableBreak(fitting(), 10);
+      expect(vivliostyle_break_position.effectiveOverflow(column, before)).toBe(
+        true,
+      );
+      expect(vivliostyle_break_position.effectiveOverflow(column, after)).toBe(
+        false,
+      );
+    });
+
+    it("keeps the two offsets of one text node apart", function () {
+      var viewNode = document.createTextNode("text");
+      var head = textPositionAt(viewNode, 1);
+      var tail = textPositionAt(viewNode, 3);
+      edgeBreakPosition(tail).findAcceptableBreak(overflowing(), 10);
+      expect(vivliostyle_break_position.effectiveOverflow(column, tail)).toBe(
+        true,
+      );
+      expect(vivliostyle_break_position.effectiveOverflow(column, head)).toBe(
+        false,
+      );
+      edgeBreakPosition(head).findAcceptableBreak(overflowing(), 10);
+      edgeBreakPosition(tail).findAcceptableBreak(fitting(), 10);
+      expect(vivliostyle_break_position.effectiveOverflow(column, head)).toBe(
+        true,
+      );
+      expect(vivliostyle_break_position.effectiveOverflow(column, tail)).toBe(
+        false,
+      );
+    });
+
+    it("keeps the record out of another column's reach", function () {
+      var position = beforeEdgeOf(document.createElement("div"));
+      edgeBreakPosition(position).findAcceptableBreak(overflowing(), 10);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(true);
+      expect(
+        vivliostyle_break_position.effectiveOverflow(stubColumn(), position),
+      ).toBe(false);
+    });
+
+    it("keeps the record a nested column's layout pass leaves alone", function () {
+      var position = beforeEdgeOf(document.createElement("div"));
+      edgeBreakPosition(position).findAcceptableBreak(overflowing(), 10);
+      vivliostyle_break_position.beginLayoutPass(Object.create(column));
+      expect(
+        vivliostyle_break_position.effectiveOverflow(column, position),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/core/test/spec/vivliostyle/break-spec.js
+++ b/packages/core/test/spec/vivliostyle/break-spec.js
@@ -17,6 +17,9 @@
 
 import * as adapt_css from "../../../src/vivliostyle/css";
 import * as vivliostyle_break from "../../../src/vivliostyle/break";
+import * as vivliostyle_layout_processor from "../../../src/vivliostyle/layout-processor";
+import * as vivliostyle_node_context from "../../../src/vivliostyle/node-context";
+import * as vivliostyle_vtree from "../../../src/vivliostyle/vtree";
 
 describe("break", function () {
   describe("convertPageBreakAliases", function () {
@@ -123,6 +126,149 @@ describe("break", function () {
 
     it("returns auto if both are auto", function () {
       expect(resolveEffectiveBreakValue("auto", "auto")).toBe("auto");
+    });
+  });
+
+  describe("column break suppression", function () {
+    function elementNodeContext(viewNode, overrides) {
+      var opened = vivliostyle_node_context.openAt(
+        document.createElement("div"),
+        null,
+        0,
+        new vivliostyle_layout_processor.BlockFormattingContext(null),
+        {
+          shadowType: vivliostyle_vtree.ShadowType.NONE,
+          shadowContext: null,
+        },
+        { offsetInNode: 0, after: false },
+      );
+      var rendered = vivliostyle_node_context.elementRenderResultOf(opened);
+      Object.keys(overrides || {}).forEach(function (field) {
+        rendered[field] = overrides[field];
+      });
+      return vivliostyle_node_context.renderedElement(
+        opened,
+        viewNode,
+        rendered,
+      );
+    }
+
+    it("masks the column break before of a suppressed view node", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, {
+        breakBefore: "column",
+      });
+      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
+        "column",
+      );
+      vivliostyle_break.suppressColumnBreakBefore(viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(null);
+    });
+
+    it("keeps the suppression a fresh column break before assignment cannot lift", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, {
+        breakBefore: "column",
+      });
+      vivliostyle_break.suppressColumnBreakBefore(viewNode);
+      var reassigned = vivliostyle_node_context.setBreakBefore(
+        nodeContext,
+        "column",
+      );
+      expect(vivliostyle_break.effectiveBreakBefore(reassigned)).toBe(null);
+      vivliostyle_break.unsuppressColumnBreakBefore(viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(reassigned)).toBe("column");
+    });
+
+    it("lifts the column break after suppression of a view node", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, { breakAfter: "column" });
+      vivliostyle_break.suppressColumnBreakAfter(viewNode);
+      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe(null);
+      vivliostyle_break.unsuppressColumnBreakAfter(viewNode);
+      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe("column");
+    });
+
+    it("keeps the suppression of the other view nodes", function () {
+      var lifted = document.createElement("div");
+      var kept = document.createElement("div");
+      var liftedContext = elementNodeContext(lifted, {
+        breakBefore: "column",
+      });
+      var keptContext = elementNodeContext(kept, { breakBefore: "column" });
+      vivliostyle_break.suppressColumnBreakBefore(lifted);
+      vivliostyle_break.suppressColumnBreakBefore(kept);
+      vivliostyle_break.unsuppressColumnBreakBefore(lifted);
+      expect(vivliostyle_break.effectiveBreakBefore(liftedContext)).toBe(
+        "column",
+      );
+      expect(vivliostyle_break.effectiveBreakBefore(keptContext)).toBe(null);
+    });
+
+    it("keeps the raw column break recoverable after reporting it", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, {
+        breakBefore: "column",
+        breakAfter: "column",
+      });
+      vivliostyle_break.suppressColumnBreakBefore(viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(viewNode);
+      nodeContext.breakBefore =
+        vivliostyle_break.reportEffectiveBreakBefore(nodeContext);
+      nodeContext.breakAfter =
+        vivliostyle_break.reportEffectiveBreakAfter(nodeContext);
+      expect(nodeContext.breakBefore).toBe(null);
+      expect(nodeContext.breakAfter).toBe(null);
+      vivliostyle_break.unsuppressColumnBreakBefore(viewNode);
+      vivliostyle_break.unsuppressColumnBreakAfter(viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
+        "column",
+      );
+      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe("column");
+    });
+
+    it("forgets the report once the value carries a break of its own", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, {
+        breakBefore: "column",
+      });
+      vivliostyle_break.suppressColumnBreakBefore(viewNode);
+      nodeContext.breakBefore =
+        vivliostyle_break.reportEffectiveBreakBefore(nodeContext);
+      nodeContext.breakBefore = "page";
+      expect(vivliostyle_break.reportEffectiveBreakBefore(nodeContext)).toBe(
+        "page",
+      );
+      nodeContext.breakBefore = null;
+      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(null);
+    });
+
+    it("reports the break of a value no suppression masks", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, {
+        breakBefore: "column",
+      });
+      expect(vivliostyle_break.reportEffectiveBreakBefore(nodeContext)).toBe(
+        "column",
+      );
+      expect(vivliostyle_break.reportEffectiveBreakAfter(nodeContext)).toBe(
+        null,
+      );
+    });
+
+    it("keeps the two directions of one view node apart", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, {
+        breakBefore: "column",
+        breakAfter: "column",
+      });
+      vivliostyle_break.suppressColumnBreakBefore(viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(viewNode);
+      vivliostyle_break.unsuppressColumnBreakBefore(viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
+        "column",
+      );
+      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe(null);
     });
   });
 });

--- a/packages/core/test/spec/vivliostyle/break-spec.js
+++ b/packages/core/test/spec/vivliostyle/break-spec.js
@@ -130,6 +130,14 @@ describe("break", function () {
   });
 
   describe("column break suppression", function () {
+    var store;
+
+    beforeEach(function () {
+      store = {
+        breakSuppressionByViewNode: new WeakMap(),
+      };
+    });
+
     function elementNodeContext(viewNode, overrides) {
       var opened = vivliostyle_node_context.openAt(
         document.createElement("div"),
@@ -158,11 +166,27 @@ describe("break", function () {
       var nodeContext = elementNodeContext(viewNode, {
         breakBefore: "column",
       });
-      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
+      expect(vivliostyle_break.effectiveBreakBefore(store, nodeContext)).toBe(
         "column",
       );
-      vivliostyle_break.suppressColumnBreakBefore(viewNode);
-      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(null);
+      vivliostyle_break.suppressColumnBreakBefore(store, viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(store, nodeContext)).toBe(
+        null,
+      );
+    });
+
+    it("keeps another document layout unsuppressed", function () {
+      var viewNode = document.createElement("div");
+      var nodeContext = elementNodeContext(viewNode, {
+        breakBefore: "column",
+      });
+      var other = {
+        breakSuppressionByViewNode: new WeakMap(),
+      };
+      vivliostyle_break.suppressColumnBreakBefore(store, viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(other, nodeContext)).toBe(
+        "column",
+      );
     });
 
     it("keeps the suppression a fresh column break before assignment cannot lift", function () {
@@ -170,23 +194,31 @@ describe("break", function () {
       var nodeContext = elementNodeContext(viewNode, {
         breakBefore: "column",
       });
-      vivliostyle_break.suppressColumnBreakBefore(viewNode);
+      vivliostyle_break.suppressColumnBreakBefore(store, viewNode);
       var reassigned = vivliostyle_node_context.setBreakBefore(
         nodeContext,
         "column",
       );
-      expect(vivliostyle_break.effectiveBreakBefore(reassigned)).toBe(null);
-      vivliostyle_break.unsuppressColumnBreakBefore(viewNode);
-      expect(vivliostyle_break.effectiveBreakBefore(reassigned)).toBe("column");
+      expect(vivliostyle_break.effectiveBreakBefore(store, reassigned)).toBe(
+        null,
+      );
+      vivliostyle_break.unsuppressColumnBreakBefore(store, viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(store, reassigned)).toBe(
+        "column",
+      );
     });
 
     it("lifts the column break after suppression of a view node", function () {
       var viewNode = document.createElement("div");
       var nodeContext = elementNodeContext(viewNode, { breakAfter: "column" });
-      vivliostyle_break.suppressColumnBreakAfter(viewNode);
-      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe(null);
-      vivliostyle_break.unsuppressColumnBreakAfter(viewNode);
-      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe("column");
+      vivliostyle_break.suppressColumnBreakAfter(store, viewNode);
+      expect(vivliostyle_break.effectiveBreakAfter(store, nodeContext)).toBe(
+        null,
+      );
+      vivliostyle_break.unsuppressColumnBreakAfter(store, viewNode);
+      expect(vivliostyle_break.effectiveBreakAfter(store, nodeContext)).toBe(
+        "column",
+      );
     });
 
     it("keeps the suppression of the other view nodes", function () {
@@ -196,13 +228,15 @@ describe("break", function () {
         breakBefore: "column",
       });
       var keptContext = elementNodeContext(kept, { breakBefore: "column" });
-      vivliostyle_break.suppressColumnBreakBefore(lifted);
-      vivliostyle_break.suppressColumnBreakBefore(kept);
-      vivliostyle_break.unsuppressColumnBreakBefore(lifted);
-      expect(vivliostyle_break.effectiveBreakBefore(liftedContext)).toBe(
+      vivliostyle_break.suppressColumnBreakBefore(store, lifted);
+      vivliostyle_break.suppressColumnBreakBefore(store, kept);
+      vivliostyle_break.unsuppressColumnBreakBefore(store, lifted);
+      expect(vivliostyle_break.effectiveBreakBefore(store, liftedContext)).toBe(
         "column",
       );
-      expect(vivliostyle_break.effectiveBreakBefore(keptContext)).toBe(null);
+      expect(vivliostyle_break.effectiveBreakBefore(store, keptContext)).toBe(
+        null,
+      );
     });
 
     it("keeps the raw column break recoverable after reporting it", function () {
@@ -211,20 +245,26 @@ describe("break", function () {
         breakBefore: "column",
         breakAfter: "column",
       });
-      vivliostyle_break.suppressColumnBreakBefore(viewNode);
-      vivliostyle_break.suppressColumnBreakAfter(viewNode);
-      nodeContext.breakBefore =
-        vivliostyle_break.reportEffectiveBreakBefore(nodeContext);
-      nodeContext.breakAfter =
-        vivliostyle_break.reportEffectiveBreakAfter(nodeContext);
+      vivliostyle_break.suppressColumnBreakBefore(store, viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(store, viewNode);
+      nodeContext.breakBefore = vivliostyle_break.reportEffectiveBreakBefore(
+        store,
+        nodeContext,
+      );
+      nodeContext.breakAfter = vivliostyle_break.reportEffectiveBreakAfter(
+        store,
+        nodeContext,
+      );
       expect(nodeContext.breakBefore).toBe(null);
       expect(nodeContext.breakAfter).toBe(null);
-      vivliostyle_break.unsuppressColumnBreakBefore(viewNode);
-      vivliostyle_break.unsuppressColumnBreakAfter(viewNode);
-      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
+      vivliostyle_break.unsuppressColumnBreakBefore(store, viewNode);
+      vivliostyle_break.unsuppressColumnBreakAfter(store, viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(store, nodeContext)).toBe(
         "column",
       );
-      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe("column");
+      expect(vivliostyle_break.effectiveBreakAfter(store, nodeContext)).toBe(
+        "column",
+      );
     });
 
     it("forgets the report once the value carries a break of its own", function () {
@@ -232,15 +272,19 @@ describe("break", function () {
       var nodeContext = elementNodeContext(viewNode, {
         breakBefore: "column",
       });
-      vivliostyle_break.suppressColumnBreakBefore(viewNode);
-      nodeContext.breakBefore =
-        vivliostyle_break.reportEffectiveBreakBefore(nodeContext);
-      nodeContext.breakBefore = "page";
-      expect(vivliostyle_break.reportEffectiveBreakBefore(nodeContext)).toBe(
-        "page",
+      vivliostyle_break.suppressColumnBreakBefore(store, viewNode);
+      nodeContext.breakBefore = vivliostyle_break.reportEffectiveBreakBefore(
+        store,
+        nodeContext,
       );
+      nodeContext.breakBefore = "page";
+      expect(
+        vivliostyle_break.reportEffectiveBreakBefore(store, nodeContext),
+      ).toBe("page");
       nodeContext.breakBefore = null;
-      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(null);
+      expect(vivliostyle_break.effectiveBreakBefore(store, nodeContext)).toBe(
+        null,
+      );
     });
 
     it("reports the break of a value no suppression masks", function () {
@@ -248,12 +292,12 @@ describe("break", function () {
       var nodeContext = elementNodeContext(viewNode, {
         breakBefore: "column",
       });
-      expect(vivliostyle_break.reportEffectiveBreakBefore(nodeContext)).toBe(
-        "column",
-      );
-      expect(vivliostyle_break.reportEffectiveBreakAfter(nodeContext)).toBe(
-        null,
-      );
+      expect(
+        vivliostyle_break.reportEffectiveBreakBefore(store, nodeContext),
+      ).toBe("column");
+      expect(
+        vivliostyle_break.reportEffectiveBreakAfter(store, nodeContext),
+      ).toBe(null);
     });
 
     it("keeps the two directions of one view node apart", function () {
@@ -262,13 +306,15 @@ describe("break", function () {
         breakBefore: "column",
         breakAfter: "column",
       });
-      vivliostyle_break.suppressColumnBreakBefore(viewNode);
-      vivliostyle_break.suppressColumnBreakAfter(viewNode);
-      vivliostyle_break.unsuppressColumnBreakBefore(viewNode);
-      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
+      vivliostyle_break.suppressColumnBreakBefore(store, viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(store, viewNode);
+      vivliostyle_break.unsuppressColumnBreakBefore(store, viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(store, nodeContext)).toBe(
         "column",
       );
-      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe(null);
+      expect(vivliostyle_break.effectiveBreakAfter(store, nodeContext)).toBe(
+        null,
+      );
     });
   });
 });

--- a/packages/core/test/spec/vivliostyle/layout-spec.js
+++ b/packages/core/test/spec/vivliostyle/layout-spec.js
@@ -17,6 +17,7 @@
 
 import * as adapt_layout from "../../../src/vivliostyle/layout";
 import * as adapt_layoutprocessor from "../../../src/vivliostyle/layout-processor";
+import * as adapt_nodecontext from "../../../src/vivliostyle/node-context";
 import * as adapt_vtree from "../../../src/vivliostyle/vtree";
 import * as adapt_css from "../../../src/vivliostyle/css";
 import * as adapt_csscasc from "../../../src/vivliostyle/css-cascade";
@@ -26,6 +27,30 @@ describe("layout", function () {
   describe("adapt_layout.TextNodeBreaker", function () {
     var breaker;
     var textNode, nodeContext;
+    function openTextNodeContext(options) {
+      var settings = options || {};
+      var context = adapt_nodecontext.openAt(
+        {},
+        null,
+        3,
+        new adapt_layoutprocessor.BlockFormattingContext(null),
+        { shadowType: adapt_vtree.ShadowType.NONE, shadowContext: null },
+        {
+          offsetInNode: 0,
+          after: !!settings.after,
+          preprocessedTextContent: [
+            [0, "abcdeabcde"],
+            [1, "\u00AD"],
+            [0, "f gh"],
+            [1, "\u00AD"],
+            [0, "j"],
+          ],
+        },
+      );
+      context.hyphenateCharacter = "_";
+      context.breakWord = !!settings.breakWord;
+      return context;
+    }
     beforeEach(function () {
       breaker = new adapt_layout.TextNodeBreaker();
 
@@ -36,21 +61,7 @@ describe("layout", function () {
       };
       spyOn(textNode, "replaceData").and.callThrough();
 
-      nodeContext = new adapt_vtree.NodeContext(
-        {},
-        null,
-        3,
-        new adapt_layoutprocessor.BlockFormattingContext(null),
-      );
-      nodeContext.preprocessedTextContent = [
-        [0, "abcdeabcde"],
-        [1, "\u00AD"],
-        [0, "f gh"],
-        [1, "\u00AD"],
-        [0, "j"],
-      ];
-      nodeContext.hyphenateCharacter = "_";
-      nodeContext.offsetInNode = 0;
+      nodeContext = openTextNodeContext();
     });
     afterEach(function () {
       textNode.replaceData.calls.reset();
@@ -58,7 +69,7 @@ describe("layout", function () {
 
     describe("#breakTextNode", function () {
       it("increments `offsetInNode` when nodeContext#after is true.", function () {
-        nodeContext.after = true;
+        nodeContext = openTextNodeContext({ after: true });
         var newContext = breaker.breakTextNode(textNode, nodeContext, 8);
         expect(newContext.offsetInNode).toEqual(17);
         expect(newContext.preprocessedTextContent).toEqual(
@@ -75,7 +86,7 @@ describe("layout", function () {
         expect(textNode.replaceData).toHaveBeenCalledWith(10, 7, "_");
       });
       it("removes characters after split point but does not insert a hyphenation character when splits a text node at the soft-hyphen character and NodeContext#breakWord is true.", function () {
-        nodeContext.breakWord = true;
+        nodeContext = openTextNodeContext({ breakWord: true });
         var newContext = breaker.breakTextNode(textNode, nodeContext, 13);
         expect(newContext.offsetInNode).toEqual(11);
         expect(newContext.preprocessedTextContent).toEqual(
@@ -100,7 +111,7 @@ describe("layout", function () {
         expect(textNode.replaceData).toHaveBeenCalledWith(8, 9, "_");
       });
       it("removes characters after split point but does not insert a hyphenation character when splits a text node at the normal character and NodeContext#breakWord is true.", function () {
-        nodeContext.breakWord = true;
+        nodeContext = openTextNodeContext({ breakWord: true });
         var newContext = breaker.breakTextNode(textNode, nodeContext, 10);
         expect(newContext.offsetInNode).toEqual(8);
         expect(newContext.preprocessedTextContent).toEqual(

--- a/packages/core/test/spec/vivliostyle/layout-spec.js
+++ b/packages/core/test/spec/vivliostyle/layout-spec.js
@@ -120,6 +120,64 @@ describe("layout", function () {
         expect(textNode.replaceData).toHaveBeenCalledWith(8, 9, "");
       });
     });
+
+    describe("#breakAfterSoftHyphen", function () {
+      function openJoiningTextNodeContext(preprocessedTextContent) {
+        var opened = adapt_nodecontext.openAt(
+          {},
+          null,
+          0,
+          new adapt_layoutprocessor.BlockFormattingContext(null),
+          { shadowType: adapt_vtree.ShadowType.NONE, shadowContext: null },
+          {
+            offsetInNode: 0,
+            after: false,
+            preprocessedTextContent: preprocessedTextContent,
+          },
+        );
+        return { ...opened, hyphenateCharacter: "_" };
+      }
+
+      it("writes the joiner into the text content every value shares", function () {
+        var joining = openJoiningTextNodeContext([[0, "\u0628\u00ADx"]]);
+        var derived = adapt_nodecontext.derived(joining);
+        var brokenNode = {
+          length: 3,
+          data: "\u0628\u00ADx",
+          replaceData: function () {},
+        };
+        var viewIndex = breaker.breakAfterSoftHyphen(
+          brokenNode,
+          brokenNode.data,
+          1,
+          joining,
+        );
+        expect(viewIndex).toBe(2);
+        expect(joining.preprocessedTextContent[0][1]).toBe(
+          "\u0628\u00AD\u200Dx",
+        );
+        expect(derived.preprocessedTextContent[0][1]).toBe(
+          "\u0628\u00AD\u200Dx",
+        );
+      });
+
+      it("leaves the text content alone where no joiner is needed", function () {
+        var plain = openJoiningTextNodeContext([[0, "a\u00ADx"]]);
+        var brokenNode = {
+          length: 3,
+          data: "a\u00ADx",
+          replaceData: function () {},
+        };
+        var viewIndex = breaker.breakAfterSoftHyphen(
+          brokenNode,
+          brokenNode.data,
+          1,
+          plain,
+        );
+        expect(viewIndex).toBe(2);
+        expect(plain.preprocessedTextContent[0][1]).toBe("a\u00ADx");
+      });
+    });
   });
 
   describe("adapt_layout.resolveHyphenateCharacter", function () {

--- a/packages/core/test/spec/vivliostyle/layout-spec.js
+++ b/packages/core/test/spec/vivliostyle/layout-spec.js
@@ -29,7 +29,7 @@ describe("layout", function () {
     var textNode, nodeContext;
     function openTextNodeContext(options) {
       var settings = options || {};
-      var context = adapt_nodecontext.openAt(
+      var opened = adapt_nodecontext.openAt(
         {},
         null,
         3,
@@ -47,9 +47,11 @@ describe("layout", function () {
           ],
         },
       );
-      context.hyphenateCharacter = "_";
-      context.breakWord = !!settings.breakWord;
-      return context;
+      return {
+        ...opened,
+        hyphenateCharacter: "_",
+        breakWord: !!settings.breakWord,
+      };
     }
     beforeEach(function () {
       breaker = new adapt_layout.TextNodeBreaker();

--- a/packages/core/test/spec/vivliostyle/layout-spec.js
+++ b/packages/core/test/spec/vivliostyle/layout-spec.js
@@ -142,6 +142,181 @@ describe("layout", function () {
       expect(adapt_layout.resolveHyphenateCharacter({})).toEqual("-");
     });
   });
+
+  describe("adapt_layout.Column#checkOverflowAndSaveEdge", function () {
+    var viewNode;
+
+    function columnWithEdgeAt(edge) {
+      var column = Object.create(adapt_layout.Column.prototype);
+      column.element = document.createElement("div");
+      column.clientLayout = {
+        pixelRatio: 1,
+        layoutUnitPerPixel: 1,
+        getElementClientRect: function () {
+          return {
+            left: 0,
+            top: edge,
+            right: 100,
+            bottom: edge,
+            width: 100,
+            height: 0,
+          };
+        },
+        getElementComputedStyle: function () {
+          return {
+            display: "block",
+            whiteSpace: "normal",
+            marginBlockStart: "0px",
+          };
+        },
+      };
+      column.vertical = false;
+      column.beforeEdge = 0;
+      column.footnoteEdge = 50;
+      column.computedBlockSize = 0;
+      column.fragmentLayoutConstraints = [];
+      column.pseudoParent = null;
+      column.nodeContextOverflowingDueToRepetitiveElements = null;
+      return column;
+    }
+
+    function blockEdgeOf(sourceNode, boxOffset, node) {
+      var opened = adapt_nodecontext.openAt(
+        sourceNode,
+        null,
+        boxOffset || 0,
+        new adapt_layoutprocessor.BlockFormattingContext(null),
+        { shadowType: adapt_vtree.ShadowType.NONE, shadowContext: null },
+        { offsetInNode: 0, after: false },
+      );
+      var rendered = adapt_nodecontext.elementRenderResultOf(opened);
+      rendered.inline = false;
+      return adapt_nodecontext.renderedElement(
+        opened,
+        node || viewNode,
+        rendered,
+      );
+    }
+
+    beforeEach(function () {
+      viewNode = document.createElement("div");
+      document.body.appendChild(viewNode);
+    });
+
+    afterEach(function () {
+      viewNode.remove();
+    });
+
+    it("reports the repetitive overflow it records", function () {
+      var column = columnWithEdgeAt(80);
+      var result = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(document.createElement("div")),
+        null,
+      );
+      expect(result.overflown).toBe(true);
+      expect(result.recordedRepetitiveOverflow).toBe(true);
+    });
+
+    it("reports the repetitive overflow another value recorded for the same position", function () {
+      var column = columnWithEdgeAt(80);
+      var sourceNode = document.createElement("div");
+      column.checkOverflowAndSaveEdge(blockEdgeOf(sourceNode), null);
+      var again = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(sourceNode),
+        null,
+      );
+      expect(again.recordedRepetitiveOverflow).toBe(true);
+    });
+
+    it("reports no repetitive overflow at another source node", function () {
+      var column = columnWithEdgeAt(80);
+      column.checkOverflowAndSaveEdge(
+        blockEdgeOf(document.createElement("div")),
+        null,
+      );
+      var other = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(document.createElement("div")),
+        null,
+      );
+      expect(other.recordedRepetitiveOverflow).toBe(false);
+    });
+
+    it("reports no repetitive overflow at the other edge of the same source node", function () {
+      var column = columnWithEdgeAt(80);
+      var sourceNode = document.createElement("div");
+      column.checkOverflowAndSaveEdge(blockEdgeOf(sourceNode), null);
+      var after = column.checkOverflowAndSaveEdge(
+        adapt_nodecontext.afterEdgeOf(blockEdgeOf(sourceNode)),
+        null,
+      );
+      expect(after.recordedRepetitiveOverflow).toBe(false);
+    });
+
+    it("reports no repetitive overflow at another box offset of the same source node", function () {
+      var column = columnWithEdgeAt(80);
+      var sourceNode = document.createElement("div");
+      column.checkOverflowAndSaveEdge(blockEdgeOf(sourceNode), null);
+      var moved = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(sourceNode, 5),
+        null,
+      );
+      expect(moved.recordedRepetitiveOverflow).toBe(false);
+    });
+
+    it("reports the repetitive overflow recorded for an orphan node", function () {
+      var column = columnWithEdgeAt(80);
+      var sourceNode = document.createElement("div");
+      column.checkOverflowAndSaveEdge(blockEdgeOf(sourceNode), null);
+      var orphan = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(sourceNode, 0, document.createElement("div")),
+        null,
+      );
+      expect(orphan.overflown).toBe(false);
+      expect(orphan.recordedRepetitiveOverflow).toBe(true);
+    });
+
+    it("reports the repetitive overflow recorded for an out-of-flow node", function () {
+      var column = columnWithEdgeAt(80);
+      var sourceNode = document.createElement("div");
+      column.checkOverflowAndSaveEdge(blockEdgeOf(sourceNode), null);
+      var floating = document.createElement("div");
+      floating.style.float = "left";
+      viewNode.appendChild(floating);
+      var outOfFlow = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(sourceNode, 0, floating),
+        null,
+      );
+      expect(outOfFlow.overflown).toBe(false);
+      expect(outOfFlow.recordedRepetitiveOverflow).toBe(true);
+    });
+
+    it("reports no repetitive overflow for an orphan node at another position", function () {
+      var column = columnWithEdgeAt(80);
+      column.checkOverflowAndSaveEdge(
+        blockEdgeOf(document.createElement("div")),
+        null,
+      );
+      var orphan = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(
+          document.createElement("div"),
+          0,
+          document.createElement("div"),
+        ),
+        null,
+      );
+      expect(orphan.recordedRepetitiveOverflow).toBe(false);
+    });
+
+    it("reports no repetitive overflow while nothing is recorded", function () {
+      var column = columnWithEdgeAt(20);
+      var result = column.checkOverflowAndSaveEdge(
+        blockEdgeOf(document.createElement("div")),
+        null,
+      );
+      expect(result.overflown).toBe(false);
+      expect(result.recordedRepetitiveOverflow).toBe(false);
+    });
+  });
 });
 
 describe("selectors", function () {

--- a/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
+++ b/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
@@ -30,6 +30,24 @@ import "../../../src/vivliostyle";
 describe("legacy-plugin-surface", function () {
   "use strict";
 
+  var breakStore;
+  var continuationStore;
+  var stores;
+
+  beforeEach(function () {
+    breakStore = {
+      breakSuppressionByViewNode: new WeakMap(),
+    };
+    continuationStore = {
+      continuationOfSlot: new WeakMap(),
+      slotOfContinuation: new WeakMap(),
+    };
+    stores = {
+      breakSuppressionStore: breakStore,
+      continuationStore: continuationStore,
+    };
+  });
+
   var hookNames = [
     "PREPROCESS_TEXT_CONTENT",
     "PREPROCESS_ELEMENT_STYLE",
@@ -86,6 +104,8 @@ describe("legacy-plugin-surface", function () {
 
   function stubLayoutContext() {
     var layoutContext = {
+      breakSuppressionStore: breakStore,
+      continuationStore: continuationStore,
       calls: [],
       cloned: null,
       rendered: null,
@@ -155,6 +175,9 @@ describe("legacy-plugin-surface", function () {
 
   function stubColumn() {
     var column = {
+      edgeOverflowStore: {
+        edgeOverflowByViewNode: new WeakMap(),
+      },
       calls: [],
       overflown: true,
       clearance: document.createElement("div"),
@@ -373,12 +396,14 @@ describe("legacy-plugin-surface", function () {
         vivliostyle_legacy.adaptLegacyLayoutProcessor(
           registered[0],
           legacyProcessor,
+          stores,
         ),
       ).not.toBe(legacyProcessor);
       expect(
         vivliostyle_legacy.adaptLegacyLayoutProcessor(
           registered[1],
           legacyProcessor,
+          stores,
         ),
       ).toBe(legacyProcessor);
       vivliostyle_plugin.removeHook(name, external);
@@ -406,6 +431,7 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = openTextNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         "PREPROCESS_TEXT_CONTENT",
+        stores,
         nodeContext,
       );
       vivliostyle_legacy.noteRetained(nodeContext);
@@ -414,6 +440,7 @@ describe("legacy-plugin-surface", function () {
       expect(
         vivliostyle_legacy.asLegacyNodeContext(
           "PREPROCESS_TEXT_CONTENT",
+          stores,
           nodeContext,
         ).shared,
       ).toBe(true);
@@ -465,13 +492,14 @@ describe("legacy-plugin-surface", function () {
     it("hands out the value itself", function () {
       var nodeContext = openTextNodeContext();
       expect(
-        vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext),
+        vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext),
       ).toBe(nodeContext);
     });
 
     it("restores the removed members", function () {
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         openTextNodeContext(),
       );
       expect(legacy.copy()).toBe(legacy);
@@ -482,21 +510,45 @@ describe("legacy-plugin-surface", function () {
       expect(legacy.belongsTo(legacy.formattingContext)).toBe(false);
     });
 
+    it("resolves a shadow sibling to its latest continuation", function () {
+      var parent = elementNodeContext();
+      var nodeContext = childNodeContext(parent);
+      var slot = openTextNodeContext();
+      var resumed = openTextNodeContext();
+      nodeContext.shadowSibling = slot;
+      vivliostyle_node_context.resumeContinuation(
+        continuationStore,
+        slot,
+        resumed,
+      );
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        stores,
+        nodeContext,
+      );
+      expect(legacy.toNodePositionStep().shadowSibling.node).toBe(
+        resumed.sourceNode,
+      );
+      expect(legacy.toNodePosition().steps[0].shadowSibling.node).toBe(
+        resumed.sourceNode,
+      );
+    });
+
     it("decorates a shadow sibling a decorated value gains later", function () {
       var nodeContext = openTextNodeContext();
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       var sibling = openTextNodeContext();
       nodeContext.shadowSibling = sibling;
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(typeof sibling.copy).toBe("function");
     });
 
     it("decorates a block container a decorated value gains later", function () {
       var nodeContext = openTextNodeContext();
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       var container = elementNodeContext();
       nodeContext.blockContainer = container;
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(typeof container.copy).toBe("function");
     });
 
@@ -505,7 +557,7 @@ describe("legacy-plugin-surface", function () {
       var second = openTextNodeContext();
       first.shadowSibling = second;
       second.shadowSibling = first;
-      vivliostyle_legacy.asLegacyNodeContext(hookName, first);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, first);
       expect(typeof first.copy).toBe("function");
       expect(typeof second.copy).toBe("function");
     });
@@ -514,6 +566,7 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = openTextNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         nodeContext,
       );
       expect(legacy.shared).toBe(false);
@@ -524,6 +577,7 @@ describe("legacy-plugin-surface", function () {
     it("marks the value on copy, as the class did", function () {
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         openTextNodeContext(),
       );
       expect(legacy.shared).toBe(false);
@@ -534,6 +588,7 @@ describe("legacy-plugin-surface", function () {
     it("modifies in place while the core does not keep the value", function () {
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         openTextNodeContext(),
       );
       expect(legacy.modify()).toBe(legacy);
@@ -543,6 +598,7 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = openTextNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         nodeContext,
       );
       vivliostyle_legacy.noteRetained(nodeContext);
@@ -561,6 +617,7 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = openTextNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         nodeContext,
       );
       legacy.overflow = true;
@@ -571,6 +628,7 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = openTextNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         nodeContext,
       );
       legacy.after = true;
@@ -586,6 +644,7 @@ describe("legacy-plugin-surface", function () {
       var parent = elementNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         childNodeContext(parent),
       );
       expect(legacy.parent.shared).toBe(false);
@@ -598,6 +657,7 @@ describe("legacy-plugin-surface", function () {
       var parent = elementNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         childNodeContext(parent),
       );
       legacy.shared = true;
@@ -609,6 +669,7 @@ describe("legacy-plugin-surface", function () {
       var parent = elementNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         childNodeContext(parent),
       );
       legacy.copy();
@@ -620,6 +681,7 @@ describe("legacy-plugin-surface", function () {
     it("keeps shared off the value's own fields", function () {
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         openTextNodeContext(),
       );
       legacy.copy();
@@ -635,6 +697,7 @@ describe("legacy-plugin-surface", function () {
       var parent = elementNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         childNodeContext(parent),
       );
       legacy.pluginProps.mark = "self";
@@ -657,14 +720,21 @@ describe("legacy-plugin-surface", function () {
       });
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         nodeContext,
       );
       expect(legacy.breakBefore).toBe("column");
       expect(legacy.breakAfter).toBe("column");
-      vivliostyle_break.suppressColumnBreakBefore(nodeContext.viewNode);
-      vivliostyle_break.suppressColumnBreakAfter(nodeContext.viewNode);
+      vivliostyle_break.suppressColumnBreakBefore(
+        breakStore,
+        nodeContext.viewNode,
+      );
+      vivliostyle_break.suppressColumnBreakAfter(
+        breakStore,
+        nodeContext.viewNode,
+      );
       expect(legacy.breakBefore).toBe("column");
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(legacy.breakBefore).toBe(null);
       expect(legacy.breakAfter).toBe(null);
     });
@@ -679,11 +749,11 @@ describe("legacy-plugin-surface", function () {
         breakAfter: "column",
       });
       nodeContext.shadowSibling = sibling;
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(sibling.breakBefore).toBe("column");
-      vivliostyle_break.suppressColumnBreakBefore(sibling.viewNode);
-      vivliostyle_break.suppressColumnBreakAfter(sibling.viewNode);
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_break.suppressColumnBreakBefore(breakStore, sibling.viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(breakStore, sibling.viewNode);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(sibling.breakBefore).toBe(null);
       expect(sibling.breakAfter).toBe(null);
     });
@@ -693,22 +763,37 @@ describe("legacy-plugin-surface", function () {
         breakBefore: "column",
         breakAfter: "column",
       });
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
-      vivliostyle_break.suppressColumnBreakBefore(nodeContext.viewNode);
-      vivliostyle_break.suppressColumnBreakAfter(nodeContext.viewNode);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
+      vivliostyle_break.suppressColumnBreakBefore(
+        breakStore,
+        nodeContext.viewNode,
+      );
+      vivliostyle_break.suppressColumnBreakAfter(
+        breakStore,
+        nodeContext.viewNode,
+      );
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         nodeContext,
       );
       expect(legacy.breakBefore).toBe(null);
       expect(legacy.breakAfter).toBe(null);
-      vivliostyle_break.unsuppressColumnBreakBefore(nodeContext.viewNode);
-      vivliostyle_break.unsuppressColumnBreakAfter(nodeContext.viewNode);
-      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
-        "column",
+      vivliostyle_break.unsuppressColumnBreakBefore(
+        breakStore,
+        nodeContext.viewNode,
       );
-      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe("column");
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_break.unsuppressColumnBreakAfter(
+        breakStore,
+        nodeContext.viewNode,
+      );
+      expect(
+        vivliostyle_break.effectiveBreakBefore(breakStore, nodeContext),
+      ).toBe("column");
+      expect(
+        vivliostyle_break.effectiveBreakAfter(breakStore, nodeContext),
+      ).toBe("column");
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(legacy.breakBefore).toBe("column");
       expect(legacy.breakAfter).toBe("column");
     });
@@ -717,20 +802,25 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = elementNodeContext({ breakBefore: "column" });
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         nodeContext,
       );
-      vivliostyle_break.suppressColumnBreakBefore(nodeContext.viewNode);
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_break.suppressColumnBreakBefore(
+        breakStore,
+        nodeContext.viewNode,
+      );
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(legacy.breakBefore).toBe(null);
       legacy.breakBefore = "column";
       expect(legacy.breakBefore).toBe("column");
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(legacy.breakBefore).toBe(null);
     });
 
     it("restores every unstyled field on resetView", function () {
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         elementNodeContext(),
       );
       var written = {
@@ -765,7 +855,7 @@ describe("legacy-plugin-surface", function () {
         shadowSibling: sibling,
         blockContainer: container,
       };
-      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext);
       expect(typeof sibling.copy).toBe("function");
       expect(typeof container.copy).toBe("function");
     });
@@ -777,6 +867,7 @@ describe("legacy-plugin-surface", function () {
       expect(
         typeof vivliostyle_legacy.asLegacyNodeContext(
           "POST_LAYOUT_BLOCK",
+          stores,
           plain,
         ).copy,
       ).toBe("undefined");
@@ -784,6 +875,7 @@ describe("legacy-plugin-surface", function () {
       expect(
         typeof vivliostyle_legacy.asLegacyNodeContext(
           "POST_LAYOUT_BLOCK",
+          stores,
           decorated,
         ).copy,
       ).toBe("function");
@@ -806,6 +898,7 @@ describe("legacy-plugin-surface", function () {
     function retagged(viewNode, after) {
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
+        stores,
         openTextNodeContext(),
       );
       legacy.viewNode = viewNode;
@@ -834,7 +927,7 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = openTextNodeContext();
       expect(
         vivliostyle_legacy.normalizeLegacyNodeContext(
-          vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext),
+          vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext),
         ),
       ).toBe(nodeContext);
     });
@@ -954,6 +1047,7 @@ describe("legacy-plugin-surface", function () {
         var nodeContext = elementNodeContext();
         var legacy = vivliostyle_legacy.asLegacyNodeContextOrNull(
           hookName,
+          stores,
           nodeContext,
         );
         expect(legacy).toBe(nodeContext);
@@ -964,7 +1058,7 @@ describe("legacy-plugin-surface", function () {
 
       it("accepts a missing value", function () {
         expect(
-          vivliostyle_legacy.asLegacyNodeContextOrNull(hookName, null),
+          vivliostyle_legacy.asLegacyNodeContextOrNull(hookName, stores, null),
         ).toBe(null);
         expect(
           vivliostyle_legacy.retagLegacyNodeContext(hookName, null),
@@ -975,6 +1069,7 @@ describe("legacy-plugin-surface", function () {
         var checkPoints = [elementNodeContext(), elementNodeContext()];
         var legacy = vivliostyle_legacy.asLegacyRenderedNodeContexts(
           hookName,
+          stores,
           checkPoints,
         );
         expect(legacy).toBe(checkPoints);
@@ -1008,6 +1103,7 @@ describe("legacy-plugin-surface", function () {
     function renderContextOf(nodeContext, rendered) {
       return vivliostyle_legacy.asLegacyRenderContext(
         hookName,
+        stores,
         nodeContext,
         vivliostyle_node_context.elementRenderProgress(nodeContext, rendered),
         rendered,
@@ -1240,7 +1336,8 @@ describe("legacy-plugin-surface", function () {
         );
         expect(composed).not.toBe(nodeContext);
         expect(
-          vivliostyle_legacy.asLegacyNodeContext(hookName, composed).shared,
+          vivliostyle_legacy.asLegacyNodeContext(hookName, stores, composed)
+            .shared,
         ).toBe(true);
       });
 
@@ -1262,7 +1359,8 @@ describe("legacy-plugin-surface", function () {
           vivliostyle_legacy.withLegacyContextWrites(nodeContext, writes),
         ).toBe(nodeContext);
         expect(
-          vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext).shared,
+          vivliostyle_legacy.asLegacyNodeContext(hookName, stores, nodeContext)
+            .shared,
         ).toBe(true);
       });
 
@@ -1283,7 +1381,8 @@ describe("legacy-plugin-surface", function () {
           ),
         );
         expect(
-          vivliostyle_legacy.asLegacyNodeContext(hookName, composed).shared,
+          vivliostyle_legacy.asLegacyNodeContext(hookName, stores, composed)
+            .shared,
         ).toBe(false);
       });
 
@@ -1351,6 +1450,7 @@ describe("legacy-plugin-surface", function () {
         expect(
           vivliostyle_legacy.asLegacyRenderContext(
             hookName,
+            stores,
             nodeContext,
             progress,
             rendered,
@@ -1443,6 +1543,22 @@ describe("legacy-plugin-surface", function () {
       expect(column.calls[0][3]).toBe(checkPoints);
     });
 
+    it("reports suppression on a node context returned by the column", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = elementNodeContext({ breakBefore: "column" });
+      vivliostyle_break.suppressColumnBreakBefore(
+        breakStore,
+        nodeContext.viewNode,
+      );
+      column.skipEdges = function () {
+        return vivliostyle_task.newResult(nodeContext);
+      };
+      expect(view.skipEdges(nodeContext, true, null).get().breakBefore).toBe(
+        null,
+      );
+    });
+
     it("serves the column's layout context through its legacy view", function () {
       var column = stubColumn();
       var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
@@ -1528,6 +1644,25 @@ describe("legacy-plugin-surface", function () {
       expect(position.kind).toBe("element");
       vivliostyle_legacy.retagLegacyNodeContexts("POST_LAYOUT_BLOCK", []);
       expect(position.kind).toBe("after-element");
+    });
+
+    it("reports suppression on a break position", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var position = elementNodeContext({ breakBefore: "column" });
+      vivliostyle_break.suppressColumnBreakBefore(
+        breakStore,
+        position.viewNode,
+      );
+      column.breakPositions.push(
+        new vivliostyle_break_position.EdgeBreakPosition(
+          position,
+          null,
+          false,
+          0,
+        ),
+      );
+      expect(view.breakPositions[0].position.breakBefore).toBe(null);
     });
 
     it("serves the pseudo parent through its own legacy view", function () {
@@ -1765,10 +1900,12 @@ describe("legacy-plugin-surface", function () {
       vivliostyle_plugin.registerHook("POST_LAYOUT_BLOCK", externalHook);
       var nodeContext = vivliostyle_legacy.asLegacyNodeContext(
         "POST_LAYOUT_BLOCK",
+        stores,
         openTextNodeContext(),
       );
       var checkPoints = vivliostyle_legacy.asLegacyRenderedNodeContexts(
         "POST_LAYOUT_BLOCK",
+        stores,
         [elementNodeContext()],
       );
       vivliostyle_plugin.removeHook("POST_LAYOUT_BLOCK", externalHook);
@@ -2349,20 +2486,51 @@ describe("legacy-plugin-surface", function () {
 
     it("hands a breaker the core resolved back as itself", function () {
       expect(
-        vivliostyle_legacy.adaptLegacyTextNodeBreaker(coreHook, legacyBreaker),
+        vivliostyle_legacy.adaptLegacyTextNodeBreaker(
+          coreHook,
+          legacyBreaker,
+          stores,
+        ),
       ).toBe(legacyBreaker);
     });
 
-    it("serves one adapter per legacy implementation", function () {
+    it("serves one adapter per legacy implementation and context stores", function () {
       expect(
         vivliostyle_legacy.adaptLegacyTextNodeBreaker(
           externalHook,
           legacyBreaker,
+          stores,
         ),
       ).toBe(
         vivliostyle_legacy.adaptLegacyTextNodeBreaker(
           externalHook,
           legacyBreaker,
+          stores,
+        ),
+      );
+    });
+
+    it("keeps adapters for distinct context states apart", function () {
+      var otherContextState = {
+        breakSuppressionStore: {
+          breakSuppressionByViewNode: new WeakMap(),
+        },
+        continuationStore: {
+          continuationOfSlot: new WeakMap(),
+          slotOfContinuation: new WeakMap(),
+        },
+      };
+      expect(
+        vivliostyle_legacy.adaptLegacyTextNodeBreaker(
+          externalHook,
+          legacyBreaker,
+          stores,
+        ),
+      ).not.toBe(
+        vivliostyle_legacy.adaptLegacyTextNodeBreaker(
+          externalHook,
+          legacyBreaker,
+          otherContextState,
         ),
       );
     });
@@ -2371,7 +2539,7 @@ describe("legacy-plugin-surface", function () {
       var nodeContext = openTextNodeContext();
       var checkPoints = [elementNodeContext()];
       var result = vivliostyle_legacy
-        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
         .breakTextNode(textNode, nodeContext, 2, checkPoints, 0, true);
       expect(calls[0].nodeContext).toBe(nodeContext);
       expect(typeof calls[0].nodeContext.copy).toBe("function");
@@ -2386,17 +2554,29 @@ describe("legacy-plugin-surface", function () {
     it("reports the soft hyphen index the legacy breaker returned", function () {
       var nodeContext = openTextNodeContext();
       var result = vivliostyle_legacy
-        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
         .breakAfterSoftHyphen(textNode, "legacy", 4, nodeContext);
       expect(result).toBe(5);
       expect(typeof calls[0].nodeContext.copy).toBe("function");
+    });
+
+    it("reports suppression to the legacy breaker", function () {
+      var nodeContext = elementNodeContext({ breakBefore: "column" });
+      vivliostyle_break.suppressColumnBreakBefore(
+        breakStore,
+        nodeContext.viewNode,
+      );
+      vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
+        .breakAfterSoftHyphen(textNode, "legacy", 4, nodeContext);
+      expect(calls[0].nodeContext.breakBefore).toBe(null);
     });
 
     it("reports the index of a break after another character", function () {
       var nodeContext = openTextNodeContext();
       expect(
         vivliostyle_legacy
-          .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+          .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
           .breakAfterOtherCharacter(textNode, "legacy", 4, nodeContext),
       ).toBe(3);
       expect(typeof calls[0].nodeContext.copy).toBe("function");
@@ -2405,7 +2585,7 @@ describe("legacy-plugin-surface", function () {
     it("retags the value updateNodeContext hands back", function () {
       var nodeContext = openTextNodeContext();
       var result = vivliostyle_legacy
-        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
         .updateNodeContext(nodeContext, 2, textNode);
       expect(typeof calls[0].nodeContext.copy).toBe("function");
       expect(result).toBe(nodeContext);
@@ -2421,7 +2601,7 @@ describe("legacy-plugin-surface", function () {
         return ctx;
       };
       vivliostyle_legacy
-        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
         .breakTextNode(textNode, nodeContext, 2, checkPoints, 0, true);
       expect(checkPoints[0].kind).toBe("after-element");
     });
@@ -2438,7 +2618,7 @@ describe("legacy-plugin-surface", function () {
         return viewIndex;
       };
       var result = vivliostyle_legacy
-        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
         .breakAfterSoftHyphen(textNode, "legacy", 4, nodeContext);
       expect(result).toBe(4);
       expect(nodeContext.kind).toBe("text");
@@ -2456,7 +2636,7 @@ describe("legacy-plugin-surface", function () {
         return viewIndex;
       };
       vivliostyle_legacy
-        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
         .breakAfterOtherCharacter(textNode, "legacy", 4, nodeContext);
       expect(nodeContext.kind).toBe("after-none");
     });
@@ -2468,6 +2648,7 @@ describe("legacy-plugin-surface", function () {
       var adapted = vivliostyle_legacy.adaptLegacyTextNodeBreaker(
         externalHook,
         legacyBreaker,
+        stores,
       );
       column.resolveTextNodeBreaker = function () {
         return adapted;
@@ -2504,6 +2685,7 @@ describe("legacy-plugin-surface", function () {
         vivliostyle_legacy.adaptLegacyTextNodeBreaker(
           externalHook,
           breakerView,
+          stores,
         ),
       ).toBe(coreBreaker);
     });
@@ -2516,7 +2698,7 @@ describe("legacy-plugin-surface", function () {
         return replacement;
       };
       var result = vivliostyle_legacy
-        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker, stores)
         .updateNodeContext(nodeContext, 2, textNode);
       expect(result).toBe(replacement);
       expect(nodeContext.kind).toBe("text");
@@ -2633,29 +2815,57 @@ describe("legacy-plugin-surface", function () {
         vivliostyle_legacy.adaptLegacyLayoutProcessor(
           coreHook,
           legacyProcessor,
+          stores,
         ),
       ).toBe(legacyProcessor);
     });
 
-    it("serves one adapter per legacy processor", function () {
+    it("serves one adapter per legacy processor and context stores", function () {
       var adapted = vivliostyle_legacy.adaptLegacyLayoutProcessor(
         externalHook,
         legacyProcessor,
+        stores,
       );
       expect(adapted).not.toBe(legacyProcessor);
       expect(
         vivliostyle_legacy.adaptLegacyLayoutProcessor(
           externalHook,
           legacyProcessor,
+          stores,
         ),
       ).toBe(adapted);
+    });
+
+    it("keeps processor adapters for distinct context states apart", function () {
+      var otherContextState = {
+        breakSuppressionStore: {
+          breakSuppressionByViewNode: new WeakMap(),
+        },
+        continuationStore: {
+          continuationOfSlot: new WeakMap(),
+          slotOfContinuation: new WeakMap(),
+        },
+      };
+      expect(
+        vivliostyle_legacy.adaptLegacyLayoutProcessor(
+          externalHook,
+          legacyProcessor,
+          stores,
+        ),
+      ).not.toBe(
+        vivliostyle_legacy.adaptLegacyLayoutProcessor(
+          externalHook,
+          legacyProcessor,
+          otherContextState,
+        ),
+      );
     });
 
     it("hands layout the node context and the column as legacy views", function () {
       var nodeContext = openTextNodeContext();
       var column = stubColumn();
       var result = vivliostyle_legacy
-        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor, stores)
         .layout(nodeContext, column, true);
       expect(calls[0].nodeContext).toBe(nodeContext);
       expect(typeof calls[0].nodeContext.copy).toBe("function");
@@ -2665,11 +2875,24 @@ describe("legacy-plugin-surface", function () {
       expect(result.get().kind).toBe("after-none");
     });
 
+    it("reports suppression to the legacy processor", function () {
+      var nodeContext = elementNodeContext({ breakBefore: "column" });
+      var column = stubColumn();
+      vivliostyle_break.suppressColumnBreakBefore(
+        breakStore,
+        nodeContext.viewNode,
+      );
+      vivliostyle_legacy
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor, stores)
+        .startNonInlineElementNode(nodeContext);
+      expect(calls[0].nodeContext.breakBefore).toBe(null);
+    });
+
     it("wraps the break position the processor creates", function () {
       var position = openTextNodeContext();
       var column = stubColumn();
       var adapted = vivliostyle_legacy
-        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor, stores)
         .createEdgeBreakPosition(position, "column", true, 120);
       expect(adapted).not.toBe(breakPosition);
       expect(calls[0].nodeContext).toBe(position);
@@ -2705,7 +2928,7 @@ describe("legacy-plugin-surface", function () {
         return core;
       };
       var created = vivliostyle_legacy
-        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor, stores)
         .createEdgeBreakPosition(position, "column", true, 120);
       expect(created).not.toBe(core);
       column.breakPositions = [created];
@@ -2715,7 +2938,7 @@ describe("legacy-plugin-surface", function () {
     it("adapts a break position a legacy processor created only once", function () {
       var position = elementNodeContext();
       var adapted = vivliostyle_legacy
-        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor, stores)
         .createEdgeBreakPosition(position, "column", true, 120);
       expect(adapted).not.toBe(breakPosition);
       var column = stubColumn();
@@ -2733,6 +2956,7 @@ describe("legacy-plugin-surface", function () {
       var adapted = vivliostyle_legacy.adaptLegacyLayoutProcessor(
         externalHook,
         legacyProcessor,
+        stores,
       );
       expect(adapted.startNonInlineElementNode(nodeContext)).toBe(true);
       expect(adapted.afterNonInlineElementNode(nodeContext, true)).toBe(false);
@@ -2764,7 +2988,7 @@ describe("legacy-plugin-surface", function () {
         return vivliostyle_task.newResult(null);
       };
       var result = vivliostyle_legacy
-        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor, stores)
         .layout(nodeContext, column, true);
       expect(result.get()).toBe(null);
       expect(nodeContext.kind).toBe("after-none");
@@ -2798,6 +3022,7 @@ describe("legacy-plugin-surface", function () {
       var adapted = vivliostyle_legacy.adaptLegacyLayoutProcessor(
         externalHook,
         legacyProcessor,
+        stores,
       );
       adapted.createEdgeBreakPosition(position, "column", true, 120);
       expect(position.kind).toBe("after-none");
@@ -2968,6 +3193,7 @@ describe("legacy-plugin-surface", function () {
 
     function firstTimeOf(formattingContext, nodeContext, firstTime) {
       return vivliostyle_legacy.legacyFirstTime(
+        stores,
         formattingContext,
         nodeContext,
         vivliostyle_node_context.elementRenderResultOf(nodeContext),
@@ -2991,6 +3217,7 @@ describe("legacy-plugin-surface", function () {
         rendered.display = "block";
         var seen = [];
         var resolved = vivliostyle_legacy.legacyFirstTime(
+          stores,
           {
             isFirstTime: function (ctx, firstTime) {
               seen.push(ctx);
@@ -3012,6 +3239,7 @@ describe("legacy-plugin-surface", function () {
         var rendered =
           vivliostyle_node_context.elementRenderResultOf(nodeContext);
         var resolved = vivliostyle_legacy.legacyFirstTime(
+          stores,
           {
             isFirstTime: function (ctx, firstTime) {
               ctx.floatSide = "left";
@@ -3044,6 +3272,233 @@ describe("legacy-plugin-surface", function () {
         expect(resolved.nodeContext.kind).toBe("after-element");
         expect(nodeContext.kind).toBe("element");
       });
+    });
+
+    it("carries stores into a formatting context installed by an element style hook", function () {
+      var styleHook = function () {};
+      vivliostyle_plugin.registerHook("PREPROCESS_ELEMENT_STYLE", styleHook);
+      try {
+        var openedParent = elementNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(openedParent);
+        var legacy = vivliostyle_legacy.asLegacyRenderContext(
+          "PREPROCESS_ELEMENT_STYLE",
+          stores,
+          openedParent,
+          vivliostyle_node_context.elementRenderProgress(
+            openedParent,
+            rendered,
+          ),
+          rendered,
+        );
+        var before = vivliostyle_legacy.captureRenderFields(
+          "PREPROCESS_ELEMENT_STYLE",
+          legacy,
+        );
+        var seen;
+        var seenBreakPenalty;
+        var replacementSawCopy;
+        var replacement =
+          new vivliostyle_layout_processor.BlockFormattingContext(null);
+        replacement.isFirstTime = function (ctx, firstTime) {
+          replacementSawCopy = typeof ctx.copy;
+          return firstTime;
+        };
+        legacy.formattingContext = {
+          isFirstTime: function (ctx, firstTime) {
+            seen = ctx.toNodePosition().steps[0].shadowSibling.node;
+            seenBreakPenalty = ctx.breakPenalty;
+            ctx.breakPenalty = 11;
+            ctx.fragmentIndex = 7;
+            ctx.parent.formattingContext = replacement;
+            return firstTime;
+          },
+        };
+        vivliostyle_legacy.applyLegacyRenderWrites(
+          [styleHook],
+          before,
+          legacy,
+          rendered,
+        );
+        var parent = vivliostyle_node_context.renderedElement(
+          openedParent,
+          document.createElement("div"),
+          rendered,
+        );
+        var child = childNodeContext(parent);
+        var slot = openTextNodeContext();
+        var resumed = openTextNodeContext();
+        child.shadowSibling = slot;
+        vivliostyle_node_context.resumeContinuation(
+          continuationStore,
+          slot,
+          resumed,
+        );
+        var childRendered =
+          vivliostyle_node_context.elementRenderResultOf(child);
+        childRendered.breakPenalty = 5;
+        childRendered.formattingContext =
+          new vivliostyle_layout_processor.BlockFormattingContext(
+            parent.formattingContext,
+          );
+        var resolved = vivliostyle_legacy.legacyFirstTime(
+          stores,
+          parent.formattingContext,
+          child,
+          childRendered,
+          true,
+        );
+        expect(seen).toBe(resumed.sourceNode);
+        expect(seenBreakPenalty).toBe(5);
+        expect(childRendered.breakPenalty).toBe(11);
+        expect(resolved.nodeContext.fragmentIndex).toBe(7);
+        var sibling = vivliostyle_node_context.openChildOf(
+          document.createElement("span"),
+          parent,
+          2,
+        );
+        firstTimeOf(parent.formattingContext, sibling, true);
+        expect(replacementSawCopy).toBe("function");
+      } finally {
+        vivliostyle_plugin.removeHook("PREPROCESS_ELEMENT_STYLE", styleHook);
+      }
+    });
+
+    it("adapts a formatting context written through the parent", function () {
+      var styleHook = function () {};
+      vivliostyle_plugin.registerHook("PREPROCESS_ELEMENT_STYLE", styleHook);
+      try {
+        var parent = elementNodeContext();
+        var openedChild = vivliostyle_node_context.openChildOf(
+          document.createElement("span"),
+          parent,
+          1,
+        );
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(openedChild);
+        var legacy = vivliostyle_legacy.asLegacyRenderContext(
+          "PREPROCESS_ELEMENT_STYLE",
+          stores,
+          openedChild,
+          vivliostyle_node_context.elementRenderProgress(openedChild, rendered),
+          rendered,
+        );
+        var before = vivliostyle_legacy.captureRenderFields(
+          "PREPROCESS_ELEMENT_STYLE",
+          legacy,
+        );
+        var seenCopy;
+        var formattingContext =
+          new vivliostyle_layout_processor.BlockFormattingContext(null);
+        formattingContext.isFirstTime = function (ctx, firstTime) {
+          seenCopy = typeof ctx.copy;
+          ctx.fragmentIndex = 7;
+          return firstTime;
+        };
+        legacy.parent.formattingContext = formattingContext;
+        vivliostyle_legacy.applyLegacyRenderWrites(
+          [styleHook],
+          before,
+          legacy,
+          rendered,
+        );
+        var sibling = vivliostyle_node_context.openChildOf(
+          document.createElement("span"),
+          parent,
+          2,
+        );
+        var resolved = firstTimeOf(parent.formattingContext, sibling, true);
+        expect(seenCopy).toBe("function");
+        expect(resolved.nodeContext.fragmentIndex).toBe(7);
+      } finally {
+        vivliostyle_plugin.removeHook("PREPROCESS_ELEMENT_STYLE", styleHook);
+      }
+    });
+
+    it("adapts an isFirstTime replacement written through the parent", function () {
+      var styleHook = function () {};
+      vivliostyle_plugin.registerHook("PREPROCESS_ELEMENT_STYLE", styleHook);
+      try {
+        var parent = elementNodeContext();
+        var openedChild = vivliostyle_node_context.openChildOf(
+          document.createElement("span"),
+          parent,
+          1,
+        );
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(openedChild);
+        var legacy = vivliostyle_legacy.asLegacyRenderContext(
+          "PREPROCESS_ELEMENT_STYLE",
+          stores,
+          openedChild,
+          vivliostyle_node_context.elementRenderProgress(openedChild, rendered),
+          rendered,
+        );
+        var before = vivliostyle_legacy.captureRenderFields(
+          "PREPROCESS_ELEMENT_STYLE",
+          legacy,
+        );
+        var seenCopy;
+        legacy.parent.formattingContext.isFirstTime = function (
+          ctx,
+          firstTime,
+        ) {
+          seenCopy = typeof ctx.copy;
+          ctx.fragmentIndex = 7;
+          return firstTime;
+        };
+        vivliostyle_legacy.applyLegacyRenderWrites(
+          [styleHook],
+          before,
+          legacy,
+          rendered,
+        );
+        var sibling = vivliostyle_node_context.openChildOf(
+          document.createElement("span"),
+          parent,
+          2,
+        );
+        var resolved = firstTimeOf(parent.formattingContext, sibling, true);
+        expect(seenCopy).toBe("function");
+        expect(resolved.nodeContext.fragmentIndex).toBe(7);
+      } finally {
+        vivliostyle_plugin.removeHook("PREPROCESS_ELEMENT_STYLE", styleHook);
+      }
+    });
+
+    it("adapts a formatting context returned from a text preprocessing hook", function () {
+      var textHook = function () {};
+      vivliostyle_plugin.registerHook("PREPROCESS_TEXT_CONTENT", textHook);
+      try {
+        var parent = elementNodeContext();
+        var child = childNodeContext(parent);
+        var legacy = vivliostyle_legacy.asLegacyNodeContext(
+          "PREPROCESS_TEXT_CONTENT",
+          stores,
+          child,
+        );
+        var seenCopy;
+        var formattingContext =
+          new vivliostyle_layout_processor.BlockFormattingContext(null);
+        formattingContext.isFirstTime = function (ctx, firstTime) {
+          seenCopy = typeof ctx.copy;
+          return firstTime;
+        };
+        legacy.parent.formattingContext = formattingContext;
+        vivliostyle_legacy.retagLegacyNodeContext(
+          "PREPROCESS_TEXT_CONTENT",
+          legacy,
+        );
+        var sibling = vivliostyle_node_context.openChildOf(
+          document.createElement("span"),
+          parent,
+          2,
+        );
+        firstTimeOf(parent.formattingContext, sibling, true);
+        expect(seenCopy).toBe("function");
+      } finally {
+        vivliostyle_plugin.removeHook("PREPROCESS_TEXT_CONTENT", textHook);
+      }
     });
 
     it("hands the core value on while no external hook is registered", function () {

--- a/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
+++ b/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
@@ -69,6 +69,27 @@ describe("legacy-plugin-surface", function () {
     });
   });
 
+  describe("noteRetained", function () {
+    it("marks the value while no external hook is registered", function () {
+      var nodeContext = openTextNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        "PREPROCESS_TEXT_CONTENT",
+        nodeContext,
+      );
+      vivliostyle_legacy.noteRetained(nodeContext);
+      var external = function () {};
+      vivliostyle_plugin.registerHook("PREPROCESS_TEXT_CONTENT", external);
+      expect(
+        vivliostyle_legacy.asLegacyNodeContext(
+          "PREPROCESS_TEXT_CONTENT",
+          nodeContext,
+        ).shared,
+      ).toBe(true);
+      vivliostyle_plugin.removeHook("PREPROCESS_TEXT_CONTENT", external);
+      expect(legacy.sourceNode).toBe(nodeContext.sourceNode);
+    });
+  });
+
   describe("legacySurfaceActive", function () {
     it("is false while only the core has registered", function () {
       hookNames.forEach(function (name) {
@@ -121,7 +142,6 @@ describe("legacy-plugin-surface", function () {
         hookName,
         openTextNodeContext(),
       );
-      expect(legacy.shared).toBe(true);
       expect(legacy.copy()).toBe(legacy);
       expect(legacy.isInsideBFC()).toBe(false);
       expect(legacy.getContainingBlockForAbsolute()).toBe(null);
@@ -130,18 +150,49 @@ describe("legacy-plugin-surface", function () {
       expect(legacy.belongsTo(legacy.formattingContext)).toBe(false);
     });
 
-    it("modifies into a separate value carrying the same position", function () {
+    it("reports shared from the core's retention of the value", function () {
+      var nodeContext = openTextNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        nodeContext,
+      );
+      expect(legacy.shared).toBe(false);
+      expect(vivliostyle_legacy.noteRetained(nodeContext)).toBeUndefined();
+      expect(legacy.shared).toBe(true);
+    });
+
+    it("marks the value on copy, as the class did", function () {
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
         hookName,
         openTextNodeContext(),
       );
+      expect(legacy.shared).toBe(false);
+      expect(legacy.copy()).toBe(legacy);
+      expect(legacy.shared).toBe(true);
+    });
+
+    it("modifies in place while the core does not keep the value", function () {
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        openTextNodeContext(),
+      );
+      expect(legacy.modify()).toBe(legacy);
+    });
+
+    it("modifies into a separate value once the core keeps it", function () {
+      var nodeContext = openTextNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        nodeContext,
+      );
+      vivliostyle_legacy.noteRetained(nodeContext);
       legacy.display = "block";
       var modified = legacy.modify();
       expect(modified).not.toBe(legacy);
       expect(modified.sourceNode).toBe(legacy.sourceNode);
       expect(modified.boxOffset).toBe(legacy.boxOffset);
       expect(modified.display).toBe("block");
-      expect(modified.shared).toBe(true);
+      expect(modified.shared).toBe(false);
       modified.display = "inline";
       expect(legacy.display).toBe("block");
     });

--- a/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
+++ b/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
@@ -68,6 +68,44 @@ describe("legacy-plugin-surface", function () {
       expect(vivliostyle_plugin.isCoreHook(registered[1])).toBe(true);
       vivliostyle_plugin.removeHook(name, external);
     });
+
+    it("adapts the results of a processor hook registered at the first", function () {
+      var external = function () {};
+      var name = "RESOLVE_LAYOUT_PROCESSOR";
+      vivliostyle_plugin.registerHook(name, external, true);
+      var registered = vivliostyle_plugin.getHooksForName(name);
+      var legacyProcessor = {};
+      var formattingContext = { isFirstTime: function () {} };
+      expect(
+        vivliostyle_legacy.adaptLegacyLayoutProcessor(
+          registered[0],
+          legacyProcessor,
+        ),
+      ).not.toBe(legacyProcessor);
+      expect(
+        vivliostyle_legacy.adaptLegacyLayoutProcessor(
+          registered[1],
+          legacyProcessor,
+        ),
+      ).toBe(legacyProcessor);
+      vivliostyle_plugin.removeHook(name, external);
+      vivliostyle_plugin.registerHook(
+        "RESOLVE_FORMATTING_CONTEXT",
+        external,
+        true,
+      );
+      var formattingHooks = vivliostyle_plugin.getHooksForName(
+        "RESOLVE_FORMATTING_CONTEXT",
+      );
+      vivliostyle_legacy.adaptLegacyFormattingContext(
+        formattingHooks[0],
+        formattingContext,
+      );
+      expect(
+        Object.prototype.hasOwnProperty.call(formattingContext, "isFirstTime"),
+      ).toBe(true);
+      vivliostyle_plugin.removeHook("RESOLVE_FORMATTING_CONTEXT", external);
+    });
   });
 
   describe("noteRetained", function () {

--- a/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
+++ b/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
@@ -31,6 +31,7 @@ describe("legacy-plugin-surface", function () {
     "PREPROCESS_ELEMENT_STYLE",
     "RESOLVE_FORMATTING_CONTEXT",
     "RESOLVE_TEXT_NODE_BREAKER",
+    "RESOLVE_LAYOUT_PROCESSOR",
     "POST_LAYOUT_BLOCK",
   ];
 

--- a/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
+++ b/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
@@ -19,7 +19,11 @@ import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
 import * as vivliostyle_legacy from "../../../src/vivliostyle/legacy-plugin-surface";
 import * as vivliostyle_node_context from "../../../src/vivliostyle/node-context";
 import * as vivliostyle_layout_processor from "../../../src/vivliostyle/layout-processor";
+import * as vivliostyle_layout from "../../../src/vivliostyle/layout";
+import * as vivliostyle_break_position from "../../../src/vivliostyle/break-position";
 import * as vivliostyle_vtree from "../../../src/vivliostyle/vtree";
+import * as vivliostyle_break from "../../../src/vivliostyle/break";
+import * as vivliostyle_task from "../../../src/vivliostyle/task";
 
 import "../../../src/vivliostyle";
 
@@ -49,6 +53,280 @@ describe("legacy-plugin-surface", function () {
     );
   }
 
+  function elementNodeContext(overrides) {
+    var opened = vivliostyle_node_context.openAt(
+      document.createElement("div"),
+      null,
+      0,
+      new vivliostyle_layout_processor.BlockFormattingContext(null),
+      {
+        shadowType: vivliostyle_vtree.ShadowType.NONE,
+        shadowContext: null,
+      },
+      { offsetInNode: 0, after: false },
+    );
+    var rendered = vivliostyle_node_context.elementRenderResultOf(opened);
+    Object.keys(overrides || {}).forEach(function (field) {
+      rendered[field] = overrides[field];
+    });
+    return vivliostyle_node_context.renderedElement(
+      opened,
+      document.createElement("div"),
+      rendered,
+    );
+  }
+
+  function childNodeContext(parent) {
+    return vivliostyle_node_context.openChildOf(
+      document.createTextNode("child"),
+      parent,
+      1,
+    );
+  }
+
+  function stubLayoutContext() {
+    var layoutContext = {
+      calls: [],
+      cloned: null,
+      rendered: null,
+      setCurrent: function (nodeContext, firstTime, atUnforcedBreak) {
+        layoutContext.calls.push([
+          "setCurrent",
+          nodeContext,
+          firstTime,
+          atUnforcedBreak,
+        ]);
+        return vivliostyle_task.newResult({
+          nodeContext: layoutContext.rendered || Object.assign({}, nodeContext),
+          processChildren: firstTime,
+        });
+      },
+      clone: function () {
+        return layoutContext.cloned;
+      },
+      applyPseudoelementStyle: function (nodeContext, pseudoName, target) {
+        layoutContext.calls.push([
+          "applyPseudoelementStyle",
+          nodeContext,
+          pseudoName,
+          target,
+        ]);
+      },
+      next: null,
+      nextInTree: function (nodeContext, atUnforcedBreak) {
+        layoutContext.calls.push(["nextInTree", nodeContext, atUnforcedBreak]);
+        return vivliostyle_task.newResult(layoutContext.next);
+      },
+      peelOff: function (nodeContext, nodeOffset) {
+        layoutContext.calls.push(["peelOff", nodeContext, nodeOffset]);
+        return vivliostyle_task.newResult(nodeContext);
+      },
+    };
+    return layoutContext;
+  }
+
+  function stubBreakPosition() {
+    return {
+      findAcceptableBreak: function () {
+        return null;
+      },
+      getMinBreakPenalty: function () {
+        return 0;
+      },
+      calculateOffset: function () {
+        return { current: 0, minimum: 0 };
+      },
+      breakPositionChosen: function () {},
+    };
+  }
+
+  function coreClassBreakPosition() {
+    var breakPosition = Object.create(
+      vivliostyle_break_position.AbstractBreakPosition.prototype,
+    );
+    breakPosition.findAcceptableBreak = function () {
+      return null;
+    };
+    breakPosition.getMinBreakPenalty = function () {
+      return 4;
+    };
+    return breakPosition;
+  }
+
+  function stubColumn() {
+    var column = {
+      calls: [],
+      overflown: true,
+      clearance: document.createElement("div"),
+      layoutContext: stubLayoutContext(),
+      checkOverflowAndSaveEdge: function (nodeContext, trailingEdgeContexts) {
+        column.calls.push([
+          "checkOverflowAndSaveEdge",
+          nodeContext,
+          trailingEdgeContexts,
+        ]);
+        return {
+          overflown: column.overflown,
+          recordedRepetitiveOverflow: false,
+        };
+      },
+      applyClearance: function (nodeContext) {
+        column.calls.push(["applyClearance", nodeContext]);
+        return column.clearance;
+      },
+      processLineStyling: function (nodeContext, resNodeContext, checkPoints) {
+        column.calls.push([
+          "processLineStyling",
+          nodeContext,
+          resNodeContext,
+          checkPoints,
+        ]);
+        return vivliostyle_task.newResult({
+          nodeContext: resNodeContext,
+          checkPoints: checkPoints,
+        });
+      },
+      isOverflown: function (edge) {
+        return edge > 0;
+      },
+      nodeContextOverflowingDueToRepetitiveElements: null,
+      pseudoParent: null,
+      breakPositions: [],
+      nextBlockEdge: null,
+      acceptableBreak: null,
+      asFloatNodeContext: function (nodeContext) {
+        column.calls.push(["asFloatNodeContext", nodeContext]);
+        return nodeContext;
+      },
+      buildViewToNextBlockEdge: function (position, checkPoints) {
+        column.calls.push(["buildViewToNextBlockEdge", position, checkPoints]);
+        return vivliostyle_task.newResult(column.nextBlockEdge);
+      },
+      layoutNext: function (nodeContext, leadingEdge, forcedBreakValue) {
+        column.calls.push([
+          "layoutNext",
+          nodeContext,
+          leadingEdge,
+          forcedBreakValue,
+        ]);
+        return vivliostyle_task.newResult(nodeContext);
+      },
+      doLayout: function (nodeContext, leadingEdge, breakAfter) {
+        column.calls.push(["doLayout", nodeContext, leadingEdge, breakAfter]);
+        return vivliostyle_task.newResult({
+          nodeContext: nodeContext,
+          overflownNodeContext: nodeContext,
+        });
+      },
+      findEndOfLine: function (linePosition, checkPoints) {
+        column.calls.push(["findEndOfLine", linePosition, checkPoints]);
+        return { nodeContext: checkPoints[0], index: 1, checkPointIndex: 0 };
+      },
+      findFirstOverflowingEdgeAndCheckPoint: function (checkPoints) {
+        column.calls.push([
+          "findFirstOverflowingEdgeAndCheckPoint",
+          checkPoints,
+        ]);
+        return { edge: 3, checkPoint: checkPoints[0] };
+      },
+      findAcceptableBreakPosition: function () {
+        column.calls.push(["findAcceptableBreakPosition"]);
+        return column.acceptableBreak;
+      },
+    };
+    return column;
+  }
+
+  var columnStubScaffolding = [
+    "calls",
+    "clearance",
+    "nextBlockEdge",
+    "acceptableBreak",
+  ];
+
+  function constructedColumn() {
+    var stop = {};
+    var captured = null;
+    var element = document.createElement("div");
+    document.body.appendChild(element);
+    try {
+      new vivliostyle_layout.Column(
+        element,
+        stubLayoutContext(),
+        {
+          getElementClientRect: function () {
+            throw stop;
+          },
+        },
+        {
+          allowLayout: function () {
+            return true;
+          },
+        },
+        {
+          withContainer: function (column) {
+            captured = column;
+            return null;
+          },
+        },
+        {},
+        null,
+        [],
+        new vivliostyle_layout_processor.BlockFormattingContext(null),
+      );
+    } catch (e) {
+      if (e !== stop) {
+        throw e;
+      }
+    }
+    element.parentNode.removeChild(element);
+    return captured;
+  }
+
+  function realColumnMembers() {
+    var members = Object.create(null);
+    var instance = constructedColumn();
+    Object.keys(instance).forEach(function (name) {
+      members[name] = true;
+    });
+    for (
+      var proto = Object.getPrototypeOf(instance);
+      proto && proto !== Object.prototype;
+      proto = Object.getPrototypeOf(proto)
+    ) {
+      Object.getOwnPropertyNames(proto).forEach(function (name) {
+        members[name] = true;
+      });
+    }
+    return members;
+  }
+
+  describe("the column stub", function () {
+    it("stands in for a column the core can build", function () {
+      expect(constructedColumn()).not.toBe(null);
+    });
+
+    it("declares only members the real column carries", function () {
+      var members = realColumnMembers();
+      expect(
+        Object.keys(stubColumn()).filter(function (name) {
+          return (
+            columnStubScaffolding.indexOf(name) < 0 && members[name] !== true
+          );
+        }),
+      ).toEqual([]);
+    });
+
+    it("keeps its scaffolding clear of the real column's members", function () {
+      var members = realColumnMembers();
+      expect(
+        columnStubScaffolding.filter(function (name) {
+          return members[name] === true;
+        }),
+      ).toEqual([]);
+    });
+  });
+
   describe("isCoreHook", function () {
     it("identifies every hook the core registered", function () {
       Object.keys(vivliostyle_plugin.HOOKS).forEach(function (name) {
@@ -66,6 +344,21 @@ describe("legacy-plugin-surface", function () {
       expect(registered[0]).toBe(external);
       expect(vivliostyle_plugin.isCoreHook(registered[0])).toBe(false);
       expect(vivliostyle_plugin.isCoreHook(registered[1])).toBe(true);
+      vivliostyle_plugin.removeHook(name, external);
+    });
+
+    it("serves the projected column to a hook registered at the first", function () {
+      var external = function () {};
+      var name = "POST_LAYOUT_BLOCK";
+      vivliostyle_plugin.registerHook(name, external, true);
+      var registered = vivliostyle_plugin.getHooksForName(name);
+      var column = stubColumn();
+      expect(vivliostyle_legacy.asLegacyColumn(registered[0], column)).not.toBe(
+        column,
+      );
+      expect(vivliostyle_legacy.asLegacyColumn(registered[1], column)).toBe(
+        column,
+      );
       vivliostyle_plugin.removeHook(name, external);
     });
 
@@ -189,6 +482,34 @@ describe("legacy-plugin-surface", function () {
       expect(legacy.belongsTo(legacy.formattingContext)).toBe(false);
     });
 
+    it("decorates a shadow sibling a decorated value gains later", function () {
+      var nodeContext = openTextNodeContext();
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      var sibling = openTextNodeContext();
+      nodeContext.shadowSibling = sibling;
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(typeof sibling.copy).toBe("function");
+    });
+
+    it("decorates a block container a decorated value gains later", function () {
+      var nodeContext = openTextNodeContext();
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      var container = elementNodeContext();
+      nodeContext.blockContainer = container;
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(typeof container.copy).toBe("function");
+    });
+
+    it("decorates a shadow sibling cycle without running away", function () {
+      var first = openTextNodeContext();
+      var second = openTextNodeContext();
+      first.shadowSibling = second;
+      second.shadowSibling = first;
+      vivliostyle_legacy.asLegacyNodeContext(hookName, first);
+      expect(typeof first.copy).toBe("function");
+      expect(typeof second.copy).toBe("function");
+    });
+
     it("reports shared from the core's retention of the value", function () {
       var nodeContext = openTextNodeContext();
       var legacy = vivliostyle_legacy.asLegacyNodeContext(
@@ -259,6 +580,2517 @@ describe("legacy-plugin-surface", function () {
       expect(nodeContext.viewNode).toBe(null);
       expect(nodeContext.fragmentIndex).toBe(1);
       expect(nodeContext.kind).toBe("open");
+    });
+
+    it("marks the ancestors on copy, as the class did", function () {
+      var parent = elementNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        childNodeContext(parent),
+      );
+      expect(legacy.parent.shared).toBe(false);
+      legacy.copy();
+      expect(legacy.shared).toBe(true);
+      expect(legacy.parent.shared).toBe(true);
+    });
+
+    it("assigns shared to the value alone", function () {
+      var parent = elementNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        childNodeContext(parent),
+      );
+      legacy.shared = true;
+      expect(legacy.shared).toBe(true);
+      expect(legacy.parent.shared).toBe(false);
+    });
+
+    it("clears shared on the value alone", function () {
+      var parent = elementNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        childNodeContext(parent),
+      );
+      legacy.copy();
+      legacy.shared = false;
+      expect(legacy.shared).toBe(false);
+      expect(legacy.parent.shared).toBe(true);
+    });
+
+    it("keeps shared off the value's own fields", function () {
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        openTextNodeContext(),
+      );
+      legacy.copy();
+      var spread = { ...legacy };
+      expect(Object.keys(legacy).indexOf("shared")).toBe(-1);
+      expect(Object.prototype.hasOwnProperty.call(spread, "shared")).toBe(
+        false,
+      );
+      expect(spread.shared).toBeUndefined();
+    });
+
+    it("gives each cloned chain item its own plugin properties", function () {
+      var parent = elementNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        childNodeContext(parent),
+      );
+      legacy.pluginProps.mark = "self";
+      legacy.parent.pluginProps.mark = "parent";
+      var cloned = legacy.clone();
+      expect(cloned).not.toBe(legacy);
+      expect(cloned.pluginProps).not.toBe(legacy.pluginProps);
+      expect(cloned.parent).not.toBe(legacy.parent);
+      expect(cloned.parent.pluginProps).not.toBe(legacy.parent.pluginProps);
+      cloned.pluginProps.mark = "clone";
+      cloned.parent.pluginProps.mark = "clone";
+      expect(legacy.pluginProps.mark).toBe("self");
+      expect(legacy.parent.pluginProps.mark).toBe("parent");
+    });
+
+    it("refreshes the break fields at every boundary", function () {
+      var nodeContext = elementNodeContext({
+        breakBefore: "column",
+        breakAfter: "column",
+      });
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        nodeContext,
+      );
+      expect(legacy.breakBefore).toBe("column");
+      expect(legacy.breakAfter).toBe("column");
+      vivliostyle_break.suppressColumnBreakBefore(nodeContext.viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(nodeContext.viewNode);
+      expect(legacy.breakBefore).toBe("column");
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(legacy.breakBefore).toBe(null);
+      expect(legacy.breakAfter).toBe(null);
+    });
+
+    it("refreshes the break fields of a shadow sibling at every boundary", function () {
+      var nodeContext = elementNodeContext({
+        breakBefore: "column",
+        breakAfter: "column",
+      });
+      var sibling = elementNodeContext({
+        breakBefore: "column",
+        breakAfter: "column",
+      });
+      nodeContext.shadowSibling = sibling;
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(sibling.breakBefore).toBe("column");
+      vivliostyle_break.suppressColumnBreakBefore(sibling.viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(sibling.viewNode);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(sibling.breakBefore).toBe(null);
+      expect(sibling.breakAfter).toBe(null);
+    });
+
+    it("lifts the suppression a boundary wrote onto the break fields", function () {
+      var nodeContext = elementNodeContext({
+        breakBefore: "column",
+        breakAfter: "column",
+      });
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      vivliostyle_break.suppressColumnBreakBefore(nodeContext.viewNode);
+      vivliostyle_break.suppressColumnBreakAfter(nodeContext.viewNode);
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        nodeContext,
+      );
+      expect(legacy.breakBefore).toBe(null);
+      expect(legacy.breakAfter).toBe(null);
+      vivliostyle_break.unsuppressColumnBreakBefore(nodeContext.viewNode);
+      vivliostyle_break.unsuppressColumnBreakAfter(nodeContext.viewNode);
+      expect(vivliostyle_break.effectiveBreakBefore(nodeContext)).toBe(
+        "column",
+      );
+      expect(vivliostyle_break.effectiveBreakAfter(nodeContext)).toBe("column");
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(legacy.breakBefore).toBe("column");
+      expect(legacy.breakAfter).toBe("column");
+    });
+
+    it("suppresses again a break field a hook wrote back", function () {
+      var nodeContext = elementNodeContext({ breakBefore: "column" });
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        nodeContext,
+      );
+      vivliostyle_break.suppressColumnBreakBefore(nodeContext.viewNode);
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(legacy.breakBefore).toBe(null);
+      legacy.breakBefore = "column";
+      expect(legacy.breakBefore).toBe("column");
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(legacy.breakBefore).toBe(null);
+    });
+
+    it("restores every unstyled field on resetView", function () {
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        elementNodeContext(),
+      );
+      var written = {
+        floatReference: "page",
+        clearSide: "left",
+        floatMinWrapBlock: {},
+        columnSpan: {},
+        flexContainer: true,
+        containingBlockForAbsolute: true,
+        breakAfter: "page",
+        repeatOnBreak: "header",
+        afterIfContinues: {},
+        footnotePolicy: {},
+      };
+      var initial = {};
+      Object.keys(written).forEach(function (field) {
+        initial[field] = legacy[field];
+        legacy[field] = written[field];
+        expect(legacy[field]).toBe(written[field]);
+      });
+      legacy.resetView();
+      Object.keys(written).forEach(function (field) {
+        expect(legacy[field]).toBe(initial[field]);
+      });
+    });
+
+    it("decorates the shadow sibling and the block container", function () {
+      var sibling = elementNodeContext();
+      var container = elementNodeContext();
+      var nodeContext = {
+        ...elementNodeContext(),
+        shadowSibling: sibling,
+        blockContainer: container,
+      };
+      vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext);
+      expect(typeof sibling.copy).toBe("function");
+      expect(typeof container.copy).toBe("function");
+    });
+
+    it("decorates the value while the external hook sits first", function () {
+      var atFirst = function () {};
+      var plain = elementNodeContext();
+      var decorated = elementNodeContext();
+      expect(
+        typeof vivliostyle_legacy.asLegacyNodeContext(
+          "POST_LAYOUT_BLOCK",
+          plain,
+        ).copy,
+      ).toBe("undefined");
+      vivliostyle_plugin.registerHook("POST_LAYOUT_BLOCK", atFirst, true);
+      expect(
+        typeof vivliostyle_legacy.asLegacyNodeContext(
+          "POST_LAYOUT_BLOCK",
+          decorated,
+        ).copy,
+      ).toBe("function");
+      vivliostyle_plugin.removeHook("POST_LAYOUT_BLOCK", atFirst);
+    });
+  });
+
+  describe("normalizeLegacyNodeContext", function () {
+    var hookName = "PREPROCESS_TEXT_CONTENT";
+    var external = function () {};
+
+    beforeEach(function () {
+      vivliostyle_plugin.registerHook(hookName, external);
+    });
+
+    afterEach(function () {
+      vivliostyle_plugin.removeHook(hookName, external);
+    });
+
+    function retagged(viewNode, after) {
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        openTextNodeContext(),
+      );
+      legacy.viewNode = viewNode;
+      legacy.after = after;
+      return vivliostyle_legacy.normalizeLegacyNodeContext(legacy);
+    }
+
+    it("tags a viewless position from its after flag", function () {
+      expect(retagged(null, false).kind).toBe("open");
+      expect(retagged(null, true).kind).toBe("after-none");
+    });
+
+    it("tags an element position from its view node", function () {
+      var element = document.createElement("div");
+      expect(retagged(element, false).kind).toBe("element");
+      expect(retagged(element, true).kind).toBe("after-element");
+    });
+
+    it("tags a text position from its view node", function () {
+      var text = document.createTextNode("legacy");
+      expect(retagged(text, false).kind).toBe("text");
+      expect(retagged(text, true).kind).toBe("after-text");
+    });
+
+    it("hands the value itself back to the core", function () {
+      var nodeContext = openTextNodeContext();
+      expect(
+        vivliostyle_legacy.normalizeLegacyNodeContext(
+          vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext),
+        ),
+      ).toBe(nodeContext);
+    });
+
+    it("passes a missing value through", function () {
+      expect(vivliostyle_legacy.normalizeLegacyNodeContext(null)).toBe(null);
+      expect(vivliostyle_legacy.normalizeLegacyNodeContext(undefined)).toBe(
+        null,
+      );
+    });
+  });
+
+  describe("the element narrowing", function () {
+    it("narrows a value whose view node is an element", function () {
+      var nodeContext = elementNodeContext();
+      expect(vivliostyle_vtree.asElementNodeContext(nodeContext)).toBe(
+        nodeContext,
+      );
+      expect(vivliostyle_vtree.asRenderedNodeContext(nodeContext)).toBe(
+        nodeContext,
+      );
+    });
+
+    it("rejects an element kind a plugin left without a view node", function () {
+      var nodeContext = elementNodeContext();
+      nodeContext.viewNode = null;
+      expect(nodeContext.kind).toBe("element");
+      expect(vivliostyle_vtree.asElementNodeContext(nodeContext)).toBe(null);
+      expect(vivliostyle_vtree.asRenderedNodeContext(nodeContext)).toBe(null);
+    });
+
+    it("rejects an element kind a plugin pointed at a text node", function () {
+      var nodeContext = elementNodeContext();
+      nodeContext.viewNode = document.createTextNode("legacy");
+      nodeContext.after = true;
+      expect(nodeContext.kind).toBe("element");
+      expect(vivliostyle_vtree.asElementNodeContext(nodeContext)).toBe(null);
+    });
+
+    it("rejects a text kind a plugin pointed at another node", function () {
+      var opened = childNodeContext(elementNodeContext());
+      var nodeContext = vivliostyle_node_context.renderedText(
+        opened,
+        document.createTextNode("legacy"),
+        [],
+      );
+      expect(vivliostyle_vtree.asTextNodeContext(nodeContext)).toBe(
+        nodeContext,
+      );
+      nodeContext.viewNode = document.createComment("legacy");
+      expect(nodeContext.kind).toBe("text");
+      expect(vivliostyle_vtree.asTextNodeContext(nodeContext)).toBe(null);
+      expect(vivliostyle_vtree.asRenderedNodeContext(nodeContext)).toBe(null);
+    });
+
+    it("narrows again once the hook boundary retagged the value", function () {
+      var hookName = "POST_LAYOUT_BLOCK";
+      var external = function () {};
+      var opened = childNodeContext(elementNodeContext());
+      var nodeContext = vivliostyle_node_context.renderedElement(
+        opened,
+        document.createElement("span"),
+        vivliostyle_node_context.elementRenderResultOf(opened),
+      );
+      nodeContext.viewNode = document.createTextNode("legacy");
+      vivliostyle_plugin.registerHook(hookName, external);
+      try {
+        vivliostyle_legacy.retagLegacyNodeContext(hookName, nodeContext);
+      } finally {
+        vivliostyle_plugin.removeHook(hookName, external);
+      }
+      expect(nodeContext.kind).toBe("text");
+      expect(vivliostyle_vtree.asElementNodeContext(nodeContext)).toBe(null);
+      expect(vivliostyle_vtree.asTextNodeContext(nodeContext)).toBe(
+        nodeContext,
+      );
+    });
+
+    it("carries the guard into the narrowings built on it", function () {
+      var floatContext = elementNodeContext({ floatSide: "left" });
+      var clearContext = elementNodeContext({ clearSide: "left" });
+      var continuesContext = elementNodeContext({ afterIfContinues: {} });
+      expect(vivliostyle_vtree.asFloatNodeContext(floatContext)).toBe(
+        floatContext,
+      );
+      expect(vivliostyle_vtree.asClearNodeContext(clearContext)).toBe(
+        clearContext,
+      );
+      expect(
+        vivliostyle_vtree.asAfterIfContinuesNodeContext(continuesContext),
+      ).toBe(continuesContext);
+      floatContext.viewNode = null;
+      clearContext.viewNode = null;
+      continuesContext.viewNode = null;
+      expect(vivliostyle_vtree.asFloatNodeContext(floatContext)).toBe(null);
+      expect(vivliostyle_vtree.asClearNodeContext(clearContext)).toBe(null);
+      expect(
+        vivliostyle_vtree.asAfterIfContinuesNodeContext(continuesContext),
+      ).toBe(null);
+    });
+  });
+
+  describe("retagLegacyNodeContext", function () {
+    var hookName = "POST_LAYOUT_BLOCK";
+    var external = function () {};
+
+    describe("while an external hook is registered", function () {
+      beforeEach(function () {
+        vivliostyle_plugin.registerHook(hookName, external);
+      });
+
+      afterEach(function () {
+        vivliostyle_plugin.removeHook(hookName, external);
+      });
+
+      it("retags the value a hook moved to its after edge", function () {
+        var nodeContext = elementNodeContext();
+        var legacy = vivliostyle_legacy.asLegacyNodeContextOrNull(
+          hookName,
+          nodeContext,
+        );
+        expect(legacy).toBe(nodeContext);
+        legacy.after = true;
+        vivliostyle_legacy.retagLegacyNodeContext(hookName, nodeContext);
+        expect(nodeContext.kind).toBe("after-element");
+      });
+
+      it("accepts a missing value", function () {
+        expect(
+          vivliostyle_legacy.asLegacyNodeContextOrNull(hookName, null),
+        ).toBe(null);
+        expect(
+          vivliostyle_legacy.retagLegacyNodeContext(hookName, null),
+        ).toBeUndefined();
+      });
+
+      it("retags the checkpoints a hook rewrote", function () {
+        var checkPoints = [elementNodeContext(), elementNodeContext()];
+        var legacy = vivliostyle_legacy.asLegacyRenderedNodeContexts(
+          hookName,
+          checkPoints,
+        );
+        expect(legacy).toBe(checkPoints);
+        expect(typeof legacy[0].copy).toBe("function");
+        legacy[0].viewNode = document.createTextNode("legacy");
+        legacy[1].after = true;
+        vivliostyle_legacy.retagLegacyNodeContexts(hookName, checkPoints);
+        expect(checkPoints[0].kind).toBe("text");
+        expect(checkPoints[1].kind).toBe("after-element");
+      });
+    });
+
+    describe("while only the core has registered", function () {
+      it("leaves the discriminant of the value alone", function () {
+        var nodeContext = elementNodeContext();
+        var checkPoints = [elementNodeContext()];
+        nodeContext.after = true;
+        checkPoints[0].after = true;
+        vivliostyle_legacy.retagLegacyNodeContext(hookName, nodeContext);
+        vivliostyle_legacy.retagLegacyNodeContexts(hookName, checkPoints);
+        expect(nodeContext.kind).toBe("element");
+        expect(checkPoints[0].kind).toBe("element");
+      });
+    });
+  });
+
+  describe("asLegacyRenderContext", function () {
+    var hookName = "PREPROCESS_ELEMENT_STYLE";
+    var external = function () {};
+
+    function renderContextOf(nodeContext, rendered) {
+      return vivliostyle_legacy.asLegacyRenderContext(
+        hookName,
+        nodeContext,
+        vivliostyle_node_context.elementRenderProgress(nodeContext, rendered),
+        rendered,
+      );
+    }
+
+    describe("while an external hook is registered", function () {
+      beforeEach(function () {
+        vivliostyle_plugin.registerHook(hookName, external);
+      });
+
+      afterEach(function () {
+        vivliostyle_plugin.removeHook(hookName, external);
+      });
+
+      it("hands out the rendered style the core has drafted", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        rendered.display = "block";
+        var legacy = renderContextOf(nodeContext, rendered);
+        expect(legacy).not.toBe(nodeContext);
+        expect(legacy.display).toBe("block");
+        expect(legacy.sourceNode).toBe(nodeContext.sourceNode);
+        expect(nodeContext.display).toBe(null);
+      });
+
+      it("keeps the core's retention of the value on the overlay", function () {
+        var nodeContext = openTextNodeContext();
+        vivliostyle_legacy.noteRetained(nodeContext);
+        var legacy = renderContextOf(
+          nodeContext,
+          vivliostyle_node_context.elementRenderResultOf(nodeContext),
+        );
+        expect(legacy.shared).toBe(true);
+      });
+
+      it("carries only the fields a hook wrote into the draft", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        rendered.display = "flex";
+        legacy.floatSide = "left";
+        vivliostyle_legacy.applyLegacyRenderWrites(
+          [external],
+          before,
+          legacy,
+          rendered,
+        );
+        expect(rendered.floatSide).toBe("left");
+        expect(rendered.display).toBe("flex");
+        expect(nodeContext.floatSide).toBe(null);
+        expect(nodeContext.display).toBe(null);
+      });
+
+      it("adapts a formatting context a hook assigned to the field", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        var seen = [];
+        var assigned = {
+          isFirstTime: function (ctx, firstTime) {
+            seen.push(ctx);
+            return firstTime;
+          },
+        };
+        legacy.formattingContext = assigned;
+        vivliostyle_legacy.applyLegacyRenderWrites(
+          [external],
+          before,
+          legacy,
+          rendered,
+        );
+        expect(rendered.formattingContext).toBe(assigned);
+        var walked = openTextNodeContext();
+        expect(rendered.formattingContext.isFirstTime(walked, true)).toBe(true);
+        expect(seen[0]).toBe(walked);
+        expect(typeof seen[0].copy).toBe("function");
+      });
+
+      it("leaves a formatting context only core hooks reached unpatched", function () {
+        var coreHook =
+          vivliostyle_plugin.getHooksForName("POST_LAYOUT_BLOCK")[0];
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        var seen = [];
+        var assigned = {
+          isFirstTime: function (ctx, firstTime) {
+            seen.push(ctx);
+            return firstTime;
+          },
+        };
+        var original = assigned.isFirstTime;
+        legacy.formattingContext = assigned;
+        vivliostyle_legacy.applyLegacyRenderWrites(
+          [coreHook],
+          before,
+          legacy,
+          rendered,
+        );
+        expect(rendered.formattingContext).toBe(assigned);
+        expect(rendered.formattingContext.isFirstTime).toBe(original);
+      });
+
+      it("leaves a frozen formatting context a hook assigned unpatched", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        var seen = [];
+        var assigned = Object.freeze({
+          isFirstTime: function (ctx, firstTime) {
+            seen.push(ctx);
+            return firstTime;
+          },
+        });
+        var original = assigned.isFirstTime;
+        legacy.formattingContext = assigned;
+        vivliostyle_legacy.applyLegacyRenderWrites(
+          [external],
+          before,
+          legacy,
+          rendered,
+        );
+        expect(rendered.formattingContext).toBe(assigned);
+        expect(rendered.formattingContext.isFirstTime).toBe(original);
+        var walked = openTextNodeContext();
+        expect(rendered.formattingContext.isFirstTime(walked, true)).toBe(true);
+        expect(seen[0]).toBe(walked);
+      });
+
+      it("reports the writes the rendered style does not carry", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        legacy.floatSide = "left";
+        legacy.fragmentIndex = 7;
+        legacy.overflow = true;
+        legacy.offsetInNode = 5;
+        var writes = vivliostyle_legacy.applyLegacyRenderWrites(
+          [external],
+          before,
+          legacy,
+          rendered,
+        );
+        expect(rendered.floatSide).toBe("left");
+        expect(writes.floatSide).toBeUndefined();
+        expect(writes.fragmentIndex).toBe(7);
+        expect(writes.overflow).toBe(true);
+        expect(writes.offsetInNode).toBe(5);
+        var composed = vivliostyle_legacy.withLegacyContextWrites(
+          nodeContext,
+          writes,
+        );
+        expect(composed).not.toBe(nodeContext);
+        expect(composed.fragmentIndex).toBe(7);
+        expect(composed.overflow).toBe(true);
+        expect(composed.offsetInNode).toBe(5);
+        expect(nodeContext.fragmentIndex).toBe(1);
+        expect(nodeContext.overflow).toBe(false);
+      });
+
+      it("retags the composed value when a hook moved it to its after edge", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        legacy.after = true;
+        var composed = vivliostyle_legacy.withLegacyContextWrites(
+          nodeContext,
+          vivliostyle_legacy.applyLegacyRenderWrites(
+            [external],
+            before,
+            legacy,
+            rendered,
+          ),
+        );
+        expect(composed.after).toBe(true);
+        expect(composed.kind).toBe("after-none");
+        expect(nodeContext.kind).toBe("open");
+      });
+
+      it("retags the composed value when a hook gave it a view node", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        legacy.viewNode = document.createElement("div");
+        var composed = vivliostyle_legacy.withLegacyContextWrites(
+          nodeContext,
+          vivliostyle_legacy.applyLegacyRenderWrites(
+            [external],
+            before,
+            legacy,
+            rendered,
+          ),
+        );
+        expect(composed.kind).toBe("element");
+      });
+
+      it("carries a retention claim into the composed value", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        expect(legacy.shared).toBe(false);
+        legacy.copy();
+        legacy.fragmentIndex = 4;
+        var composed = vivliostyle_legacy.withLegacyContextWrites(
+          nodeContext,
+          vivliostyle_legacy.applyLegacyRenderWrites(
+            [external],
+            before,
+            legacy,
+            rendered,
+          ),
+        );
+        expect(composed).not.toBe(nodeContext);
+        expect(
+          vivliostyle_legacy.asLegacyNodeContext(hookName, composed).shared,
+        ).toBe(true);
+      });
+
+      it("carries a retention claim onto the value the core keeps", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        legacy.shared = true;
+        var writes = vivliostyle_legacy.applyLegacyRenderWrites(
+          [external],
+          before,
+          legacy,
+          rendered,
+        );
+        expect(Object.keys(writes).length).toBe(0);
+        expect(
+          vivliostyle_legacy.withLegacyContextWrites(nodeContext, writes),
+        ).toBe(nodeContext);
+        expect(
+          vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext).shared,
+        ).toBe(true);
+      });
+
+      it("leaves the value unclaimed while a hook made no claim", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        legacy.fragmentIndex = 4;
+        var composed = vivliostyle_legacy.withLegacyContextWrites(
+          nodeContext,
+          vivliostyle_legacy.applyLegacyRenderWrites(
+            [external],
+            before,
+            legacy,
+            rendered,
+          ),
+        );
+        expect(
+          vivliostyle_legacy.asLegacyNodeContext(hookName, composed).shared,
+        ).toBe(false);
+      });
+
+      it("carries a rewritten source node, parent and block container", function () {
+        var nodeContext = openTextNodeContext();
+        var parent = elementNodeContext();
+        var sourceNode = document.createTextNode("rewritten");
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        legacy.sourceNode = sourceNode;
+        legacy.parent = parent;
+        legacy.blockContainer = parent;
+        var writes = vivliostyle_legacy.applyLegacyRenderWrites(
+          [external],
+          before,
+          legacy,
+          rendered,
+        );
+        expect(writes.sourceNode).toBe(sourceNode);
+        expect(writes.parent).toBe(parent);
+        expect(writes.blockContainer).toBe(parent);
+        var composed = vivliostyle_legacy.withLegacyContextWrites(
+          nodeContext,
+          writes,
+        );
+        expect(composed.sourceNode).toBe(sourceNode);
+        expect(composed.parent).toBe(parent);
+        expect(composed.blockContainer).toBe(parent);
+        expect(nodeContext.sourceNode).not.toBe(sourceNode);
+        expect(nodeContext.parent).toBe(null);
+      });
+
+      it("leaves the discriminant alone for a write beside it", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var legacy = renderContextOf(nodeContext, rendered);
+        var before = vivliostyle_legacy.captureRenderFields(hookName, legacy);
+        legacy.fragmentIndex = 3;
+        var composed = vivliostyle_legacy.withLegacyContextWrites(
+          nodeContext,
+          vivliostyle_legacy.applyLegacyRenderWrites(
+            [external],
+            before,
+            legacy,
+            rendered,
+          ),
+        );
+        expect(composed.fragmentIndex).toBe(3);
+        expect(composed.kind).toBe("open");
+      });
+    });
+
+    describe("while only the core has registered", function () {
+      it("hands out the value the core carries", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var progress = vivliostyle_node_context.elementRenderProgress(
+          nodeContext,
+          rendered,
+        );
+        expect(
+          vivliostyle_legacy.asLegacyRenderContext(
+            hookName,
+            nodeContext,
+            progress,
+            rendered,
+          ),
+        ).toBe(progress);
+        expect(vivliostyle_legacy.captureRenderFields(hookName, progress)).toBe(
+          null,
+        );
+      });
+
+      it("writes nothing into the draft without a snapshot", function () {
+        var nodeContext = openTextNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var progress = vivliostyle_node_context.elementRenderProgress(
+          nodeContext,
+          rendered,
+        );
+        progress.display = "block";
+        expect(
+          vivliostyle_legacy.applyLegacyRenderWrites(
+            [external],
+            null,
+            progress,
+            rendered,
+          ),
+        ).toEqual({});
+        expect(rendered.display).toBe(null);
+      });
+
+      it("keeps the value while a hook wrote nothing beside the style", function () {
+        var nodeContext = openTextNodeContext();
+        expect(
+          vivliostyle_legacy.withLegacyContextWrites(nodeContext, {}),
+        ).toBe(nodeContext);
+      });
+    });
+  });
+
+  describe("asLegacyColumn", function () {
+    var externalHook = function () {};
+    var coreHook = vivliostyle_plugin.getHooksForName("POST_LAYOUT_BLOCK")[0];
+
+    it("hands the column itself to a hook the core registered", function () {
+      var column = stubColumn();
+      expect(vivliostyle_legacy.asLegacyColumn(coreHook, column)).toBe(column);
+    });
+
+    it("serves one view per column to an external hook", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view).not.toBe(column);
+      expect(vivliostyle_legacy.asLegacyColumn(externalHook, column)).toBe(
+        view,
+      );
+    });
+
+    it("reports the overflow check as a boolean", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = openTextNodeContext();
+      expect(view.checkOverflowAndSaveEdge(nodeContext, null)).toBe(true);
+      expect(column.calls[0][1]).toBe(nodeContext);
+      column.overflown = false;
+      expect(view.checkOverflowAndSaveEdge(null, null)).toBe(false);
+    });
+
+    it("reports the clearance as a boolean", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = elementNodeContext();
+      expect(view.applyClearance(nodeContext)).toBe(true);
+      expect(column.calls[0][1]).toBe(nodeContext);
+      column.clearance = null;
+      expect(view.applyClearance(nodeContext)).toBe(false);
+    });
+
+    it("reports the line styling result as the node context alone", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = openTextNodeContext();
+      var resNodeContext = openTextNodeContext();
+      var checkPoints = [elementNodeContext()];
+      var result = view.processLineStyling(
+        nodeContext,
+        resNodeContext,
+        checkPoints,
+      );
+      expect(result.get()).toBe(resNodeContext);
+      expect(column.calls[0][3]).toBe(checkPoints);
+    });
+
+    it("serves the column's layout context through its legacy view", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view.layoutContext).not.toBe(column.layoutContext);
+      expect(view.layoutContext).toBe(
+        vivliostyle_legacy.asLegacyLayoutContext(column.layoutContext),
+      );
+    });
+
+    it("passes the members the contract kept through to the column", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view.isOverflown(1)).toBe(true);
+      expect(view.isOverflown(-1)).toBe(false);
+    });
+
+    it("calls the replacement after a member is written through the view", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view.isOverflown(1)).toBe(true);
+      view.isOverflown = function () {
+        return "patched";
+      };
+      expect(view.isOverflown(1)).toBe("patched");
+      expect(column.isOverflown(1)).toBe("patched");
+    });
+
+    it("records the clearance on the node context it was given", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = elementNodeContext();
+      expect(view.applyClearance(nodeContext)).toBe(true);
+      expect(nodeContext.clearSpacer).toBe(column.clearance);
+    });
+
+    it("serves the repetitive overflow position through its legacy view", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view.nodeContextOverflowingDueToRepetitiveElements).toBe(null);
+      var nodeContext = elementNodeContext();
+      column.nodeContextOverflowingDueToRepetitiveElements = nodeContext;
+      expect(view.nodeContextOverflowingDueToRepetitiveElements).toBe(
+        nodeContext,
+      );
+      expect(typeof nodeContext.copy).toBe("function");
+    });
+
+    it("retags the repetitive overflow position it serves", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = elementNodeContext();
+      nodeContext.after = true;
+      column.nodeContextOverflowingDueToRepetitiveElements = nodeContext;
+      expect(view.nodeContextOverflowingDueToRepetitiveElements.kind).toBe(
+        "after-element",
+      );
+    });
+
+    it("retags the repetitive overflow position a hook wrote to after reading", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = elementNodeContext();
+      column.nodeContextOverflowingDueToRepetitiveElements = nodeContext;
+      view.nodeContextOverflowingDueToRepetitiveElements.after = true;
+      expect(nodeContext.kind).toBe("element");
+      vivliostyle_legacy.retagLegacyNodeContext("POST_LAYOUT_BLOCK", null);
+      expect(nodeContext.kind).toBe("after-element");
+    });
+
+    it("retags the break position a hook wrote to after reading", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var position = elementNodeContext();
+      column.breakPositions.push(
+        new vivliostyle_break_position.EdgeBreakPosition(
+          position,
+          null,
+          false,
+          0,
+        ),
+      );
+      view.breakPositions[0].position.after = true;
+      expect(position.kind).toBe("element");
+      vivliostyle_legacy.retagLegacyNodeContexts("POST_LAYOUT_BLOCK", []);
+      expect(position.kind).toBe("after-element");
+    });
+
+    it("serves the pseudo parent through its own legacy view", function () {
+      var column = stubColumn();
+      var pseudoParent = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view.pseudoParent).toBe(null);
+      column.pseudoParent = pseudoParent;
+      expect(view.pseudoParent).not.toBe(pseudoParent);
+      expect(view.pseudoParent).toBe(
+        vivliostyle_legacy.asLegacyColumn(externalHook, pseudoParent),
+      );
+      expect(view.pseudoParent.isOverflown(1)).toBe(true);
+    });
+
+    it("decorates the node contexts its members hand back", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = openTextNodeContext();
+      var checkPoints = [elementNodeContext()];
+      column.acceptableBreak = {
+        breakPosition: stubBreakPosition(),
+        nodeContext: openTextNodeContext(),
+      };
+      expect(view.asFloatNodeContext(nodeContext)).toBe(nodeContext);
+      expect(typeof nodeContext.copy).toBe("function");
+      expect(typeof view.layoutNext(nodeContext, true).get().copy).toBe(
+        "function",
+      );
+      var laidOut = view.doLayout(nodeContext, true).get();
+      expect(typeof laidOut.nodeContext.copy).toBe("function");
+      expect(typeof laidOut.overflownNodeContext.copy).toBe("function");
+      expect(
+        typeof view.findEndOfLine(1, checkPoints, false).nodeContext.copy,
+      ).toBe("function");
+      expect(
+        typeof view.findFirstOverflowingEdgeAndCheckPoint(checkPoints)
+          .checkPoint.copy,
+      ).toBe("function");
+      expect(typeof view.findAcceptableBreakPosition().nodeContext.copy).toBe(
+        "function",
+      );
+    });
+
+    it("serves the checkpoints its members pushed through their legacy view", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var pushed = elementNodeContext();
+      var checkPoints = [];
+      column.buildViewToNextBlockEdge = function (position, points) {
+        points.push(pushed);
+        return vivliostyle_task.newResult(null);
+      };
+      expect(view.buildViewToNextBlockEdge(null, checkPoints).get()).toBe(null);
+      expect(checkPoints[0]).toBe(pushed);
+      expect(typeof pushed.copy).toBe("function");
+    });
+
+    it("replaces the checkpoints the line styling rebuilt", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = openTextNodeContext();
+      var resNodeContext = openTextNodeContext();
+      var rebuilt = elementNodeContext();
+      var checkPoints = [elementNodeContext()];
+      column.processLineStyling = function (ctx, resCtx) {
+        return vivliostyle_task.newResult({
+          nodeContext: resCtx,
+          checkPoints: [rebuilt],
+        });
+      };
+      var result = view.processLineStyling(
+        nodeContext,
+        resNodeContext,
+        checkPoints,
+      );
+      expect(result.get()).toBe(resNodeContext);
+      expect(typeof resNodeContext.copy).toBe("function");
+      expect(checkPoints.length).toBe(1);
+      expect(checkPoints[0]).toBe(rebuilt);
+      expect(typeof rebuilt.copy).toBe("function");
+    });
+
+    it("passes a missing node context through its members", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view.buildViewToNextBlockEdge(null, []).get()).toBe(null);
+      expect(view.findAcceptableBreakPosition()).toBe(null);
+    });
+
+    it("serves the break position it found through its legacy view", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var broken = elementNodeContext();
+      var seen = [];
+      var breakPosition = {
+        findAcceptableBreak: function (col, penalty) {
+          seen.push(["findAcceptableBreak", col, penalty]);
+          return broken;
+        },
+        getMinBreakPenalty: function () {
+          return 5;
+        },
+        calculateOffset: function (col) {
+          seen.push(["calculateOffset", col]);
+          return { current: 2, minimum: 1 };
+        },
+        breakPositionChosen: function (col) {
+          seen.push(["breakPositionChosen", col]);
+        },
+        getNodeContext: function () {
+          return broken;
+        },
+      };
+      column.acceptableBreak = {
+        breakPosition: breakPosition,
+        nodeContext: openTextNodeContext(),
+      };
+      var found = view.findAcceptableBreakPosition();
+      expect(found.breakPosition).not.toBe(breakPosition);
+      expect(found.breakPosition).toBe(
+        view.findAcceptableBreakPosition().breakPosition,
+      );
+      expect(found.breakPosition.getMinBreakPenalty()).toBe(5);
+      expect(found.breakPosition.findAcceptableBreak(view, 3)).toBe(broken);
+      expect(typeof broken.copy).toBe("function");
+      expect(seen[0][1]).toBe(column);
+      expect(seen[0][2]).toBe(3);
+      expect(found.breakPosition.calculateOffset(view).current).toBe(2);
+      expect(seen[1][1]).toBe(column);
+      found.breakPosition.breakPositionChosen(view);
+      expect(seen[2][1]).toBe(column);
+      expect(found.breakPosition.getNodeContext()).toBe(broken);
+    });
+
+    it("mirrors the break position list between both contracts", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var core = stubBreakPosition();
+      core.getMinBreakPenalty = function () {
+        return 4;
+      };
+      column.breakPositions = [core];
+      var list = view.breakPositions;
+      expect(list.length).toBe(1);
+      expect(list[0]).not.toBe(core);
+      expect(list[0]).toBe(view.breakPositions[0]);
+      expect(list[0].getMinBreakPenalty()).toBe(4);
+      list[0] = list[0];
+      expect(column.breakPositions[0]).toBe(core);
+    });
+
+    it("adapts a break position a plugin pushed onto the list", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var broken = elementNodeContext();
+      var seen = [];
+      var legacyBreakPosition = {
+        findAcceptableBreak: function (col, penalty) {
+          seen.push([col, penalty]);
+          broken.after = true;
+          return broken;
+        },
+        getMinBreakPenalty: function () {
+          return 7;
+        },
+        calculateOffset: function () {
+          return { current: 0, minimum: 0 };
+        },
+        breakPositionChosen: function () {},
+      };
+      view.breakPositions.push(legacyBreakPosition);
+      expect(column.breakPositions.length).toBe(1);
+      expect(column.breakPositions[0]).not.toBe(legacyBreakPosition);
+      expect(column.breakPositions[0].getMinBreakPenalty()).toBe(7);
+      expect(view.breakPositions[0].getMinBreakPenalty()).toBe(7);
+      expect(column.breakPositions[0].findAcceptableBreak(column, 2)).toBe(
+        broken,
+      );
+      expect(seen[0][0]).not.toBe(column);
+      expect(seen[0][0].isOverflown(1)).toBe(true);
+      expect(seen[0][1]).toBe(2);
+      expect(broken.kind).toBe("after-element");
+    });
+
+    it("serves the text node breaker it resolved under the old contract", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = openTextNodeContext();
+      var broken = elementNodeContext();
+      var textNode = document.createTextNode("legacy");
+      var checkPoints = [elementNodeContext()];
+      var seenCheckPoints = null;
+      var seenNodeContext = null;
+      var coreBreaker = {
+        breakTextNode: function (node, ctx, low, points, index, force) {
+          seenNodeContext = ctx;
+          seenCheckPoints = points;
+          return broken;
+        },
+        breakAfterSoftHyphen: function (node, text, viewIndex) {
+          return viewIndex + 1;
+        },
+        breakAfterOtherCharacter: function (node, text, viewIndex) {
+          return viewIndex - 1;
+        },
+        updateNodeContext: function () {
+          return broken;
+        },
+      };
+      column.resolveTextNodeBreaker = function () {
+        return coreBreaker;
+      };
+      var breaker = view.resolveTextNodeBreaker(nodeContext);
+      expect(breaker).not.toBe(coreBreaker);
+      expect(view.resolveTextNodeBreaker(nodeContext)).toBe(breaker);
+      expect(
+        breaker.breakTextNode(textNode, nodeContext, 2, checkPoints, 0, true),
+      ).toBe(broken);
+      expect(seenNodeContext).toBe(nodeContext);
+      expect(seenCheckPoints).toBe(checkPoints);
+      expect(typeof broken.copy).toBe("function");
+      expect(
+        breaker.breakAfterSoftHyphen(textNode, "legacy", 4, nodeContext),
+      ).toBe(5);
+      expect(
+        breaker.breakAfterOtherCharacter(textNode, "legacy", 4, nodeContext),
+      ).toBe(3);
+      expect(breaker.updateNodeContext(nodeContext, 2, textNode)).toBe(broken);
+    });
+
+    it("retags what it is handed before the core text breaker reads it", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      vivliostyle_plugin.registerHook("POST_LAYOUT_BLOCK", externalHook);
+      var nodeContext = vivliostyle_legacy.asLegacyNodeContext(
+        "POST_LAYOUT_BLOCK",
+        openTextNodeContext(),
+      );
+      var checkPoints = vivliostyle_legacy.asLegacyRenderedNodeContexts(
+        "POST_LAYOUT_BLOCK",
+        [elementNodeContext()],
+      );
+      vivliostyle_plugin.removeHook("POST_LAYOUT_BLOCK", externalHook);
+      var seen = [];
+      var coreBreaker = {
+        breakTextNode: function (node, ctx, low, points) {
+          seen.push(ctx.kind, points[0].kind);
+          return ctx;
+        },
+        breakAfterSoftHyphen: function (node, text, viewIndex, ctx) {
+          seen.push(ctx.kind);
+          return viewIndex;
+        },
+        breakAfterOtherCharacter: function (node, text, viewIndex, ctx) {
+          seen.push(ctx.kind);
+          return viewIndex;
+        },
+        updateNodeContext: function (ctx) {
+          seen.push(ctx.kind);
+          return ctx;
+        },
+      };
+      column.resolveTextNodeBreaker = function () {
+        return coreBreaker;
+      };
+      var breaker = view.resolveTextNodeBreaker(nodeContext);
+      breaker.breakTextNode(
+        document.createTextNode("legacy"),
+        nodeContext,
+        0,
+        checkPoints,
+        0,
+        true,
+      );
+      expect(seen).toEqual(["open", "element"]);
+      nodeContext.viewNode = document.createElement("div");
+      checkPoints[0].after = true;
+      breaker.breakTextNode(
+        document.createTextNode("legacy"),
+        nodeContext,
+        0,
+        checkPoints,
+        0,
+        true,
+      );
+      expect(seen.slice(2)).toEqual(["element", "after-element"]);
+      nodeContext.after = true;
+      breaker.breakAfterSoftHyphen(
+        document.createTextNode("legacy"),
+        "legacy",
+        0,
+        nodeContext,
+      );
+      breaker.breakAfterOtherCharacter(
+        document.createTextNode("legacy"),
+        "legacy",
+        0,
+        nodeContext,
+      );
+      breaker.updateNodeContext(nodeContext, 0, document.createTextNode("x"));
+      expect(seen.slice(4)).toEqual([
+        "after-element",
+        "after-element",
+        "after-element",
+      ]);
+    });
+
+    it("keeps a write to a projected member inside the view", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var replacement = function () {
+        return "patched";
+      };
+      var applyClearance = column.applyClearance;
+      view.applyClearance = replacement;
+      expect(view.applyClearance).toBe(replacement);
+      expect(view.applyClearance(null)).toBe("patched");
+      expect(column.applyClearance).toBe(applyClearance);
+      expect(
+        vivliostyle_legacy.asLegacyColumn(externalHook, stubColumn())
+          .applyClearance,
+      ).not.toBe(replacement);
+    });
+
+    it("keeps a write to the projected layout context inside the view", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var replacement = stubLayoutContext();
+      var layoutContext = column.layoutContext;
+      view.layoutContext = replacement;
+      expect(view.layoutContext).toBe(replacement);
+      expect(column.layoutContext).toBe(layoutContext);
+    });
+
+    it("answers the names every object inherits", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      expect(view.hasOwnProperty("breakPositions")).toBe(true);
+      expect(view.hasOwnProperty("noSuchMember")).toBe(false);
+      expect(view.propertyIsEnumerable("breakPositions")).toBe(true);
+      expect(view.valueOf()).toBe(column);
+      expect(String(view)).toBe("[object Object]");
+      expect(view.toLocaleString()).toBe("[object Object]");
+      expect(typeof view.constructor).toBe("function");
+      expect(Object.getPrototypeOf(view)).toBe(Object.prototype);
+    });
+
+    it("writes a replacement of an inherited name through to the column", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var replacement = function () {
+        return "patched";
+      };
+      view.toString = replacement;
+      expect(column.toString).toBe(replacement);
+      expect(String(view)).toBe("patched");
+    });
+
+    it("retags a node context a plugin mutated before a member reads it", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var nodeContext = openTextNodeContext();
+      expect(view.asFloatNodeContext(nodeContext)).toBe(nodeContext);
+      nodeContext.viewNode = document.createElement("div");
+      expect(nodeContext.kind).toBe("open");
+      view.asFloatNodeContext(nodeContext);
+      expect(nodeContext.kind).toBe("element");
+      nodeContext.after = true;
+      view.layoutNext(nodeContext, true);
+      expect(nodeContext.kind).toBe("after-element");
+    });
+
+    it("retags the node contexts inside an array a plugin hands over", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var checkPoints = [elementNodeContext()];
+      view.findEndOfLine(1, checkPoints, false);
+      checkPoints[0].after = true;
+      expect(checkPoints[0].kind).toBe("element");
+      view.findEndOfLine(1, checkPoints, false);
+      expect(checkPoints[0].kind).toBe("after-element");
+    });
+  });
+
+  describe("the break position bridge", function () {
+    var externalHook = function () {};
+
+    it("keeps the class and the fields of an edge break position", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var position = elementNodeContext();
+      var core = new vivliostyle_break_position.EdgeBreakPosition(
+        position,
+        "column",
+        true,
+        120,
+      );
+      column.breakPositions = [core];
+      var seen = view.breakPositions[0];
+      expect(seen).not.toBe(core);
+      expect(seen instanceof vivliostyle_break_position.EdgeBreakPosition).toBe(
+        true,
+      );
+      expect(seen.position).toBe(position);
+      expect(seen.breakOnEdge).toBe("column");
+      expect(seen.overflows).toBe(true);
+      expect(seen.computedBlockSize).toBe(120);
+      expect(seen.overflowIfRepetitiveElementsDropped).toBe(true);
+    });
+
+    it("serves the node context of an edge break position under the old contract", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var position = elementNodeContext();
+      column.breakPositions = [
+        new vivliostyle_break_position.EdgeBreakPosition(
+          position,
+          "column",
+          true,
+          120,
+        ),
+      ];
+      var seen = view.breakPositions[0];
+      expect(seen.position).toBe(position);
+      expect(typeof seen.position.copy).toBe("function");
+      expect(typeof seen.position.modify).toBe("function");
+    });
+
+    it("writes a replacement position through to the break position", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var core = new vivliostyle_break_position.EdgeBreakPosition(
+        elementNodeContext(),
+        "column",
+        true,
+        120,
+      );
+      column.breakPositions = [core];
+      var replacement = elementNodeContext();
+      var seen = view.breakPositions[0];
+      seen.position = replacement;
+      expect(core.position).toBe(replacement);
+      expect(seen.position).toBe(replacement);
+      expect(typeof seen.position.copy).toBe("function");
+    });
+
+    it("serves the node contexts of a box break position under the old contract", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var checkPoints = [elementNodeContext()];
+      var core = new vivliostyle_layout.BoxBreakPosition(checkPoints, 3);
+      core.breakNodeContext = elementNodeContext();
+      column.breakPositions = [core];
+      var seen = view.breakPositions[0];
+      expect(seen.checkPoints).toBe(checkPoints);
+      expect(typeof seen.checkPoints[0].copy).toBe("function");
+      expect(seen.breakNodeContext).toBe(core.breakNodeContext);
+      expect(typeof seen.breakNodeContext.copy).toBe("function");
+    });
+
+    it("keeps the class and the fields of a box break position", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var checkPoints = [elementNodeContext()];
+      var core = new vivliostyle_layout.BoxBreakPosition(checkPoints, 3);
+      column.breakPositions = [core];
+      var seen = view.breakPositions[0];
+      expect(seen instanceof vivliostyle_layout.BoxBreakPosition).toBe(true);
+      expect(seen.checkPoints).toBe(checkPoints);
+      expect(seen.penalty).toBe(3);
+      expect(seen.breakNodeContext).toBe(null);
+      expect(seen.getMinBreakPenalty()).toBe(3);
+    });
+
+    it("hands a break position the core built back as itself", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var core = new vivliostyle_layout.BoxBreakPosition(
+        [elementNodeContext()],
+        1,
+      );
+      column.breakPositions = [core];
+      var seen = view.breakPositions[0];
+      expect(view.breakPositions[0]).toBe(seen);
+      view.breakPositions[0] = seen;
+      expect(column.breakPositions[0]).toBe(core);
+    });
+
+    it("decorates the node context a break position reports", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var position = elementNodeContext();
+      column.breakPositions = [
+        new vivliostyle_break_position.EdgeBreakPosition(
+          position,
+          "column",
+          false,
+          0,
+        ),
+      ];
+      expect(view.breakPositions[0].getNodeContext()).toBe(position);
+      expect(typeof position.copy).toBe("function");
+    });
+
+    it("retags the position a break position hands out", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var position = elementNodeContext();
+      column.breakPositions = [
+        new vivliostyle_break_position.EdgeBreakPosition(
+          position,
+          "column",
+          false,
+          0,
+        ),
+      ];
+      var seen = view.breakPositions[0];
+      seen.position.viewNode = null;
+      expect(seen.position).toBe(position);
+      expect(position.kind).toBe("open");
+    });
+
+    it("retags the checkpoints a break position hands out", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var checkPoints = [elementNodeContext()];
+      var core = new vivliostyle_layout.BoxBreakPosition(checkPoints, 3);
+      core.breakNodeContext = elementNodeContext();
+      column.breakPositions = [core];
+      var seen = view.breakPositions[0];
+      seen.checkPoints[0].after = true;
+      seen.breakNodeContext.after = true;
+      expect(seen.checkPoints[0]).toBe(checkPoints[0]);
+      expect(seen.checkPoints[0].kind).toBe("after-element");
+      expect(seen.breakNodeContext.kind).toBe("after-element");
+    });
+
+    it("reports no node context for a break position without one", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      column.breakPositions = [stubBreakPosition()];
+      expect(view.breakPositions[0].getNodeContext).toBeUndefined();
+    });
+
+    it("adapts a break position built on the core class for the column", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var legacyBreakPosition = coreClassBreakPosition();
+      var position = elementNodeContext();
+      legacyBreakPosition.findAcceptableBreak = function (column) {
+        return column.checkOverflowAndSaveEdge(position, null)
+          ? position
+          : null;
+      };
+      column.overflown = false;
+      view.breakPositions.push(legacyBreakPosition);
+      expect(column.breakPositions[0]).not.toBe(legacyBreakPosition);
+      expect(column.breakPositions[0].findAcceptableBreak(column, 0)).toBe(
+        null,
+      );
+      view.breakPositions[0] = view.breakPositions[0];
+      expect(view.breakPositions[0]).toBe(legacyBreakPosition);
+    });
+
+    it("hands a break position built on the core class back as itself", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var legacyBreakPosition = coreClassBreakPosition();
+      view.breakPositions.push(legacyBreakPosition);
+      var seen = view.breakPositions[0];
+      expect(seen).toBe(legacyBreakPosition);
+      expect(seen.getMinBreakPenalty()).toBe(4);
+      expect(view.breakPositions.indexOf(legacyBreakPosition)).toBe(0);
+    });
+
+    it("finds a break position a plugin built for itself in the list", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var legacyBreakPosition = stubBreakPosition();
+      view.breakPositions.push(legacyBreakPosition);
+      expect(view.breakPositions.indexOf(legacyBreakPosition)).toBe(0);
+    });
+
+    it("keeps the position a break position built on the core class holds", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var legacyBreakPosition = coreClassBreakPosition();
+      var position = elementNodeContext();
+      legacyBreakPosition.position = position;
+      view.breakPositions.push(legacyBreakPosition);
+      expect(view.breakPositions[0].position).toBe(position);
+    });
+
+    it("hands a break position a plugin pushed back as itself", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var legacyBreakPosition = stubBreakPosition();
+      view.breakPositions.push(legacyBreakPosition);
+      var adapted = column.breakPositions[0];
+      expect(adapted).not.toBe(legacyBreakPosition);
+      expect(view.breakPositions[0]).toBe(legacyBreakPosition);
+      view.breakPositions[0] = view.breakPositions[0];
+      expect(column.breakPositions[0]).toBe(adapted);
+    });
+
+    it("unwraps a break position on its way back to the column", function () {
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var seen = [];
+      column.findEdgeBreakPosition = function (bp) {
+        seen.push(bp);
+        return null;
+      };
+      column.findBoxBreakPosition = function (bp, force) {
+        seen.push(bp, force);
+        return null;
+      };
+      var edge = new vivliostyle_break_position.EdgeBreakPosition(
+        elementNodeContext(),
+        "column",
+        true,
+        1,
+      );
+      var box = new vivliostyle_layout.BoxBreakPosition(
+        [elementNodeContext()],
+        2,
+      );
+      column.breakPositions = [edge, box];
+      view.findEdgeBreakPosition(view.breakPositions[0]);
+      view.findBoxBreakPosition(view.breakPositions[1], true);
+      expect(seen[0]).toBe(edge);
+      expect(seen[1]).toBe(box);
+      expect(seen[2]).toBe(true);
+      var legacyBreakPosition = stubBreakPosition();
+      legacyBreakPosition.getMinBreakPenalty = function () {
+        return 9;
+      };
+      view.findEdgeBreakPosition(legacyBreakPosition);
+      expect(seen[3]).not.toBe(legacyBreakPosition);
+      expect(seen[3].getMinBreakPenalty()).toBe(9);
+    });
+  });
+
+  describe("asLegacyLayoutContext", function () {
+    it("reports setCurrent as whether children are processed", function () {
+      var layoutContext = stubLayoutContext();
+      var view = vivliostyle_legacy.asLegacyLayoutContext(layoutContext);
+      var nodeContext = openTextNodeContext();
+      expect(view.setCurrent(nodeContext, true, false).get()).toBe(true);
+      expect(view.setCurrent(nodeContext, false, true).get()).toBe(false);
+      expect(layoutContext.calls[0][1]).toBe(nodeContext);
+      expect(layoutContext.calls[0][3]).toBe(false);
+    });
+
+    it("writes the rendered node context back into the one it was given", function () {
+      var layoutContext = stubLayoutContext();
+      var view = vivliostyle_legacy.asLegacyLayoutContext(layoutContext);
+      var nodeContext = openTextNodeContext();
+      var viewNode = document.createElement("div");
+      var formattingContext =
+        new vivliostyle_layout_processor.BlockFormattingContext(null);
+      layoutContext.rendered = Object.assign({}, nodeContext, {
+        kind: "element",
+        viewNode: viewNode,
+        display: "block",
+        inline: false,
+        floatSide: "left",
+        formattingContext: formattingContext,
+      });
+      expect(view.setCurrent(nodeContext, true, false).get()).toBe(true);
+      expect(nodeContext.viewNode).toBe(viewNode);
+      expect(nodeContext.display).toBe("block");
+      expect(nodeContext.inline).toBe(false);
+      expect(nodeContext.floatSide).toBe("left");
+      expect(nodeContext.formattingContext).toBe(formattingContext);
+      expect(nodeContext.kind).toBe("element");
+    });
+
+    it("retags the node context it writes back from what the fields imply", function () {
+      var layoutContext = stubLayoutContext();
+      var view = vivliostyle_legacy.asLegacyLayoutContext(layoutContext);
+      var nodeContext = openTextNodeContext();
+      layoutContext.rendered = Object.assign({}, nodeContext, {
+        kind: "open",
+        viewNode: document.createTextNode("rendered"),
+        after: true,
+      });
+      view.setCurrent(nodeContext, true, false).get();
+      expect(nodeContext.kind).toBe("after-text");
+      expect(typeof nodeContext.copy).toBe("function");
+    });
+
+    it("serves a cloned layout context through its legacy view", function () {
+      var layoutContext = stubLayoutContext();
+      layoutContext.cloned = stubLayoutContext();
+      var cloned = vivliostyle_legacy
+        .asLegacyLayoutContext(layoutContext)
+        .clone();
+      expect(cloned).not.toBe(layoutContext.cloned);
+      expect(cloned).toBe(
+        vivliostyle_legacy.asLegacyLayoutContext(layoutContext.cloned),
+      );
+      expect(cloned.setCurrent(openTextNodeContext(), true).get()).toBe(true);
+    });
+
+    it("passes applyPseudoelementStyle through to the layout context", function () {
+      var layoutContext = stubLayoutContext();
+      var view = vivliostyle_legacy.asLegacyLayoutContext(layoutContext);
+      var nodeContext = openTextNodeContext();
+      var target = document.createElement("span");
+      view.applyPseudoelementStyle(nodeContext, "before", target);
+      expect(layoutContext.calls[0][0]).toBe("applyPseudoelementStyle");
+      expect(layoutContext.calls[0][1]).toBe(nodeContext);
+      expect(layoutContext.calls[0][2]).toBe("before");
+      expect(layoutContext.calls[0][3]).toBe(target);
+    });
+
+    it("serves the node contexts it walks to through their legacy view", function () {
+      var layoutContext = stubLayoutContext();
+      var view = vivliostyle_legacy.asLegacyLayoutContext(layoutContext);
+      var nodeContext = openTextNodeContext();
+      expect(view.nextInTree(nodeContext, true).get()).toBe(null);
+      layoutContext.next = nodeContext;
+      var walked = view.nextInTree(nodeContext, false).get();
+      expect(walked).toBe(nodeContext);
+      expect(typeof walked.copy).toBe("function");
+      var peeled = view.peelOff(nodeContext, 2).get();
+      expect(peeled).toBe(nodeContext);
+      expect(typeof peeled.copy).toBe("function");
+      expect(layoutContext.calls[2][0]).toBe("peelOff");
+      expect(layoutContext.calls[2][2]).toBe(2);
+    });
+
+    it("retags a node context handed to a member the contract kept", function () {
+      var layoutContext = stubLayoutContext();
+      var view = vivliostyle_legacy.asLegacyLayoutContext(layoutContext);
+      var nodeContext = openTextNodeContext();
+      layoutContext.next = nodeContext;
+      expect(view.nextInTree(nodeContext, false).get()).toBe(nodeContext);
+      nodeContext.viewNode = document.createElement("div");
+      expect(nodeContext.kind).toBe("open");
+      view.applyPseudoelementStyle(
+        nodeContext,
+        "before",
+        document.createElement("span"),
+      );
+      expect(nodeContext.kind).toBe("element");
+    });
+  });
+
+  describe("adaptLegacyTextNodeBreaker", function () {
+    var externalHook = function () {};
+    var coreHook = vivliostyle_plugin.getHooksForName("POST_LAYOUT_BLOCK")[0];
+    var calls;
+    var legacyBreaker;
+    var textNode;
+
+    beforeEach(function () {
+      calls = [];
+      textNode = document.createTextNode("legacy");
+      legacyBreaker = {
+        breakTextNode: function (
+          brokenNode,
+          nodeContext,
+          low,
+          checkPoints,
+          checkpointIndex,
+          force,
+        ) {
+          calls.push({
+            name: "breakTextNode",
+            nodeContext: nodeContext,
+            checkPoints: checkPoints,
+            low: low,
+            checkpointIndex: checkpointIndex,
+            force: force,
+          });
+          nodeContext.after = true;
+          return nodeContext;
+        },
+        breakAfterSoftHyphen: function (
+          brokenNode,
+          text,
+          viewIndex,
+          nodeContext,
+        ) {
+          calls.push({
+            name: "breakAfterSoftHyphen",
+            nodeContext: nodeContext,
+            text: text,
+          });
+          return viewIndex + 1;
+        },
+        breakAfterOtherCharacter: function (
+          brokenNode,
+          text,
+          viewIndex,
+          nodeContext,
+        ) {
+          calls.push({
+            name: "breakAfterOtherCharacter",
+            nodeContext: nodeContext,
+            text: text,
+          });
+          return viewIndex - 1;
+        },
+        updateNodeContext: function (nodeContext, viewIndex, updatedNode) {
+          calls.push({
+            name: "updateNodeContext",
+            nodeContext: nodeContext,
+            viewIndex: viewIndex,
+          });
+          nodeContext.viewNode = updatedNode;
+          return nodeContext;
+        },
+      };
+    });
+
+    it("hands a breaker the core resolved back as itself", function () {
+      expect(
+        vivliostyle_legacy.adaptLegacyTextNodeBreaker(coreHook, legacyBreaker),
+      ).toBe(legacyBreaker);
+    });
+
+    it("serves one adapter per legacy implementation", function () {
+      expect(
+        vivliostyle_legacy.adaptLegacyTextNodeBreaker(
+          externalHook,
+          legacyBreaker,
+        ),
+      ).toBe(
+        vivliostyle_legacy.adaptLegacyTextNodeBreaker(
+          externalHook,
+          legacyBreaker,
+        ),
+      );
+    });
+
+    it("hands the node context and the checkpoints over as legacy views", function () {
+      var nodeContext = openTextNodeContext();
+      var checkPoints = [elementNodeContext()];
+      var result = vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .breakTextNode(textNode, nodeContext, 2, checkPoints, 0, true);
+      expect(calls[0].nodeContext).toBe(nodeContext);
+      expect(typeof calls[0].nodeContext.copy).toBe("function");
+      expect(calls[0].checkPoints).toBe(checkPoints);
+      expect(typeof checkPoints[0].copy).toBe("function");
+      expect(calls[0].low).toBe(2);
+      expect(calls[0].force).toBe(true);
+      expect(result).toBe(nodeContext);
+      expect(result.kind).toBe("after-none");
+    });
+
+    it("reports the soft hyphen index the legacy breaker returned", function () {
+      var nodeContext = openTextNodeContext();
+      var result = vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .breakAfterSoftHyphen(textNode, "legacy", 4, nodeContext);
+      expect(result).toBe(5);
+      expect(typeof calls[0].nodeContext.copy).toBe("function");
+    });
+
+    it("reports the index of a break after another character", function () {
+      var nodeContext = openTextNodeContext();
+      expect(
+        vivliostyle_legacy
+          .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+          .breakAfterOtherCharacter(textNode, "legacy", 4, nodeContext),
+      ).toBe(3);
+      expect(typeof calls[0].nodeContext.copy).toBe("function");
+    });
+
+    it("retags the value updateNodeContext hands back", function () {
+      var nodeContext = openTextNodeContext();
+      var result = vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .updateNodeContext(nodeContext, 2, textNode);
+      expect(typeof calls[0].nodeContext.copy).toBe("function");
+      expect(result).toBe(nodeContext);
+      expect(result.viewNode).toBe(textNode);
+      expect(result.kind).toBe("text");
+    });
+
+    it("retags the checkpoints a text break mutated in place", function () {
+      var nodeContext = openTextNodeContext();
+      var checkPoints = [elementNodeContext()];
+      legacyBreaker.breakTextNode = function (brokenNode, ctx, low, points) {
+        points[0].after = true;
+        return ctx;
+      };
+      vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .breakTextNode(textNode, nodeContext, 2, checkPoints, 0, true);
+      expect(checkPoints[0].kind).toBe("after-element");
+    });
+
+    it("retags the value a soft hyphen break mutated in place", function () {
+      var nodeContext = openTextNodeContext();
+      legacyBreaker.breakAfterSoftHyphen = function (
+        brokenNode,
+        text,
+        viewIndex,
+        ctx,
+      ) {
+        ctx.viewNode = brokenNode;
+        return viewIndex;
+      };
+      var result = vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .breakAfterSoftHyphen(textNode, "legacy", 4, nodeContext);
+      expect(result).toBe(4);
+      expect(nodeContext.kind).toBe("text");
+    });
+
+    it("retags the value a break after another character mutated", function () {
+      var nodeContext = openTextNodeContext();
+      legacyBreaker.breakAfterOtherCharacter = function (
+        brokenNode,
+        text,
+        viewIndex,
+        ctx,
+      ) {
+        ctx.after = true;
+        return viewIndex;
+      };
+      vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .breakAfterOtherCharacter(textNode, "legacy", 4, nodeContext);
+      expect(nodeContext.kind).toBe("after-none");
+    });
+
+    it("hands a breaker a plugin registered back as itself", function () {
+      var external = function () {};
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(external, column);
+      var adapted = vivliostyle_legacy.adaptLegacyTextNodeBreaker(
+        externalHook,
+        legacyBreaker,
+      );
+      column.resolveTextNodeBreaker = function () {
+        return adapted;
+      };
+      expect(view.resolveTextNodeBreaker(openTextNodeContext())).toBe(
+        legacyBreaker,
+      );
+    });
+
+    it("adapts a breaker view back to the breaker the core resolved", function () {
+      var external = function () {};
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(external, column);
+      var coreBreaker = {
+        breakTextNode: function (node, ctx) {
+          return ctx;
+        },
+        breakAfterSoftHyphen: function (node, text, viewIndex) {
+          return viewIndex;
+        },
+        breakAfterOtherCharacter: function (node, text, viewIndex) {
+          return viewIndex;
+        },
+        updateNodeContext: function (ctx) {
+          return ctx;
+        },
+      };
+      column.resolveTextNodeBreaker = function () {
+        return coreBreaker;
+      };
+      var breakerView = view.resolveTextNodeBreaker(openTextNodeContext());
+      expect(breakerView).not.toBe(coreBreaker);
+      expect(
+        vivliostyle_legacy.adaptLegacyTextNodeBreaker(
+          externalHook,
+          breakerView,
+        ),
+      ).toBe(coreBreaker);
+    });
+
+    it("retags the value updateNodeContext mutated but did not return", function () {
+      var nodeContext = openTextNodeContext();
+      var replacement = elementNodeContext();
+      legacyBreaker.updateNodeContext = function (ctx, viewIndex, updatedNode) {
+        ctx.viewNode = updatedNode;
+        return replacement;
+      };
+      var result = vivliostyle_legacy
+        .adaptLegacyTextNodeBreaker(externalHook, legacyBreaker)
+        .updateNodeContext(nodeContext, 2, textNode);
+      expect(result).toBe(replacement);
+      expect(nodeContext.kind).toBe("text");
+    });
+  });
+
+  describe("adaptLegacyLayoutProcessor", function () {
+    var externalHook = function () {};
+    var coreHook = vivliostyle_plugin.getHooksForName(
+      "RESOLVE_LAYOUT_PROCESSOR",
+    )[0];
+    var calls;
+    var breakPosition;
+    var legacyProcessor;
+
+    beforeEach(function () {
+      calls = [];
+      breakPosition = {
+        broken: null,
+        findAcceptableBreak: function (column, penalty) {
+          calls.push({
+            name: "findAcceptableBreak",
+            column: column,
+            penalty: penalty,
+          });
+          return breakPosition.broken;
+        },
+        getMinBreakPenalty: function () {
+          return 3;
+        },
+        calculateOffset: function (column) {
+          calls.push({ name: "calculateOffset", column: column });
+          return { current: 1, minimum: 0 };
+        },
+        breakPositionChosen: function (column) {
+          calls.push({ name: "breakPositionChosen", column: column });
+        },
+      };
+      legacyProcessor = {
+        layout: function (nodeContext, column, leadingEdge) {
+          calls.push({
+            name: "layout",
+            nodeContext: nodeContext,
+            column: column,
+            leadingEdge: leadingEdge,
+          });
+          nodeContext.after = true;
+          return vivliostyle_task.newResult(nodeContext);
+        },
+        createEdgeBreakPosition: function (
+          position,
+          breakOnEdge,
+          overflows,
+          columnBlockSize,
+        ) {
+          calls.push({
+            name: "createEdgeBreakPosition",
+            nodeContext: position,
+            breakOnEdge: breakOnEdge,
+            overflows: overflows,
+            columnBlockSize: columnBlockSize,
+          });
+          return breakPosition;
+        },
+        startNonInlineElementNode: function (nodeContext) {
+          calls.push({
+            name: "startNonInlineElementNode",
+            nodeContext: nodeContext,
+          });
+          return true;
+        },
+        afterNonInlineElementNode: function (nodeContext, stopAtOverflow) {
+          calls.push({
+            name: "afterNonInlineElementNode",
+            nodeContext: nodeContext,
+            stopAtOverflow: stopAtOverflow,
+          });
+          return false;
+        },
+        finishBreak: function (
+          column,
+          nodeContext,
+          forceRemoveSelf,
+          endOfColumn,
+        ) {
+          calls.push({
+            name: "finishBreak",
+            column: column,
+            nodeContext: nodeContext,
+            forceRemoveSelf: forceRemoveSelf,
+            endOfColumn: endOfColumn,
+          });
+          return vivliostyle_task.newResult(true);
+        },
+        clearOverflownViewNodes: function (
+          column,
+          parentNodeContext,
+          nodeContext,
+          removeSelf,
+        ) {
+          calls.push({
+            name: "clearOverflownViewNodes",
+            column: column,
+            parentNodeContext: parentNodeContext,
+            nodeContext: nodeContext,
+            removeSelf: removeSelf,
+          });
+        },
+      };
+    });
+
+    it("hands the processor itself to a hook the core registered", function () {
+      expect(
+        vivliostyle_legacy.adaptLegacyLayoutProcessor(
+          coreHook,
+          legacyProcessor,
+        ),
+      ).toBe(legacyProcessor);
+    });
+
+    it("serves one adapter per legacy processor", function () {
+      var adapted = vivliostyle_legacy.adaptLegacyLayoutProcessor(
+        externalHook,
+        legacyProcessor,
+      );
+      expect(adapted).not.toBe(legacyProcessor);
+      expect(
+        vivliostyle_legacy.adaptLegacyLayoutProcessor(
+          externalHook,
+          legacyProcessor,
+        ),
+      ).toBe(adapted);
+    });
+
+    it("hands layout the node context and the column as legacy views", function () {
+      var nodeContext = openTextNodeContext();
+      var column = stubColumn();
+      var result = vivliostyle_legacy
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .layout(nodeContext, column, true);
+      expect(calls[0].nodeContext).toBe(nodeContext);
+      expect(typeof calls[0].nodeContext.copy).toBe("function");
+      expect(calls[0].column).not.toBe(column);
+      expect(calls[0].column.checkOverflowAndSaveEdge(null, null)).toBe(true);
+      expect(result.get()).toBe(nodeContext);
+      expect(result.get().kind).toBe("after-none");
+    });
+
+    it("wraps the break position the processor creates", function () {
+      var position = openTextNodeContext();
+      var column = stubColumn();
+      var adapted = vivliostyle_legacy
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .createEdgeBreakPosition(position, "column", true, 120);
+      expect(adapted).not.toBe(breakPosition);
+      expect(calls[0].nodeContext).toBe(position);
+      expect(typeof calls[0].nodeContext.copy).toBe("function");
+      expect(calls[0].breakOnEdge).toBe("column");
+      expect(calls[0].columnBlockSize).toBe(120);
+      expect(adapted.getMinBreakPenalty()).toBe(3);
+      expect(adapted.calculateOffset(column).current).toBe(1);
+      expect(calls[1].column).not.toBe(column);
+      breakPosition.broken = elementNodeContext();
+      breakPosition.broken.after = true;
+      expect(adapted.findAcceptableBreak(column, 2)).toBe(breakPosition.broken);
+      expect(calls[2].column).not.toBe(column);
+      expect(calls[2].column.isOverflown(1)).toBe(true);
+      expect(breakPosition.broken.kind).toBe("after-element");
+      breakPosition.broken = null;
+      expect(adapted.findAcceptableBreak(column, 2)).toBe(null);
+      adapted.breakPositionChosen(column);
+      expect(calls[4].name).toBe("breakPositionChosen");
+    });
+
+    it("adapts the break position class a legacy processor created", function () {
+      var position = elementNodeContext();
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      var core = new vivliostyle_break_position.EdgeBreakPosition(
+        position,
+        "column",
+        true,
+        120,
+      );
+      legacyProcessor.createEdgeBreakPosition = function () {
+        return core;
+      };
+      var created = vivliostyle_legacy
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .createEdgeBreakPosition(position, "column", true, 120);
+      expect(created).not.toBe(core);
+      column.breakPositions = [created];
+      expect(view.breakPositions[0]).toBe(core);
+    });
+
+    it("adapts a break position a legacy processor created only once", function () {
+      var position = elementNodeContext();
+      var adapted = vivliostyle_legacy
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .createEdgeBreakPosition(position, "column", true, 120);
+      expect(adapted).not.toBe(breakPosition);
+      var column = stubColumn();
+      var view = vivliostyle_legacy.asLegacyColumn(externalHook, column);
+      column.breakPositions = [adapted];
+      expect(view.breakPositions[0]).toBe(breakPosition);
+      view.breakPositions[0] = view.breakPositions[0];
+      expect(column.breakPositions[0]).toBe(adapted);
+    });
+
+    it("hands the remaining node contexts over as legacy views", function () {
+      var nodeContext = openTextNodeContext();
+      var parentNodeContext = elementNodeContext();
+      var column = stubColumn();
+      var adapted = vivliostyle_legacy.adaptLegacyLayoutProcessor(
+        externalHook,
+        legacyProcessor,
+      );
+      expect(adapted.startNonInlineElementNode(nodeContext)).toBe(true);
+      expect(adapted.afterNonInlineElementNode(nodeContext, true)).toBe(false);
+      expect(adapted.finishBreak(column, nodeContext, false, true).get()).toBe(
+        true,
+      );
+      adapted.clearOverflownViewNodes(
+        column,
+        parentNodeContext,
+        nodeContext,
+        true,
+      );
+      adapted.clearOverflownViewNodes(column, null, nodeContext, false);
+      calls.forEach(function (call) {
+        expect(call.nodeContext).toBe(nodeContext);
+        expect(typeof call.nodeContext.copy).toBe("function");
+      });
+      expect(typeof calls[3].parentNodeContext.copy).toBe("function");
+      expect(calls[4].parentNodeContext).toBe(null);
+      expect(calls[2].column).not.toBe(column);
+      expect(calls[2].column.isOverflown(1)).toBe(true);
+    });
+
+    it("retags the value layout mutated but did not return", function () {
+      var nodeContext = openTextNodeContext();
+      var column = stubColumn();
+      legacyProcessor.layout = function (ctx) {
+        ctx.after = true;
+        return vivliostyle_task.newResult(null);
+      };
+      var result = vivliostyle_legacy
+        .adaptLegacyLayoutProcessor(externalHook, legacyProcessor)
+        .layout(nodeContext, column, true);
+      expect(result.get()).toBe(null);
+      expect(nodeContext.kind).toBe("after-none");
+    });
+
+    it("retags the values the remaining members mutated in place", function () {
+      var nodeContext = openTextNodeContext();
+      var parentNodeContext = elementNodeContext();
+      var position = openTextNodeContext();
+      var column = stubColumn();
+      legacyProcessor.startNonInlineElementNode = function (ctx) {
+        ctx.after = true;
+        return true;
+      };
+      legacyProcessor.afterNonInlineElementNode = function (ctx) {
+        ctx.after = true;
+        return false;
+      };
+      legacyProcessor.createEdgeBreakPosition = function (ctx) {
+        ctx.after = true;
+        return breakPosition;
+      };
+      legacyProcessor.finishBreak = function (col, ctx) {
+        ctx.after = true;
+        return vivliostyle_task.newResult(true);
+      };
+      legacyProcessor.clearOverflownViewNodes = function (col, parent, ctx) {
+        parent.after = true;
+        ctx.after = true;
+      };
+      var adapted = vivliostyle_legacy.adaptLegacyLayoutProcessor(
+        externalHook,
+        legacyProcessor,
+      );
+      adapted.createEdgeBreakPosition(position, "column", true, 120);
+      expect(position.kind).toBe("after-none");
+      adapted.startNonInlineElementNode(nodeContext);
+      expect(nodeContext.kind).toBe("after-none");
+      adapted.afterNonInlineElementNode(nodeContext, true);
+      expect(nodeContext.kind).toBe("after-none");
+      expect(adapted.finishBreak(column, nodeContext, false, true).get()).toBe(
+        true,
+      );
+      adapted.clearOverflownViewNodes(
+        column,
+        parentNodeContext,
+        nodeContext,
+        true,
+      );
+      expect(parentNodeContext.kind).toBe("after-element");
+      expect(nodeContext.kind).toBe("after-none");
+    });
+  });
+
+  describe("adaptLegacyFormattingContext", function () {
+    var externalHook = function () {};
+    var coreHook = vivliostyle_plugin.getHooksForName(
+      "RESOLVE_FORMATTING_CONTEXT",
+    )[0];
+
+    function StubFormattingContext() {
+      this.calls = [];
+    }
+
+    StubFormattingContext.prototype.isFirstTime = function (
+      nodeContext,
+      firstTime,
+    ) {
+      this.calls.push({ nodeContext: nodeContext, firstTime: firstTime });
+      return firstTime;
+    };
+
+    it("leaves the formatting context of a core hook alone", function () {
+      var formattingContext = new StubFormattingContext();
+      expect(
+        vivliostyle_legacy.adaptLegacyFormattingContext(
+          coreHook,
+          formattingContext,
+        ),
+      ).toBe(formattingContext);
+      expect(
+        Object.prototype.hasOwnProperty.call(formattingContext, "isFirstTime"),
+      ).toBe(false);
+    });
+
+    it("keeps the identity and the prototype of the returned value", function () {
+      var formattingContext = new StubFormattingContext();
+      var adapted = vivliostyle_legacy.adaptLegacyFormattingContext(
+        externalHook,
+        formattingContext,
+      );
+      expect(adapted).toBe(formattingContext);
+      expect(adapted instanceof StubFormattingContext).toBe(true);
+      expect(Object.getPrototypeOf(adapted)).toBe(
+        StubFormattingContext.prototype,
+      );
+      expect(
+        Object.prototype.hasOwnProperty.call(formattingContext, "isFirstTime"),
+      ).toBe(true);
+    });
+
+    it("hands the node context to isFirstTime as a legacy view", function () {
+      var formattingContext = new StubFormattingContext();
+      vivliostyle_legacy.adaptLegacyFormattingContext(
+        externalHook,
+        formattingContext,
+      );
+      var nodeContext = openTextNodeContext();
+      expect(formattingContext.isFirstTime(nodeContext, true)).toBe(true);
+      expect(formattingContext.calls.length).toBe(1);
+      expect(formattingContext.calls[0].nodeContext).toBe(nodeContext);
+      expect(typeof formattingContext.calls[0].nodeContext.copy).toBe(
+        "function",
+      );
+    });
+
+    it("replaces isFirstTime once", function () {
+      var formattingContext = new StubFormattingContext();
+      vivliostyle_legacy.adaptLegacyFormattingContext(
+        externalHook,
+        formattingContext,
+      );
+      var replaced = formattingContext.isFirstTime;
+      expect(
+        vivliostyle_legacy.adaptLegacyFormattingContext(
+          externalHook,
+          formattingContext,
+        ),
+      ).toBe(formattingContext);
+      expect(formattingContext.isFirstTime).toBe(replaced);
+      formattingContext.isFirstTime(openTextNodeContext(), false);
+      expect(formattingContext.calls.length).toBe(1);
+    });
+
+    it("leaves a frozen formatting context unpatched", function () {
+      var formattingContext = Object.freeze(new StubFormattingContext());
+      var original = formattingContext.isFirstTime;
+      expect(
+        vivliostyle_legacy.adaptLegacyFormattingContext(
+          externalHook,
+          formattingContext,
+        ),
+      ).toBe(formattingContext);
+      expect(formattingContext.isFirstTime).toBe(original);
+      expect(
+        Object.prototype.hasOwnProperty.call(formattingContext, "isFirstTime"),
+      ).toBe(false);
+      var nodeContext = openTextNodeContext();
+      expect(formattingContext.isFirstTime(nodeContext, true)).toBe(true);
+      expect(formattingContext.calls[0].nodeContext).toBe(nodeContext);
+    });
+
+    it("leaves a formatting context whose isFirstTime is read-only unpatched", function () {
+      var calls = [];
+      var formattingContext = {};
+      var original = function (nodeContext, firstTime) {
+        calls.push(nodeContext);
+        return firstTime;
+      };
+      Object.defineProperty(formattingContext, "isFirstTime", {
+        value: original,
+        writable: false,
+        enumerable: true,
+        configurable: false,
+      });
+      expect(
+        vivliostyle_legacy.adaptLegacyFormattingContext(
+          externalHook,
+          formattingContext,
+        ),
+      ).toBe(formattingContext);
+      expect(formattingContext.isFirstTime).toBe(original);
+      var nodeContext = openTextNodeContext();
+      expect(formattingContext.isFirstTime(nodeContext, true)).toBe(true);
+      expect(calls[0]).toBe(nodeContext);
+    });
+
+    it("patches a sealed formatting context that carries its own isFirstTime", function () {
+      var calls = [];
+      var formattingContext = Object.seal({
+        isFirstTime: function (nodeContext, firstTime) {
+          calls.push(nodeContext);
+          return firstTime;
+        },
+      });
+      var original = formattingContext.isFirstTime;
+      vivliostyle_legacy.adaptLegacyFormattingContext(
+        externalHook,
+        formattingContext,
+      );
+      expect(formattingContext.isFirstTime).not.toBe(original);
+      var nodeContext = openTextNodeContext();
+      expect(formattingContext.isFirstTime(nodeContext, true)).toBe(true);
+      expect(typeof calls[0].copy).toBe("function");
+    });
+  });
+
+  describe("legacyFirstTime", function () {
+    var hookName = "RESOLVE_FORMATTING_CONTEXT";
+    var external = function () {};
+
+    function firstTimeOf(formattingContext, nodeContext, firstTime) {
+      return vivliostyle_legacy.legacyFirstTime(
+        formattingContext,
+        nodeContext,
+        vivliostyle_node_context.elementRenderResultOf(nodeContext),
+        firstTime,
+      );
+    }
+
+    describe("while an external hook is registered", function () {
+      beforeEach(function () {
+        vivliostyle_plugin.registerHook(hookName, external);
+      });
+
+      afterEach(function () {
+        vivliostyle_plugin.removeHook(hookName, external);
+      });
+
+      it("hands the rendered draft to the formatting context", function () {
+        var nodeContext = elementNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        rendered.display = "block";
+        var seen = [];
+        var resolved = vivliostyle_legacy.legacyFirstTime(
+          {
+            isFirstTime: function (ctx, firstTime) {
+              seen.push(ctx);
+              return !firstTime;
+            },
+          },
+          nodeContext,
+          rendered,
+          false,
+        );
+        expect(resolved.firstTime).toBe(true);
+        expect(seen[0]).not.toBe(nodeContext);
+        expect(seen[0].display).toBe("block");
+        expect(typeof seen[0].copy).toBe("function");
+      });
+
+      it("carries what the formatting context wrote back to the core", function () {
+        var nodeContext = elementNodeContext();
+        var rendered =
+          vivliostyle_node_context.elementRenderResultOf(nodeContext);
+        var resolved = vivliostyle_legacy.legacyFirstTime(
+          {
+            isFirstTime: function (ctx, firstTime) {
+              ctx.floatSide = "left";
+              ctx.fragmentIndex = 7;
+              return firstTime;
+            },
+          },
+          nodeContext,
+          rendered,
+          true,
+        );
+        expect(rendered.floatSide).toBe("left");
+        expect(resolved.nodeContext).not.toBe(nodeContext);
+        expect(resolved.nodeContext.fragmentIndex).toBe(7);
+        expect(nodeContext.fragmentIndex).toBe(1);
+      });
+
+      it("retags the value the formatting context moved to its after edge", function () {
+        var nodeContext = elementNodeContext();
+        var resolved = firstTimeOf(
+          {
+            isFirstTime: function (ctx, firstTime) {
+              ctx.after = true;
+              return firstTime;
+            },
+          },
+          nodeContext,
+          true,
+        );
+        expect(resolved.nodeContext.kind).toBe("after-element");
+        expect(nodeContext.kind).toBe("element");
+      });
+    });
+
+    it("hands the core value on while no external hook is registered", function () {
+      var nodeContext = elementNodeContext();
+      var seen = [];
+      var resolved = firstTimeOf(
+        {
+          isFirstTime: function (ctx, firstTime) {
+            seen.push(ctx);
+            return firstTime;
+          },
+        },
+        nodeContext,
+        false,
+      );
+      expect(resolved.firstTime).toBe(false);
+      expect(resolved.nodeContext).toBe(nodeContext);
+      expect(typeof seen[0].copy).toBe("undefined");
+    });
+  });
+
+  describe("the post layout block boundary", function () {
+    var hookName = "POST_LAYOUT_BLOCK";
+
+    it("retags what a hook mutated before the next hook reads it", function () {
+      var column = constructedColumn();
+      var nodeContext = elementNodeContext();
+      var checkPoints = [elementNodeContext()];
+      var mutating = function (seenNodeContext, seenCheckPoints) {
+        seenNodeContext.after = true;
+        seenCheckPoints[0].after = true;
+      };
+      var seen = [];
+      var reading = function (seenNodeContext, seenCheckPoints) {
+        seen.push(seenNodeContext.kind, seenCheckPoints[0].kind);
+      };
+      vivliostyle_plugin.registerHook(hookName, reading, true);
+      vivliostyle_plugin.registerHook(hookName, mutating, true);
+      try {
+        column.postLayoutBlock(nodeContext, checkPoints);
+      } finally {
+        vivliostyle_plugin.removeHook(hookName, mutating);
+        vivliostyle_plugin.removeHook(hookName, reading);
+      }
+      expect(seen).toEqual(["after-element", "after-element"]);
+      expect(nodeContext.kind).toBe("after-element");
+      expect(checkPoints[0].kind).toBe("after-element");
     });
   });
 });

--- a/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
+++ b/packages/core/test/spec/vivliostyle/legacy-plugin-surface-spec.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
+import * as vivliostyle_legacy from "../../../src/vivliostyle/legacy-plugin-surface";
+import * as vivliostyle_node_context from "../../../src/vivliostyle/node-context";
+import * as vivliostyle_layout_processor from "../../../src/vivliostyle/layout-processor";
+import * as vivliostyle_vtree from "../../../src/vivliostyle/vtree";
+
+import "../../../src/vivliostyle";
+
+describe("legacy-plugin-surface", function () {
+  "use strict";
+
+  var hookNames = [
+    "PREPROCESS_TEXT_CONTENT",
+    "PREPROCESS_ELEMENT_STYLE",
+    "RESOLVE_FORMATTING_CONTEXT",
+    "RESOLVE_TEXT_NODE_BREAKER",
+    "POST_LAYOUT_BLOCK",
+  ];
+
+  function openTextNodeContext() {
+    return vivliostyle_node_context.openAt(
+      document.createTextNode("legacy"),
+      null,
+      3,
+      new vivliostyle_layout_processor.BlockFormattingContext(null),
+      {
+        shadowType: vivliostyle_vtree.ShadowType.NONE,
+        shadowContext: null,
+      },
+      { offsetInNode: 0, after: false },
+    );
+  }
+
+  describe("isCoreHook", function () {
+    it("identifies every hook the core registered", function () {
+      Object.keys(vivliostyle_plugin.HOOKS).forEach(function (name) {
+        vivliostyle_plugin.getHooksForName(name).forEach(function (fn) {
+          expect(vivliostyle_plugin.isCoreHook(fn)).toBe(true);
+        });
+      });
+    });
+
+    it("tells an externally registered hook apart wherever it sits", function () {
+      var external = function () {};
+      var name = "POST_LAYOUT_BLOCK";
+      vivliostyle_plugin.registerHook(name, external, true);
+      var registered = vivliostyle_plugin.getHooksForName(name);
+      expect(registered[0]).toBe(external);
+      expect(vivliostyle_plugin.isCoreHook(registered[0])).toBe(false);
+      expect(vivliostyle_plugin.isCoreHook(registered[1])).toBe(true);
+      vivliostyle_plugin.removeHook(name, external);
+    });
+  });
+
+  describe("legacySurfaceActive", function () {
+    it("is false while only the core has registered", function () {
+      hookNames.forEach(function (name) {
+        expect(vivliostyle_legacy.legacySurfaceActive(name)).toBe(false);
+      });
+    });
+
+    it("is true while an external hook is registered", function () {
+      var external = function () {};
+      hookNames.forEach(function (name) {
+        vivliostyle_plugin.registerHook(name, external);
+        expect(vivliostyle_legacy.legacySurfaceActive(name)).toBe(true);
+        vivliostyle_plugin.removeHook(name, external);
+        expect(vivliostyle_legacy.legacySurfaceActive(name)).toBe(false);
+      });
+    });
+
+    it("is true while an external hook is registered at the first", function () {
+      var external = function () {};
+      hookNames.forEach(function (name) {
+        vivliostyle_plugin.registerHook(name, external, true);
+        expect(vivliostyle_legacy.legacySurfaceActive(name)).toBe(true);
+        vivliostyle_plugin.removeHook(name, external);
+        expect(vivliostyle_legacy.legacySurfaceActive(name)).toBe(false);
+      });
+    });
+  });
+
+  describe("asLegacyNodeContext", function () {
+    var hookName = "PREPROCESS_TEXT_CONTENT";
+    var external = function () {};
+
+    beforeEach(function () {
+      vivliostyle_plugin.registerHook(hookName, external);
+    });
+
+    afterEach(function () {
+      vivliostyle_plugin.removeHook(hookName, external);
+    });
+
+    it("hands out the value itself", function () {
+      var nodeContext = openTextNodeContext();
+      expect(
+        vivliostyle_legacy.asLegacyNodeContext(hookName, nodeContext),
+      ).toBe(nodeContext);
+    });
+
+    it("restores the removed members", function () {
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        openTextNodeContext(),
+      );
+      expect(legacy.shared).toBe(true);
+      expect(legacy.copy()).toBe(legacy);
+      expect(legacy.isInsideBFC()).toBe(false);
+      expect(legacy.getContainingBlockForAbsolute()).toBe(null);
+      expect(legacy.toNodePositionStep().node).toBe(legacy.sourceNode);
+      expect(legacy.toNodePosition().steps.length).toBe(1);
+      expect(legacy.belongsTo(legacy.formattingContext)).toBe(false);
+    });
+
+    it("modifies into a separate value carrying the same position", function () {
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        openTextNodeContext(),
+      );
+      legacy.display = "block";
+      var modified = legacy.modify();
+      expect(modified).not.toBe(legacy);
+      expect(modified.sourceNode).toBe(legacy.sourceNode);
+      expect(modified.boxOffset).toBe(legacy.boxOffset);
+      expect(modified.display).toBe("block");
+      expect(modified.shared).toBe(true);
+      modified.display = "inline";
+      expect(legacy.display).toBe("block");
+    });
+
+    it("takes plugin writes on the value the core keeps", function () {
+      var nodeContext = openTextNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        nodeContext,
+      );
+      legacy.overflow = true;
+      expect(nodeContext.overflow).toBe(true);
+    });
+
+    it("resets the view in place and retags the value", function () {
+      var nodeContext = openTextNodeContext();
+      var legacy = vivliostyle_legacy.asLegacyNodeContext(
+        hookName,
+        nodeContext,
+      );
+      legacy.after = true;
+      legacy.fragmentIndex = 4;
+      legacy.resetView();
+      expect(nodeContext.after).toBe(false);
+      expect(nodeContext.viewNode).toBe(null);
+      expect(nodeContext.fragmentIndex).toBe(1);
+      expect(nodeContext.kind).toBe("open");
+    });
+  });
+});

--- a/packages/core/test/spec/vivliostyle/node-context-spec.js
+++ b/packages/core/test/spec/vivliostyle/node-context-spec.js
@@ -181,6 +181,59 @@ describe("node-context", function () {
     });
   });
 
+  describe("continuation", function () {
+    it("keeps the continuation of each slot apart", function () {
+      var oneSlot = openedAt(false);
+      var otherSlot = openedAt(false);
+      var one = vivliostyle_node_context.derived(oneSlot);
+      var other = vivliostyle_node_context.derived(otherSlot);
+      vivliostyle_node_context.resumeContinuation(oneSlot, one);
+      vivliostyle_node_context.resumeContinuation(otherSlot, other);
+      var moved = vivliostyle_node_context.derived(one);
+      vivliostyle_node_context.followContinuation(one, moved);
+      expect(vivliostyle_node_context.latestContinuation(oneSlot)).toBe(moved);
+      expect(vivliostyle_node_context.latestContinuation(otherSlot)).toBe(
+        other,
+      );
+    });
+
+    it("releases the value a slot no longer continues at", function () {
+      var slot = openedAt(false);
+      var first = vivliostyle_node_context.derived(slot);
+      vivliostyle_node_context.resumeContinuation(slot, first);
+      var second = vivliostyle_node_context.derived(slot);
+      vivliostyle_node_context.resumeContinuation(slot, second);
+      expect(vivliostyle_node_context.latestContinuation(slot)).toBe(second);
+      var moved = vivliostyle_node_context.derived(first);
+      vivliostyle_node_context.followContinuation(first, moved);
+      expect(vivliostyle_node_context.latestContinuation(slot)).toBe(second);
+    });
+
+    it("lets a released value carry the continuation of another slot", function () {
+      var slot = openedAt(false);
+      var first = vivliostyle_node_context.derived(slot);
+      vivliostyle_node_context.resumeContinuation(slot, first);
+      var second = vivliostyle_node_context.derived(slot);
+      vivliostyle_node_context.resumeContinuation(slot, second);
+      var otherSlot = openedAt(false);
+      vivliostyle_node_context.resumeContinuation(otherSlot, first);
+      var moved = vivliostyle_node_context.derived(first);
+      vivliostyle_node_context.followContinuation(first, moved);
+      expect(vivliostyle_node_context.latestContinuation(otherSlot)).toBe(
+        moved,
+      );
+      expect(vivliostyle_node_context.latestContinuation(slot)).toBe(second);
+    });
+
+    it("leaves a value no slot continues at alone", function () {
+      var value = openedAt(false);
+      var next = vivliostyle_node_context.derived(value);
+      vivliostyle_node_context.followContinuation(value, next);
+      expect(vivliostyle_node_context.latestContinuation(value)).toBe(value);
+      expect(vivliostyle_node_context.latestContinuation(next)).toBe(next);
+    });
+  });
+
   describe("openNextSiblingOf", function () {
     it("keeps the inherited fields the previous sibling carried", function () {
       var element = elementNodeContext();

--- a/packages/core/test/spec/vivliostyle/node-context-spec.js
+++ b/packages/core/test/spec/vivliostyle/node-context-spec.js
@@ -182,55 +182,89 @@ describe("node-context", function () {
   });
 
   describe("continuation", function () {
+    var store;
+
+    beforeEach(function () {
+      store = {
+        continuationOfSlot: new WeakMap(),
+        slotOfContinuation: new WeakMap(),
+      };
+    });
+
     it("keeps the continuation of each slot apart", function () {
       var oneSlot = openedAt(false);
       var otherSlot = openedAt(false);
       var one = vivliostyle_node_context.derived(oneSlot);
       var other = vivliostyle_node_context.derived(otherSlot);
-      vivliostyle_node_context.resumeContinuation(oneSlot, one);
-      vivliostyle_node_context.resumeContinuation(otherSlot, other);
+      vivliostyle_node_context.resumeContinuation(store, oneSlot, one);
+      vivliostyle_node_context.resumeContinuation(store, otherSlot, other);
       var moved = vivliostyle_node_context.derived(one);
-      vivliostyle_node_context.followContinuation(one, moved);
-      expect(vivliostyle_node_context.latestContinuation(oneSlot)).toBe(moved);
-      expect(vivliostyle_node_context.latestContinuation(otherSlot)).toBe(
-        other,
+      vivliostyle_node_context.followContinuation(store, one, moved);
+      expect(vivliostyle_node_context.latestContinuation(store, oneSlot)).toBe(
+        moved,
+      );
+      expect(
+        vivliostyle_node_context.latestContinuation(store, otherSlot),
+      ).toBe(other);
+    });
+
+    it("keeps another document layout at the original slot", function () {
+      var slot = openedAt(false);
+      var resumed = vivliostyle_node_context.derived(slot);
+      var other = {
+        continuationOfSlot: new WeakMap(),
+        slotOfContinuation: new WeakMap(),
+      };
+      vivliostyle_node_context.resumeContinuation(store, slot, resumed);
+      expect(vivliostyle_node_context.latestContinuation(other, slot)).toBe(
+        slot,
       );
     });
 
     it("releases the value a slot no longer continues at", function () {
       var slot = openedAt(false);
       var first = vivliostyle_node_context.derived(slot);
-      vivliostyle_node_context.resumeContinuation(slot, first);
+      vivliostyle_node_context.resumeContinuation(store, slot, first);
       var second = vivliostyle_node_context.derived(slot);
-      vivliostyle_node_context.resumeContinuation(slot, second);
-      expect(vivliostyle_node_context.latestContinuation(slot)).toBe(second);
+      vivliostyle_node_context.resumeContinuation(store, slot, second);
+      expect(vivliostyle_node_context.latestContinuation(store, slot)).toBe(
+        second,
+      );
       var moved = vivliostyle_node_context.derived(first);
-      vivliostyle_node_context.followContinuation(first, moved);
-      expect(vivliostyle_node_context.latestContinuation(slot)).toBe(second);
+      vivliostyle_node_context.followContinuation(store, first, moved);
+      expect(vivliostyle_node_context.latestContinuation(store, slot)).toBe(
+        second,
+      );
     });
 
     it("lets a released value carry the continuation of another slot", function () {
       var slot = openedAt(false);
       var first = vivliostyle_node_context.derived(slot);
-      vivliostyle_node_context.resumeContinuation(slot, first);
+      vivliostyle_node_context.resumeContinuation(store, slot, first);
       var second = vivliostyle_node_context.derived(slot);
-      vivliostyle_node_context.resumeContinuation(slot, second);
+      vivliostyle_node_context.resumeContinuation(store, slot, second);
       var otherSlot = openedAt(false);
-      vivliostyle_node_context.resumeContinuation(otherSlot, first);
+      vivliostyle_node_context.resumeContinuation(store, otherSlot, first);
       var moved = vivliostyle_node_context.derived(first);
-      vivliostyle_node_context.followContinuation(first, moved);
-      expect(vivliostyle_node_context.latestContinuation(otherSlot)).toBe(
-        moved,
+      vivliostyle_node_context.followContinuation(store, first, moved);
+      expect(
+        vivliostyle_node_context.latestContinuation(store, otherSlot),
+      ).toBe(moved);
+      expect(vivliostyle_node_context.latestContinuation(store, slot)).toBe(
+        second,
       );
-      expect(vivliostyle_node_context.latestContinuation(slot)).toBe(second);
     });
 
     it("leaves a value no slot continues at alone", function () {
       var value = openedAt(false);
       var next = vivliostyle_node_context.derived(value);
-      vivliostyle_node_context.followContinuation(value, next);
-      expect(vivliostyle_node_context.latestContinuation(value)).toBe(value);
-      expect(vivliostyle_node_context.latestContinuation(next)).toBe(next);
+      vivliostyle_node_context.followContinuation(store, value, next);
+      expect(vivliostyle_node_context.latestContinuation(store, value)).toBe(
+        value,
+      );
+      expect(vivliostyle_node_context.latestContinuation(store, next)).toBe(
+        next,
+      );
     });
   });
 

--- a/packages/core/test/spec/vivliostyle/node-context-spec.js
+++ b/packages/core/test/spec/vivliostyle/node-context-spec.js
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as vivliostyle_layout_processor from "../../../src/vivliostyle/layout-processor";
+import * as vivliostyle_node_context from "../../../src/vivliostyle/node-context";
+import * as vivliostyle_vtree from "../../../src/vivliostyle/vtree";
+
+describe("node-context", function () {
+  "use strict";
+
+  function openedAt(after) {
+    return vivliostyle_node_context.openAt(
+      document.createElement("div"),
+      null,
+      0,
+      new vivliostyle_layout_processor.BlockFormattingContext(null),
+      {
+        shadowType: vivliostyle_vtree.ShadowType.NONE,
+        shadowContext: null,
+      },
+      { offsetInNode: 0, after: !!after },
+    );
+  }
+
+  function elementNodeContext() {
+    var opened = openedAt(false);
+    return vivliostyle_node_context.renderedElement(
+      opened,
+      document.createElement("div"),
+      vivliostyle_node_context.elementRenderResultOf(opened),
+    );
+  }
+
+  function textNodeContext() {
+    var parent = elementNodeContext();
+    var child = vivliostyle_node_context.openChildOf(
+      document.createTextNode("text"),
+      parent,
+      1,
+    );
+    return vivliostyle_node_context.renderedText(
+      child,
+      document.createTextNode("text"),
+      [],
+    );
+  }
+
+  var renderProgress = {
+    lang: "ja",
+    vertical: true,
+    direction: "rtl",
+    inheritedProps: { "font-size": 12 },
+    establishesBFC: true,
+    display: "block",
+    floatSide: "left",
+    breakBefore: "page",
+    formattingContext: new vivliostyle_layout_processor.BlockFormattingContext(
+      null,
+    ),
+  };
+
+  var renderedFields = {
+    nodeShadow: { root: "shadow" },
+    inline: false,
+    breakPenalty: 7,
+    pageType: "cover",
+    captionSide: "bottom",
+    inlineBorderSpacing: 3,
+    blockBorderSpacing: 5,
+    firstPseudo: { count: 1 },
+    whitespace: vivliostyle_vtree.Whitespace.PRESERVE,
+    hyphenateCharacter: "=",
+    breakWord: true,
+  };
+
+  var elementStyleFields = {
+    floatReference: "page",
+    clearSide: "both",
+    floatMinWrapBlock: { value: 1 },
+    columnSpan: { value: "all" },
+    flexContainer: true,
+    containingBlockForAbsolute: true,
+    breakAfter: "page",
+    repeatOnBreak: "header",
+    afterIfContinues: { source: "after" },
+    footnotePolicy: { name: "line" },
+  };
+
+  function renderResultOf(nodeContext) {
+    var result = vivliostyle_node_context.elementRenderResultOf(nodeContext);
+    [renderProgress, renderedFields, elementStyleFields].forEach(
+      function (fields) {
+        Object.keys(fields).forEach(function (field) {
+          result[field] = fields[field];
+        });
+      },
+    );
+    return result;
+  }
+
+  describe("viewlessRender", function () {
+    it("carries the render progress of the result", function () {
+      var opened = openedAt(false);
+      var rendered = vivliostyle_node_context.viewlessRender(
+        opened,
+        renderResultOf(opened),
+      );
+      Object.keys(renderProgress).forEach(function (field) {
+        expect(rendered[field]).toBe(renderProgress[field]);
+      });
+    });
+
+    it("carries the rendered fields of the result", function () {
+      var opened = openedAt(false);
+      var rendered = vivliostyle_node_context.viewlessRender(
+        opened,
+        renderResultOf(opened),
+      );
+      Object.keys(renderedFields).forEach(function (field) {
+        expect(rendered[field]).toBe(renderedFields[field]);
+      });
+    });
+
+    it("leaves the element style fields of the result behind", function () {
+      var opened = openedAt(false);
+      var rendered = vivliostyle_node_context.viewlessRender(
+        opened,
+        renderResultOf(opened),
+      );
+      Object.keys(elementStyleFields).forEach(function (field) {
+        expect(rendered[field]).not.toBe(elementStyleFields[field]);
+        expect(rendered[field]).toBe(opened[field]);
+      });
+    });
+
+    it("keeps the element style fields an open context already carries", function () {
+      var opened = openedAt(false);
+      opened.breakAfter = "column";
+      var rendered = vivliostyle_node_context.viewlessRender(
+        opened,
+        renderResultOf(opened),
+      );
+      expect(rendered.breakAfter).toBe("column");
+    });
+
+    it("keeps an open context open and viewless", function () {
+      var opened = openedAt(false);
+      var rendered = vivliostyle_node_context.viewlessRender(
+        opened,
+        renderResultOf(opened),
+      );
+      expect(rendered.kind).toBe("open");
+      expect(rendered.after).toBe(false);
+      expect(rendered.viewNode).toBe(null);
+    });
+
+    it("keeps an after-none context after and viewless", function () {
+      var opened = openedAt(true);
+      expect(opened.kind).toBe("after-none");
+      var rendered = vivliostyle_node_context.viewlessRender(
+        opened,
+        renderResultOf(opened),
+      );
+      expect(rendered.kind).toBe("after-none");
+      expect(rendered.after).toBe(true);
+      expect(rendered.viewNode).toBe(null);
+    });
+  });
+
+  describe("openNextSiblingOf", function () {
+    it("keeps the inherited fields the previous sibling carried", function () {
+      var element = elementNodeContext();
+      element.lang = "ja";
+      element.direction = "rtl";
+      element.inheritedProps = { widows: 3 };
+      var next = vivliostyle_node_context.openNextSiblingOf(
+        element,
+        document.createTextNode("text"),
+        7,
+      );
+      expect(next.lang).toBe("ja");
+      expect(next.direction).toBe("rtl");
+      expect(next.inheritedProps).toBe(element.inheritedProps);
+    });
+
+    it("opens the sibling on the view the previous one held", function () {
+      var element = elementNodeContext();
+      element.breakAfter = "page";
+      var sourceNode = document.createTextNode("text");
+      var next = vivliostyle_node_context.openNextSiblingOf(
+        element,
+        sourceNode,
+        7,
+      );
+      expect(next.kind).toBe("open");
+      expect(next.after).toBe(false);
+      expect(next.viewNode).toBe(null);
+      expect(next.breakAfter).toBe(null);
+      expect(next.sourceNode).toBe(sourceNode);
+      expect(next.boxOffset).toBe(7);
+    });
+  });
+
+  describe("viewless", function () {
+    it("hands an open context back as itself", function () {
+      var opened = openedAt(false);
+      expect(vivliostyle_node_context.viewless(opened)).toBe(opened);
+    });
+
+    it("hands an after-none context back as itself", function () {
+      var opened = openedAt(true);
+      expect(vivliostyle_node_context.viewless(opened)).toBe(opened);
+    });
+
+    it("opens an element context and unstyles it", function () {
+      var element = elementNodeContext();
+      element.breakAfter = "page";
+      var viewless = vivliostyle_node_context.viewless(element);
+      expect(element.kind).toBe("element");
+      expect(viewless.kind).toBe("open");
+      expect(viewless.after).toBe(false);
+      expect(viewless.viewNode).toBe(null);
+      expect(viewless.breakAfter).toBe(null);
+    });
+
+    it("opens a text context and unstyles it", function () {
+      var text = textNodeContext();
+      text.breakAfter = "page";
+      var viewless = vivliostyle_node_context.viewless(text);
+      expect(text.kind).toBe("text");
+      expect(viewless.kind).toBe("open");
+      expect(viewless.after).toBe(false);
+      expect(viewless.viewNode).toBe(null);
+      expect(viewless.breakAfter).toBe(null);
+    });
+
+    it("closes an after-element context and unstyles it", function () {
+      var afterElement =
+        vivliostyle_node_context.afterEdgeOf(elementNodeContext());
+      afterElement.breakAfter = "page";
+      var viewless = vivliostyle_node_context.viewless(afterElement);
+      expect(afterElement.kind).toBe("after-element");
+      expect(viewless.kind).toBe("after-none");
+      expect(viewless.after).toBe(true);
+      expect(viewless.viewNode).toBe(null);
+      expect(viewless.breakAfter).toBe(null);
+    });
+  });
+});

--- a/packages/core/test/spec/vivliostyle/node-context-spec.js
+++ b/packages/core/test/spec/vivliostyle/node-context-spec.js
@@ -234,20 +234,46 @@ describe("node-context", function () {
     });
   });
 
+  describe("derived", function () {
+    it("preserves the fields of the source value", function () {
+      var source = elementNodeContext();
+      source.lang = "ja";
+      source.direction = "rtl";
+      source.inheritedProps = { widows: 3 };
+      var derived = vivliostyle_node_context.derived(source);
+      expect(derived).not.toBe(source);
+      expect(derived.lang).toBe(source.lang);
+      expect(derived.direction).toBe(source.direction);
+      expect(derived.inheritedProps).toBe(source.inheritedProps);
+    });
+  });
+
   describe("openNextSiblingOf", function () {
-    it("keeps the inherited fields the previous sibling carried", function () {
-      var element = elementNodeContext();
+    it("resets inherited fields from the parent", function () {
+      var parent = elementNodeContext();
+      parent.direction = "rtl";
+      parent.inheritedProps = { widows: 3 };
+      var opened = vivliostyle_node_context.openChildOf(
+        document.createElement("div"),
+        parent,
+        1,
+      );
+      var element = vivliostyle_node_context.renderedElement(
+        opened,
+        document.createElement("div"),
+        vivliostyle_node_context.elementRenderResultOf(opened),
+      );
       element.lang = "ja";
-      element.direction = "rtl";
-      element.inheritedProps = { widows: 3 };
+      element.direction = "ltr";
+      element.inheritedProps = { widows: 5 };
       var next = vivliostyle_node_context.openNextSiblingOf(
         element,
         document.createTextNode("text"),
         7,
       );
-      expect(next.lang).toBe("ja");
+      expect(next.lang).toBe(null);
       expect(next.direction).toBe("rtl");
-      expect(next.inheritedProps).toBe(element.inheritedProps);
+      expect(next.inheritedProps).toBe(parent.inheritedProps);
     });
 
     it("opens the sibling on the view the previous one held", function () {

--- a/packages/core/test/spec/vivliostyle/view-factory-spec.js
+++ b/packages/core/test/spec/vivliostyle/view-factory-spec.js
@@ -1,0 +1,34 @@
+import * as vivliostyle_vgen from "../../../src/vivliostyle/vgen";
+
+describe("ViewFactory", function () {
+  function viewFactory(breakSuppressionStore, continuationStore) {
+    return new vivliostyle_vgen.ViewFactory(
+      "body",
+      breakSuppressionStore,
+      continuationStore,
+      null,
+      { document: document },
+      {
+        counterListener: {
+          getExprContentListener: function () {
+            return null;
+          },
+        },
+      },
+    );
+  }
+
+  it("shares document-scoped stores with a clone", function () {
+    var breakSuppressionStore = {
+      breakSuppressionByViewNode: new WeakMap(),
+    };
+    var continuationStore = {
+      continuationOfSlot: new WeakMap(),
+      slotOfContinuation: new WeakMap(),
+    };
+    var original = viewFactory(breakSuppressionStore, continuationStore);
+    var cloned = original.clone();
+    expect(cloned.breakSuppressionStore).toBe(breakSuppressionStore);
+    expect(cloned.continuationStore).toBe(continuationStore);
+  });
+});


### PR DESCRIPTION
Vivliostyle.js全体で使われる`NodeContext`クラスを、TypeScriptで標準的なイディオムの[discriminated union](https://typescriptbook.jp/reference/values-types-variables/discriminated-union)＋不変オブジェクトに移行する大規模な変更です。

`NodeContext`クラスは「要素を処理する前」「要素を描画した後」「テキスト内の位置」…のような状態を数十個の可変フィールドの組み合わせで表現していました。一連のリファクタリングで状態ごとのフィールドを分離してきましたが、これを再構成し`NodeContext`が取りうるすべての状態を明確にします。この変更自体は`strictNullChecks`のエラー残数を減らしませんが、後続の型エラーをTypeScript的に理想的な形で解消するために必要になると判断したものです。refs: #2049

`NodeContext`クラスは公開APIにも露出しているので、破壊的変更にならないよう`LegacyNodeContext`を設けました。将来的にメジャーバージョンを上げる機会に撤廃する想定です。これだけのために急にメジャーバージョンを上げる必要はないと思います。

各コミットには`AI-Assisted-By`トレーラーをつけました。こちらでよろしかったでしょうか。