### PR TITLE
refactor: Ground cascade rule values in their actual domains

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5219,7 +5219,6 @@ export const pseudoNames = [
 export enum ParseState {
   TOP,
   SELECTOR,
-  RULE,
 }
 
 //------------- parsing ------------
@@ -5289,14 +5288,12 @@ export class CascadeParserHandler
   elementStyle: ElementStyle = {};
   /** Identity of the declaration block being parsed, for `revert-rule`. */
   ruleId: number = 0;
-  conditionCount: number = 0;
   pseudoelement: string | null = null;
   footnoteContent: boolean = false;
   cascade: Cascade;
   layer: CascadeLayer | null;
   state: ParseState;
   viewConditionId: string | null = null;
-  insideSelectorRule: ParseState | undefined;
   invalid: boolean = false; // for `@supports selector()` check
 
   constructor(
@@ -5627,7 +5624,7 @@ export class CascadeParserHandler
     }
     this.specificity += 256;
     value = value || "";
-    let action;
+    let action: ChainedAction;
     switch (op) {
       case TokenType.EOF:
         action = new CheckAttributePresentAction(ns, name);
@@ -5831,11 +5828,6 @@ export class CascadeParserHandler
     if (this.state == ParseState.SELECTOR) {
       this.state = ParseState.TOP;
     }
-  }
-
-  override endRule(): void {
-    super.endRule();
-    this.insideSelectorRule = ParseState.TOP;
   }
 
   finishChain(): void {

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5286,7 +5286,7 @@ export class CascadeParserHandler
   selectorListVoided: boolean = false;
   private pendingChained: CascadeAction[] = [];
   specificity: number = 0;
-  elementStyle: ElementStyle | null = null;
+  elementStyle: ElementStyle = {};
   /** Identity of the declaration block being parsed, for `revert-rule`. */
   ruleId: number = 0;
   conditionCount: number = 0;
@@ -5795,7 +5795,7 @@ export class CascadeParserHandler
       return;
     }
     this.state = ParseState.SELECTOR;
-    this.elementStyle = {} as ElementStyle;
+    this.elementStyle = {};
     this.ruleId = nextRuleId();
     this.pseudoelement = null;
     this.viewConditionId = null;

--- a/packages/core/src/vivliostyle/css-page.ts
+++ b/packages/core/src/vivliostyle/css-page.ts
@@ -3224,7 +3224,7 @@ export class PageParserHandler
 
   override tagSelector(ns: string | null, name: string | null): void {
     Asserts.assert(name);
-    this.currentNamedPageSelector = name;
+    this.currentNamedPageSelector = name ?? "";
     if (name) {
       this.chain.push(new CheckPageTypeAction(name));
       this.specificity += 65536;


### PR DESCRIPTION
`CascadeParserHandler.elementStyle`は`ElementStyle | null`として`null`で初期化されていましたが、宣言の処理とルール適用アクションの構築では常に`ElementStyle`として参照されます。有効なセレクタルールでは`startSelectorRule`が先に空の`ElementStyle`を用意するため、この`null`は実際のルール処理に現れない状態です。

[CSS Paged Media Level 3](https://www.w3.org/TR/css-page-3/#syntax-page-selector)の`<page-selector>`はページタイプ名を省略できます。`PageParserHandler`はその不在を空文字列で管理している一方、共通の`tagSelector`が受け取る`string | null`のページ名を`string`のフィールドへ直接代入していました。

このPRでは、`CascadeParserHandler`に構築時から空の`ElementStyle`を持たせ、ページ名は既存の不在表現である空文字列へ正規化します。あわせて、使われていない`ParseState.RULE`、`insideSelectorRule`、インスタンス側の`conditionCount`と、`insideSelectorRule`の更新のためだけに存在した`endRule`のoverrideを削除します。属性セレクタで構築するアクションも`ChainedAction`として明示します。

Assisted-by: Claude Code:claude-opus-5

<details>
<summary>How the AI was used</summary>

- The human author selected these cascade parser value changes from the broader `strictNullChecks` work, defined the intended non-null and empty-value contracts, and required valid CSS behavior to remain unchanged.
- Claude Code inspected the parser state and value flow, implemented the initialization and normalization changes, and removed the unused rule state.
- The human author retains responsibility for reviewing the diff and completing the final build and test verification before submission.

</details>