### PR TITLE
fix: Avoid invoking a cleared print error callback

### DIFF
--- a/packages/core/src/vivliostyle/print.ts
+++ b/packages/core/src/vivliostyle/print.ts
@@ -117,7 +117,7 @@ class VivliostylePrint {
           const message =
             payload.content.error?.toString() ??
             payload.content.messages.join("\n");
-          this.errorCallback(message);
+          this.errorCallback?.(message);
         });
       }
 


### PR DESCRIPTION
`errorCallback: ((message: string) => void) | null`なので、`if (this.errorCallback)`でガードしていても、コールバックの実行時には`null`になっている可能性があります（`window.printInstance.errorCallback = null;`で書き換えるなど）。