### PR TITLE
fix: avoid blank pages before referenced forced-break targets

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -944,6 +944,7 @@ export class CounterStore {
     Object.create(null);
   resolvedReferences: { [key: string]: TargetCounterReference[] } =
     Object.create(null);
+  private targetsMovedEarlierAfterPageBreak = new Set<string>();
   pageControlledCounterNames: { [key: string]: boolean } = Object.assign(
     Object.create(null),
     { page: true },
@@ -1348,7 +1349,15 @@ export class CounterStore {
         }
 
         const oldPageIndex = this.pageIndicesById[id];
-        if (oldPageIndex && oldPageIndex.pageIndex < pageIndex) {
+        const movedLater = oldPageIndex && oldPageIndex.pageIndex < pageIndex;
+        const movedEarlierAfterPageBreak =
+          oldPageIndex &&
+          oldPageIndex.pageIndex > pageIndex &&
+          !this.targetsMovedEarlierAfterPageBreak.has(id);
+        if (movedEarlierAfterPageBreak) {
+          this.targetsMovedEarlierAfterPageBreak.add(id);
+        }
+        if (movedLater || movedEarlierAfterPageBreak) {
           const resolvedRefs = this.resolvedReferences[id];
           if (resolvedRefs) {
             let unresolvedRefs = this.unresolvedReferences[id];
@@ -1899,6 +1908,16 @@ export class CounterStore {
   createLayoutConstraint(pageIndex: number): Layout.LayoutConstraint {
     return new LayoutConstraint(this, pageIndex);
   }
+
+  canTargetMoveEarlierAfterPageBreak(id: string): boolean {
+    // Keep the anti-oscillation guarantee introduced by b0288a35: a target
+    // gets one exception for a page break that has already been satisfied,
+    // but cannot repeatedly alternate between earlier and later pages.
+    if (this.targetsMovedEarlierAfterPageBreak.has(id)) {
+      return false;
+    }
+    return true;
+  }
 }
 
 export const PAGES_COUNTER_ATTR = "data-vivliostyle-pages-counter";
@@ -1923,25 +1942,17 @@ class LayoutConstraint implements Layout.LayoutConstraint {
   ) {}
 
   /** @override */
+  allowLayoutAfterPageBreak(nodeContext: Vtree.NodeContext): boolean {
+    if (this.allowLayout(nodeContext)) {
+      return true;
+    }
+    const id = this.getReferencedTargetId(nodeContext);
+    return !!id && this.counterStore.canTargetMoveEarlierAfterPageBreak(id);
+  }
+
   allowLayout(nodeContext: Vtree.NodeContext): boolean {
-    if (!nodeContext || nodeContext.after) {
-      return true;
-    }
-    const viewNode = nodeContext.viewNode;
-    if (!viewNode || viewNode.nodeType !== 1) {
-      return true;
-    }
-    const id =
-      (viewNode as Element).getAttribute("data-vivliostyle-id") ||
-      (viewNode as Element).getAttribute("id") ||
-      (viewNode as Element).getAttribute("name");
+    const id = this.getReferencedTargetId(nodeContext);
     if (!id) {
-      return true;
-    }
-    if (
-      !this.counterStore.resolvedReferences[id] &&
-      !this.counterStore.unresolvedReferences[id]
-    ) {
       return true;
     }
     const pageIndex = this.counterStore.pageIndicesById[id];
@@ -1949,5 +1960,29 @@ class LayoutConstraint implements Layout.LayoutConstraint {
       return true;
     }
     return this.pageIndex >= pageIndex.pageIndex;
+  }
+
+  private getReferencedTargetId(nodeContext: Vtree.NodeContext): string | null {
+    if (!nodeContext || nodeContext.after) {
+      return null;
+    }
+    const viewNode = nodeContext.viewNode;
+    if (!viewNode || viewNode.nodeType !== 1) {
+      return null;
+    }
+    const id =
+      (viewNode as Element).getAttribute("data-vivliostyle-id") ||
+      (viewNode as Element).getAttribute("id") ||
+      (viewNode as Element).getAttribute("name");
+    if (!id) {
+      return null;
+    }
+    if (
+      !this.counterStore.resolvedReferences[id] &&
+      !this.counterStore.unresolvedReferences[id]
+    ) {
+      return null;
+    }
+    return id;
   }
 }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1600,6 +1600,13 @@ export type OPFViewItem = {
   pageCounterStarts: CssCascade.CounterValues[];
 };
 
+type DeferredReferencePage = {
+  viewItem: OPFViewItem;
+  page: Vtree.Page;
+  pageIndex: number;
+  nextLayoutPosition: Vtree.LayoutPosition | null;
+};
+
 export class OPFView implements Vgen.CustomRendererFactory {
   spineItems: (OPFViewItem | null)[] = [];
   spineItemLoadingContinuations: (Task.Continuation<any>[] | null)[] = [];
@@ -1610,6 +1617,8 @@ export class OPFView implements Vgen.CustomRendererFactory {
   tocAutohide: boolean = false;
   tocVisible: boolean = false;
   tocView?: Toc.TOCView;
+  private deferredReferencePages: DeferredReferencePage[] = [];
+  private resolvingDeferredReferences: boolean = false;
   private paginationProgress = {
     totalOffsetsBySpine: [] as number[],
     renderedOffsetsBySpine: [] as number[],
@@ -2162,6 +2171,18 @@ export class OPFView implements Vgen.CustomRendererFactory {
     // target pages are rendered in the normal (non-cascade) flow.
     // (fix for issue #1686)
     const inCounterResolveScope = this.isInCounterResolveScope();
+    if (inCounterResolveScope) {
+      // A cascaded page can invalidate references even when it is not the
+      // page that started the current counter-resolution scope. Remember the
+      // actual page at the point where #1686 defers it, so the outermost pop
+      // can revisit it later.
+      this.deferReferencesForPage(
+        viewItem,
+        page,
+        pageIndex,
+        nextLayoutPosition,
+      );
+    }
     const unresolvedRefs = inCounterResolveScope
       ? []
       : this.counterStore.getUnresolvedRefsToPage(page);
@@ -2279,6 +2300,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
             );
             this.counterStore.popPageCounters();
             this.counterStore.popReferencesToSolve();
+            const continueLoopAfterDeferredReferences = () => {
+              const rerenderedTargetPage = result.pageAndPosition.page;
+              this.resolveDeferredReferencesAfterCounterScope(
+                targetViewItem,
+                rerenderedTargetPage,
+                result.pageAndPosition.position.pageIndex,
+                result.nextLayoutPosition,
+              ).then(() => loopFrame.continueLoop());
+            };
             if (
               result.pageAndPosition.position.spineIndex ===
                 currentPage.spineIndex &&
@@ -2388,7 +2418,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
                     this.counterStore.currentPageCounters =
                       savedCountersBeforePending;
                   }
-                  loopFrame.continueLoop();
+                  continueLoopAfterDeferredReferences();
                 },
               );
               return;
@@ -2400,7 +2430,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             if (isCrossSpine) {
               this.markSpineItemCompleteIfReady(targetViewItem);
             }
-            loopFrame.continueLoop();
+            continueLoopAfterDeferredReferences();
           });
         });
       })
