### PR TITLE
fix: Fix background-position with var() being dropped on `@page` and root backgrounds

### DIFF
--- a/packages/core/src/vivliostyle/css-styler.ts
+++ b/packages/core/src/vivliostyle/css-styler.ts
@@ -648,6 +648,21 @@ export class Styler implements AbstractStyler {
         (backgroundImage && !Css.isDefaultingValue(backgroundImage))
       ) {
         this.transferPropsToRoot(elemStyle, this.validatorSet.backgroundProps);
+        // background-position-x/-y are not part of the `background` shorthand
+        // grammar, so they are absent from backgroundProps. Move them only when
+        // the source style actually has them: transferPropsToRoot assigns a
+        // default for every property of the map, and a default axis value here
+        // would override the background-position moved just above.
+        for (const pname of [
+          "background-position-x",
+          "background-position-y",
+        ]) {
+          const cascval = elemStyle[pname];
+          if (cascval) {
+            this.rootStyle[pname] = cascval;
+            delete elemStyle[pname];
+          }
+        }
         this.rootBackgroundAssigned = true;
       }
     }

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -2029,6 +2029,9 @@ export class ValidatorSet {
     if (Css.isCustomPropName(name)) {
       return null;
     }
+    // CSS property names are ASCII case-insensitive, and callers may pass a
+    // name that kept the author's casing, so normalize before every lookup.
+    name = name.toLowerCase();
     const shorthand = this.shorthands[name];
     if (shorthand) {
       if (
@@ -2678,7 +2681,11 @@ export class ValidatorSet {
       // Register browser-supported shorthands before var() resolution so the
       // later cascade pass can still expand mixed shorthand/longhand usage.
       this.getShorthand(shorthandName, value);
-      receiver.simpleProperty(origName, value, important);
+      // Store the declaration under the name the rest of the engine looks up.
+      // The non-var path below stores the lowercased name for properties
+      // Vivliostyle validates itself, and consumers such as passPostProperties
+      // and transferPropsToRoot() look them up that way.
+      receiver.simpleProperty(shorthandName, value, important);
       return;
     }
     const px = this.prefixes[name];

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -2039,6 +2039,13 @@ export class ValidatorSet {
       }
       return shorthand;
     }
+    if (this.validators[name]) {
+      // Vivliostyle has its own validator for this property and looks it up by
+      // this name after the cascade, so it must not be split into the browser's
+      // longhands even when the browser treats it as a shorthand
+      // (e.g. `background-position` → `background-position-x`/`-y`).
+      return null;
+    }
     if (this.browserShorthandMisses[name]) {
       return null;
     }

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1824,6 +1824,13 @@ export const passPostProperties = [
   "background-image",
   "background-repeat",
   "background-position",
+  // The browser CSSOM treats background-position as a shorthand of these two.
+  // Vivliostyle keeps background-position whole (see ValidatorSet.getShorthand),
+  // so all three are propagated. They are listed after the shorthand so that an
+  // author overriding one axis after the shorthand wins, as in the usual
+  // `background-position: ...; background-position-x: ...` pattern.
+  "background-position-x",
+  "background-position-y",
   "background-clip",
   "background-origin",
   "background-size",

--- a/packages/core/test/files/background-position-longhand-root.html
+++ b/packages/core/test/files/background-position-longhand-root.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2116: background-position-x/-y on the body element must reach the root background -->
+<html>
+  <head>
+    <title>background-position longhands on the root background (Issue #2116)</title>
+    <style>
+      :root {
+        --pos-x: 15mm;
+        --pos-y: 12.6mm;
+      }
+      @page {
+        size: 100mm 100mm;
+        margin: 15mm;
+      }
+      body {
+        margin: 0;
+        font: 3mm/1.4 sans-serif;
+        /* The body background is transferred to the root, so it becomes the
+           canvas background: painted over the whole page, but positioned
+           relative to the root element's box. */
+        background-image: linear-gradient(#0057b8, #0057b8);
+        background-size: 30mm 5mm;
+        background-repeat: no-repeat;
+        background-position-x: var(--pos-x);
+        background-position-y: var(--pos-y);
+      }
+      .content {
+        /* keep the text clear of the canvas background bar */
+        padding-top: 18mm;
+      }
+      pre {
+        margin: 2mm 0;
+        font: 2.6mm/1.3 monospace;
+      }
+      /* Same background-position-x as the canvas, for a left-edge comparison. */
+      .ref {
+        height: 6mm;
+        border: 0.2mm solid #888;
+        background-image: linear-gradient(#c00, #c00);
+        background-size: 20mm 4mm;
+        background-repeat: no-repeat;
+        background-position-x: var(--pos-x);
+        background-position-y: center;
+      }
+      .note {
+        margin-top: 3mm;
+        font-size: 2.6mm;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <p><strong>Root background, axis longhands</strong></p>
+      <pre>body {
+  background-position-x: var(--pos-x);
+  background-position-y: var(--pos-y);
+}</pre>
+      <div class="ref"></div>
+      <p class="note">
+        The body background becomes the canvas background: painted over the
+        whole page, but positioned relative to the root element's box — here the
+        page area. The blue bar's left edge must line up with the red bar's.
+      </p>
+    </div>
+  </body>
+</html>

--- a/packages/core/test/files/background-position-var.html
+++ b/packages/core/test/files/background-position-var.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2116: var() in background-position is dropped for @page / root backgrounds -->
+<html>
+  <head>
+    <title>background-position with var() (Issue #2116)</title>
+    <style>
+      :root {
+        --pos: 15mm 12.6mm;
+        --pos-x: 15mm;
+        --pos-y: 12.6mm;
+      }
+      @page {
+        size: 100mm 100mm;
+        margin: 15mm;
+        background-image: linear-gradient(#0057b8, #0057b8);
+        background-size: 30mm 5mm;
+        background-repeat: no-repeat;
+      }
+      /* Page 1: the position comes from a custom property. */
+      @page var-page {
+        background-position: var(--pos);
+      }
+      /* Page 2: the same position written literally, as the reference. */
+      @page literal-page {
+        background-position: 15mm 12.6mm;
+      }
+      /* Page 3: the same position through the axis longhands. */
+      @page xy-page {
+        background-position-x: var(--pos-x);
+        background-position-y: var(--pos-y);
+      }
+      body {
+        margin: 0;
+        font: 3mm/1.4 sans-serif;
+      }
+      section {
+        /* keep the text clear of the page background bar on every page */
+        padding-top: 5mm;
+      }
+      section:not(:last-of-type) {
+        break-after: page;
+      }
+      section.var-page {
+        page: var-page;
+      }
+      section.literal-page {
+        page: literal-page;
+      }
+      section.xy-page {
+        page: xy-page;
+      }
+      pre {
+        margin: 2mm 0;
+        font: 2.6mm/1.3 monospace;
+      }
+      .box {
+        height: 18mm;
+        border: 0.2mm solid #888;
+        background-image: linear-gradient(#c00, #c00);
+        background-size: 20mm 4mm;
+        background-repeat: no-repeat;
+      }
+      .box.var-pos {
+        background-position: var(--pos);
+      }
+      .box.literal-pos {
+        background-position: 15mm 12.6mm;
+      }
+      .box.xy-pos {
+        background-position-x: var(--pos-x);
+        background-position-y: var(--pos-y);
+      }
+      .note {
+        margin-top: 3mm;
+        font-size: 2.6mm;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="var-page">
+      <p><strong>Page 1 — shorthand with <code>var()</code></strong></p>
+      <pre>@page var-page {
+  background-position: var(--pos);
+}</pre>
+      <div class="box var-pos"></div>
+      <p class="note">
+        All three pages must render identically: the blue bar starts 15mm /
+        12.6mm from the top-left corner of the <em>page box</em> — page margins
+        included, so not the page area.
+      </p>
+    </section>
+    <section class="literal-page">
+      <p><strong>Page 2 — literal value (reference)</strong></p>
+      <pre>@page literal-page {
+  background-position: 15mm 12.6mm;
+}</pre>
+      <div class="box literal-pos"></div>
+      <p class="note">
+        All three pages must render identically: the blue bar starts 15mm /
+        12.6mm from the top-left corner of the <em>page box</em> — page margins
+        included, so not the page area.
+      </p>
+    </section>
+    <section class="xy-page">
+      <p><strong>Page 3 — axis longhands with <code>var()</code></strong></p>
+      <pre>@page xy-page {
+  background-position-x: var(--pos-x);
+  background-position-y: var(--pos-y);
+}</pre>
+      <div class="box xy-pos"></div>
+      <p class="note">
+        All three pages must render identically: the blue bar starts 15mm /
+        12.6mm from the top-left corner of the <em>page box</em> — page margins
+        included, so not the page area.
+      </p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -187,6 +187,15 @@ module.exports = [
       },
       { file: "math-sample.html", title: "MathJax" },
       { file: "background-shorthand.html", title: "Background shorthand" },
+      {
+        file: "background-position-var.html",
+        title: "background-position with var() (Issue #2116)",
+      },
+      {
+        file: "background-position-longhand-root.html",
+        title:
+          "background-position longhands on the root background (Issue #2116)",
+      },
       { file: "prefixed_properties.html", title: "Prefixed properties" },
       { file: "filter_property.html", title: "Filter property" },
       { file: "attr-type.html", title: "Typed attr() values (Issue #1485)" },

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -2668,6 +2668,28 @@ describe("css-cascade", function () {
       expect(style["transition-property"].value).toBe(adapt_css.ident.initial);
       expect(style["transition-duration"].value).toBe(adapt_css.ident.initial);
     });
+
+    it("keeps var-substituted properties that Vivliostyle validates itself (Issue #2116)", function () {
+      var element = document.createElement("div");
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      var style = {
+        "--pos": createCascadeValue("15mm 12.6mm"),
+        "background-position": createCascadeValue("var(--pos)"),
+        overflow: createCascadeValue("var(--ov)"),
+        "--ov": createCascadeValue("hidden"),
+      };
+
+      applyVarFilter(style, element, null, validatorSet);
+
+      expect(style["background-position"]).toBeDefined();
+      expect(style["background-position"].value.toString()).toBe("15mm 12.6mm");
+      expect(style["background-position-x"]).toBeUndefined();
+      expect(style["background-position-y"]).toBeUndefined();
+      expect(style.overflow).toBeDefined();
+      expect(style.overflow.value.toString()).toBe("hidden");
+      expect(style["overflow-x"]).toBeUndefined();
+      expect(style["overflow-y"]).toBeUndefined();
+    });
   });
 
   describe("AttrValueFilterVisitor regression coverage", function () {

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -140,9 +140,23 @@ describe("css-validator", function () {
       var validatorSet = adapt_cssvalid.baseValidatorSet();
       spyOn(validatorSet, "expandBrowserShorthand").and.callThrough();
 
-      expect(validatorSet.getShorthand("color", "red")).toBeNull();
-      expect(validatorSet.getShorthand("color", "blue")).toBeNull();
+      expect(validatorSet.getShorthand("accent-color", "red")).toBeNull();
+      expect(validatorSet.getShorthand("accent-color", "blue")).toBeNull();
       expect(validatorSet.expandBrowserShorthand).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not probe the browser for properties Vivliostyle validates itself", function () {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      spyOn(validatorSet, "expandBrowserShorthand").and.callThrough();
+
+      // These are shorthands in the browser CSSOM, but Vivliostyle looks them
+      // up by their own name after the cascade. (Issue #2116)
+      expect(
+        validatorSet.getShorthand("background-position", "var(--pos)"),
+      ).toBeNull();
+      expect(validatorSet.getShorthand("overflow", "var(--ov)")).toBeNull();
+      expect(validatorSet.getShorthand("white-space", "var(--ws)")).toBeNull();
+      expect(validatorSet.expandBrowserShorthand).not.toHaveBeenCalled();
     });
 
     it("does not cache a browser shorthand miss for unresolved var values", function () {

--- a/packages/core/test/spec/vivliostyle/css-validator-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-validator-spec.js
@@ -159,6 +159,38 @@ describe("css-validator", function () {
       expect(validatorSet.expandBrowserShorthand).not.toHaveBeenCalled();
     });
 
+    it("looks properties up case-insensitively", function () {
+      var validatorSet = adapt_cssvalid.baseValidatorSet();
+      spyOn(validatorSet, "expandBrowserShorthand").and.callThrough();
+
+      // CSS property names are ASCII case-insensitive, so a name that kept the
+      // author's casing must not fall through to browser expansion. (Issue #2116)
+      expect(
+        validatorSet.getShorthand("BACKGROUND-POSITION", "var(--pos)"),
+      ).toBeNull();
+      expect(
+        validatorSet.getShorthand("Border-Spacing", "var(--bs)"),
+      ).toBeNull();
+      expect(validatorSet.expandBrowserShorthand).not.toHaveBeenCalled();
+
+      // Vivliostyle's own shorthands are found regardless of casing too.
+      expect(validatorSet.getShorthand("MARGIN")).toBe(
+        validatorSet.getShorthand("margin"),
+      );
+    });
+
+    it("stores var() declarations of mixed-case properties under the lowercased name", function (done) {
+      parseCascade(
+        "div { BORDER-SPACING: var(--bs); }",
+        done,
+        function (cascade) {
+          expect(cascade.tags.div).toBeDefined();
+          expect(cascade.tags.div.style["border-spacing"]).toBeDefined();
+          expect(cascade.tags.div.style["BORDER-SPACING"]).toBeUndefined();
+        },
+      );
+    });
+
     it("does not cache a browser shorthand miss for unresolved var values", function () {
       var validatorSet = adapt_cssvalid.baseValidatorSet();
       spyOn(validatorSet, "expandBrowserShorthand").and.callFake(

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -256,3 +256,31 @@
   baselineLabel: canary
   baselineUrl: >-
     https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/cascade-layers-import.html&zoom=1&spread=false
+- category: General
+  title: "background-position with var() (Issue #2116)"
+  file: background-position-var.html
+  decision: expected  # regression / expected / skip
+  notes: >-
+    New test file for Issue #2116: canary drops `background-position: var(--pos)` on @page and the root because the
+    browser CSSOM expands it into background-position-x/-y, so it renders at 0% 0%.
+  approvedViewer: git-fix-issue2116  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/background-position-var.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: >-
+    https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/background-position-var.html&zoom=1&spread=false
+- category: General
+  title: "background-position longhands on the root background (Issue #2116)"
+  file: background-position-longhand-root.html
+  decision: expected  # regression / expected / skip
+  notes: >-
+    New test file for Issue #2116: canary drops `background-position-x`/`-y` specified on the body element, because
+    they are not part of the `background` shorthand grammar and so never reach the root background.
+  approvedViewer: git-fix-issue2116  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/background-position-longhand-root.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: >-
+    https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/background-position-longhand-root.html&zoom=1&spread=false


### PR DESCRIPTION
`background-position: var(--pos)` on `@page` (and on the root/body element) rendered as `0% 0%`.

`ValidatorSet.getShorthand()` fell through to `expandBrowserShorthand()`, which uses a detached `CSSStyleDeclaration` as a shorthand parser. The browser CSSOM reports `background-position` as a shorthand of `background-position-x`/`-y`, so `applyVarFilter()` split any `var()`-containing declaration into those longhands and deleted `background-position` from the cascaded style. Everything that looks the property up by name — `passPostProperties` in `page-master.ts`, `transferPropsToRoot()` in `css-styler.ts` — then fell back to the initial value, with no warning. `overflow`, `white-space`, `border-spacing` and `mask` were affected the same way.

Only `var()` values were broken because the non-var path in `validatePropertyAndHandleShorthand()` is already guarded by the `this.prefixes[name]` check; the `containsVar(value)` branch sits above it and skipped that check. `getShorthand()` now returns `null` for any property Vivliostyle validates itself, so both paths agree: browser shorthand expansion stays reserved for properties that have no validation grammar of their own.

While verifying this, a second gap turned up: `background-position-x`/`-y` are not part of the `background` shorthand grammar in `assets.ts`, so they never reached the page or root background at all, with or without `var()`. They are now propagated explicitly:

- added to `passPostProperties` so they apply to `@page` backgrounds
- moved to the root style in `css-styler.ts` when the body specifies them. They are deliberately kept out of `validatorSet.backgroundProps`, because `transferPropsToRoot()` assigns a default for every property in that map and a default axis value would override the `background-position` moved alongside it.

### Case-insensitive property names

Review of the first commit found that both lookups were case-sensitive, while CSS property names are ASCII case-insensitive and the parser keeps the author's casing (`propName = token.text`). With `--bs: 8mm 4mm` on a table:

| declaration | computed `border-spacing` | table size |
| --- | --- | --- |
| `border-spacing: var(--bs)` | `30.125px 15px` | 296×176 |
| `BORDER-SPACING: var(--bs)` | `2px` (initial) | 148×85 |

`getShorthand()` now lowercases the name before every lookup and registration, and the `containsVar()` branch stores the declaration under the same name the non-var path uses, so the consumers that look up the lowercase form find it. Prefixed names keep their existing handling.

Only the first of these two is tied to this issue. The second predates it: the `var()` early return has stored the author's casing ever since `var()` support was added in cd076546b (2022-07-28), where it sat above the `name = name.toLowerCase()` line. So any `var()` value on a property name not written in lowercase was lost whenever Vivliostyle read that property by name — not just for the properties the browser expands. `BREAK-BEFORE: var(--brk)` with `--brk: page` renders on one page on `master` and on two with this branch; `break-before` is not a browser shorthand, and only Vivliostyle acts on it. Properties that are merely passed through to the DOM were unaffected, because the browser matches names case-insensitively, which is likely why this went unnoticed.

### Known limitation

When a shorthand and an axis longhand are mixed in the same rule, the longhands always win regardless of CSS source order, because Vivliostyle keeps them as independent properties and applies them in list order. This matches the usual `background-position: ...; background-position-x: ...` override pattern but not the reverse. Resolving it properly would mean making `background-position` a real Vivliostyle shorthand and rewriting every consumer, which is out of scope here.

### Test cases

- `background-position-var.html` — three `@page` backgrounds that must render identically: shorthand with `var()`, the same value written literally (reference), and the axis longhands with `var()`.
- `background-position-longhand-root.html` — `background-position-x`/`-y` on `body` reaching the root background.

### Verification

- `yarn test:core` — 728/728 pass, including new unit tests in `css-validator-spec.js` and `css-cascade-spec.js`
- `yarn lint` — clean
- `yarn test:layout-regression --actual-viewer dev --baseline-viewer canary` — 358 entries, no differences. The two new test files are triaged `expected` with this branch's preview as their `approvedViewer` and match it; against canary they differ, since canary does not have the fix. For `background-position-var.html` that difference is on pages 1 and 3 only — page 2, the literal reference, matches canary.

Closes #2116

Assisted-by: Claude Code:claude-opus-5

<details>
<summary>How the AI was used</summary>

- The human author triaged the issue report, chose to take the minimal fix proposed in it rather than realigning Vivliostyle's property definitions with the current CSS specification, and decided to include the `background-position-x`/`-y` gap in the same branch.
- The human author rejected the AI's first version of the test case: it misused the term "page area" for the page box, it had lost the page 1 / page 2 `var()`-vs-literal comparison from the original report, and one of its comparison boxes spilled onto the next page.
- The human author also identified that a stale `artifacts/layout-regression/triage.yaml` — not viewer drift, as the AI had reported — was why an unrelated already-triaged entry (Issue #1122) resurfaced in the regression run.
- The case-sensitivity bug was missed by the AI and raised in review by GitHub Copilot. The human author asked for the claim to be checked rather than acted on directly; the AI then reproduced it by measurement, found that the second lookup in the `containsVar()` branch was affected the same way — which the review comment had not covered and which a fix to `getShorthand()` alone would not have resolved — and fixed both.
- The AI located the code path, wrote the fixes and the unit tests, built the test cases, and ran the unit, lint and layout-regression suites, confirming the before/after rendering by measurement rather than by eye.
- The human author reviewed each diff and commit message before it was pushed.

</details>

