### PR TITLE
chore: Respect global ignores for local Claude skills

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,4 +1,0 @@
-*
-!.gitignore
-!skills
-!skills/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.claude/*
+!/.claude/skills/
+
 *.code-workspace
 .vscode
 .vercel


### PR DESCRIPTION
`.claude/.gitignore` (introduced in #2112, mirroring vivliostyle-cli's `.claude/.gitignore` from [vivliostyle-cli#883](https://github.com/vivliostyle/vivliostyle-cli/pull/883)) un-ignores `.claude/skills/**` recursively. A `.gitignore` file inside `.claude/` is closer to that path than a contributor's global `excludesFile`, so Git always prefers the closer file's rule — the recursive `!skills/**` negation wins over any global ignore rule a contributor may have for personal or project-local skills they keep under `.claude/skills/`, forcing those files to show up as untracked and risking an accidental commit.

This moves the equivalent rules into the root `.gitignore`:

```
/.claude/*
!/.claude/skills/
```

Un-ignoring only the `skills` directory entry itself (no `!/.claude/skills/**`) lets Git continue to consult a contributor's own global ignore rules for files placed inside it, while `.claude/skills` (currently a symlink to `.agents/skills`) and any already-tracked files stay tracked as before.

This mirrors the same fix already applied in vivliostyle-cli ([vivliostyle-cli#884](https://github.com/vivliostyle/vivliostyle-cli/pull/884)), keeping the two projects' `.claude` setup consistent.

Assisted-by: Claude Code:claude-sonnet-5

<details>
<summary>How the AI was used</summary>

- The human author noticed vivliostyle-cli had fixed this issue in a follow-up PR after the two projects' `.claude` setups were aligned, and asked the AI to research the rationale and evaluate applying the same fix here.
- The AI read the vivliostyle-cli PR discussion, verified the git ignore precedence mechanism (`.gitignore` files closer to a path outrank the global `excludesFile`), and confirmed the issue and fix by experimenting with `git check-ignore` and `git status` against the actual repository layout (including the `.claude/skills` symlink, which differs from vivliostyle-cli's structure).
- The AI made the change, verified with the same manual git commands that tracked files stay tracked, `.claude/settings.local.json`-style local files stay ignored, and personal skill files remain ignorable via a global gitignore rule.
- The human author reviewed the analysis and diff before requesting this PR be opened.

</details>
