### PR TITLE
feat: Support cascade layer order for name-defining at-rules

### DIFF
--- a/packages/core/src/vivliostyle/counter-style.ts
+++ b/packages/core/src/vivliostyle/counter-style.ts
@@ -1718,6 +1718,13 @@ class EthiopicNumeric extends CounterStyle {
 export class CounterStyleStore {
   #store: CounterStyleStoreMap;
 
+  /**
+   * What the cascade sorted the currently winning definition of each name by,
+   * so that a definition parsed later cannot override one from a
+   * higher-priority origin or cascade layer (css-cascade-5 §6.4).
+   */
+  #winners: Map<string, CssCascade.CascadePriority> = new Map();
+
   constructor() {
     this.#store = new Map();
 
@@ -1755,14 +1762,30 @@ export class CounterStyleStore {
     );
   }
 
+  /**
+   * @param priority where the `@counter-style` rule sits in the cascade. When
+   *     omitted, the definition simply overrides the previous one.
+   */
   define(
     name: string,
     descriptors: CssCascade.ElementStyle,
+    priority?: CssCascade.CascadePriority,
   ): CounterStyle | null {
     if (!validateNameForDefinition(name)) {
       return null;
     }
     const counterStyle = CounterStyle.create(this.#store, descriptors);
+    const winner = priority && this.#winners.get(name);
+    if (winner && CssCascade.comparePriority(priority, winner) < 0) {
+      // A definition of the same name in a higher-priority origin or cascade
+      // layer has already won.
+      return counterStyle;
+    }
+    if (priority) {
+      this.#winners.set(name, priority);
+    } else {
+      this.#winners.delete(name);
+    }
     this.#store.set(name, counterStyle);
     return counterStyle;
   }

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -358,6 +358,17 @@ export function nextRuleId(): number {
 }
 
 /**
+ * What the cascade sorts by, apart from the document order. Cascaded values
+ * are the usual case, but the name-defining at-rules (`@font-face`,
+ * `@counter-style`, `@-epubx-page-master`) are sorted the same way
+ * (css-cascade-5 §6.4).
+ */
+export interface CascadePriority {
+  readonly priority: number;
+  readonly layer: CascadeLayer | null;
+}
+
+/**
  * The cascade origin a cascaded value belongs to, disregarding `!important`:
  * 0 for the user-agent origin, 1 for the user origin and 2 for the author
  * origin, of which the style attribute is a part.
@@ -400,24 +411,27 @@ function layerSetOf(cascVal: CascadeValue): number {
  * The position of a cascaded value's layer in its origin. Unlayered
  * declarations act as the final layer (css-cascade-5 §6.4.2).
  */
-function layerOrderOf(cascVal: CascadeValue): number {
+function layerOrderOf(cascVal: CascadePriority): number {
   return cascVal.layer ? cascVal.layer.order : Infinity;
 }
 
 /**
- * Compares two cascaded values. Cascade layers are sorted between the origin
- * and the selector specificity, and unlayered declarations act as a final
- * layer (css-cascade-5 §6.4.2).
+ * Compares two cascaded values (or two name-defining at-rules). Cascade layers
+ * are sorted between the origin and the selector specificity, and unlayered
+ * declarations act as a final layer (css-cascade-5 §6.4.2).
  */
-export function comparePriority(a: CascadeValue, b: CascadeValue): number {
+export function comparePriority(
+  a: CascadePriority,
+  b: CascadePriority,
+): number {
   const originA = Math.floor(a.priority / ORIGIN_UNIT);
   const originB = Math.floor(b.priority / ORIGIN_UNIT);
   if (originA !== originB) {
     return originA - originB;
   }
   if (a.layer !== b.layer) {
-    const orderA = a.layer ? a.layer.order : Infinity;
-    const orderB = b.layer ? b.layer.order : Infinity;
+    const orderA = layerOrderOf(a);
+    const orderB = layerOrderOf(b);
     if (orderA !== orderB) {
       const higher = orderA > orderB ? 1 : -1;
       return originA >= FIRST_IMPORTANT_ORIGIN ? -higher : higher;
@@ -6288,6 +6302,7 @@ export class PropSetParserHandler
     public readonly validatorSet: CssValidator.ValidatorSet,
     delegation: CssParser.Delegation,
     public readonly ruleType?: string,
+    public readonly layer: CascadeLayer | null = null,
   ) {
     super(scope, owner, delegation);
     this.order = 0;
@@ -6334,10 +6349,10 @@ export class PropSetParserHandler
           value,
           specificity,
           this.condition,
-          null,
+          this.layer,
           this.ruleId,
         )
-      : new CascadeValue(value, specificity, null, this.ruleId);
+      : new CascadeValue(value, specificity, this.layer, this.ruleId);
     setPropCascadeValue(this.elementStyle, name, cascval);
   }
 }

--- a/packages/core/src/vivliostyle/font.ts
+++ b/packages/core/src/vivliostyle/font.ts
@@ -68,6 +68,12 @@ export class Face {
   blobs: Blob[] = [];
   family: string | null;
 
+  /**
+   * The `<style>` element carrying this face's `@font-face` rule in the view
+   * document. Only the view faces made by {@link Mapper.initFont} have one.
+   */
+  styleElement: HTMLStyleElement | null = null;
+
   constructor(public readonly properties: { [key: string]: Css.Val }) {
     this.fontTraitKey = makeFontTraitKey(this.properties);
     this.src = this.properties["src"]
@@ -218,6 +224,7 @@ export class Mapper {
     const style = this.head.ownerDocument.createElement("style");
     style.textContent = viewFontFace.makeAtRule(src, fontBytes);
     this.head.appendChild(style);
+    viewFontFace.styleElement = style;
     Logging.logger.debug("Load font:", src);
     frame.finish(viewFontFace);
     return frame.result();
@@ -278,9 +285,28 @@ export class Mapper {
       }
       fetchers.push(this.loadFont(srcFace, documentFaces));
     }
-    return TaskUtil.waitForFetchers(fetchers).thenAsync(() =>
-      this.waitFontLoading(),
-    );
+    return TaskUtil.waitForFetchers(fetchers).thenAsync(() => {
+      this.reorderFontFaceRules(fetchers);
+      return this.waitFontLoading();
+    });
+  }
+
+  /**
+   * Puts the `@font-face` rules of the view document back in the order of the
+   * rules they came from, which the cascade has already sorted. A font that
+   * needs deobfuscation is added when its fetch completes, so the order the
+   * rules were added in is not the order they were declared in, and the
+   * browser lets the last of the matching rules win.
+   */
+  private reorderFontFaceRules(
+    fetchers: TaskUtil.Fetcher<Face | null>[],
+  ): void {
+    for (const fetcher of fetchers) {
+      const styleElement = fetcher.resource?.styleElement;
+      if (styleElement?.parentNode === this.head) {
+        this.head.appendChild(styleElement); // moves it to the end
+      }
+    }
   }
 
   waitFontLoading(): Task.Result<boolean> {

--- a/packages/core/src/vivliostyle/ops.ts
+++ b/packages/core/src/vivliostyle/ops.ts
@@ -65,10 +65,25 @@ import {
   UserAgentTocCss,
 } from "./assets";
 
+/**
+ * A `@font-face` rule. `priority` and `layer` are what the cascade sorts the
+ * rule by when several rules define the same font (css-cascade-5 §6.4).
+ */
 export type FontFace = {
   properties: CssCascade.ElementStyle;
   condition: Exprs.Val | null;
+  priority: number;
+  layer: CssCascade.CascadeLayer | null;
 };
+
+/**
+ * Sorts `@font-face` rules by cascade origin and layer, keeping the document
+ * order within a layer (`Array.prototype.sort` is stable). The browser lets the
+ * last matching rule win, so the winner of the cascade must be emitted last.
+ */
+export function sortFontFaces(fontFaces: FontFace[]): FontFace[] {
+  return [...fontFaces].sort(CssCascade.comparePriority);
+}
 
 class CounterStyleParserHandler extends CssCascade.PropSetParserHandler {
   constructor(
@@ -79,6 +94,7 @@ class CounterStyleParserHandler extends CssCascade.PropSetParserHandler {
     private readonly counterStyleName: string,
     private readonly counterStyles: CounterStyle.CounterStyleStore,
     delegation: CssParser.Delegation,
+    layer: CssCascade.CascadeLayer | null,
   ) {
     super(
       scope,
@@ -88,12 +104,18 @@ class CounterStyleParserHandler extends CssCascade.PropSetParserHandler {
       validatorSet,
       delegation,
       "counter-style",
+      layer,
     );
   }
 
   override endRule(): void {
     super.endRule();
-    if (!this.counterStyles.define(this.counterStyleName, this.elementStyle)) {
+    if (
+      !this.counterStyles.define(this.counterStyleName, this.elementStyle, {
+        priority: this.getBaseSpecificity(),
+        layer: this.layer,
+      })
+    ) {
       Logging.logger.warn(
         `E_CSS_COUNTER_STYLE_INVALID: @counter-style ${this.counterStyleName}`,
       );
@@ -3382,6 +3404,7 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
       this.masterHandler.rootBox,
       this.condition,
       this.owner.getBaseSpecificity(),
+      this.layer,
     );
     this.owner.delegateTo(
       (delegation) =>
@@ -3445,6 +3468,8 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
     this.masterHandler.fontFaces.push({
       properties,
       condition: this.condition,
+      priority: this.getBaseSpecificity(),
+      layer: this.layer,
     });
     this.owner.delegateTo(
       (delegation) =>
@@ -3456,6 +3481,7 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
           this.masterHandler.validatorSet,
           delegation,
           "font-face",
+          this.layer,
         ),
     );
   }
@@ -3471,6 +3497,7 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
           name,
           this.masterHandler.counterStyles,
           delegation,
+          this.layer,
         ),
     );
   }
@@ -3490,6 +3517,8 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
           style,
           this.masterHandler.validatorSet,
           delegation,
+          undefined,
+          this.layer,
         ),
     );
   }
@@ -3506,6 +3535,8 @@ export class BaseParserHandler extends CssCascade.CascadeParserHandler {
           viewportProps,
           this.masterHandler.validatorSet,
           delegation,
+          undefined,
+          this.layer,
         ),
     );
   }
@@ -3908,7 +3939,7 @@ export class OPSDocStore extends Net.ResourceStore<XmlDoc.XMLDocHolder> {
                   sph.pageScope,
                   cascade,
                   sph.rootBox,
-                  sph.fontFaces,
+                  sortFontFaces(sph.fontFaces),
                   sph.footnoteProps,
                   sph.flowProps,
                   sph.viewportProps,

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -1946,6 +1946,11 @@ export class RootPageBoxInstance extends PageBoxInstance<RootPageBox> {
     super.applyCascadeAndInit(cascade, docElementStyle);
 
     // Sort page masters using origin, cascade layer, specificity and order.
+    // Page masters are a list tried in order: the first one whose conditions
+    // are met is used for the next page (EPUB Adaptive Layout 3.5). So the
+    // ties are broken by ascending index on purpose, keeping the "declared
+    // first, tried first" order that lets a general fallback page master be
+    // written last.
     const pageMasters = this.children;
     (pageMasters as PageMasterInstance[]).sort(
       (a, b) =>

--- a/packages/core/src/vivliostyle/page-master.ts
+++ b/packages/core/src/vivliostyle/page-master.ts
@@ -165,6 +165,7 @@ export class PageMaster<
     parent: RootPageBox,
     public readonly condition: Exprs.Val | null,
     public readonly specificity: number,
+    public readonly layer: CssCascade.CascadeLayer | null = null,
   ) {
     super(scope, name, pseudoName, classes, parent);
     // if PageMasterScope object is passed, use (share) it.
@@ -207,6 +208,7 @@ export class PageMaster<
       this.parent as RootPageBox,
       this.condition,
       this.specificity,
+      this.layer,
     );
     this.copySpecified(cloned);
     this.cloneChildren(cloned);
@@ -1922,6 +1924,16 @@ export const delayedProperties = ["transform", "transform-origin"];
 
 export const userAgentPageMasterPseudo = "background-host";
 
+/**
+ * What the cascade sorts a page box by. Only page masters carry an origin and
+ * a cascade layer; for anything else the comparison yields NaN and the
+ * document order decides.
+ */
+function cascadePriorityOf(pageBox: PageBox): CssCascade.CascadePriority {
+  const pageMaster = pageBox as PageMaster;
+  return { priority: pageMaster.specificity, layer: pageMaster.layer ?? null };
+}
+
 export class RootPageBoxInstance extends PageBoxInstance<RootPageBox> {
   constructor(pageBox: RootPageBox) {
     super(null, pageBox);
@@ -1933,11 +1945,14 @@ export class RootPageBoxInstance extends PageBoxInstance<RootPageBox> {
   ): void {
     super.applyCascadeAndInit(cascade, docElementStyle);
 
-    // Sort page masters using order and specificity.
+    // Sort page masters using origin, cascade layer, specificity and order.
     const pageMasters = this.children;
     (pageMasters as PageMasterInstance[]).sort(
       (a, b) =>
-        (b.pageBox as any).specificity - (a.pageBox as any).specificity || // probably cause NaN
+        CssCascade.comparePriority(
+          cascadePriorityOf(b.pageBox),
+          cascadePriorityOf(a.pageBox),
+        ) || // NaN unless both are page masters
         a.pageBox.index - b.pageBox.index,
     );
   }

--- a/packages/core/test/files/cascade-layers-counter-style.html
+++ b/packages/core/test/files/cascade-layers-counter-style.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2110: cascade layer order for @counter-style -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS Cascade Layers: @counter-style</title>
+    <style>
+      @page {
+        size: 200mm 150mm;
+        margin: 15mm;
+      }
+
+      /* `theme` has higher priority than `vendor`, although every `vendor`
+         block below comes later in the source. */
+      @layer vendor, theme;
+
+      /* ---- A. Layer order from the @layer statement ---- */
+
+      @layer theme {
+        @counter-style a {
+          system: cyclic;
+          symbols: "\2714"; /* ✔ */
+        }
+      }
+      @layer vendor {
+        @counter-style a {
+          system: cyclic;
+          symbols: "\2718"; /* ✘ */
+        }
+      }
+
+      /* ---- B. Unlayered definition beats any layer ---- */
+
+      @counter-style b {
+        system: cyclic;
+        symbols: "\2714"; /* ✔ */
+      }
+      @layer theme {
+        @counter-style b {
+          system: cyclic;
+          symbols: "\2718"; /* ✘ */
+        }
+      }
+
+      /* ---- C. Nested layers ---- */
+
+      @layer theme.early, theme.late;
+
+      @layer theme.late {
+        @counter-style c {
+          system: cyclic;
+          symbols: "\2714"; /* ✔ */
+        }
+      }
+      @layer theme.early {
+        @counter-style c {
+          system: cyclic;
+          symbols: "\2718"; /* ✘ */
+        }
+      }
+
+      /* ---- D. `system: extends` follows the winning definition ---- */
+
+      @layer theme {
+        @counter-style d-base {
+          system: cyclic;
+          symbols: "\2714"; /* ✔ */
+        }
+      }
+      @layer vendor {
+        @counter-style d-base {
+          system: cyclic;
+          symbols: "\2718"; /* ✘ */
+        }
+      }
+      @counter-style d {
+        system: extends d-base;
+      }
+
+      body {
+        font: 12pt/1.6 Georgia, serif;
+        margin: 0;
+      }
+      ol {
+        padding-left: 2em;
+      }
+      li::marker {
+        color: green;
+      }
+      .a {
+        list-style-type: a;
+      }
+      .b {
+        list-style-type: b;
+      }
+      .c {
+        list-style-type: c;
+      }
+      .d {
+        list-style-type: d;
+      }
+      .e::before {
+        content: counter(dummy, a) " ";
+        color: green;
+      }
+      .e {
+        list-style-type: none;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cascade Layers and <code>@counter-style</code></h1>
+    <p>Every marker below must be ✔. A ✘ marker means that the wrong
+      <code>@counter-style</code> definition won.</p>
+    <ul>
+      <li class="a">A layer order from <code>@layer vendor, theme;</code></li>
+      <li class="b">B unlayered definition beats the layered one after it</li>
+      <li class="c">C nested layer <code>theme.late</code> beats
+        <code>theme.early</code></li>
+      <li class="d">D <code>system: extends</code> uses the winning definition</li>
+      <li class="e">E the same counter style in <code>content: counter()</code></li>
+    </ul>
+  </body>
+</html>

--- a/packages/core/test/files/cascade-layers-font-face.html
+++ b/packages/core/test/files/cascade-layers-font-face.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2110: cascade layer order for @font-face -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS Cascade Layers: @font-face</title>
+    <style>
+      @page {
+        size: 200mm 150mm;
+        margin: 15mm;
+      }
+
+      /* `theme` has higher priority than `vendor`, although every `vendor`
+         block below comes later in the source. */
+      @layer vendor, theme;
+
+      /* ---- A. Layer order from the @layer statement ---- */
+
+      @layer theme {
+        @font-face {
+          font-family: font-a;
+          src: local("Courier New"), local("DejaVu Sans Mono"), local("Liberation Mono");
+        }
+      }
+      @layer vendor {
+        @font-face {
+          font-family: font-a;
+          src: local("Georgia"), local("DejaVu Serif"), local("Liberation Serif");
+        }
+      }
+
+      /* ---- B. Unlayered definition beats any layer ---- */
+
+      @font-face {
+        font-family: font-b;
+        src: local("Courier New"), local("DejaVu Sans Mono"), local("Liberation Mono");
+      }
+      @layer theme {
+        @font-face {
+          font-family: font-b;
+          src: local("Georgia"), local("DejaVu Serif"), local("Liberation Serif");
+        }
+      }
+
+      body {
+        font: 12pt/1.6 Georgia, serif;
+        margin: 0;
+      }
+      .a {
+        font-family: font-a, Georgia, serif;
+      }
+      .b {
+        font-family: font-b, Georgia, serif;
+      }
+      .reference-mono {
+        font-family: "Courier New", Courier, monospace;
+      }
+      .reference-serif {
+        font-family: Georgia, "Times New Roman", serif;
+      }
+      p {
+        margin: 0.4em 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cascade Layers and <code>@font-face</code></h1>
+    <p>The first two lines must be rendered with the monospaced font of the
+      reference line below them, not with the serif font.</p>
+    <p class="a">A The quick brown fox jumps over the lazy dog. (layer order
+      from <code>@layer vendor, theme;</code>)</p>
+    <p class="b">B The quick brown fox jumps over the lazy dog. (unlayered
+      definition beats the layered one after it)</p>
+    <hr />
+    <p class="reference-mono">Reference: The quick brown fox jumps over the lazy
+      dog. (monospaced &mdash; expected)</p>
+    <p class="reference-serif">Reference: The quick brown fox jumps over the lazy
+      dog. (serif &mdash; wrong)</p>
+  </body>
+</html>

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -339,6 +339,14 @@ module.exports = [
         file: "cascade-layers-import.html",
         title: "Cascade layers with @import (Issue #977)",
       },
+      {
+        file: "cascade-layers-counter-style.html",
+        title: "Cascade layers with @counter-style (Issue #2110)",
+      },
+      {
+        file: "cascade-layers-font-face.html",
+        title: "Cascade layers with @font-face (Issue #2110)",
+      },
     ],
   },
   {

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -1,72 +1,79 @@
-- id: "0106"
-  category: Explicit Defaulting Keywords
+- category: Cascade Layers
+  title: "Cascade layers with @counter-style (Issue #2110)"
+  file: cascade-layers-counter-style.html
+  decision: expected  # regression / expected / skip
+  notes: ""
+  approvedViewer: git-feat-issue2110  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/cascade-layers-counter-style.html&zoom=1&spread=false
+  baselineLabel: stable
+  baselineUrl: >-
+    https://vivliostyle.org/viewer/#src=http://localhost:3300/core/test/files/cascade-layers-counter-style.html&zoom=1&spread=false
+- category: Cascade Layers
+  title: "Cascade layers with @font-face (Issue #2110)"
+  file: cascade-layers-font-face.html
+  decision: expected  # regression / expected / skip
+  notes: ""
+  approvedViewer: git-feat-issue2110  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/cascade-layers-font-face.html&zoom=1&spread=false
+  baselineLabel: stable
+  baselineUrl: >-
+    https://vivliostyle.org/viewer/#src=http://localhost:3300/core/test/files/cascade-layers-font-face.html&zoom=1&spread=false
+- category: Explicit Defaulting Keywords
   title: "revert keyword (Issue #2111)"
   file: revert.html
-  type: difference
   decision: expected  # regression / expected / skip
   notes: >-
-    New test case for Issue #2111: `revert` is now resolved by Vivliostyle's own cascade instead of being handed to the browser, so the reverted values differ from canary.
+    New test case for Issue #2111: `revert` is now resolved by Vivliostyle's own cascade instead of being handed to the
+    browser, so the reverted values differ from canary.
   approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
   actualLabel: dev
   actualUrl: >-
     http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert.html&zoom=1&spread=false
   baselineLabel: canary
   baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert.html&zoom=1&spread=false
-  diffPages:
-    - 1
-- id: "0107"
-  category: Explicit Defaulting Keywords
+- category: Explicit Defaulting Keywords
   title: "revert-layer keyword (Issue #2111)"
   file: revert-layer.html
-  type: difference
   decision: expected  # regression / expected / skip
   notes: >-
-    New test case for Issue #2111: `revert-layer` is now implemented, so it rolls back to the previous layer (including a `break-before: page`, hence the extra page) instead of being handed to the browser.
+    New test case for Issue #2111: `revert-layer` is now implemented, so it rolls back to the previous layer (including
+    a `break-before: page`, hence the extra page) instead of being handed to the browser.
   approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
   actualLabel: dev
   actualUrl: >-
     http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert-layer.html&zoom=1&spread=false
   baselineLabel: canary
   baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert-layer.html&zoom=1&spread=false
-  pageCountActual: 2
-  pageCountBaseline: 1
-  diffPages:
-    - 1
-- id: "0108"
-  category: Explicit Defaulting Keywords
+- category: Explicit Defaulting Keywords
   title: "revert-rule keyword (Issue #2111)"
   file: revert-rule.html
-  type: difference
   decision: expected  # regression / expected / skip
   notes: >-
-    New test case for Issue #2111: `revert-rule` is now implemented, so it rolls back to the previous rule (including a `break-before: page`, hence the extra page) instead of being handed to the browser.
+    New test case for Issue #2111: `revert-rule` is now implemented, so it rolls back to the previous rule (including a
+    `break-before: page`, hence the extra page) instead of being handed to the browser.
   approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
   actualLabel: dev
   actualUrl: >-
     http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert-rule.html&zoom=1&spread=false
   baselineLabel: canary
   baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert-rule.html&zoom=1&spread=false
-  pageCountActual: 2
-  pageCountBaseline: 1
-  diffPages:
-    - 1
-- id: "0109"
-  category: Explicit Defaulting Keywords
+- category: Explicit Defaulting Keywords
   title: "Rollback keywords in @page (Issue #2111)"
   file: revert-page.html
-  type: error
   decision: expected  # regression / expected / skip
   notes: >-
-    New test case for Issue #2111: canary times out on `@page { margin-left: revert }`, which this change resolves in the cascade instead of forwarding the keyword to the browser.
+    New test case for Issue #2111: canary times out on `@page { margin-left: revert }`, which this change resolves in
+    the cascade instead of forwarding the keyword to the browser.
   approvedViewer: git-feat-issue2111  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
   actualLabel: dev
   actualUrl: >-
     http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/revert-page.html&zoom=1&spread=false
   baselineLabel: canary
   baselineUrl: https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/revert-page.html&zoom=1&spread=false
-  errorSide: canary
-  errorName: TimeoutError
-  errorMessage: "Timeout (30000ms): waiting for viewer ready"
 - category: General
   title: "writing-mode on body not inherited by page context (Issue #1122)"
   file: writing-mode-body-page-context.html


### PR DESCRIPTION
Closes #2110.

Cascade layers (#2109) applied only to cascaded values. The name-defining
at-rules still resolved name collisions by source order, so a definition in a
lower-priority layer could override one in a higher-priority layer:

```css
@layer vendor, theme;

@layer theme {
  @counter-style a { system: cyclic; symbols: "\2714" }
}
@layer vendor {
  @counter-style a { system: cyclic; symbols: "\2718" }  /* used to win */
}
```

This PR makes `@font-face`, `@counter-style`, `@-epubx-page-master`,
`@-epubx-flow` and `@-epubx-viewport` resolve collisions with the cascade
order defined in [css-cascade-5 §6.4](https://drafts.csswg.org/css-cascade-5/#cascade-sort):
origin, then cascade layer, then specificity and order.

### Changes

- **`css-cascade.ts`**: `comparePriority()` now takes a structural
  `CascadePriority` (`{ priority, layer }`) instead of a `CascadeValue`, so the
  at-rules can be sorted by the same rule. `PropSetParserHandler` carries the
  cascade layer and puts it on the values it produces.
- **`ops.ts`**: every name-defining at-rule receives the layer of the handler
  that parses it. `@font-face` rules are sorted by origin and layer before they
  are handed to the style (the browser lets the last matching rule win, so the
  cascade winner must be emitted last; `Array.prototype.sort` is stable, so the
  document order within a layer is kept).
- **`counter-style.ts`**: `CounterStyleStore.define()` takes the rule's cascade
  priority and keeps the winner per name, so a definition parsed later cannot
  override one from a higher-priority origin or layer.
- **`page-master.ts`**: `PageMaster` carries its layer, and `RootPageBoxInstance`
  sorts page masters by origin and layer as well as specificity and order.
- **`font.ts`**: each `@font-face` rule of the source document is copied into
  the view document as a `<style>` element when its font finishes loading, so
  an obfuscated font — which has to be fetched and deobfuscated first — used to
  land after rules that were declared later, undoing the sort above. The view
  `Face` now keeps a reference to its `<style>` element, and they are moved back
  into the sorted order once all the fetchers are done.
- **Tests**: two visual test cases,
  `packages/core/test/files/cascade-layers-counter-style.html` (layer statement
  order, unlayered beats layered, nested layers, `system: extends`,
  `content: counter()`) and `cascade-layers-font-face.html`.

`@-epubx-flow` and `@-epubx-viewport` need no dedicated merge logic: their
descriptors go through `setPropCascadeValue()`, which already uses
`comparePriority()`, so carrying the layer on the values is enough.

Page masters keep their ascending-index tiebreaker within a layer. They are not
resolved by name collision but tried in order — the first one whose conditions
are met is used for the next page (EPUB Adaptive Layout 3.5) — and all author
page masters share the same specificity, so "declared first, tried first" is
the established behavior and is what lets a general fallback page master be
written last. A comment at the sort site records this.

`revert-layer` is listed as out of scope in the issue and was implemented
separately in #2119.

### Verification

- `yarn lint`, `npx tsc --noEmit`
- `yarn test:core`: 736/736 passing
- Both new test cases checked in Vivliostyle Viewer: all markers render ✔ and
  both `@font-face` cases use the monospaced (winning) font.
- `yarn test:layout-regression --actual-viewer dev --baseline-viewer canary`
  (365 entries): no regressions. The only differences are the two new test
  files, which render the wrong result on canary and the expected one on this
  branch.
- Re-run against `stable` after the review round, with the two new entries
  approved against this branch in `scripts/layout-regression-triage.yaml`
  (`decision: expected`, `approvedViewer: git-feat-issue2110`): all 29 triage
  entries expected, no pending and no regressions.

Assisted-by: Claude Code:claude-opus-5

<details>
<summary>How the AI was used</summary>

- The human author had already implemented cascade layers (#2109) and
  `revert`/`revert-layer`/`revert-rule` (#2119), filed #2110 with the list of
  at-rules to cover and the requirement to reuse `comparePriority()`, and
  decided that `revert-layer` was out of scope here.
- The AI traced where each name-defining at-rule resolves collisions, proposed
  generalizing `comparePriority()` to a structural `CascadePriority` so the
  at-rules and the cascaded values share one comparison, wrote the
  implementation and the two visual test cases, and ran the type check, unit
  tests and the full layout regression suite.
- On the automated review comments, the AI assessed both: it confirmed the
  `@font-face` ordering gap was real and wrote the `font.ts` fix and the
  explanation of why the page master tiebreaker is pre-existing, specified
  behavior rather than a defect, and drafted both replies.
- The human author reviewed the design and the diff, verified both test cases
  in the Viewer, decided how to handle each review comment after reading the
  AI's analysis, re-ran the layout regression suite, and filled in the triage
  decisions before requesting review.

</details>