@@ -2426,6 +2456,92 @@ export class OPFView implements Vgen.CustomRendererFactory {
         frame.finish(currentPage);
       });
     return frame.result();
+  }
+
+  private resolveDeferredReferencesAfterCounterScope(
+    viewItem: OPFViewItem,
+    page: Vtree.Page,
+    pageIndex: number,
+    nextLayoutPosition: Vtree.LayoutPosition | null,
+  ): Task.Result<Vtree.Page> {
+    // A target page may be rerendered several scopes deep. Processing its
+    // newly invalidated references immediately after the innermost pop still
+    // hits the #1686 recursion guard because an outer counter scope remains.
+    // Keep the page until the outermost scope is restored, then drain all
+    // deferred pages in order.
+    this.deferReferencesForPage(viewItem, page, pageIndex, nextLayoutPosition);
+    const deferredReferencePages = (this.deferredReferencePages ??= []);
+
+    if (
+      this.isInCounterResolveScope() ||
+      this.resolvingDeferredReferences ||
+      deferredReferencePages.length === 0
+    ) {
+      return Task.newResult(page);
+    }
+
+    const frame: Task.Frame<Vtree.Page> = Task.newFrame(
+      "resolveDeferredReferencesAfterCounterScope",
+    );
+    this.resolvingDeferredReferences = true;
+    frame
+      .loopWithFrame((loopFrame) => {
+        const entry = deferredReferencePages.shift();
+        if (!entry) {
+          loopFrame.breakLoop();
+          return;
+        }
+        const currentPage =
+          entry.viewItem.pages?.[entry.pageIndex] || entry.page;
+        if (!this.hasUnresolvedReferencesToPage(currentPage)) {
+          loopFrame.continueLoop();
+          return;
+        }
+        this.resolveUnresolvedReferencesForPage(
+          entry.viewItem,
+          currentPage,
+          entry.pageIndex,
+          entry.nextLayoutPosition,
+        ).then(() => loopFrame.continueLoop());
+      })
+      .then(() => {
+        this.resolvingDeferredReferences = false;
+        frame.finish(page);
+      });
+    return frame.result();
+  }
+
+  private hasUnresolvedReferencesToPage(page: Vtree.Page): boolean {
+    return this.counterStore
+      .getUnresolvedRefsToPage(page)
+      .some((group) => group.refs.some((ref) => !ref.isResolved()));
+  }
+
+  private deferReferencesForPage(
+    viewItem: OPFViewItem,
+    page: Vtree.Page,
+    pageIndex: number,
+    nextLayoutPosition: Vtree.LayoutPosition | null,
+  ): void {
+    const latestPage = viewItem.pages?.[pageIndex] || page;
+    if (!this.hasUnresolvedReferencesToPage(latestPage)) {
+      return;
+    }
+    const deferredReferencePages = (this.deferredReferencePages ??= []);
+    const queued = deferredReferencePages.find(
+      (entry) => entry.viewItem === viewItem && entry.pageIndex === pageIndex,
+    );
+    if (queued) {
+      queued.page = latestPage;
+      queued.nextLayoutPosition = nextLayoutPosition;
+    } else {
+      deferredReferencePages.push({
+        viewItem,
+        page: latestPage,
+        pageIndex,
+        nextLayoutPosition,
+      });
+    }
   }
 
   /**
@@ -2476,9 +2592,19 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
     viewItem.instance.layoutNextPage(page, pos).then((posParam) => {
       pos = posParam;
-      const pageIndex = pos
-        ? pos.page - 1
-        : viewItem.layoutPositions.length - 1;
+      if (!pos) {
+        // A rerender can make the final page move to an earlier slot. Remove
+        // stale following pages and their saved starts before storing the new
+        // final page in the requested slot.
+        const finalLength = pageIndexToRender + 1;
+        viewItem.pages
+          .slice(finalLength)
+          .forEach((stalePage) => stalePage.container.remove());
+        viewItem.pages.splice(finalLength);
+        viewItem.layoutPositions.splice(finalLength);
+        viewItem.pageCounterStarts.splice(finalLength);
+      }
+      const pageIndex = pos ? pos.page - 1 : pageIndexToRender;
       this.finishPageContainer(viewItem, page, pageIndex);
       this.counterStore.finishPage(page.spineIndex, pageIndex);
 

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -336,6 +336,14 @@ export class AllLayoutConstraint implements LayoutConstraint {
   allowLayout(nodeContext: Vtree.NodeContext): boolean {
     return this.constraints.every((c) => c.allowLayout(nodeContext));
   }
+
+  allowLayoutAfterPageBreak(nodeContext: Vtree.NodeContext): boolean {
+    return this.constraints.every(
+      (c) =>
+        c.allowLayoutAfterPageBreak?.(nodeContext) ??
+        c.allowLayout(nodeContext),
+    );
+  }
 }
 
 /**
@@ -3776,6 +3784,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let leadingEdgeContexts: Vtree.RenderedNodeContext[] = [];
     let trailingEdgeContexts: Vtree.NodeContext[] = [];
     let onStartEdges = false;
+    let hasSatisfiedLeadingPageBreak = false;
 
     // Issue #1842: if a stronger page/spread break wins at the page's first
     // column, drop weaker ancestor column breaks so they do not fire again
@@ -3839,6 +3848,23 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       breakAtTheEdge = null;
     }
 
+    // A page-level break at the start of the page's first column has already
+    // been satisfied by entering this page. Consume the accumulated edge
+    // value, but keep the break on the node context so continuation positions
+    // still point at the forced-break target.
+    function consumeSatisfiedLeadingPageBreak(): void {
+      if (
+        !leadingEdge ||
+        column.isNonFirstColumn ||
+        forcedBreakValue ||
+        !Break.isPageLevelForcedBreak(breakAtTheEdge)
+      ) {
+        return;
+      }
+      hasSatisfiedLeadingPageBreak = true;
+      breakAtTheEdge = null;
+    }
+
     function suppressWeakerTrailingColumnBreaks(
       currentNodeContext: Vtree.NodeContext,
     ): void {
@@ -3866,6 +3892,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       breakAtTheEdge = Break.resolveEffectiveBreakValue(
         breakAtTheEdge,
         nextBreakValue,
+      );
+    }
+
+    function allowLayout(nodeContext: Vtree.NodeContext): boolean {
+      if (!hasSatisfiedLeadingPageBreak) {
+        return column.layoutConstraint.allowLayout(nodeContext);
+      }
+      return (
+        column.layoutConstraint.allowLayoutAfterPageBreak?.(nodeContext) ??
+        column.layoutConstraint.allowLayout(nodeContext)
       );
     }
 
@@ -4013,6 +4049,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 setBreakAtTheEdge(nodeContext.breakBefore);
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
+                consumeSatisfiedLeadingPageBreak();
                 // Leading edge of non-empty block -> finished going through
                 // all starting edges of the box
                 if (needForcedBreak()) {
@@ -4138,6 +4175,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 setBreakAtTheEdge(nodeContext.breakBefore);
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
+                consumeSatisfiedLeadingPageBreak();
 
                 // check if a forced break must occur before the block.
                 if (needForcedBreak()) {
@@ -4149,7 +4187,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     true,
                     breakAtTheEdge,
                   ) ||
-                  !this.layoutConstraint.allowLayout(nodeContext)
+                  !allowLayout(nodeContext)
                 ) {
                   // overflow
                   nodeContext = (
@@ -4280,6 +4318,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               setBreakAtTheEdge(nodeContext.breakBefore);
               suppressWeakerLeadingColumnBreaks(nodeContext);
               consumeSatisfiedLeadingColumnBreak(nodeContext);
+              consumeSatisfiedLeadingPageBreak();
 
               // Prevent unnecessary blank pages by removing unnecessary forced column breaks
               if (
@@ -4295,7 +4334,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               if (
                 (nodeContext.pageType != nodeContext.parent?.pageType || // Fix for issue #771
                   !Break.isForcedBreakValue(breakAtTheEdge)) && // Fix for issue #722
-                !this.layoutConstraint.allowLayout(nodeContext)
+                !allowLayout(nodeContext)
               ) {
                 this.checkOverflowAndSaveEdgeAndBreakPosition(
                   lastAfterNodeContext,

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -70,6 +70,11 @@ export namespace Layout {
      * current position.
      */
     allowLayout(nodeContext: Vtree.NodeContext): boolean;
