### PR TITLE
refactor: Give value-less media feature tests their own expression class

### DIFF
--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1029,10 +1029,9 @@ export class Parser {
         }
         if (tok == TokenType.O_PAR) {
           if (val.isMediaName()) {
-            val = new Exprs.MediaTest(
+            val = new Exprs.MediaBooleanTest(
               handler.getScope(),
               val as Exprs.MediaName,
-              null,
             );
           }
           op = TokenType.EOF;

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -1353,7 +1353,7 @@ export class MediaBooleanTest extends Val {
 
   override appendTo(buf: Base.StringBuffer, priority: number): void {
     buf.append("(");
-    buf.append(Base.escapeCSSStr(this.name.name));
+    buf.append(Base.escapeCSSIdent(this.name.name));
     buf.append(")");
   }
 
@@ -1373,7 +1373,7 @@ export class MediaTest extends Val {
 
   override appendTo(buf: Base.StringBuffer, priority: number): void {
     buf.append("(");
-    buf.append(Base.escapeCSSStr(this.name.name));
+    buf.append(Base.escapeCSSIdent(this.name.name));
     buf.append(":");
     this.value.appendTo(buf, 0);
     buf.append(")");

--- a/packages/core/src/vivliostyle/exprs.ts
+++ b/packages/core/src/vivliostyle/exprs.ts
@@ -494,56 +494,61 @@ export class Context {
     return not ? !enabled : enabled;
   }
 
-  evalMediaTest(feature: string, value: Val | null): boolean {
+  private parseMediaFeature(feature: string): {
+    feature: string;
+    prefix: string;
+  } {
     let prefix = "";
     const r = feature.match(/^(min|max)-(.*)$/);
     if (r) {
       prefix = r[1];
       feature = r[2];
     }
-    let req: Result | null = null;
-    let actual: number | null = null;
+
+    return { feature, prefix };
+  }
+
+  private actualMediaFeatureValue(feature: string): number | null {
     switch (feature) {
       case "width":
+        return this.pageWidth();
       case "height":
+        return this.pageHeight();
       case "device-width":
+        return window.screen.availWidth;
       case "device-height":
+        return window.screen.availHeight;
       case "color":
-        if (value) {
-          req = value.evaluate(this);
-        }
-        break;
+        return window.screen.pixelDepth;
+      default:
+        return null;
     }
-    switch (feature) {
-      case "width":
-        actual = this.pageWidth();
-        break;
-      case "height":
-        actual = this.pageHeight();
-        break;
-      case "device-width":
-        actual = window.screen.availWidth;
-        break;
-      case "device-height":
-        actual = window.screen.availHeight;
-        break;
-      case "color":
-        actual = window.screen.pixelDepth;
-        break;
+  }
+
+  evalMediaBooleanTest(feature: string): boolean {
+    const parsedFeature = this.parseMediaFeature(feature);
+    const actual = this.actualMediaFeatureValue(parsedFeature.feature);
+    return actual != null && actual !== 0;
+  }
+
+  evalMediaTest(feature: string, value: Val): boolean {
+    const parsedFeature = this.parseMediaFeature(feature);
+    const actual = this.actualMediaFeatureValue(parsedFeature.feature);
+    if (actual == null) {
+      return false;
     }
-    if (actual != null && req != null) {
-      switch (prefix) {
-        case "min":
-          return actual >= Number(req);
-        case "max":
-          return actual <= Number(req);
-        default:
-          return actual == req;
-      }
-    } else if (actual != null && value == null) {
-      return actual !== 0;
+    const req = value.evaluate(this);
+    if (req == null) {
+      return false;
     }
-    return false;
+    switch (parsedFeature.prefix) {
+      case "min":
+        return actual >= Number(req);
+      case "max":
+        return actual <= Number(req);
+      default:
+        return actual == req;
+    }
   }
 
   evalSupportsTest(name: string, value: string, isFunc: boolean): boolean {
@@ -1338,11 +1343,30 @@ export class Const extends Val {
   }
 }
 
+export class MediaBooleanTest extends Val {
+  constructor(
+    scope: LexicalScope,
+    public name: MediaName,
+  ) {
+    super(scope);
+  }
+
+  override appendTo(buf: Base.StringBuffer, priority: number): void {
+    buf.append("(");
+    buf.append(Base.escapeCSSStr(this.name.name));
+    buf.append(")");
+  }
+
+  override evaluateCore(context: Context): Result {
+    return context.evalMediaBooleanTest(this.name.name);
+  }
+}
+
 export class MediaTest extends Val {
   constructor(
     scope: LexicalScope,
     public name: MediaName,
-    public value: Val | null,
+    public value: Val,
   ) {
     super(scope);
   }

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -81,6 +81,36 @@ describe("css-parser", function () {
       }
     }
 
+    function parseMediaQuery(text) {
+      const mediaScope = new adapt_exprs.LexicalScope(null);
+      const mediaHandler = new adapt_cssparse.ParserHandler(mediaScope);
+      const tokenizer = new adapt_csstok.Tokenizer(text, mediaHandler);
+      const expression = adapt_cssparse
+        .parseMediaQuery(tokenizer, mediaHandler, "")
+        .toExpr();
+      return { expression, mediaScope };
+    }
+
+    describe("media queries", function () {
+      it("represents value-less and value-bearing features separately", function () {
+        const valueLess = parseMediaQuery("(color)").expression;
+        const valueBearing = parseMediaQuery("(min-width: 600px)").expression;
+
+        expect(valueLess).toEqual(jasmine.any(adapt_exprs.MediaBooleanTest));
+        expect(valueLess.toString()).toBe("(color)");
+        expect(valueBearing).toEqual(jasmine.any(adapt_exprs.MediaTest));
+      });
+
+      it("evaluates both feature variants in one condition", function () {
+        const { expression, mediaScope } = parseMediaQuery(
+          "(width) and (min-width: 600px)",
+        );
+        const context = new adapt_exprs.Context(mediaScope, 800, 600, 16, 20);
+
+        expect(expression.evaluate(context)).toBe(true);
+      });
+    });
+
     describe("css nesting", function () {
       it("expands nested selectors using :is() semantics", function () {
         expect(

--- a/packages/core/test/spec/vivliostyle/css-parser-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-parser-spec.js
@@ -101,6 +101,14 @@ describe("css-parser", function () {
         expect(valueBearing).toEqual(jasmine.any(adapt_exprs.MediaTest));
       });
 
+      it("serializes escaped feature names as identifiers", function () {
+        const valueLess = parseMediaQuery("(foo\\20 bar)").expression;
+        const valueBearing = parseMediaQuery("(foo\\20 bar: 1)").expression;
+
+        expect(valueLess.toString()).toBe("(foo\\20 bar)");
+        expect(valueBearing.toString()).toBe("(foo\\20 bar:1)");
+      });
+
       it("evaluates both feature variants in one condition", function () {
         const { expression, mediaScope } = parseMediaQuery(
           "(width) and (min-width: 600px)",

--- a/packages/core/test/spec/vivliostyle/exprs-spec.js
+++ b/packages/core/test/spec/vivliostyle/exprs-spec.js
@@ -43,6 +43,63 @@ describe("exprs", function () {
     }
   }
 
+  function mediaName(name) {
+    return new Exprs.MediaName(scope, false, name);
+  }
+
+  describe("media feature tests", function () {
+    it("evaluates value-less features in a boolean context", function () {
+      expect(
+        new Exprs.MediaBooleanTest(scope, mediaName("width")).evaluate(context),
+      ).toBe(true);
+      expect(
+        new Exprs.MediaBooleanTest(scope, mediaName("unknown")).evaluate(
+          context,
+        ),
+      ).toBe(false);
+      expect(
+        new Exprs.MediaBooleanTest(scope, mediaName("min-width")).evaluate(
+          context,
+        ),
+      ).toBe(true);
+
+      const zeroWidthContext = new Exprs.Context(scope, 0, 600, 16, 20);
+      expect(
+        new Exprs.MediaBooleanTest(scope, mediaName("width")).evaluate(
+          zeroWidthContext,
+        ),
+      ).toBe(false);
+    });
+
+    it("evaluates value-bearing features against their requested values", function () {
+      [
+        ["width", 800, true],
+        ["width", 799, false],
+        ["min-width", 799, true],
+        ["min-width", 801, false],
+        ["max-width", 801, true],
+        ["max-width", 799, false],
+      ].forEach(([name, value, expected]) => {
+        expect(
+          new Exprs.MediaTest(
+            scope,
+            mediaName(name),
+            new Exprs.Const(scope, value),
+          ).evaluate(context),
+        ).toBe(expected);
+      });
+    });
+
+    it("does not evaluate the requested value of an unknown feature", function () {
+      const evaluateValue = jasmine.createSpy("evaluateValue");
+      const value = new Exprs.Native(scope, evaluateValue, "value");
+      const test = new Exprs.MediaTest(scope, mediaName("unknown"), value);
+
+      expect(test.evaluate(context)).toBe(false);
+      expect(evaluateValue).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Negate", function () {
     it("coerces expression result types to numbers", function () {
       [


### PR DESCRIPTION
[CSS Media Queries Level 4](https://www.w3.org/TR/mediaqueries-4/#typedef-media-feature)では、`(color)`のように値を持たない`<mf-boolean>`と、`(min-width: 600px)`のように値を持つ`<mf-plain>`は別の構文として定義されています。現在の実装では両方を`MediaTest`で表し、前者については`value`に`null`を渡して表現しており。他方、`appendTo`、`dependCore`、`expand`は`value`を常に`Val`として参照しており、これが`strictNullChecks`下では問題があります。

このPRでは、値なしのメディア特性を表す`MediaBooleanTest`を導入し、パーサーが`(color)`をこのクラスとして構築するようにします。`MediaTest`は値ありの構文だけを受け持ち、`value`を`Val`に戻します。`Context`の評価処理も、値なし形式の`evalMediaBooleanTest(feature)`と値あり形式の`evalMediaTest(feature, value)`に分けます。

Assisted-by: Claude Code:claude-opus-5
Assisted-by: Codex:gpt-5

<details>
<summary>How the AI was used</summary>

- The human author identified the mismatch between the media feature syntax variants and their expression representation, selected the class split, and required the distinction to continue through evaluation.
- The AI implemented the separate expression and evaluation paths, added tests for their parser integration and evaluation behavior, and ran the build, lint, and core test suite.
- The human author reviewed and supervised the design, checked it against the Media Queries specification, and retains responsibility for the final code review and verification before submission.

</details>