### PR TITLE
refactor: Spell out the coercion the expression operators perform

### DIFF
--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -813,7 +813,7 @@ export class Negate extends Prefix {
   }
 
   override evalPrefix(val: Result): Result {
-    return -val;
+    return -Number(val);
   }
 }
 
@@ -885,7 +885,9 @@ export class Lt extends Comparison {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return lhs < rhs;
+    return typeof lhs === "string" && typeof rhs === "string"
+      ? lhs < rhs
+      : Number(lhs) < Number(rhs);
   }
 }
 
@@ -899,7 +901,9 @@ export class Le extends Comparison {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return lhs <= rhs;
+    return typeof lhs === "string" && typeof rhs === "string"
+      ? lhs <= rhs
+      : Number(lhs) <= Number(rhs);
   }
 }
 
@@ -913,7 +917,9 @@ export class Gt extends Comparison {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return lhs > rhs;
+    return typeof lhs === "string" && typeof rhs === "string"
+      ? lhs > rhs
+      : Number(lhs) > Number(rhs);
   }
 }
 
@@ -927,7 +933,9 @@ export class Ge extends Comparison {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return lhs >= rhs;
+    return typeof lhs === "string" && typeof rhs === "string"
+      ? lhs >= rhs
+      : Number(lhs) >= Number(rhs);
   }
 }
 
@@ -969,7 +977,9 @@ export class Add extends Additive {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return (lhs as any) + rhs;
+    return typeof lhs === "string" || typeof rhs === "string"
+      ? `${lhs}${rhs}`
+      : Number(lhs) + Number(rhs);
   }
 }
 
@@ -983,7 +993,7 @@ export class Subtract extends Additive {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return (lhs as any) - (rhs as any);
+    return Number(lhs) - Number(rhs);
   }
 }
 
@@ -997,7 +1007,7 @@ export class Multiply extends Multiplicative {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return (lhs as any) * (rhs as any);
+    return Number(lhs) * Number(rhs);
   }
 }
 
@@ -1011,7 +1021,7 @@ export class Divide extends Multiplicative {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return (lhs as any) / (rhs as any);
+    return Number(lhs) / Number(rhs);
   }
 }
 
@@ -1025,7 +1035,7 @@ export class Modulo extends Multiplicative {
   }
 
   override evalInfix(lhs: Result, rhs: Result): Result {
-    return (lhs as any) % (rhs as any);
+    return Number(lhs) % Number(rhs);
   }
 }
 

--- a/packages/core/test/spec/vivliostyle/exprs-spec.js
+++ b/packages/core/test/spec/vivliostyle/exprs-spec.js
@@ -37,7 +37,7 @@ describe("exprs", function () {
 
   function expectResult(actual, expected) {
     if (Number.isNaN(expected)) {
-      expect(Number.isNaN(actual)).toBeTrue();
+      expect(Number.isNaN(actual)).toBe(true);
     } else {
       expect(actual).toBe(expected);
     }

--- a/packages/core/test/spec/vivliostyle/exprs-spec.js
+++ b/packages/core/test/spec/vivliostyle/exprs-spec.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle.js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Vivliostyle.js.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as Exprs from "../../../src/vivliostyle/exprs";
+
+describe("exprs", function () {
+  const scope = new Exprs.LexicalScope(null);
+  const context = new Exprs.Context(scope, 800, 600, 16, 20);
+
+  function evaluatePrefix(Operator, operand) {
+    return new Operator(scope, new Exprs.Const(scope, operand)).evaluate(
+      context,
+    );
+  }
+
+  function evaluateInfix(Operator, lhs, rhs) {
+    return new Operator(
+      scope,
+      new Exprs.Const(scope, lhs),
+      new Exprs.Const(scope, rhs),
+    ).evaluate(context);
+  }
+
+  function expectResult(actual, expected) {
+    if (Number.isNaN(expected)) {
+      expect(Number.isNaN(actual)).toBeTrue();
+    } else {
+      expect(actual).toBe(expected);
+    }
+  }
+
+  describe("Negate", function () {
+    it("coerces expression result types to numbers", function () {
+      [
+        [2, -2],
+        ["2", -2],
+        [true, -1],
+        [undefined, NaN],
+      ].forEach(([operand, expected]) => {
+        expectResult(evaluatePrefix(Exprs.Negate, operand), expected);
+      });
+    });
+  });
+
+  describe("relational operators", function () {
+    it("compare two strings as strings and other result types as numbers", function () {
+      [
+        ["10", "2", true, true, false, false],
+        ["10", 2, false, false, true, true],
+        [false, true, true, true, false, false],
+        [undefined, 0, false, false, false, false],
+      ].forEach(([lhs, rhs, lt, le, gt, ge]) => {
+        expect(evaluateInfix(Exprs.Lt, lhs, rhs)).toBe(lt);
+        expect(evaluateInfix(Exprs.Le, lhs, rhs)).toBe(le);
+        expect(evaluateInfix(Exprs.Gt, lhs, rhs)).toBe(gt);
+        expect(evaluateInfix(Exprs.Ge, lhs, rhs)).toBe(ge);
+      });
+    });
+  });
+
+  describe("Add", function () {
+    it("concatenates strings and otherwise adds numbers", function () {
+      [
+        [1, 2, 3],
+        ["1", 2, "12"],
+        [1, "2", "12"],
+        [false, true, 1],
+        [undefined, 1, NaN],
+        ["value:", undefined, "value:undefined"],
+      ].forEach(([lhs, rhs, expected]) => {
+        expectResult(evaluateInfix(Exprs.Add, lhs, rhs), expected);
+      });
+    });
+  });
+
+  describe("numeric infix operators", function () {
+    it("coerce expression result types to numbers", function () {
+      [
+        [Exprs.Subtract, [4, 4, -1, NaN]],
+        [Exprs.Multiply, [12, 12, 2, NaN]],
+        [Exprs.Divide, [3, 3, 0.5, NaN]],
+        [Exprs.Modulo, [0, 0, 1, NaN]],
+      ].forEach(([Operator, expectedResults]) => {
+        [
+          [6, 2],
+          ["6", 2],
+          [true, 2],
+          [undefined, 2],
+        ].forEach(([lhs, rhs], index) => {
+          expectResult(
+            evaluateInfix(Operator, lhs, rhs),
+            expectedResults[index],
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
refs: #2049 , #2108

`strictNullChecks`への型リファクタリングのうち、v3ブランチを切る前に取り込める内容を先に提出していきます。

---

[`EPUB Adaptive Layout 2.1`](https://www.idpf.org/epub/pgt/#s2.1)では、式の演算子が`number`、`string`、`boolean`の3つの基本型を扱い、型変換を含む挙動はECMAScriptに従います。一方、実装の`Result`は`string | number | boolean | undefined`と宣言されているものの、単項演算と比較演算はJavaScriptの暗黙の型変換に任せ、算術演算は`as any`でTypeScriptの型検査から外していました。

このPRでは、`as any`を削除し型変換を`Result`の定義域に沿って表現します。各型の代表値について単体テストを追加して挙動の保存を確認しています。

Assisted-by: Claude Code:claude-opus-5
Assisted-by: Codex:gpt-5

<details>
<summary>How the AI was used</summary>

- The human author asked the AI to investigate potential type problems in the expression result domain, and the AI identified the affected operator family and reported its implicit coercion and `as any` assertions.
- The human author reviewed the findings and approved the scope and approach, after which the AI implemented the explicit coercion.
- The AI explained the final implementation and its rationale, and the human author reviewed and approved the explanation and changes.

</details>
