### PR TITLE
feat: Support the `revert`, `revert-layer` and `revert-rule` keywords

### DIFF
--- a/docs/ja/supported-css-features.md
+++ b/docs/ja/supported-css-features.md
@@ -6,7 +6,9 @@ Vivliostyle は現在、以下の各 CSS 機能（[値](#値)、[セレクタ](#
 
 ## 値
 
-- [CSS 全体キーワード](https://www.w3.org/TR/css-values/#common-keywords): `initial`, `inherit`, `unset`, `revert`
+- [CSS 全体キーワード](https://www.w3.org/TR/css-values/#common-keywords): `initial`, `inherit`, `unset`, `revert`, `revert-layer`, `revert-rule`
+  - カスケードを巻き戻す[明示的デフォルト指定キーワード](https://www.w3.org/TR/css-cascade-5/#defaulting-keywords)は Vivliostyle 自身のカスケードで解決されるため、巻き戻した値がレイアウトエンジンやページ関連機能から見えます。`revert` は前のカスケードオリジンへ、`revert-layer` は現在より前のカスケードレイヤーへ、`revert-rule` は現在のルールを除いたカスケードへ巻き戻します。`@page` ルールとページマージンボックス、`all`、カスタムプロパティ、`var()` のフォールバックとしての記述でも動作します。[Issue #2111](https://github.com/vivliostyle/vivliostyle.js/issues/2111) を参照
+  - 注意: カスタムプロパティを経由して届いたキーワード (`--x: var(--y, revert-layer); color: var(--x)`) は巻き戻しとして扱われません（ブラウザの挙動に合わせています）。シャドウツリー (`:host`、`::slotted`) への巻き戻しは、Vivliostyle のカスケードが Shadow DOM を実装していないためサポートしません
 - [長さの単位](https://www.w3.org/TR/css-values/#lengths): `em`, `ex`, `ch`, `rem`, `lh`, `rlh`, `vw`, `vh`, `vmin, vmax`, `vi`, `vb`, `cm`, `mm`, `q`, `in`, `pc`, `pt`, `px`.
 - サイジングキーワード: [min-content](https://www.w3.org/TR/css-sizing-3/#valdef-width-min-content), [max-content](https://www.w3.org/TR/css-sizing-3/#valdef-width-max-content), [fit-content](https://www.w3.org/TR/css-sizing-4/#valdef-width-fit-content)
 - カラー値
@@ -139,7 +141,7 @@ Vivliostyle は現在、以下の各 CSS 機能（[値](#値)、[セレクタ](#
 
 - [@layer](https://www.w3.org/TR/css-cascade-5/#layering)
   - ブロック形式 (`@layer name { … }`、`@layer { … }`) と文形式 (`@layer a, b;`)、および `@import … layer` / `@import … layer(name)` をサポートしています。
-  - 注意: `revert-layer` キーワードはまだサポートしていません。
+  - [`revert-layer` キーワード](https://www.w3.org/TR/css-cascade-5/#valdef-all-revert-layer)をサポートしています。[値](#値)も参照してください。
 
 ### [CSS Namespaces 3](https://www.w3.org/TR/css3-namespace/)
 

--- a/docs/supported-css-features.md
+++ b/docs/supported-css-features.md
@@ -6,7 +6,9 @@ In addition, essentially all CSS properties and values supported by the browser 
 
 ## Values
 
-- [CSS-wide keywords](https://www.w3.org/TR/css-values/#common-keywords): `initial`, `inherit`, `unset`, `revert`
+- [CSS-wide keywords](https://www.w3.org/TR/css-values/#common-keywords): `initial`, `inherit`, `unset`, `revert`, `revert-layer`, `revert-rule`
+  - The [explicit defaulting keywords](https://www.w3.org/TR/css-cascade-5/#defaulting-keywords) that roll the cascade back are resolved by Vivliostyle's own cascade, so the value rolled back to is visible to the layout engine and to paged-media features. `revert` rolls back to the previous cascade origin, `revert-layer` to the layers before the current one, and `revert-rule` to the cascade without the current rule. They work in `@page` rules and page-margin boxes, with `all`, with custom properties, and written as a `var()` fallback. See [Issue #2111](https://github.com/vivliostyle/vivliostyle.js/issues/2111)
+  - Note: a rollback keyword reaching a property through a custom property (`--x: var(--y, revert-layer); color: var(--x)`) is not a rollback, matching browser behavior. Rolling back into a shadow tree (`:host`, `::slotted`) is not supported, because Vivliostyle's cascade does not implement Shadow DOM
 - [Length units](https://www.w3.org/TR/css-values/#lengths): `em`, `ex`, `ch`, `rem`, `lh`, `rlh`, `vw`, `vh`, `vmin, vmax`, `vi`, `vb`, `cm`, `mm`, `q`, `in`, `pc`, `pt`, `px`.
 - Sizing keywords: [min-content](https://www.w3.org/TR/css-sizing-3/#valdef-width-min-content), [max-content](https://www.w3.org/TR/css-sizing-3/#valdef-width-max-content), [fit-content](https://www.w3.org/TR/css-sizing-4/#valdef-width-fit-content)
 - Color values
@@ -139,7 +141,7 @@ See [PR #1889](https://github.com/vivliostyle/vivliostyle.js/pull/1889).
 
 - [@layer](https://www.w3.org/TR/css-cascade-5/#layering)
   - Both the block form (`@layer name { … }`, `@layer { … }`) and the statement form (`@layer a, b;`) are supported, as well as `@import … layer` / `@import … layer(name)`.
-  - Note: The `revert-layer` keyword is not supported yet.
+  - The [`revert-layer` keyword](https://www.w3.org/TR/css-cascade-5/#valdef-all-revert-layer) is supported. See also [Values](#values)
 
 ### [CSS Namespaces 3](https://www.w3.org/TR/css3-namespace/)
 

--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1098,7 +1098,6 @@ th {
   font-weight: bolder;
   text-align: center;
 }
-*[hidden],
 link,
 style,
 script {
@@ -1437,6 +1436,22 @@ epub|case[required-namespace::supported] ~ epub|default {
 }
 `;
 
+/**
+ * user-agent-hidden.css
+ *
+ * The `hidden` attribute, kept out of `user-agent-base.css` so that it can be
+ * left out when the document is rendered into the viewer's TOC box: an entry
+ * hidden from the printed table of contents is still listed in the TOC menu
+ * (see PR #1269).
+ */
+export const UserAgentHiddenCss = `
+@namespace "http://www.w3.org/1999/xhtml";
+
+*[hidden] {
+  display: none;
+}
+`;
+
 /** user-agent-toc.css */
 export const UserAgentTocCss = `
 @namespace "http://www.w3.org/1999/xhtml";
@@ -1448,9 +1463,8 @@ export const UserAgentTocCss = `
   display: none;
 }
 
-[hidden] {
-  display: revert;
-}
+/* Note: the hidden attribute does not hide anything here, because
+   user-agent-hidden.css is not loaded for the TOC box. */
 
 [data-vivliostyle-role=doc-toc] li a {
   -adapt-behavior: toc-node-anchor;

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -346,6 +346,64 @@ const ORIGIN_UNIT = 0x1000000;
  */
 const FIRST_IMPORTANT_ORIGIN = 4;
 
+let lastRuleId = 0;
+
+/**
+ * A fresh identity for one declaration block, so that `revert-rule` can tell
+ * the declarations of its own rule from the rest of the cascade. Zero is
+ * reserved for values the engine synthesizes outside of any rule.
+ */
+export function nextRuleId(): number {
+  return ++lastRuleId;
+}
+
+/**
+ * The cascade origin a cascaded value belongs to, disregarding `!important`:
+ * 0 for the user-agent origin, 1 for the user origin and 2 for the author
+ * origin, of which the style attribute is a part.
+ */
+function originOf(cascVal: CascadeValue): number {
+  switch (Math.floor(cascVal.priority / ORIGIN_UNIT)) {
+    case 0:
+      return 0; // user agent (shares one bucket with its !important side)
+    case 1:
+    case 6:
+      return 1; // user
+    default:
+      return 2; // author, including the style attribute
+  }
+}
+
+/**
+ * The set of declarations within which cascade layers are compared. Layers
+ * belong to one origin, and the element-attached styles (the `style`
+ * attribute) form a set of their own, so that `revert-layer` used there rolls
+ * back only the style attribute and lands on the author style sheets
+ * (css-cascade-5 §7.3.5, WPT css-cascade/revert-layer-009).
+ */
+function layerSetOf(cascVal: CascadeValue): number {
+  switch (Math.floor(cascVal.priority / ORIGIN_UNIT)) {
+    case 0:
+      return 0; // user agent
+    case 1:
+    case 6:
+      return 1; // user
+    case 3:
+    case 4:
+      return 3; // element-attached styles
+    default:
+      return 2; // author style sheets
+  }
+}
+
+/**
+ * The position of a cascaded value's layer in its origin. Unlayered
+ * declarations act as the final layer (css-cascade-5 §6.4.2).
+ */
+function layerOrderOf(cascVal: CascadeValue): number {
+  return cascVal.layer ? cascVal.layer.order : Infinity;
+}
+
 /**
  * Compares two cascaded values. Cascade layers are sorted between the origin
  * and the selector specificity, and unlayered declarations act as a final
@@ -373,18 +431,26 @@ export class CascadeValue implements CssCascade.CascadeValue {
     public readonly value: Css.Val,
     public readonly priority: number,
     public readonly layer: CascadeLayer | null = null,
+    public readonly ruleId: number = 0,
   ) {}
 
   getBaseValue(): CascadeValue {
     return this;
   }
 
-  filterValue(visitor: Css.Visitor): CascadeValue {
-    const value = this.value.visit(visitor);
+  /**
+   * A copy of this cascaded value carrying another CSS value, keeping
+   * everything the cascade sorts by (priority, layer and rule identity).
+   */
+  withValue(value: Css.Val): CascadeValue {
     if (value === this.value) {
       return this;
     }
-    return new CascadeValue(value, this.priority, this.layer);
+    return new CascadeValue(value, this.priority, this.layer, this.ruleId);
+  }
+
+  filterValue(visitor: Css.Visitor): CascadeValue {
+    return this.withValue(this.value.visit(visitor));
   }
 
   increaseSpecificity(specificity: number): CascadeValue {
@@ -395,6 +461,7 @@ export class CascadeValue implements CssCascade.CascadeValue {
       this.value,
       this.priority + specificity,
       this.layer,
+      this.ruleId,
     );
   }
 
@@ -431,16 +498,16 @@ export class ConditionalCascadeValue extends CascadeValue {
     priority: number,
     public readonly condition: Exprs.Val,
     layer: CascadeLayer | null = null,
+    ruleId: number = 0,
   ) {
-    super(value, priority, layer);
+    super(value, priority, layer, ruleId);
   }
 
   override getBaseValue(): CascadeValue {
-    return new CascadeValue(this.value, this.priority, this.layer);
+    return new CascadeValue(this.value, this.priority, this.layer, this.ruleId);
   }
 
-  override filterValue(visitor: Css.Visitor): CascadeValue {
-    const value = this.value.visit(visitor);
+  override withValue(value: Css.Val): CascadeValue {
     if (value === this.value) {
       return this;
     }
@@ -449,6 +516,7 @@ export class ConditionalCascadeValue extends CascadeValue {
       this.priority,
       this.condition,
       this.layer,
+      this.ruleId,
     );
   }
 
@@ -461,6 +529,7 @@ export class ConditionalCascadeValue extends CascadeValue {
       this.priority + specificity,
       this.condition,
       this.layer,
+      this.ruleId,
     );
   }
 
@@ -505,18 +574,224 @@ export function setPropCascadeValue(
   }
   if (!value) {
     delete style[name];
-  } else {
-    const tv = style[name] as CascadeValue;
-    if (!tv || comparePriority(value, tv) >= 0) {
-      if (context) {
-        if (value.isEnabled(context)) {
-          style[name] = value.getBaseValue();
+    return;
+  }
+  if (context && !value.isEnabled(context)) {
+    return;
+  }
+  recordCascadeHistory(style, name, value);
+  const tv = style[name] as CascadeValue;
+  if (!tv || comparePriority(value, tv) >= 0) {
+    style[name] = context ? value.getBaseValue() : value;
+  }
+}
+
+/**
+ * Property names for which a rollback keyword (`revert`, `revert-layer` or
+ * `revert-rule`) has been seen in any parsed style sheet. Resolving such a
+ * keyword is the only thing that needs to look below the winner of the
+ * cascade, so the declarations that lose are kept only for these properties.
+ */
+const rollbackDeclaredProps = new Set<string>();
+
+/**
+ * Called for every declaration as it is parsed, to note the properties whose
+ * cascade history has to be retained.
+ */
+export function noteRollbackDeclaration(
+  name: string,
+  value: Css.Val,
+  validatorSet?: CssValidator.ValidatorSet,
+): void {
+  if (Css.isRollbackValue(value)) {
+    rollbackDeclaredProps.add(name);
+    return;
+  }
+  if (!Css.containsRollbackValue(value)) {
+    return;
+  }
+  // A keyword that is not the whole value only survives validation inside a
+  // var() fallback, from where substitution can still make it the whole value
+  // — of this property, or of the longhands a shorthand expands into once the
+  // substituted value turns out to be a CSS-wide keyword.
+  rollbackDeclaredProps.add(name);
+  const propList = validatorSet?.getShorthand(name, value)?.propList;
+  if (propList) {
+    for (const nameLH of propList) {
+      rollbackDeclaredProps.add(nameLH);
+    }
+  }
+}
+
+/**
+ * The declarations that lost the cascade, for the properties in
+ * {@link rollbackDeclaredProps}. Held outside of the ElementStyle so that the
+ * code walking a style is not disturbed by an entry of a different shape, and
+ * dropped together with the style it belongs to.
+ */
+const cascadeHistories = new WeakMap<
+  ElementStyle,
+  { [name: string]: CascadeValue[] }
+>();
+
+function recordCascadeHistory(
+  style: ElementStyle,
+  name: string,
+  value: CascadeValue,
+): void {
+  if (!rollbackDeclaredProps.has(name) || value.value === Css.empty) {
+    // `Css.empty` only reserves a longhand slot for a shorthand declaration,
+    // so it is not something a rollback can land on.
+    return;
+  }
+  let history = cascadeHistories.get(style);
+  if (!history) {
+    history = {};
+    cascadeHistories.set(style, history);
+  }
+  let values = history[name];
+  if (!values) {
+    values = history[name] = [];
+    // The style may already hold a declaration that never passed through here,
+    // most notably the one from the `style` attribute.
+    const current = style[name] as CascadeValue;
+    if (current && current.value !== Css.empty) {
+      values.push(current);
+    }
+  }
+  values.push(value);
+}
+
+/**
+ * Whether `candidate` is one of the declarations that `reverting` rolls back,
+ * i.e. one of those the cascade has to be run without.
+ */
+function isRolledBackBy(
+  candidate: CascadeValue,
+  reverting: CascadeValue,
+): boolean {
+  switch (reverting.value) {
+    case Css.ident.revert_rule:
+      return candidate.ruleId === reverting.ruleId;
+    case Css.ident.revert_layer:
+      // `revert-layer` rolls back to the layers *before* the current one, so
+      // the current layer and every later one drop out — including the
+      // important declarations of later layers, which outrank the current
+      // layer for normal declarations but are rolled back all the same
+      // (WPT css-cascade/revert-layer-005).
+      return (
+        layerSetOf(candidate) === layerSetOf(reverting) &&
+        layerOrderOf(candidate) >= layerOrderOf(reverting)
+      );
+    default:
+      // `revert` rolls back to the earlier origin, so the current origin and
+      // every later one drop out: a user declaration reverts past the author
+      // origin as well (css-cascade-5 §7.3.4).
+      return originOf(candidate) >= originOf(reverting);
+  }
+}
+
+/**
+ * The value a rollback keyword resolves to: the winner of the cascade run
+ * again without the declarations the keyword rolls back. The value found may
+ * itself be a rollback keyword, in which case the rollback is applied again on
+ * top of the previous one; a cycle exhausts the candidates and ends up with no
+ * declaration at all.
+ */
+function resolveRollbackValue(
+  name: string,
+  reverting: CascadeValue,
+  candidates: CascadeValue[],
+): Css.Val {
+  let remaining = candidates;
+  while (Css.isRollbackValue(reverting.value)) {
+    // The reverting declaration itself always belongs to what it rolls back,
+    // so `remaining` strictly shrinks and this terminates.
+    remaining = remaining.filter((v) => !isRolledBackBy(v, reverting));
+    let winner: CascadeValue | null = null;
+    for (const candidate of remaining) {
+      if (!winner || comparePriority(candidate, winner) >= 0) {
+        winner = candidate;
+      }
+    }
+    if (!winner) {
+      // Nothing is left to roll back to, so the property is as if it had never
+      // been declared. For a custom property that is the guaranteed-invalid
+      // value, which this engine spells `initial`.
+      return Css.isCustomPropName(name) ? Css.ident.initial : Css.ident.unset;
+    }
+    reverting = winner;
+  }
+  return reverting.value;
+}
+
+/**
+ * Replace every rollback keyword that won the cascade with the declaration it
+ * rolls back to, so that neither the layout engine nor the `style` attribute
+ * of the generated element ever sees the keyword.
+ *
+ * This runs twice: once as soon as the cascade is settled, because the value
+ * rolled back to may itself be a shorthand or contain var(), and once more
+ * after var() substitution, because a keyword written in a var() fallback
+ * only becomes the whole value there.
+ *
+ * @param afterVarSubstitution whether this is the second pass. Custom
+ *     properties are left alone then: a custom property whose *substituted*
+ *     value happens to spell a rollback keyword is not a rollback, it is just
+ *     a token stream that no property can use (WPT-matching browser
+ *     behavior). This pass also discards the retained cascade history.
+ * @returns whether a value was rolled back to one that still contains var()
+ */
+export function resolveRollbackValues(
+  style: ElementStyle,
+  afterVarSubstitution: boolean = false,
+): boolean {
+  if (!rollbackDeclaredProps.size) {
+    return false;
+  }
+  const history = cascadeHistories.get(style);
+  let varSubstitutionNeeded = false;
+  for (const name in style) {
+    if (isMapName(name)) {
+      const styleMap = getStyleMap(style, name);
+      for (const key in styleMap) {
+        // Note: `||=` would short-circuit the recursion away once one of the
+        // sub-styles has asked for another var() pass.
+        if (resolveRollbackValues(styleMap[key], afterVarSubstitution)) {
+          varSubstitutionNeeded = true;
         }
-      } else {
-        style[name] = value;
+      }
+    } else if (name === "_viewConditionalStyles") {
+      for (const entry of getViewConditionalStyleMap(style)) {
+        if (resolveRollbackValues(entry.styles, afterVarSubstitution)) {
+          varSubstitutionNeeded = true;
+        }
+      }
+    } else if (isPropName(name)) {
+      const cascVal = getProp(style, name);
+      if (!cascVal || !Css.isRollbackValue(cascVal.value)) {
+        continue;
+      }
+      if (afterVarSubstitution && Css.isCustomPropName(name)) {
+        // A custom property whose *substituted* value happens to spell a
+        // rollback keyword is not a rollback: it is a token stream that no
+        // property can use, which is the guaranteed-invalid value.
+        style[name] = cascVal.withValue(Css.ident.initial);
+        continue;
+      }
+      const value = resolveRollbackValue(name, cascVal, history?.[name] ?? []);
+      style[name] = cascVal.withValue(value);
+      if (CssValidator.containsVar(value)) {
+        varSubstitutionNeeded = true;
       }
     }
   }
+  if (afterVarSubstitution) {
+    // The cascade for this style is over, so the declarations that lost it are
+    // of no further use.
+    cascadeHistories.delete(style);
+  }
+  return varSubstitutionNeeded;
 }
 
 export type ElementStyleMap = {
@@ -759,7 +1034,7 @@ export function mergeIn(
       const propListLH = validatorSet?.getShorthand(prop, av.value)?.propList;
       if (propListLH) {
         for (const propLH of propListLH) {
-          const avLH = new CascadeValue(Css.empty, av.priority, av.layer);
+          const avLH = av.withValue(Css.empty);
           setPropCascadeValue(target, propLH, avLH, context);
         }
       }
@@ -4101,6 +4376,13 @@ export class CascadeInstance {
     // Substitute var()
     this.applyVarFilter([baseStyle], element);
 
+    // Replace the rollback keywords that only became the whole value once
+    // var() had been substituted. A rollback can land on a declaration that
+    // uses var() itself, in which case one more substitution is needed.
+    if (resolveRollbackValues(baseStyle, true)) {
+      this.applyVarFilter([baseStyle], element);
+    }
+
     // Calculate calc()
     this.applyCalcFilter(baseStyle, this.context);
 
@@ -4517,7 +4799,7 @@ export class CascadeInstance {
         if (
           val === Css.ident.inherit ||
           val === Css.ident.unset ||
-          val === Css.ident.revert
+          Css.isRollbackValue(val)
         ) {
           continue;
         } else if (val === Css.ident.initial) {
@@ -4541,7 +4823,7 @@ export class CascadeInstance {
       if (
         val !== Css.ident.inherit &&
         val !== Css.ident.unset &&
-        val !== Css.ident.revert
+        !Css.isRollbackValue(val)
       ) {
         if (val === Css.ident.initial) {
           return this.validatorSet.defaultValues[propName] ?? null;
@@ -4571,14 +4853,7 @@ export class CascadeInstance {
           continue;
         }
         const validatedValue = visitor.validatePropertyValue(filtered.value);
-        elementStyle[propName] =
-          validatedValue === filtered.value
-            ? filtered
-            : new CascadeValue(
-                validatedValue,
-                filtered.priority,
-                cascVal.layer,
-              );
+        elementStyle[propName] = filtered.withValue(validatedValue);
       }
     }
   }
@@ -4654,11 +4929,7 @@ export class CascadeInstance {
         if (shorthand) {
           if (Css.isDefaultingValue(value)) {
             for (const nameLH of shorthand.propList) {
-              const avLH = new CascadeValue(
-                value,
-                cascVal.priority,
-                cascVal.layer,
-              );
+              const avLH = cascVal.withValue(value);
               const tvLH = getProp(elementStyle, nameLH);
               setProp(propsLH, nameLH, cascadeValues(this.context, tvLH, avLH));
             }
@@ -4677,12 +4948,10 @@ export class CascadeInstance {
               valueSH.visit(shorthand);
               if (!shorthand.error) {
                 for (const nameLH of shorthand.propList) {
-                  const avLH = new CascadeValue(
+                  const avLH = cascVal.withValue(
                     shorthand.values[nameLH] ??
                       this.validatorSet.defaultValues[nameLH] ??
                       Css.ident.initial,
-                    cascVal.priority,
-                    cascVal.layer,
                   );
                   const tvLH = getProp(elementStyle, nameLH);
                   setProp(
@@ -4696,11 +4965,7 @@ export class CascadeInstance {
             }
           }
         } else {
-          elementStyle[name] = new CascadeValue(
-            value,
-            cascVal.priority,
-            cascVal.layer,
-          );
+          elementStyle[name] = cascVal.withValue(value);
         }
       }
       if (propsLH[name]) {
@@ -4762,14 +5027,7 @@ export class CascadeInstance {
         }
       } else if (isPropName(name) && !Css.isCustomPropName(name)) {
         const cascVal = getProp(elementStyle, name);
-        const value = cascVal.value.visit(visitor);
-        if (value !== cascVal.value) {
-          elementStyle[name] = new CascadeValue(
-            value,
-            cascVal.priority,
-            cascVal.layer,
-          );
-        }
+        elementStyle[name] = cascVal.withValue(cascVal.value.visit(visitor));
       }
     }
   }
@@ -4812,11 +5070,7 @@ export class CascadeInstance {
           if (visitor.hadDeviceCmyk()) {
             visitor.recordConversion(pseudoPrefix + name, originalValue);
           }
-          elementStyle[name] = new CascadeValue(
-            value,
-            cascVal.priority,
-            cascVal.layer,
-          );
+          elementStyle[name] = cascVal.withValue(value);
         }
       }
     }
@@ -4870,6 +5124,10 @@ export class CascadeInstance {
     }
     this.isFirst = true;
     this.isRoot = false;
+
+    // The cascade is settled, so the rollback keywords can now be replaced by
+    // the declarations they roll back to.
+    resolveRollbackValues(cascadeInstance.currentStyle);
   }
 
   private pop(): void {
@@ -5001,6 +5259,8 @@ export class CascadeParserHandler
   private pendingChained: CascadeAction[] = [];
   specificity: number = 0;
   elementStyle: ElementStyle | null = null;
+  /** Identity of the declaration block being parsed, for `revert-rule`. */
+  ruleId: number = 0;
   conditionCount: number = 0;
   pseudoelement: string | null = null;
   footnoteContent: boolean = false;
@@ -5508,6 +5768,7 @@ export class CascadeParserHandler
     }
     this.state = ParseState.SELECTOR;
     this.elementStyle = {} as ElementStyle;
+    this.ruleId = nextRuleId();
     this.pseudoelement = null;
     this.viewConditionId = null;
     this.specificity = 0;
@@ -5651,9 +5912,16 @@ export class CascadeParserHandler
       ? this.getImportantSpecificity()
       : this.getBaseSpecificity();
     const priority = specificity + this.cascade.nextOrder();
+    noteRollbackDeclaration(name, value, this.validatorSet);
     const cascval = this.condition
-      ? new ConditionalCascadeValue(value, priority, this.condition, this.layer)
-      : new CascadeValue(value, priority, this.layer);
+      ? new ConditionalCascadeValue(
+          value,
+          priority,
+          this.condition,
+          this.layer,
+          this.ruleId,
+        )
+      : new CascadeValue(value, priority, this.layer, this.ruleId);
     setPropCascadeValue(this.elementStyle, name, cascval);
   }
 
@@ -6010,6 +6278,7 @@ export class PropSetParserHandler
   implements CssValidator.PropertyReceiver
 {
   order: number;
+  readonly ruleId: number = nextRuleId();
 
   constructor(
     scope: Exprs.LexicalScope,
@@ -6059,9 +6328,16 @@ export class PropSetParserHandler
       : this.getBaseSpecificity();
     specificity += this.order;
     this.order += ORDER_INCREMENT;
+    noteRollbackDeclaration(name, value, this.validatorSet);
     const cascval = this.condition
-      ? new ConditionalCascadeValue(value, specificity, this.condition)
-      : new CascadeValue(value, specificity);
+      ? new ConditionalCascadeValue(
+          value,
+          specificity,
+          this.condition,
+          null,
+          this.ruleId,
+        )
+      : new CascadeValue(value, specificity, null, this.ruleId);
     setPropCascadeValue(this.elementStyle, name, cascval);
   }
 }
@@ -6072,6 +6348,7 @@ export class PropertyParserHandler
 {
   elementStyle = {} as ElementStyle;
   order: number = 0;
+  readonly ruleId: number = nextRuleId();
 
   constructor(
     scope: Exprs.LexicalScope,
@@ -6111,7 +6388,8 @@ export class PropertyParserHandler
       : CssParser.SPECIFICITY_STYLE;
     specificity += this.order;
     this.order += ORDER_INCREMENT;
-    const cascval = new CascadeValue(value, specificity);
+    noteRollbackDeclaration(name, value, this.validatorSet);
+    const cascval = new CascadeValue(value, specificity, null, this.ruleId);
     setPropCascadeValue(this.elementStyle, name, cascval);
   }
 }
@@ -6169,8 +6447,8 @@ export function isVertical(
     if (
       writingMode &&
       writingMode !== Css.ident.inherit &&
-      writingMode !== Css.ident.revert &&
-      writingMode !== Css.ident.unset
+      writingMode !== Css.ident.unset &&
+      !Css.isRollbackValue(writingMode)
     ) {
       return writingMode === Css.ident.vertical_rl;
     }
@@ -6189,8 +6467,8 @@ export function isRtl(
     if (
       direction &&
       direction !== Css.ident.inherit &&
-      direction !== Css.ident.revert &&
-      direction !== Css.ident.unset
+      direction !== Css.ident.unset &&
+      !Css.isRollbackValue(direction)
     ) {
       return direction === Css.ident.rtl;
     }
@@ -6328,12 +6606,10 @@ export const convertToPhysical = <T>(
         (cascVal.value === Css.ident.inside ||
           cascVal.value === Css.ident.outside)
       ) {
-        cascVal = new CascadeValue(
+        cascVal = cascVal.withValue(
           leftPageSide === (cascVal.value === Css.ident.inside)
             ? Css.ident.right
             : Css.ident.left,
-          cascVal.priority,
-          cascVal.layer,
         );
       }
     }
@@ -6390,7 +6666,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
         if (
           val === Css.ident.inherit ||
           val === Css.ident.unset ||
-          val === Css.ident.revert
+          Css.isRollbackValue(val)
         ) {
           continue;
         }
@@ -6422,7 +6698,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
       if (
         val === Css.ident.inherit ||
         val === Css.ident.unset ||
-        val === Css.ident.revert
+        Css.isRollbackValue(val)
       ) {
         continue;
       }
@@ -6540,7 +6816,7 @@ export class VarFilterVisitor extends Css.FilterVisitor {
     if (
       val === Css.ident.inherit ||
       val === Css.ident.unset ||
-      val === Css.ident.revert
+      Css.isRollbackValue(val)
     ) {
       return { found: true, value: null, continueLookup: true };
     }

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -3363,11 +3363,7 @@ export class PageParserHandler
       const noPageSelectorProps = pageProps[""];
       this.currentPageSelectors.forEach((s) => {
         // update specificity to reflect the specificity of the selector
-        const result = new CssCascade.CascadeValue(
-          cascVal.value,
-          cascVal.priority + s.specificity,
-          cascVal.layer,
-        );
+        const result = cascVal.increaseSpecificity(s.specificity);
         const selector = s.selectors ? s.selectors.join("") : "";
         let props = pageProps[selector];
         if (!props) {
@@ -3485,6 +3481,8 @@ export class PageMarginBoxParserHandler
     super(scope, owner, delegation);
   }
 
+  readonly ruleId: number = CssCascade.nextRuleId();
+
   override property(name: string, value: Css.Val, important: boolean): void {
     this.validatorSet.validatePropertyAndHandleShorthand(
       name,
@@ -3510,7 +3508,13 @@ export class PageMarginBoxParserHandler
     const specificity = important
       ? this.getImportantSpecificity()
       : this.getBaseSpecificity();
-    const cascval = new CssCascade.CascadeValue(value, specificity, this.layer);
+    CssCascade.noteRollbackDeclaration(name, value, this.validatorSet);
+    const cascval = new CssCascade.CascadeValue(
+      value,
+      specificity,
+      this.layer,
+      this.ruleId,
+    );
     CssCascade.setProp(this.boxStyle, name, cascval);
   }
 }
@@ -3533,6 +3537,8 @@ export class PageFootnoteAreaParserHandler
     super(scope, owner, delegation);
   }
 
+  readonly ruleId: number = CssCascade.nextRuleId();
+
   override property(name: string, value: Css.Val, important: boolean): void {
     this.validatorSet.validatePropertyAndHandleShorthand(
       name,
@@ -3558,7 +3564,13 @@ export class PageFootnoteAreaParserHandler
     const specificity = important
       ? this.getImportantSpecificity()
       : this.getBaseSpecificity();
-    const cascval = new CssCascade.CascadeValue(value, specificity, this.layer);
+    CssCascade.noteRollbackDeclaration(name, value, this.validatorSet);
+    const cascval = new CssCascade.CascadeValue(
+      value,
+      specificity,
+      this.layer,
+      this.ruleId,
+    );
     CssCascade.setProp(this.areaStyle, name, cascval);
   }
 }

--- a/packages/core/src/vivliostyle/css-validator.ts
+++ b/packages/core/src/vivliostyle/css-validator.ts
@@ -2689,9 +2689,18 @@ export class ValidatorSet {
       return;
     }
     const px = this.prefixes[name];
+    // The rollback keywords (`revert`, `revert-layer` and `revert-rule`) are
+    // resolved by Vivliostyle's own cascade rather than handed to the browser,
+    // so whether this browser build happens to support the keyword must not
+    // decide whether the declaration is valid, nor how a shorthand expands.
+    // Probe the property with `unset` instead, which every browser accepts
+    // wherever a CSS-wide keyword is allowed.
+    const probeText = Css.isRollbackValue(value) ? "unset" : value.toString();
     if (!px || !px[prefix]) {
-      if (CSS.supports(origName, value.toString())) {
-        const shorthand = this.getShorthand(shorthandName, value)?.clone(scope);
+      if (CSS.supports(origName, probeText)) {
+        const shorthand = this.getShorthand(shorthandName, probeText)?.clone(
+          scope,
+        );
         if (shorthand) {
           if (Css.isDefaultingValue(value)) {
             shorthand.propagateDefaultingValue(value, important, receiver);

--- a/packages/core/src/vivliostyle/css.ts
+++ b/packages/core/src/vivliostyle/css.ts
@@ -677,6 +677,8 @@ export const ident: { [key: string]: Ident } = {
   page: getName("page"),
   relative: getName("relative"),
   revert: getName("revert"),
+  revert_layer: getName("revert-layer"),
+  revert_rule: getName("revert-rule"),
   right: getName("right"),
   same: getName("same"),
   scale: getName("scale"),
@@ -721,9 +723,43 @@ export function isDefaultingValue(value: Val | null | undefined): boolean {
   return (
     value === ident.inherit ||
     value === ident.initial ||
-    value === ident.revert ||
-    value === ident.unset
+    value === ident.unset ||
+    isRollbackValue(value)
   );
+}
+
+/**
+ * Whether the value is one of the CSS-wide keywords that roll the cascade back
+ * to a declaration that lost (css-cascade-5 §7.3 Explicit Defaulting).
+ */
+export function isRollbackValue(value: Val | null | undefined): boolean {
+  return (
+    value === ident.revert ||
+    value === ident.revert_layer ||
+    value === ident.revert_rule
+  );
+}
+
+class RollbackValueVisitor extends Visitor {
+  found: boolean = false;
+
+  override visitIdent(ident: Ident): Val | null {
+    if (isRollbackValue(ident)) {
+      this.found = true;
+    }
+    return null;
+  }
+}
+
+/**
+ * Whether a rollback keyword appears anywhere inside the value. A keyword that
+ * is not the whole value only survives validation inside a var() fallback,
+ * where substitution can still leave it as the whole value.
+ */
+export function containsRollbackValue(value: Val): boolean {
+  const visitor = new RollbackValueVisitor();
+  value.visit(visitor);
+  return visitor.found;
 }
 
 /**

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -60,6 +60,7 @@ import { Layout as LayoutType, PageFloats as PageFloatsType } from "./types";
 import {
   UserAgentBaseCss,
   UserAgentCounterStylesCss,
+  UserAgentHiddenCss,
   UserAgentPageCss,
   UserAgentTocCss,
 } from "./assets";
@@ -453,6 +454,9 @@ export class StyleInstance
 
       // Substitute var() in @page
       this.styler.cascade.applyVarFilter([pageStyle], null);
+      if (CssCascade.resolveRollbackValues(pageStyle, true)) {
+        this.styler.cascade.applyVarFilter([pageStyle], null);
+      }
 
       // Calculate calc()
       this.styler.cascade.applyCalcFilter(pageStyle, this.styler.context);
@@ -3147,6 +3151,9 @@ export class StyleInstance
 
     // Substitute var()
     this.styler.cascade.applyVarFilter([cascadedPageStyle], null);
+    if (CssCascade.resolveRollbackValues(cascadedPageStyle, true)) {
+      this.styler.cascade.applyVarFilter([cascadedPageStyle], null);
+    }
 
     // Calculate calc()
     this.styler.cascade.applyCalcFilter(cascadedPageStyle, this.styler.context);
@@ -3783,6 +3790,15 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
             media: null,
           });
         } else {
+          // The `hidden` attribute hides nothing in the TOC box, so this sheet
+          // is loaded only for the document itself (see PR #1269).
+          sources.push({
+            url: Base.resolveURL("user-agent-hidden.css", Base.resourceBaseURL),
+            text: UserAgentHiddenCss,
+            flavor: CssParser.StylesheetFlavor.USER_AGENT,
+            classes: null,
+            media: null,
+          });
           const elemList =
             xmldoc.document.querySelectorAll("style, link, meta");
           for (const elem of elemList) {

--- a/packages/core/src/vivliostyle/vgen.ts
+++ b/packages/core/src/vivliostyle/vgen.ts
@@ -1005,8 +1005,8 @@ export class ViewFactory
           value &&
           value !== Css.ident.inherit &&
           value !== Css.ident.unset &&
-          value !== Css.ident.revert &&
-          value !== Css.empty
+          value !== Css.empty &&
+          !Css.isRollbackValue(value)
         ) {
           blockedInheritedByCurrent.add(name);
         }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -342,6 +342,31 @@ module.exports = [
     ],
   },
   {
+    category: "Explicit Defaulting Keywords",
+    files: [
+      {
+        file: "revert.html",
+        title: "revert keyword (Issue #2111)",
+      },
+      {
+        file: "revert-layer.html",
+        title: "revert-layer keyword (Issue #2111)",
+      },
+      {
+        file: "revert-rule.html",
+        title: "revert-rule keyword (Issue #2111)",
+      },
+      {
+        file: "revert-page.html",
+        title: "Rollback keywords in @page (Issue #2111)",
+      },
+      {
+        file: "toc-hidden.html",
+        title: "hidden attribute in the table of contents (PR #1269)",
+      },
+    ],
+  },
+  {
     category: "Spread inside/outside properties",
     files: [
       {

--- a/packages/core/test/files/revert-layer.html
+++ b/packages/core/test/files/revert-layer.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2111: the `revert-layer` explicit defaulting keyword -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>revert-layer keyword</title>
+    <style>
+      @page {
+        size: 210mm 230mm;
+        margin: 10mm;
+      }
+
+      body {
+        font: 12px/1.5 Georgia, serif;
+        /* red is the "not rolled back" colour, so anything that must not be
+           green has to say so */
+        color: red;
+      }
+      h1,
+      .intro {
+        color: black;
+      }
+      /* the items that must end up with an inherited colour sit inside a
+         green list item */
+      .green-parent {
+        color: green;
+      }
+
+      /* ---- A. Rolling back to the previous layer ---- */
+
+      @layer a1base {
+        .a1 {
+          color: green;
+        }
+      }
+      @layer a1theme {
+        .a1 {
+          color: revert-layer;
+        }
+      }
+
+      /* unlayered declarations are the implicit final layer, so reverting
+         one of them rolls back to the last explicit layer */
+      @layer a2 {
+        .a2 {
+          color: green;
+        }
+      }
+      .a2 {
+        color: revert-layer;
+      }
+
+      /* three layers: the rollback lands on the layer before the current one */
+      @layer a3a {
+        .a3 {
+          color: red;
+        }
+      }
+      @layer a3b {
+        .a3 {
+          color: green;
+        }
+      }
+      @layer a3c {
+        .a3 {
+          color: revert-layer;
+        }
+      }
+
+      /* a layer's own declarations form an implicit final sub-layer of it,
+         so reverting them rolls back to the nested layer */
+      @layer a4 {
+        @layer a4inner {
+          .a4 {
+            color: green;
+          }
+        }
+        .a4 {
+          color: revert-layer;
+        }
+      }
+
+      /* nothing before the first layer, so the origin itself is rolled back
+         and the inherited value applies */
+      @layer a5 {
+        .a5 {
+          color: revert-layer;
+        }
+      }
+
+      /* ---- B. The style attribute is rolled back on its own ---- */
+
+      /* the style attribute is not part of any layer of the author style
+         sheets, so reverting it lands on the author style sheets
+         (WPT css-cascade/revert-layer-009) */
+      .b1 {
+        color: green;
+      }
+
+      /* ...and it lands on whatever wins there, layers included */
+      @layer b2 {
+        .b2 {
+          color: red;
+        }
+      }
+      .b2 {
+        color: green;
+      }
+
+      /* ---- C. !important reverses the layer order, the rollback does not ---- */
+
+      /* an important revert-layer still rolls back to the *earlier* layer, so
+         the important declaration of the later layer goes with it
+         (WPT css-cascade/revert-layer-005) */
+      @layer c1a {
+        .c1 {
+          color: green;
+        }
+      }
+      @layer c1b {
+        .c1 {
+          color: red;
+          color: red !important;
+          color: revert-layer !important;
+        }
+      }
+      @layer c1c {
+        .c1 {
+          color: red !important;
+        }
+      }
+
+      /* nothing before the first layer, so even the later layer's important
+         declaration is rolled back and the inherited value applies */
+      @layer c2a {
+        .c2 {
+          color: revert-layer !important;
+        }
+      }
+      @layer c2b {
+        .c2 {
+          color: red !important;
+        }
+      }
+
+      /* an unlayered important declaration rolls back every layered and
+         unlayered declaration of the author style sheets */
+      @layer c3 {
+        .c3 {
+          color: green;
+        }
+      }
+      .c3 {
+        color: red;
+      }
+      .c3x {
+        color: revert-layer !important;
+      }
+
+      /* ---- D. `all` and custom properties ---- */
+
+      @layer d1base {
+        .d1 {
+          color: green;
+          font-style: italic;
+        }
+      }
+      @layer d1theme {
+        .d1 {
+          color: red;
+          font-style: normal;
+          all: revert-layer;
+        }
+      }
+
+      @layer d2base {
+        .d2 {
+          --c: green;
+        }
+      }
+      @layer d2theme {
+        .d2 {
+          --c: red;
+          --c: revert-layer;
+        }
+      }
+      .d2 {
+        color: var(--c);
+      }
+
+      /* ---- E. The rolled-back value reaches the layout engine ---- */
+
+      @layer e1base {
+        .e1 {
+          break-before: page;
+          color: green;
+        }
+      }
+      @layer e1theme {
+        .e1 {
+          break-before: auto;
+          break-before: revert-layer;
+        }
+      }
+
+      /* ---- F. Written in a var() fallback ---- */
+
+      /* the idiom for an optional design token: use the token if it is set,
+         otherwise defer to the earlier layer */
+      @layer f1base {
+        .f1 {
+          color: green;
+        }
+      }
+      @layer f1theme {
+        .f1 {
+          color: var(--f1-color, revert-layer);
+        }
+      }
+
+      /* ...and the token still wins when it is set */
+      @layer f2base {
+        .f2 {
+          color: red;
+        }
+      }
+      @layer f2theme {
+        .f2 {
+          --f2-color: green;
+          color: var(--f2-color, revert-layer);
+        }
+      }
+
+      /* the same from the style attribute */
+      .f3 {
+        color: green;
+      }
+
+      /* the declaration rolled back to uses var() itself */
+      .f4 {
+        --f4-color: green;
+      }
+      @layer f4base {
+        .f4 {
+          color: var(--f4-color);
+        }
+      }
+      @layer f4theme {
+        .f4 {
+          color: var(--none, revert-layer);
+        }
+      }
+
+      /* a keyword reaching the property through a custom property is *not* a
+         rollback: it is a token stream no property can use, so the
+         declaration is invalid and the inherited value applies */
+      @layer f5base {
+        .f5 {
+          color: green;
+        }
+      }
+      @layer f5theme {
+        .f5 {
+          --f5: var(--none, revert-layer);
+          color: var(--f5);
+        }
+      }
+
+      /* both pseudo-elements of one element roll back to a value that uses
+         var() itself, so each of them needs the second substitution pass */
+      .f7 {
+        --f7-color: green;
+      }
+      @layer f7base {
+        .f7::before {
+          content: "F7 ";
+          color: var(--f7-color);
+        }
+        .f7::after {
+          content: " (and its ::after)";
+          color: var(--f7-color);
+        }
+      }
+      @layer f7theme {
+        .f7::before {
+          color: var(--none, revert-layer);
+        }
+        .f7::after {
+          color: var(--none, revert-layer);
+        }
+      }
+      .f7 {
+        color: green;
+      }
+
+      /* a shorthand written as a var() fallback rolls back its longhands */
+      .f6 {
+        color: green;
+      }
+      @layer f6base {
+        .f6 {
+          margin-left: 40mm;
+        }
+      }
+      @layer f6theme {
+        .f6 {
+          margin: var(--none, revert-layer);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>The <code>revert-layer</code> keyword</h1>
+    <p class="intro">Every list item below must be green.</p>
+    <ol>
+      <li class="a1">A1 revert-layer rolls back to the previous layer</li>
+      <li class="a2">A2 revert-layer in an unlayered declaration</li>
+      <li class="a3">A3 the rollback lands on the layer before this one</li>
+      <li class="a4">A4 a layer's own rules roll back to its nested layer</li>
+      <li class="green-parent">
+        <span class="a5">A5 revert-layer before the first layer</span>
+      </li>
+      <li class="b1" style="color: red; color: revert-layer">
+        B1 revert-layer in the style attribute
+      </li>
+      <li class="b2" style="color: red; color: revert-layer">
+        B2 the style attribute rolls back to the author style sheets
+      </li>
+      <li class="c1">C1 important revert-layer goes to the earlier layer</li>
+      <li class="green-parent">
+        <span class="c2">C2 important revert-layer before the first layer</span>
+      </li>
+      <li class="c3 c3x">C3 unlayered important revert-layer</li>
+      <li class="d1">D1 all: revert-layer</li>
+      <li class="d2">D2 revert-layer on a custom property</li>
+      <li class="f1">F1 revert-layer as a var() fallback</li>
+      <li class="f2">F2 var() fallback, token set</li>
+      <li class="f3" style="color: red; color: var(--none, revert-layer)">
+        F3 var() fallback in the style attribute
+      </li>
+      <li class="f4">F4 rolled back onto a declaration that uses var()</li>
+      <li class="green-parent">
+        <span class="f5">F5 keyword through a custom property is not a rollback</span>
+      </li>
+      <li class="f7">both pseudo-elements roll back</li>
+    </ol>
+    <p class="f6">
+      F6 A shorthand written as a var() fallback rolls back its longhands: this
+      paragraph must be indented by 40mm.
+    </p>
+    <p class="e1">
+      E1 This paragraph must be green and must start a new page, because
+      <code>break-before: revert-layer</code> rolls back to the
+      <code>break-before: page</code> of the earlier layer.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/revert-page.html
+++ b/packages/core/test/files/revert-page.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2111: rollback keywords in @page rules and page-margin boxes -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>revert keywords in @page</title>
+    <style>
+      @page {
+        size: 210mm 200mm;
+        /* declared per side, so that the layered declarations below are not
+           shadowed by an unlayered `margin-top` */
+        margin-left: 10mm;
+        margin-right: 10mm;
+        margin-bottom: 10mm;
+      }
+
+      /* A. revert-layer in an @page rule rolls back to the previous layer */
+      @layer pagebase {
+        @page {
+          margin-top: 40mm;
+        }
+      }
+      @layer pagetheme {
+        @page {
+          margin-top: 5mm;
+          margin-top: revert-layer;
+        }
+      }
+
+      /* B. revert-rule in a page-margin box */
+      @page {
+        @top-center {
+          content: "This header must be green and 20pt";
+          color: green;
+          font-size: 20pt;
+        }
+      }
+      @page {
+        @top-center {
+          color: red;
+          color: revert-rule;
+          font-size: 8pt;
+          font-size: revert-rule;
+        }
+      }
+
+      /* C. revert in an @page rule rolls back to the user-agent style sheet,
+         whose print @page rule says `margin: 10%` */
+      @page :nth(2) {
+        margin-left: revert;
+        margin-right: revert;
+      }
+
+      body {
+        font: 12px/1.5 Georgia, serif;
+        color: green;
+        margin: 0;
+      }
+
+      .newpage {
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Rollback keywords in <code>@page</code></h1>
+    <p>
+      A. The top margin of this page must be 40mm (rolled back to the
+      <code>pagebase</code> layer), not 5mm.
+    </p>
+    <p>
+      B. The page header must be green and 20pt: both declarations of the
+      second <code>@top-center</code> rule roll their own rule back.
+    </p>
+    <p class="newpage">
+      C. The left and right margins of this second page must be 10% of the page
+      width (21mm), rolled back to the user-agent style sheet, while the top
+      margin is still 40mm.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/revert-rule.html
+++ b/packages/core/test/files/revert-rule.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2111: the `revert-rule` explicit defaulting keyword -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>revert-rule keyword</title>
+    <style>
+      @page {
+        size: 210mm 200mm;
+        margin: 10mm;
+      }
+
+      body {
+        font: 12px/1.5 Georgia, serif;
+        /* red is the "not reverted" colour, so anything that must not be
+           green has to say so */
+        color: red;
+      }
+      h1,
+      .intro {
+        color: black;
+      }
+
+      /* ---- A. Rolling back the rule the keyword sits in ---- */
+
+      .a1 {
+        color: green;
+      }
+      .a1 {
+        color: red;
+        color: revert-rule;
+      }
+
+      /* the rollback target is decided by cascade order, not source order:
+         the lower-specificity rule that follows still wins over the one
+         above it */
+      .a2 {
+        color: red;
+      }
+      #a2 {
+        color: revert-rule;
+      }
+      li.a2.a2y {
+        color: green;
+      }
+
+      /* a rollback can land on another rollback */
+      .a3 {
+        color: green;
+      }
+      .a3x {
+        color: revert-rule;
+      }
+      #a3 {
+        color: revert-rule;
+      }
+
+      /* declarations caught in a cycle drop out of the cascade */
+      .a4 {
+        color: green;
+      }
+      #a4 {
+        color: revert-rule;
+      }
+      #a4.a4x {
+        color: revert-rule;
+      }
+
+      /* ---- B. Importance, layers and the other rollback keywords ---- */
+
+      .b1 {
+        color: green !important;
+      }
+      #b1 {
+        color: red !important;
+        color: revert-rule !important;
+      }
+
+      @layer b2a {
+        .b2 {
+          color: green;
+        }
+      }
+      @layer b2b {
+        .b2 {
+          color: red;
+          color: revert-rule;
+        }
+      }
+
+      /* revert-rule rolling back onto a revert-layer */
+      @layer b3a {
+        .b3 {
+          color: green;
+        }
+      }
+      @layer b3b {
+        .b3 {
+          color: revert-layer;
+        }
+      }
+      @layer b3c {
+        .b3 {
+          color: revert-rule;
+        }
+      }
+
+      /* ---- C. Custom properties and `all` ---- */
+
+      .c1 {
+        --c: green;
+      }
+      #c1 {
+        --c: red;
+        --c: revert-rule;
+      }
+      .c1 {
+        color: var(--c);
+      }
+
+      .c2 {
+        color: green;
+        font-style: italic;
+      }
+      #c2 {
+        color: red;
+        font-style: normal;
+        all: revert-rule;
+      }
+
+      /* revert-rule written in a var() fallback */
+      .c3 {
+        color: green;
+      }
+      #c3 {
+        color: red;
+        color: var(--c3-color, revert-rule);
+      }
+
+      /* ---- D. The rolled-back value reaches the layout engine ---- */
+
+      .d1 {
+        break-before: page;
+        color: green;
+      }
+      .d1 {
+        break-before: auto;
+        break-before: revert-rule;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>The <code>revert-rule</code> keyword</h1>
+    <p class="intro">Every list item below must be green.</p>
+    <ol>
+      <li class="a1">A1 revert-rule skips its own rule entirely</li>
+      <li class="a2 a2y" id="a2">A2 cascade order, not source order</li>
+      <li class="a3 a3x" id="a3">A3 a rollback landing on another rollback</li>
+      <li class="a4 a4x" id="a4">A4 declarations in a cycle drop out</li>
+      <li class="b1" id="b1">B1 revert-rule with !important</li>
+      <li class="b2">B2 revert-rule inside a cascade layer</li>
+      <li class="b3">B3 revert-rule rolling back onto a revert-layer</li>
+      <li class="c1" id="c1">C1 revert-rule on a custom property</li>
+      <li class="c2" id="c2">C2 all: revert-rule</li>
+      <li class="c3" id="c3">C3 revert-rule written in a var() fallback</li>
+    </ol>
+    <p class="d1">
+      D1 This paragraph must be green and must start a new page, because
+      <code>break-before: revert-rule</code> rolls back to the
+      <code>break-before: page</code> of the earlier rule.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/revert.html
+++ b/packages/core/test/files/revert.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2111: the `revert` explicit defaulting keyword -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>revert keyword</title>
+    <style>
+      @page {
+        size: 210mm 200mm;
+        margin: 10mm;
+      }
+
+      body {
+        font: 12px/1.5 Georgia, serif;
+        color: green;
+      }
+
+      /* ---- A. revert rolls the whole author origin back ---- */
+
+      .a1 {
+        color: red;
+      }
+      .a1 {
+        color: revert;
+      }
+
+      /* revert ignores the layer it sits in and rolls back the origin */
+      @layer a2 {
+        .a2 {
+          color: red;
+        }
+      }
+      @layer a2b {
+        .a2 {
+          color: revert;
+        }
+      }
+
+      /* revert in an unlayered rule rolls back the layers too, which is
+         where it differs from revert-layer */
+      @layer a3 {
+        .a3 {
+          color: red;
+        }
+      }
+      .a3 {
+        color: revert;
+      }
+      .a3x {
+        color: red;
+      }
+      #a3x {
+        color: revert;
+      }
+
+      /* !important reverts within the author origin too */
+      .a4 {
+        color: red !important;
+      }
+      #a4 {
+        color: revert !important;
+      }
+
+      /* revert loses to a declaration that beats it in the cascade */
+      .a5 {
+        color: revert;
+      }
+      #a5 {
+        color: green;
+      }
+
+      /* ---- B. revert rolls back to the user-agent style sheet ---- */
+
+      /* the UA style sheet says `li { display: list-item }`, so the marker
+         must come back — and it must be Vivliostyle that puts it there */
+      ol.b1 > li {
+        display: block;
+      }
+      ol.b1 > li {
+        display: revert;
+      }
+
+      /* the UA style sheet says `b, strong { font-weight: bolder }` */
+      .b2 strong {
+        font-weight: normal;
+      }
+      .b2 strong {
+        font-weight: revert;
+      }
+
+      /* ---- C. revert with `all` and with custom properties ---- */
+
+      .c1 {
+        color: red;
+        font-style: italic;
+        all: revert;
+      }
+
+      .c2 {
+        --c: red;
+      }
+      .c2 {
+        --c: revert;
+      }
+      .c2 {
+        /* the reverted custom property is guaranteed-invalid, so the
+           fallback applies */
+        color: var(--c, green);
+      }
+
+      /* revert written in a var() fallback */
+      .c3 {
+        color: red;
+      }
+      .c3 {
+        color: var(--c3-color, revert);
+      }
+
+      /* ---- D. revert reaches the layout engine ---- */
+
+      @layer d1 {
+        .d1 {
+          break-before: page;
+        }
+      }
+      .d1 {
+        break-before: revert;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>The <code>revert</code> keyword</h1>
+    <p>Every list item below must be green.</p>
+    <ol>
+      <li class="a1">A1 revert with nothing below it inherits</li>
+      <li class="a2">A2 revert ignores layers and rolls back the origin</li>
+      <li class="a3">A3 revert rolls back the layers of its origin</li>
+      <li class="a3x" id="a3x">A3x revert rolls back a lower-specificity rule</li>
+      <li class="a4" id="a4">A4 revert with !important</li>
+      <li class="a5" id="a5">A5 revert loses to a stronger declaration</li>
+      <li class="c1">C1 all: revert</li>
+      <li class="c2">C2 revert on a custom property</li>
+      <li class="c3">C3 revert written in a var() fallback</li>
+      <li class="b2">
+        B2 revert to the UA font-weight: <strong>this must be bold</strong>
+      </li>
+    </ol>
+    <p>The list below must show its markers.</p>
+    <ol class="b1">
+      <li>B1 revert to the UA display: list-item</li>
+      <li>B1 second item</li>
+    </ol>
+    <p class="d1">
+      D1 <code>revert</code> rolls back the whole author origin, layers
+      included, so the <code>break-before: page</code> declared in a layer is
+      gone and this paragraph must stay on the same page as the list above.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/toc-hidden.html
+++ b/packages/core/test/files/toc-hidden.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2111 / PR #1269: the `hidden` attribute keeps an entry
+     out of the printed table of contents, but not out of the viewer's TOC menu -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>hidden in the table of contents</title>
+    <style>
+      @page {
+        size: 148mm 210mm;
+        margin: 15mm;
+      }
+
+      body {
+        font: 12px/1.5 Georgia, serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Hidden entries in the table of contents</h1>
+    <p>
+      The <code>hidden</code> table of contents below must not appear on this
+      page, but the viewer's TOC menu must list all three of its entries,
+      including the one whose <code>li</code> carries
+      <code>hidden</code> itself.
+    </p>
+    <nav role="doc-toc" hidden>
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#one">One</a></li>
+        <li hidden><a href="#two">Two (hidden entry)</a></li>
+        <li><a href="#three">Three</a></li>
+      </ol>
+    </nav>
+    <p hidden>
+      This paragraph carries the <code>hidden</code> attribute and must not be
+      rendered on the page.
+    </p>
+    <section id="one">
+      <h2>One</h2>
+      <p>First section.</p>
+    </section>
+    <section id="two">
+      <h2>Two</h2>
+      <p>Second section.</p>
+    </section>
+    <section id="three">
+      <h2>Three</h2>
+      <p>Third section.</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -2776,4 +2776,158 @@ describe("css-cascade", function () {
       expect(style["font-size"].value.toString()).toBe("50px");
     });
   });
+
+  describe("rollback keywords", function () {
+    beforeEach(function () {
+      // Every style sheet is parsed before the cascade runs, so the property
+      // is known to need its losing declarations kept before any of them is
+      // merged in.
+      adapt_csscasc.noteRollbackDeclaration("color", adapt_css.ident.revert);
+    });
+
+    function declare(style, value, priority, layer, ruleId) {
+      adapt_csscasc.setPropCascadeValue(
+        style,
+        "color",
+        new adapt_csscasc.CascadeValue(
+          value,
+          priority,
+          layer || null,
+          ruleId || 0,
+        ),
+      );
+    }
+
+    function resolved(style) {
+      adapt_csscasc.resolveRollbackValues(style);
+      return style.color.value;
+    }
+
+    var green = adapt_css.getName("green");
+    var red = adapt_css.getName("red");
+    var blue = adapt_css.getName("blue");
+
+    it("rolls an author declaration back to the user-agent origin", function () {
+      var style = {};
+      declare(style, green, adapt_cssparse.SPECIFICITY_USER_AGENT);
+      declare(style, red, adapt_cssparse.SPECIFICITY_AUTHOR);
+      declare(
+        style,
+        adapt_css.ident.revert,
+        adapt_cssparse.SPECIFICITY_AUTHOR + 1,
+      );
+
+      expect(resolved(style)).toBe(green);
+    });
+
+    it("rolls a user declaration back past the author origin", function () {
+      var style = {};
+      declare(style, green, adapt_cssparse.SPECIFICITY_USER_AGENT);
+      declare(style, red, adapt_cssparse.SPECIFICITY_AUTHOR_IMPORTANT);
+      declare(
+        style,
+        adapt_css.ident.revert,
+        adapt_cssparse.SPECIFICITY_USER_IMPORTANT,
+      );
+
+      expect(resolved(style)).toBe(green);
+    });
+
+    it("becomes unset when there is nothing left to roll back to", function () {
+      var style = {};
+      declare(style, red, adapt_cssparse.SPECIFICITY_AUTHOR);
+      declare(
+        style,
+        adapt_css.ident.revert,
+        adapt_cssparse.SPECIFICITY_AUTHOR + 1,
+      );
+
+      expect(resolved(style)).toBe(adapt_css.ident.unset);
+    });
+
+    it("rolls revert-layer back to the previous layer", function () {
+      var tree = new adapt_csscasc.CascadeLayerTree();
+      var first = tree.register(null, ["first"]);
+      var second = tree.register(null, ["second"]);
+      var style = {};
+      declare(style, green, adapt_cssparse.SPECIFICITY_AUTHOR, first);
+      declare(
+        style,
+        adapt_css.ident.revert_layer,
+        adapt_cssparse.SPECIFICITY_AUTHOR,
+        second,
+      );
+
+      expect(resolved(style)).toBe(green);
+    });
+
+    // WPT css/css-cascade/revert-layer-005.html
+    it("rolls an important revert-layer back to the earlier layer, dropping the later layer's important declaration", function () {
+      var tree = new adapt_csscasc.CascadeLayerTree();
+      var a = tree.register(null, ["a"]);
+      var b = tree.register(null, ["b"]);
+      var c = tree.register(null, ["c"]);
+      var style = {};
+      declare(style, green, adapt_cssparse.SPECIFICITY_AUTHOR, a);
+      declare(
+        style,
+        adapt_css.ident.revert_layer,
+        adapt_cssparse.SPECIFICITY_AUTHOR_IMPORTANT,
+        b,
+      );
+      declare(style, red, adapt_cssparse.SPECIFICITY_AUTHOR_IMPORTANT, c);
+
+      expect(resolved(style)).toBe(green);
+    });
+
+    // WPT css/css-cascade/revert-layer-009.html
+    it("rolls revert-layer in the style attribute back to the author style sheets", function () {
+      var style = {};
+      declare(style, green, adapt_cssparse.SPECIFICITY_AUTHOR);
+      declare(style, red, adapt_cssparse.SPECIFICITY_STYLE);
+      declare(
+        style,
+        adapt_css.ident.revert_layer,
+        adapt_cssparse.SPECIFICITY_STYLE + 1,
+      );
+
+      expect(resolved(style)).toBe(green);
+    });
+
+    it("skips every declaration of its own rule for revert-rule", function () {
+      var style = {};
+      declare(style, green, adapt_cssparse.SPECIFICITY_AUTHOR, null, 1);
+      declare(style, red, adapt_cssparse.SPECIFICITY_AUTHOR + 1, null, 2);
+      declare(
+        style,
+        adapt_css.ident.revert_rule,
+        adapt_cssparse.SPECIFICITY_AUTHOR + 2,
+        null,
+        2,
+      );
+
+      expect(resolved(style)).toBe(green);
+    });
+
+    it("takes declarations caught in a revert-rule cycle out of the cascade", function () {
+      var style = {};
+      declare(style, blue, adapt_cssparse.SPECIFICITY_AUTHOR, null, 1);
+      declare(
+        style,
+        adapt_css.ident.revert_rule,
+        adapt_cssparse.SPECIFICITY_AUTHOR + 1,
+        null,
+        2,
+      );
+      declare(
+        style,
+        adapt_css.ident.revert_rule,
+        adapt_cssparse.SPECIFICITY_AUTHOR + 2,
+        null,
+        3,
+      );
+
+      expect(resolved(style)).toBe(blue);
+    });
+  });
 });

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -1,8 +1,75 @@
-- id: "0045"
-  category: General
+- id: "0106"
+  category: Explicit Defaulting Keywords
+  title: "revert keyword (Issue #2111)"
+  file: revert.html
+  type: difference
+  decision: expected  # regression / expected / skip
+  notes: >-
+    New test case for Issue #2111: `revert` is now resolved by Vivliostyle's own cascade instead of being handed to the browser, so the reverted values differ from canary.
+  approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert.html&zoom=1&spread=false
+  diffPages:
+    - 1
+- id: "0107"
+  category: Explicit Defaulting Keywords
+  title: "revert-layer keyword (Issue #2111)"
+  file: revert-layer.html
+  type: difference
+  decision: expected  # regression / expected / skip
+  notes: >-
+    New test case for Issue #2111: `revert-layer` is now implemented, so it rolls back to the previous layer (including a `break-before: page`, hence the extra page) instead of being handed to the browser.
+  approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert-layer.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert-layer.html&zoom=1&spread=false
+  pageCountActual: 2
+  pageCountBaseline: 1
+  diffPages:
+    - 1
+- id: "0108"
+  category: Explicit Defaulting Keywords
+  title: "revert-rule keyword (Issue #2111)"
+  file: revert-rule.html
+  type: difference
+  decision: expected  # regression / expected / skip
+  notes: >-
+    New test case for Issue #2111: `revert-rule` is now implemented, so it rolls back to the previous rule (including a `break-before: page`, hence the extra page) instead of being handed to the browser.
+  approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert-rule.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert-rule.html&zoom=1&spread=false
+  pageCountActual: 2
+  pageCountBaseline: 1
+  diffPages:
+    - 1
+- id: "0109"
+  category: Explicit Defaulting Keywords
+  title: "Rollback keywords in @page (Issue #2111)"
+  file: revert-page.html
+  type: error
+  decision: expected  # regression / expected / skip
+  notes: >-
+    New test case for Issue #2111: canary times out on `@page { margin-left: revert }`, which this change resolves in the cascade instead of forwarding the keyword to the browser.
+  approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert-page.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert-page.html&zoom=1&spread=false
+  errorSide: canary
+  errorName: TimeoutError
+  errorMessage: "Timeout (30000ms): waiting for viewer ready"
+- category: General
   title: "writing-mode on body not inherited by page context (Issue #1122)"
   file: writing-mode-body-page-context.html
-  type: difference
   decision: expected  # regression / expected / skip
   notes: >-
     Fix for Issue #1122: writing-mode on body is propagated to the root as a used value only, so the page context
@@ -14,8 +81,6 @@
   baselineLabel: canary
   baselineUrl: >-
     https://vivliostyle-git-fix-issue1122-vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/writing-mode-body-page-context.html&zoom=1&spread=false
-  diffPages:
-    - 1
 - category: General
   title: "Lowercase doctype must not cause parser error (Issue #2101)"
   file: lowercase-doctype
@@ -218,8 +283,7 @@
   actualUrl: >-
     http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/cascade-layers.html&zoom=1&spread=false
   baselineLabel: canary
-  baselineUrl: >-
-    https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/cascade-layers.html&zoom=1&spread=false
+  baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/cascade-layers.html&zoom=1&spread=false
 - category: Cascade Layers
   title: "Cascade layers with !important (Issue #977)"
   file: cascade-layers-important.html
@@ -275,8 +339,8 @@
   file: background-position-longhand-root.html
   decision: expected  # regression / expected / skip
   notes: >-
-    New test file for Issue #2116: canary drops `background-position-x`/`-y` specified on the body element, because
-    they are not part of the `background` shorthand grammar and so never reach the root background.
+    New test file for Issue #2116: canary drops `background-position-x`/`-y` specified on the body element, because they
+    are not part of the `background` shorthand grammar and so never reach the root background.
   approvedViewer: git-fix-issue2116  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
   actualLabel: dev
   actualUrl: >-


### PR DESCRIPTION
Closes #2111.

> [!NOTE]
> **Follow-up: #2123.** Two WPT tests in `css/css-ui` regressed here, because a rollback with nothing left in Vivliostyle's own cascade resolved to `unset` and so dropped the native border of a form control. #2123 keeps the value as `revert` in that case instead, so the browser resolves it against its own user-agent style sheet. That also makes the `user-agent-hidden.css` split described under “`[hidden]` in the TOC box” below unnecessary, and it has been removed again.

The three rollback keywords of [css-cascade-5 §7.3](https://drafts.csswg.org/css-cascade-5/#defaulting-keywords) are now resolved by Vivliostyle's own cascade instead of being forwarded to the browser.

`ValidatorSet.validatePropertyAndHandleShorthand()` accepted them through its `CSS.supports()` fallback, and the winning value was written verbatim into the `style` attribute of the generated element. The browser then resolved it with no knowledge of Vivliostyle's origins, layers or rules: `revert` rolled back to Chromium's user-agent style sheet rather than Vivliostyle's, and an inline style has neither a layer nor a preceding rule, so `revert-layer` and `revert-rule` had nothing to roll back to at all. The layout engine never saw the reverted value either, so fragmentation, page layout and counters got the wrong answer.

### How it works

The cascade kept only the single winning `CascadeValue` per property, so there was nothing to roll back to. Two things make that possible:

- `noteRollbackDeclaration()` records at parse time which property names carry a rollback declaration anywhere. Only for those does `setPropCascadeValue()` retain the declarations that lose, in a `WeakMap` keyed by the `ElementStyle` — deliberately not on the `ElementStyle` itself, because the loops that walk a style would trip over an entry of a different shape.
- `CascadeValue.ruleId`, handed out per declaration block by `nextRuleId()`, gives `revert-rule` an identity for "the current rule".

`resolveRollbackValues()` then re-runs the cascade without the rolled-back declarations, chaining when the value it finds is itself a rollback keyword and ending in `unset` (`initial`, the guaranteed-invalid value, for a custom property) when a `revert-rule` cycle exhausts the candidates.

It runs twice. Once as soon as the cascade is settled, so the value rolled back to can still be a shorthand or contain `var()`; and once more after `var()` substitution, because a keyword written in a `var()` fallback only becomes the whole value there. That second pass matters in practice: `var(--token, revert-layer)` is the only way to say "use this token if it is set, otherwise defer to the earlier layer", which is what a themable component wants.

Resolution walks `_pseudos`, `_regions`, `_marginBoxes` and `_footnoteArea`, so the keywords work in `@page` rules and page-margin boxes too. `ValidatorSet` now probes the property with `unset` instead of the keyword itself, so neither validity nor shorthand expansion depends on whether the running browser happens to know `revert-rule`.

### Semantics measured against Chromium

The spec prose leaves the exclusion rules open, so they were pinned down by measuring Chromium rather than by reading:

- **`revert`** drops the current cascade origin *and every later one*, so a user declaration reverts past the author origin as well.
- **`revert-layer`** drops the current layer and every **later** one, including the important declarations of later layers. Those outrank the current layer for normal declarations, but they are rolled back all the same — this is what WPT `revert-layer-005` checks, and "remove the current layer and re-run the cascade" gets it wrong.
- The **`style` attribute** forms a layer set of its own, so `revert-layer` there rolls back only the style attribute and lands on the author style sheets (WPT `revert-layer-009`).
- A keyword that reaches a property **through a custom property** (`--x: var(--y, revert-layer); color: var(--x)`) is *not* a rollback. Chromium treats it as a token stream no property can use, so such a custom property becomes the guaranteed-invalid value.

### `[hidden]` in the TOC box

`user-agent-toc.css` said `[hidden] { display: revert }` to undo `*[hidden] { display: none }` from `user-agent-base.css`, keeping an entry that is hidden from the printed table of contents visible in the viewer's TOC menu (#1269). That relied on the browser resolving the keyword, and once Vivliostyle resolves it the declaration computes to `unset`.

No rollback keyword can express what that rule meant, because both rules sit in the same origin and the same (implicit) layer — `revert` overshoots to `unset`, and `revert-rule`/`revert-layer` still leave `*[hidden]` winning. So `*[hidden]` moves into its own `user-agent-hidden.css`, which `ops.ts` loads only when the document is not being rendered into the TOC box. Verified against canary: the hidden `nav` and a `<p hidden>` stay off the page, and the TOC menu lists all entries, exactly as before.

**Update:** this split has been undone in #2123, which hands a rollback with nothing left to roll back to over to the browser. `user-agent-toc.css` says `[hidden] { display: revert }` again, and `user-agent-hidden.css` is gone.

### Known limitations

- A rollback keyword reaching a property through a custom property is not a rollback (see above). This matches Chromium.
- Rolling back into a shadow tree is not supported, because Vivliostyle's cascade does not implement Shadow DOM.

Both are documented in `docs/supported-css-features.md` and its Japanese counterpart, which also drop the "`revert-layer` is not supported yet" note on `@layer`.

### Test cases

| file | covers |
| --- | --- |
| `revert.html` | rolling back the author origin, `!important`, `all: revert`, custom properties, rolling back to the Vivliostyle UA style sheet (`display: list-item`, `font-weight: bolder`), `var()` fallback |
| `revert-layer.html` | previous layer, unlayered declarations, nested layers, before the first layer, the style attribute (WPT `-009`), important layer order (WPT `-005`), `all`, custom properties, `break-before` reaching the layout engine, and six `var()` fallback cases |
| `revert-rule.html` | the rule's own declarations, cascade order rather than source order, chained rollbacks, cycles, `!important`, layers, `all`, custom properties, `var()` fallback |
| `revert-page.html` | `revert-layer` on `@page` margins, `revert-rule` in a page-margin box, `revert` rolling back to the UA `@media print { @page { margin: 10% } }` |
| `toc-hidden.html` | the `hidden` attribute staying out of the printed TOC while the viewer's TOC menu lists it |

Eight unit tests in `css-cascade-spec.js` cover the origin and layer ordering directly, including the user-origin case, which a self-contained test document cannot reach.

### Verification

- `yarn lint`, `yarn build`, `yarn test` — 736/736 pass.
- `yarn test:reftest-diff --actual-viewer dev --baseline-viewer canary --wpt-path-prefix css/css-cascade/` — WPT `revert-layer-001`, `-002`, `-003`, `-005`, `-007` and `-009` go from fail to pass.
  `-004`, `-013` and `-014` regress. They passed only because the forwarded keyword was resolved by the browser against a shadow tree that Vivliostyle's cascade does not implement, so they join `-010` and `-011` (animations) as known failures from unimplemented features.
- `yarn test:layout-regression --actual-viewer dev --baseline-viewer canary` — 363 entries, no differences across the 359 existing ones. The four new entries are triaged `expected`.

Assisted-by: Claude Code:claude-opus-5

<details>
<summary>How the AI was used</summary>

- The human author wrote the issue analysis in #2111, including the two candidate approaches and the warning that `user-agent-toc.css` would need rechecking, and set the scope of this PR.
- The AI implemented the cascade-history and rule-identity machinery, the two-pass resolution, and the test documents and unit tests, and ran the WPT and layout regression suites.
- The human author caught the first attempt at the `[hidden]` rule — rewriting it as `display: none` — as a regression, and supplied the #1269 rationale that a hidden table-of-contents entry must still appear in the viewer's TOC menu. The AI then reproduced the breakage against canary and replaced the rewrite with the `user-agent-hidden.css` split.
- The human author ran the WPT `revert-layer` tests independently, reported `-005` and `-009` as genuine failures, and ruled `-010`/`-011` out of scope. The AI measured Chromium to settle the ambiguous spec points behind them.
- The human author decided that the `var()` fallback case belonged in this PR rather than a follow-up, and accepted `-004`/`-013`/`-014` as known failures from unimplemented Shadow DOM support.
- A review pass found two defects that the AI then fixed: a `||=` short-circuit that skipped the second-pass recursion for sibling sub-styles, and `revert` in a user-origin declaration failing to roll back past the author origin. Both are now covered by tests.
- The human author reviewed the final diff and confirmed the test results before requesting review.

</details>

