### PR TITLE
docs: sync sponsor list with GitHub Sponsors (y-mikou past, Motoki-N tier fix)

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -31,14 +31,14 @@ vvakame🌟
 u1f992🌟
 <p><a href="https://github.com/yamahige"><img src="https://github.com/yamahige.png" title="yamahige" width="60" height="60" style="max-width:100%;"></a>
 yamahige🌟
-<p><a href="https://github.com/Motoki-N"><img src="https://github.com/Motoki-N.png" title="Motoki-N" width="60" height="60" style="max-width:100%;"></a>
-Motoki-N🌟
 <p><a href="https://github.com/munepi"><img src="https://github.com/munepi.png" title="Munehiro Yamamoto" width="60" height="60" style="max-width:100%;"></a>
 Munehiro Yamamoto⭐️
 <p><a href="https://github.com/zonuexe"><img src="https://github.com/zonuexe.png" title="USAMI Kenta" width="60" height="60" style="max-width:100%;"></a>
 USAMI Kenta⭐️
 <p><a href="https://github.com/monami-ya"><img src="https://github.com/monami-ya.png" title="monami-ya" width="60" height="60" style="max-width:100%;"></a>
 monami-ya⭐️
+<p><a href="https://github.com/Motoki-N"><img src="https://github.com/Motoki-N.png" title="Motoki-N" width="60" height="60" style="max-width:100%;"></a>
+Motoki-N⭐️
 
 ### Past Sponsors
 

--- a/BACKERS.md
+++ b/BACKERS.md
@@ -27,8 +27,6 @@ Atsushi Morimoto🌟
 NoBooking🌟
 <p><a href="https://github.com/vvakame"><img src="https://github.com/vvakame.png" title="vvakame" width="60" height="60" style="max-width:100%;"></a>
 vvakame🌟
-<p><a href="https://github.com/y-mikou"><img src="https://github.com/y-mikou.png" title="y-mikou" width="60" height="60" style="max-width:100%;"></a>
-y-mikou🌟
 <p><a href="https://github.com/u1f992"><img src="https://github.com/u1f992.png" title="u1f992" width="60" height="60" style="max-width:100%;"></a>
 u1f992🌟
 <p><a href="https://github.com/yamahige"><img src="https://github.com/yamahige.png" title="yamahige" width="60" height="60" style="max-width:100%;"></a>
@@ -54,6 +52,8 @@ udon-a🌹
 Satoshi KOJIMA🌟
 <p><a href="https://github.com/sarashino"><img src="https://github.com/sarashino.png" title="sarashino" width="60" height="60" style="max-width:100%;"></a>
 sarashino🌟
+<p><a href="https://github.com/y-mikou"><img src="https://github.com/y-mikou.png" title="y-mikou" width="60" height="60" style="max-width:100%;"></a>
+y-mikou🌟
 <p><a href="https://github.com/monaka"><img src="https://github.com/monaka.png" title="monaka" width="60" height="60" style="max-width:100%;"></a>
 monaka⭐️
 <p><a href="https://github.com/okuzawats"><img src="https://github.com/okuzawats.png" title="okuzawats" width="60" height="60" style="max-width:100%;"></a>


### PR DESCRIPTION
## Summary
- Move y-mikou to Past Sponsors — sponsorship cancelled 2026-08-18 per GitHub Sponsors activity feed.
- Fix Motoki-N's tier badge — sponsors at $1/month (⭐️ tier), was incorrectly listed under the $3/month (🌟) tier.

Companion PR: https://github.com/vivliostyle/vivliostyle.org/pull/176 (same two changes applied to `_data/sponsor.yml`, which drives the `ja`/`en` sponsor pages and the homepage).

## Test plan
- [x] Verified all 14 active sponsors and their tiers against the GitHub Sponsors "Active sponsors" and "Sponsor tiers" screens
- [x] Verified all past-sponsor entries against the GitHub Sponsors "Activity feed"
