### PR TITLE
fix: Give the text-spacing filler font vertical metrics

### DIFF
--- a/packages/core/src/vivliostyle/assets.ts
+++ b/packages/core/src/vivliostyle/assets.ts
@@ -1551,7 +1551,7 @@ span.viv-anonymous-block {
 /* see #2034 */
 @font-face {
   font-family: "-viv-ts-sp";
-  src: url("data:font/woff2;base64,d09GMgABAAAAAADcAAoAAAAAAhwAAACWAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAANAoUNgE2AiQDDAsIAAQgBQYHLhuDAfivCuyG888wVNS8F/ZFrDP4HM9/f7Fz/327szNpE39MLJMEEwhM4rqEpw5WA/yHf662vHz4yq43QNDB8YgOIBcKMTAeaQjBDrH14HBRR74Oowl4tbBt3gYLxV0Fd2NjjGDXnS4ACk4ExYDAJc3tIYAgPOf4u3qBDwf8K4JaIACDfyIAgMIABFUBC6LutJhuZR3vCA==") format("woff2");
+  src: url("data:font/woff2;base64,d09GMgABAAAAAADsAAoAAAAAAhwAAACkAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAANAoUNgE2AiQDDAsIAAQgBQYHLhuDATAvDuxmH09wwcdQfVXDjoN4/uuenbvv/WombeKVxJoJmsgSDAIMQBNI2364+oJVIbt1VpdteYNucBxRTKkHHAAtsOCiG02Dh+ybQCFXG3XLx6aFAW6lt2nu/R/sYAIAJhgonJTgpE20Fsy1eGx9BUCBHYJCAxpAKsezAIKwvzuuv0MdwOvy2w0RlAHC9crGWiIAgIIGCEoJGCTsDC4sx/ZMAAA=") format("woff2");
 }
 viv-ts-open.viv-ts-auto > viv-ts-inner,
 viv-ts-open.viv-ts-trim > viv-ts-inner {

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -602,6 +602,10 @@ module.exports = [
         file: "text-spacing/inherited-spacing-properties.html",
         title: "Text-spacing fillers with inherited spacing properties",
       },
+      {
+        file: "text-spacing/text-decoration.html",
+        title: "Continuous text decorations across text-autospace",
+      },
     ],
   },
   {

--- a/packages/core/test/files/text-spacing/text-decoration.html
+++ b/packages/core/test/files/text-spacing/text-decoration.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Continuous text decorations across text-autospace</title>
+    <style>
+      .sample {
+        font-size: 48px;
+        text-decoration-color: cyan;
+        text-decoration-thickness: 0.2em;
+      }
+      .vertical {
+        writing-mode: vertical-rl;
+      }
+      .underline {
+        text-decoration-line: underline;
+      }
+      .overline {
+        text-decoration-line: overline;
+      }
+      .line-through {
+        text-decoration-line: line-through;
+      }
+      .letter-spacing {
+        letter-spacing: 0.25em;
+      }
+      .color-only {
+        text-decoration-color: red;
+      }
+      .wrap {
+        white-space: normal;
+      }
+      .inner u {
+        text-decoration: underline 0.2em magenta;
+        text-decoration-skip-ink: none;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Continuous text decorations across text-autospace</h1>
+
+    <h2>reference without decoration</h2>
+    <p class="sample">漢ABC漢123漢</p>
+
+    <h2>horizontal underline</h2>
+    <p class="sample underline">漢ABC漢123漢</p>
+
+    <h2>horizontal overline</h2>
+    <p class="sample overline">漢ABC漢123漢</p>
+
+    <h2>horizontal line-through</h2>
+    <p class="sample line-through">漢ABC漢123漢</p>
+
+    <h2>decoration only on the inner element (spacing stays outside)</h2>
+    <p class="sample inner">漢漢<u>ABC</u>漢漢</p>
+    <p class="sample inner">ABC<u>漢漢</u>ABC</p>
+
+    <h2>underline with letter-spacing</h2>
+    <p class="sample underline letter-spacing">漢ABC漢123漢</p>
+
+    <h2>vertical underline</h2>
+    <p class="sample vertical underline">漢ABC漢123漢</p>
+
+    <h2>vertical overline</h2>
+    <p class="sample vertical overline">漢ABC漢123漢</p>
+
+    <h2>vertical line-through</h2>
+    <p class="sample vertical line-through">漢ABC漢123漢</p>
+
+    <h2>vertical, decoration only on the inner element</h2>
+    <p class="sample vertical inner">漢漢<u>ABC</u>漢漢</p>
+    <p class="sample vertical inner">ABC<u>漢漢</u>ABC</p>
+
+    <h2>vertical, underline with letter-spacing</h2>
+    <p class="sample vertical underline letter-spacing">漢ABC漢123漢</p>
+  </body>
+</html>

--- a/scripts/generate-text-spacing-fonts.py
+++ b/scripts/generate-text-spacing-fonts.py
@@ -25,6 +25,25 @@ from typing import BinaryIO
 from fontTools.fontBuilder import FontBuilder
 from fontTools.misc.timeTools import timestampSinceEpoch
 from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.ttLib import TTFont
+
+
+def set_vertical_metrics(
+    font: TTFont, ascender: int, descender: int, line_gap: int
+) -> None:
+    hhea = font["hhea"]
+    hhea.ascent = ascender
+    hhea.descent = descender
+    hhea.lineGap = line_gap
+    os2 = font["OS/2"]
+    os2.version = 4
+    os2.sTypoAscender = ascender
+    os2.sTypoDescender = descender
+    os2.sTypoLineGap = line_gap
+    os2.usWinAscent = ascender
+    os2.usWinDescent = -descender
+    USE_TYPO_METRICS = 1 << 7
+    os2.fsSelection |= USE_TYPO_METRICS
 
 
 def build_woff2(space_advance: int, units_per_em: int, f: BinaryIO) -> None:
@@ -59,6 +78,29 @@ def build_woff2(space_advance: int, units_per_em: int, f: BinaryIO) -> None:
     fb.setupNameTable({})
     fb.setupOS2()
     fb.setupPost()
+
+    # FIXME: Workaround for the regression introduced by #2035.
+    # Give the font the metrics of Times, namely those of Liberation Serif, the
+    # standard substitute for "Times" on Linux.
+    # https://github.com/liberationfonts/liberation-fonts/releases/tag/2.1.5
+    # Without vertical metrics, underlines vanish. For overlines and
+    # line-throughs to behave like native spacing with an arbitrary font, the
+    # filler would need the same vertical metrics as that font; this problem
+    # predates #2035.
+    TIMES_UNITS_PER_EM = 2048
+
+    def times_metric(value: int) -> int:
+        return round(value * units_per_em / TIMES_UNITS_PER_EM)
+
+    TIMES_ASCENDER = 1825
+    TIMES_DESCENDER = -443
+    TIMES_LINE_GAP = 87
+    set_vertical_metrics(
+        fb.font,
+        times_metric(TIMES_ASCENDER),
+        times_metric(TIMES_DESCENDER),
+        times_metric(TIMES_LINE_GAP),
+    )
 
     # For deterministic output
     epoch = timestampSinceEpoch(0)


### PR DESCRIPTION
see: https://vivliostyle.slack.com/archives/CNN5GPF9V/p1787310168792239?thread_ts=1786613080.456429&cid=CNN5GPF9V

#2035 で埋め込んだフィラー用フォント`-viv-ts-sp`は垂直メトリクスがすべて0でした。Blinkはascentとdescentが0のフォントに装飾線を描かず、フィラーの位置ごとにunderline / overline / line-throughが途切れていました。このPRでは、フィラー用フォントに、埋め込みフォント以前に指定されていたTimes（のオープンソースの代替であるLiberation Serif）のメトリクスを設定します。これで3種の装飾について、以前の挙動が再現されます。

このPRでは復元だけを行っており、根本的な改善ではありません。underlineは非0であればascentとdescentによらず揃う一方で、ascentとdescentを使うoverline / line-throughは、 #2035 以前から引き続き、スペーシングを適用する相手フォント次第でフィラーの位置に段差が発生しています。

なお村上さんにご提案いただいた案を採用できなかったのは、垂直メトリクスが0のままではvisibleにしてもunderlineは描画されないためです。

> 根本的な解決策を見つけるまで、次のCSSを修正してunderlineだけの場合のみvisibleにするのでどうでしょう？
> ```
> [style*=text-decoration] :is(viv-ts-thin-sp, viv-ts-close.viv-ts-auto)::after {
>   visibility: visible;
> }
> ```

Assisted-by: Claude Code:claude-fable-5

<details>
<summary>How the AI was used</summary>

- The human author wrote the regression test, identified the cause as the embedded font lacking vertical metrics, specified the fix (USE_TYPO_METRICS with sTypo\*, usWin\* and hhea), chose the Times metrics as the target, and restructured and documented the generator script.
- The AI prepared worktrees and dev servers for the commits around #2035, ran the layout regression tests against the parent of #2035, implemented the metric changes in the generator, regenerated and embedded the font, traced the text decoration painting in Skia and Blink sources, and ran the visual A/B comparisons.
- The human author reviewed the changes and the rationale, corrected the AI's misattributions along the way, and verified the final regression test result.

</details>