+    /**
+     * Returns if this constraint allows the node context immediately after a
+     * page-level break has already been satisfied.
+     */
+    allowLayoutAfterPageBreak?(nodeContext: Vtree.NodeContext): boolean;
   }
   /**
    * Represents constraints on laying out fragments

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -768,6 +768,10 @@ module.exports = [
         title: "Combine break value regressions (Issue #1842)",
       },
       {
+        file: "page_breaks/break-before-flex-at-page-start.html",
+        title: "Consumed break-before on a flex box at page start",
+      },
+      {
         file: "page_breaks/break_left_right.html",
         title: "break-before/after: left/right",
       },

--- a/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html
+++ b/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Consumed break-before on a flex box at page start</title>
+    <style>
+      @page {
+        size: 200px 200px;
+        margin: 20px;
+        @bottom-center {
+          content: counter(page);
+        }
+      }
+      body {
+        margin: 0;
+      }
+      .trigger {
+        font: 10px/20px monospace;
+        inline-size: 10ch;
+        margin: 0;
+        word-break: break-all;
+      }
+      h2 {
+        display: flex;
+        margin: 0;
+      }
+      section {
+        break-before: page;
+        break-inside: avoid;
+      }
+      a::after {
+        content: " (page " target-counter(attr(href url), page) ")";
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      The unresolved "??" target counter makes this paragraph 9 lines high.
+      Once it resolves to "2", the paragraph becomes exactly 8 lines and fits
+      on page 1. The forced break must then put the target on page 2 without
+      retaining the now-stale page 3 position.
+    -->
+    <p class="trigger">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx<a href="#target"></a></p>
+    <section>
+      <h2 id="target">This heading should be on page 2.</h2>
+      <p>There must not be a blank page before this heading.</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import * as Counters from "../../../src/vivliostyle/counters";
+import * as Layout from "../../../src/vivliostyle/layout";
+import * as LayoutProcessor from "../../../src/vivliostyle/layout-processor";
+import * as Vtree from "../../../src/vivliostyle/vtree";
+
+const documentURLTransformer = {
+  transformFragment(fragment) {
+    return fragment;
+  },
+  transformURL(url) {
+    return url;
+  },
+  restoreURL(url) {
+    return [url];
+  },
+};
+
+function createNodeContext(id) {
+  const element = document.createElement("h2");
+  element.id = id;
+  const nodeContext = new Vtree.NodeContext(
+    element,
+    null,
+    0,
+    new LayoutProcessor.BlockFormattingContext(null),
+  );
+  nodeContext.viewNode = element;
+  return nodeContext;
+}
+
+describe("cross-reference layout constraint", function () {
+  it("allows a target to move earlier after a satisfied page break", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const reference = new Counters.TargetCounterReference("target", true);
+    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 2 };
+    store.resolvedReferences.target = [reference];
+
+    const constraint = store.createLayoutConstraint(1);
+    const nodeContext = createNodeContext("target");
+
+    expect(constraint.allowLayout(nodeContext)).toBe(false);
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
+
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
+  });
+
+  it("keeps non-counter constraints after a satisfied page break", function () {
+    const nodeContext = createNodeContext("target");
+    const counterConstraint = {
+      allowLayout() {
+        return false;
+      },
+      allowLayoutAfterPageBreak() {
+        return true;
+      },
+    };
+    const rejectingConstraint = {
+      allowLayout() {
+        return false;
+      },
+    };
+    const constraint = new Layout.AllLayoutConstraint([
+      counterConstraint,
+      rejectingConstraint,
+    ]);
+
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(false);
+  });
+
+  it("re-resolves references when a target moves to an earlier page", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const reference = new Counters.TargetCounterReference("target", true);
+    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 2 };
+    store.resolvedReferences.target = [reference];
+
+    const container = document.createElement("div");
+    const page = new Vtree.Page(container, container);
+    const target = document.createElement("h2");
+    target.id = "target";
+    page.elementsById.target = [target];
+    store.currentPage = page;
+
+    const constraint = store.createLayoutConstraint(1);
+    const nodeContext = createNodeContext("target");
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
+
+    store.finishPage(0, 1);
+
+    expect(reference.isResolved()).toBe(false);
+    expect(store.resolvedReferences.target).toEqual([]);
+    expect(store.unresolvedReferences.target).toEqual([reference]);
+
+    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 1 };
+    const earlierConstraint = store.createLayoutConstraint(0);
+    expect(earlierConstraint.allowLayoutAfterPageBreak(nodeContext)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -467,6 +467,202 @@ describe("epub", function () {
         return testFrame.result();
       });
     });
+
+    it("reuses the requested slot when a final-page rerender shrinks the spine", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = { spineIndex: 0, offset: 0, fetchers: [] };
+        var viewItem = {
+          layoutPositions: new Array(17).fill(null),
+          pages: Array.from({ length: 17 }, function () {
+            return { container: { remove: function () {} } };
+          }),
+          pageCounterStarts: new Array(17).fill(null),
+          instance: {
+            getPageNumberContextDepth: function () {
+              return 0;
+            },
+            pushPageNumberContext: function () {},
+            restorePageNumberContextDepth: function () {},
+            layoutNextPage: function () {
+              return adapt_task.newResult(null);
+            },
+          },
+        };
+        view.counterStore = { finishPage: function () {} };
+        view.isInCounterResolveScope = function () {
+          return false;
+        };
+        view.preparePageCountersForRender = function () {
+          return null;
+        };
+        view.makePage = function () {
+          return page;
+        };
+        view.resolvePageTypeForRenderSlot = function () {};
+        spyOn(view, "finishPageContainer");
+        view.reportPaginationProgress = function () {};
+        view.maybeRelayoutFollowingPage = function () {
+          return adapt_task.newResult(true);
+        };
+        view.resolveUnresolvedReferencesForPage = function () {
+          return adapt_task.newResult(page);
+        };
+
+        view.renderSinglePage(viewItem, { page: 15 }).then(function () {
+          expect(view.finishPageContainer).toHaveBeenCalledWith(
+            viewItem,
+            page,
+            15,
+          );
+          expect(viewItem.pages.length).toBe(16);
+          expect(viewItem.layoutPositions.length).toBe(16);
+          expect(viewItem.pageCounterStarts.length).toBe(16);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("resolves references deferred by a nested counter scope", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = {};
+        var viewItem = {};
+        var nextLayoutPosition = { page: 16 };
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return false;
+        };
+        spyOn(view, "resolveUnresolvedReferencesForPage").and.returnValue(
+          adapt_task.newResult(page),
+        );
+
+        view
+          .resolveDeferredReferencesAfterCounterScope(
+            viewItem,
+            page,
+            15,
+            nextLayoutPosition,
+          )
+          .then(function (result) {
+            expect(
+              view.resolveUnresolvedReferencesForPage,
+            ).toHaveBeenCalledWith(viewItem, page, 15, nextLayoutPosition);
+            expect(result).toBe(page);
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("remembers the cascaded page where a counter scope defers references", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = {
+          container: {
+            parentElement: {},
+            setAttribute: function () {},
+          },
+          spineIndex: 0,
+        };
+        var viewItem = { pages: [page], item: { spineIndex: 0 } };
+        var nextLayoutPosition = { page: 1 };
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.opf = { spine: [{}, {}] };
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return true;
+        };
+        spyOn(view, "deferReferencesForPage").and.callThrough();
+
+        view
+          .resolveUnresolvedReferencesForPage(
+            viewItem,
+            page,
+            0,
+            nextLayoutPosition,
+          )
+          .then(function () {
+            expect(view.deferReferencesForPage).toHaveBeenCalledWith(
+              viewItem,
+              page,
+              0,
+              nextLayoutPosition,
+            );
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("queues deferred references until the outermost counter scope is restored", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = {};
+        var viewItem = { pages: [page] };
+        var inCounterScope = true;
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return inCounterScope;
+        };
+        spyOn(view, "resolveUnresolvedReferencesForPage").and.returnValue(
+          adapt_task.newResult(page),
+        );
+
+        view
+          .resolveDeferredReferencesAfterCounterScope(viewItem, page, 0, null)
+          .then(function () {
+            expect(
+              view.resolveUnresolvedReferencesForPage,
+            ).not.toHaveBeenCalled();
+            inCounterScope = false;
+            view
+              .resolveDeferredReferencesAfterCounterScope(
+                viewItem,
+                page,
+                0,
+                null,
+              )
+              .then(function () {
+                expect(
+                  view.resolveUnresolvedReferencesForPage,
+                ).toHaveBeenCalledWith(viewItem, page, 0, null);
+                expect(
+                  view.resolveUnresolvedReferencesForPage.calls.count(),
+                ).toBe(1);
+                done();
+              });
+          });
+        return adapt_task.newResult(true);
+      });
+    });
   });
   describe("OPFView pagination progress", function () {
     function createFakeView(totalOffsets) {


### PR DESCRIPTION
## Summary

- consume page-level forced breaks that have already been satisfied at a fresh page start without losing the target continuation
- allow one stable earlier-page correction for referenced targets while retaining the existing anti-oscillation guard
- reuse the requested page slot when a final-page rerender shrinks a spine
- revisit references deferred on cascaded pages after the outermost counter-resolution scope is restored

## Root cause

A referenced target with `break-before: page` could be laid out one page late during target-counter resolution:

1. the forced page break was already satisfied, but its page-level break state remained at the fresh page start;
2. the reference-target constraint introduced in b0288a356d78d6d92b0d256e6233b7044e07cde5 rejected the target's earlier corrected placement;
3. when the corrected rerender shortened the spine, the final page was stored in the stale last slot and the old blank page remained; and
4. references invalidated on a cascaded page inside a nested counter-resolution scope were skipped by the #1686 recursion guard and never revisited after the outermost scope was restored.

## Regression boundary

The first observable bad commit in the production publication is 2bacf4bd455dcec41ef06c0f339a38422bf4e1b8 (`fix: Make text-spacing filler widths independent of installed fonts (#2035)`):

- parent 88418bc25a68cbefec8bcc129d644ca807831a3d: 315 pages, no extra blank page
- 2bacf4bd455dcec41ef06c0f339a38422bf4e1b8: 307 pages, extra blank page before the chapter summary
- releases 2.41–2.43: unaffected
- releases 2.44–2.45: affected

That commit does not introduce the faulty break or reference logic. Its font-independent text-spacing metrics change the page geometry and expose the older reference-target behavior. The anti-backward constraint itself dates to b0288a356d78d6d92b0d256e6233b7044e07cde5.

I also tested 2a0f1a41529f7a6971ef0eb05abf73027b3e84b8 (`Restore target-counter references for redirected chapter URLs`) and its parent; both are unaffected.

## Validation

- all 755 core tests pass
- CI passes on macOS Chrome, macOS Firefox, Ubuntu Chrome, and Windows Chrome
- added a visual regression fixture for a referenced flex target with `break-before: page` at a fresh page start
- added unit coverage for the one-time earlier move, anti-oscillation behavior, final-page shrink, deferred-reference queueing, and cascaded-page registration
- verified against the production 298-page Japanese publication with production fonts:
  - chapter body ends on page 33
  - chapter summary is on page 34
  - the intentional parity blank is on page 35
  - the next chapter starts on page 36
  - the TOC reports page 34
- compared the full extracted text with the previous candidate; the only difference is the corrected TOC value, 35 → 34

Related: #1842, #2034, #1497, #1498, #1686

Assisted-by: Codex:gpt-5.6-sol

<details>
<summary>AI assistance disclosure</summary>

Codex (GPT-5.6 Sol) assisted with debugging, source tracing, test design, implementation, and drafting this change. I reviewed the implementation and validation results.

</details>
