### PR TITLE
Avoid flaky leader rendering in table regression test

### DIFF
--- a/packages/core/test/files/table/table-rowspan-anchor-target.html
+++ b/packages/core/test/files/table/table-rowspan-anchor-target.html
@@ -32,7 +32,7 @@
       }
 
       nav a::after {
-        content: leader(dotted) target-counter(attr(href url), page);
+        content: " " target-counter(attr(href url), page);
       }
 
       .toc-number {


### PR DESCRIPTION
Fixes #2103.

Remove `leader(dotted)` from the Issue #1905 regression fixture while retaining
`target-counter()`, which triggers the retry layout needed to test rowspan
continuation.

The leader positioning hook incorporates `getBoundingClientRect()` measurements
that can vary with Chromium's raster alignment under load. Changing the global
layout regression threshold could hide real regressions, while rounding leader
coordinates in Vivliostyle would affect legitimate subpixel positioning across
all leader layouts. Restricting the change to this fixture avoids those broader
risks without reducing its intended coverage.

## Verification

- Ran four parallel dev-to-dev layout regression comparisons
- Confirmed zero differences across all three pages
- Confirmed identical SHA-256 hashes for every corresponding screenshot
- Visually confirmed the rowspan continuation across the page boundary
- Ran Prettier and `git diff --check`

Assisted-by: GitHub Copilot:gpt-5.6-sol

<details>
<summary>How the AI was used</summary>

- The human author identified the flaky layout regression test and requested
  evaluation of fixes in the test tool, Vivliostyle core, and the fixture.
- The AI analyzed the comparison threshold, leader positioning code, and the
  original Issue #1905 regression coverage, then drafted the fixture change and
  performed focused verification.
- The human author reviewed and approved the proposed approach and is responsible
  for the final change and verification before submission.

</details>