### PR TITLE
fix: stabilize cross-reference relayout after spine shrinkage

### DIFF
--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -769,6 +769,17 @@ export class AdaptiveViewer {
     }
   }
 
+  private truncatePageSizes(pageCount: number) {
+    if (this.pageSizes.length <= pageCount) {
+      return;
+    }
+    this.pageSizes.splice(pageCount);
+    this.removePageSizePageRules();
+    if (this.pageSizes.length > 0) {
+      this.setPageSizePageRules(this.pageSizes.length - 1);
+    }
+  }
+
   private setPageSizePageRules(pageIndex: number) {
     // In this implementation, it generates one page rule with the largest
     // page size both in width and height in the multiple page sizes.
@@ -853,6 +864,7 @@ export class AdaptiveViewer {
       this.pref,
       this.setPageSize.bind(this),
       this.cmykReserveMap,
+      this.truncatePageSizes.bind(this),
     );
     if (tocVisible) {
       this.sendCommand({ a: "toc", v: "show", autohide: tocAutohide });

--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -775,8 +775,15 @@ export class AdaptiveViewer {
     }
     this.pageSizes.splice(pageCount);
     this.removePageSizePageRules();
-    if (this.pageSizes.length > 0) {
-      this.setPageSizePageRules(this.pageSizes.length - 1);
+    let lastPageSizeIndex = this.pageSizes.length - 1;
+    while (
+      lastPageSizeIndex >= 0 &&
+      this.pageSizes[lastPageSizeIndex] == null
+    ) {
+      lastPageSizeIndex--;
+    }
+    if (lastPageSizeIndex >= 0) {
+      this.setPageSizePageRules(lastPageSizeIndex);
     }
   }
 
@@ -784,16 +791,19 @@ export class AdaptiveViewer {
     // In this implementation, it generates one page rule with the largest
     // page size both in width and height in the multiple page sizes.
     // (Resolve issue #751)
+    const currentPageSize = this.pageSizes[pageIndex];
     if (
       this.pageRuleStyleElement &&
+      currentPageSize &&
       (!this.pageSheetSizeAlreadySet ||
-        this.pageSizes[pageIndex].width !==
-          this.pageSizes[pageIndex - 1]?.width ||
-        this.pageSizes[pageIndex].height !==
-          this.pageSizes[pageIndex - 1]?.height)
+        currentPageSize.width !== this.pageSizes[pageIndex - 1]?.width ||
+        currentPageSize.height !== this.pageSizes[pageIndex - 1]?.height)
     ) {
-      const widthMax = Math.max(...this.pageSizes.map((p) => p.width));
-      const heightMax = Math.max(...this.pageSizes.map((p) => p.height));
+      const definedPageSizes = this.pageSizes.filter(
+        (pageSize) => pageSize != null,
+      );
+      const widthMax = Math.max(...definedPageSizes.map((p) => p.width));
+      const heightMax = Math.max(...definedPageSizes.map((p) => p.height));
 
       function convertSize(px: number): number {
         const pt = px * 0.75;

--- a/packages/core/src/vivliostyle/adaptive-viewer.ts
+++ b/packages/core/src/vivliostyle/adaptive-viewer.ts
@@ -770,10 +770,9 @@ export class AdaptiveViewer {
   }
 
   private truncatePageSizes(pageCount: number) {
-    if (this.pageSizes.length <= pageCount) {
-      return;
+    if (this.pageSizes.length > pageCount) {
+      this.pageSizes.splice(pageCount);
     }
-    this.pageSizes.splice(pageCount);
     this.removePageSizePageRules();
     let lastPageSizeIndex = this.pageSizes.length - 1;
     while (

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1617,7 +1617,8 @@ export class CounterStore {
    * Walk through target-counter DOM nodes in the given page containers and
    * update their text content from the current pageCountersById snapshots.
    */
-  updateTargetCounterNodesInPages(pages: Vtree.Page[]): void {
+  updateTargetCounterNodesInPages(pages: Vtree.Page[]): Set<Vtree.Page> {
+    const changedPages = new Set<Vtree.Page>();
     for (const page of pages) {
       if (!page || !page.container) continue;
       const nodes = page.container.querySelectorAll(`[${TARGET_COUNTER_ATTR}]`);
@@ -1629,18 +1630,24 @@ export class CounterStore {
           if (counterValue) {
             const arr: number[] = counterValue[expr.name];
             if (arr) {
-              node.textContent = expr.format(arr[arr.length - 1]);
+              const value = expr.format(arr[arr.length - 1]);
+              if (node.textContent !== value) {
+                node.textContent = value;
+                changedPages.add(page);
+              }
             }
           }
         }
       }
     }
+    return changedPages;
   }
 
   /**
    * Update target-text() nodes retained outside a rebuilt spine suffix.
    */
-  updateTargetTextNodesInPages(pages: Vtree.Page[]): void {
+  updateTargetTextNodesInPages(pages: Vtree.Page[]): Set<Vtree.Page> {
+    const changedPages = new Set<Vtree.Page>();
     for (const page of pages) {
       if (!page || !page.container) continue;
       const nodes = page.container.querySelectorAll(`[${TARGET_TEXT_ATTR}]`);
@@ -1650,18 +1657,23 @@ export class CounterStore {
         if (expr && expr.transformedId) {
           const text = this.pageTextById[expr.transformedId];
           if (text) {
+            let value: string;
             if (expr.pseudoElement === "first-letter") {
               const fullText =
                 (text.before ?? "") + (text.content ?? "") + (text.after ?? "");
-              node.textContent =
-                fullText.match(Base.firstLetterPattern)?.[0] ?? "";
+              value = fullText.match(Base.firstLetterPattern)?.[0] ?? "";
             } else {
-              node.textContent = text[expr.pseudoElement] ?? "";
+              value = text[expr.pseudoElement] ?? "";
+            }
+            if (node.textContent !== value) {
+              node.textContent = value;
+              changedPages.add(page);
             }
           }
         }
       }
     }
+    return changedPages;
   }
 
   /**

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1444,6 +1444,30 @@ export class CounterStore {
     );
   }
 
+  getRebuildStartForReferences(firstSpineIndex: number): number {
+    let rebuildStart = firstSpineIndex;
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const id of Object.keys(this.pageIndicesById)) {
+        if (this.pageIndicesById[id].spineIndex < rebuildStart) {
+          continue;
+        }
+        const refs = [
+          ...(this.resolvedReferences[id] || []),
+          ...(this.unresolvedReferences[id] || []),
+        ];
+        for (const ref of refs) {
+          if (ref.spineIndex >= 0 && ref.spineIndex < rebuildStart) {
+            rebuildStart = ref.spineIndex;
+            changed = true;
+          }
+        }
+      }
+    }
+    return rebuildStart;
+  }
+
   /**
    * Record a snapshot of the current page counters keyed by the page's element
    * offset range, so page-based counters in named strings (string-set) can be

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1624,6 +1624,26 @@ export class CounterStore {
   }
 
   /**
+   * Update target-text() nodes retained outside a rebuilt spine suffix.
+   */
+  updateTargetTextNodesInPages(pages: Vtree.Page[]): void {
+    for (const page of pages) {
+      if (!page || !page.container) continue;
+      const nodes = page.container.querySelectorAll(`[${TARGET_TEXT_ATTR}]`);
+      for (const node of nodes) {
+        const key = node.getAttribute(TARGET_TEXT_ATTR);
+        const expr = this.targetTextExprs.find((o) => o.expr.key === key);
+        if (expr && expr.transformedId) {
+          const text = this.pageTextById[expr.transformedId];
+          if (text) {
+            node.textContent = text[expr.pseudoElement] ?? "";
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Resolve page-level counter values for a page.
    *
    * Prefer an explicit per-page snapshot when one is supplied. Otherwise fall

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1349,27 +1349,8 @@ export class CounterStore {
         }
 
         const oldPageIndex = this.pageIndicesById[id];
-        const movedLater = oldPageIndex && oldPageIndex.pageIndex < pageIndex;
-        const movedEarlierAfterPageBreak =
-          oldPageIndex &&
-          oldPageIndex.pageIndex > pageIndex &&
-          !this.targetsMovedEarlierAfterPageBreak.has(id);
-        if (movedEarlierAfterPageBreak) {
-          this.targetsMovedEarlierAfterPageBreak.add(id);
-        }
-        if (movedLater || movedEarlierAfterPageBreak) {
-          const resolvedRefs = this.resolvedReferences[id];
-          if (resolvedRefs) {
-            let unresolvedRefs = this.unresolvedReferences[id];
-            if (!unresolvedRefs) {
-              unresolvedRefs = this.unresolvedReferences[id] = [];
-            }
-            let ref: TargetCounterReference | undefined;
-            while ((ref = resolvedRefs.shift())) {
-              ref.unresolve();
-              unresolvedRefs.push(ref);
-            }
-          }
+        if (oldPageIndex && oldPageIndex.pageIndex < pageIndex) {
+          this.unresolveReferences(id);
         }
         this.pageIndicesById[id] = { spineIndex, pageIndex };
       });
@@ -1959,14 +1940,39 @@ export class CounterStore {
     return new LayoutConstraint(this, pageIndex);
   }
 
-  canTargetMoveEarlierAfterPageBreak(id: string): boolean {
+  moveTargetEarlierAfterPageBreak(id: string, pageIndex: number): boolean {
+    const oldPageIndex = this.pageIndicesById[id];
+    if (!oldPageIndex || pageIndex >= oldPageIndex.pageIndex) {
+      return true;
+    }
     // Keep the anti-oscillation guarantee introduced by b0288a35: a target
-    // gets one exception for a page break that has already been satisfied,
-    // but cannot repeatedly alternate between earlier and later pages.
+    // gets one earlier-page correction for a break that has already been
+    // satisfied, but cannot repeatedly alternate between earlier and later
+    // pages. Commit the correction at the point it is accepted so subsequent
+    // constraint checks use the new position instead of retrying indefinitely.
     if (this.targetsMovedEarlierAfterPageBreak.has(id)) {
       return false;
     }
+    this.targetsMovedEarlierAfterPageBreak.add(id);
+    this.pageIndicesById[id] = { ...oldPageIndex, pageIndex };
+    this.unresolveReferences(id);
     return true;
+  }
+
+  private unresolveReferences(id: string): void {
+    const resolvedRefs = this.resolvedReferences[id];
+    if (!resolvedRefs) {
+      return;
+    }
+    let unresolvedRefs = this.unresolvedReferences[id];
+    if (!unresolvedRefs) {
+      unresolvedRefs = this.unresolvedReferences[id] = [];
+    }
+    let ref: TargetCounterReference | undefined;
+    while ((ref = resolvedRefs.shift())) {
+      ref.unresolve();
+      unresolvedRefs.push(ref);
+    }
   }
 }
 
@@ -1997,7 +2003,10 @@ class LayoutConstraint implements Layout.LayoutConstraint {
       return true;
     }
     const id = this.getReferencedTargetId(nodeContext);
-    return !!id && this.counterStore.canTargetMoveEarlierAfterPageBreak(id);
+    return (
+      !!id &&
+      this.counterStore.moveTargetEarlierAfterPageBreak(id, this.pageIndex)
+    );
   }
 
   allowLayout(nodeContext: Vtree.NodeContext): boolean {

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -944,6 +944,10 @@ export class CounterStore {
     Object.create(null);
   resolvedReferences: { [key: string]: TargetCounterReference[] } =
     Object.create(null);
+  private referenceTargetIdsBySourcePage = new Map<
+    number,
+    Map<number, Set<string>>
+  >();
   private targetsMovedEarlierAfterPageBreak = new Set<string>();
   pageControlledCounterNames: { [key: string]: boolean } = Object.assign(
     Object.create(null),
@@ -1377,6 +1381,17 @@ export class CounterStore {
       if (arr.every((r) => !ref.equals(r))) {
         arr.push(ref);
       }
+      let targetIdsByPage = this.referenceTargetIdsBySourcePage.get(spineIndex);
+      if (!targetIdsByPage) {
+        targetIdsByPage = new Map();
+        this.referenceTargetIdsBySourcePage.set(spineIndex, targetIdsByPage);
+      }
+      let targetIds = targetIdsByPage.get(pageIndex);
+      if (!targetIds) {
+        targetIds = new Set();
+        targetIdsByPage.set(pageIndex, targetIds);
+      }
+      targetIds.add(ref.targetId);
     }
     if (this.hasDeferredNamedStrings && this.currentPage) {
       this.recordNamedStringPageSnapshot(spineIndex);
@@ -1384,14 +1399,12 @@ export class CounterStore {
     this.currentPage = null;
   }
 
-  private discardReferencesFromPage(
-    spineIndex: number,
-    pageIndex: number,
-  ): void {
-    const targetIds = new Set([
-      ...Object.keys(this.resolvedReferences),
-      ...Object.keys(this.unresolvedReferences),
-    ]);
+  discardReferencesFromPage(spineIndex: number, pageIndex: number): void {
+    const targetIdsByPage = this.referenceTargetIdsBySourcePage.get(spineIndex);
+    const targetIds = targetIdsByPage?.get(pageIndex);
+    if (!targetIds) {
+      return;
+    }
     for (const id of targetIds) {
       const keepOtherPage = (ref: TargetCounterReference) =>
         ref.spineIndex !== spineIndex || ref.pageIndex !== pageIndex;
@@ -1411,6 +1424,16 @@ export class CounterStore {
       } else {
         delete this.unresolvedReferences[id];
       }
+    }
+    const keepOtherPage = (ref: TargetCounterReference) =>
+      ref.spineIndex !== spineIndex || ref.pageIndex !== pageIndex;
+    this.referencesToSolve = this.referencesToSolve.filter(keepOtherPage);
+    this.referencesToSolveStack = this.referencesToSolveStack.map((refs) =>
+      refs.filter(keepOtherPage),
+    );
+    targetIdsByPage.delete(pageIndex);
+    if (targetIdsByPage.size === 0) {
+      this.referenceTargetIdsBySourcePage.delete(spineIndex);
     }
   }
 
@@ -1557,6 +1580,12 @@ export class CounterStore {
       const snapshot = this.namedStringPageSnapshots[parseInt(key, 10)];
       if (snapshot.spineIndex >= firstSpineIndex) {
         delete this.namedStringPageSnapshots[parseInt(key, 10)];
+      }
+    }
+
+    for (const spineIndex of this.referenceTargetIdsBySourcePage.keys()) {
+      if (spineIndex >= firstSpineIndex) {
+        this.referenceTargetIdsBySourcePage.delete(spineIndex);
       }
     }
 

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1650,7 +1650,14 @@ export class CounterStore {
         if (expr && expr.transformedId) {
           const text = this.pageTextById[expr.transformedId];
           if (text) {
-            node.textContent = text[expr.pseudoElement] ?? "";
+            if (expr.pseudoElement === "first-letter") {
+              const fullText =
+                (text.before ?? "") + (text.content ?? "") + (text.after ?? "");
+              node.textContent =
+                fullText.match(Base.firstLetterPattern)?.[0] ?? "";
+            } else {
+              node.textContent = text[expr.pseudoElement] ?? "";
+            }
           }
         }
       }

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -944,6 +944,7 @@ export class CounterStore {
     Object.create(null);
   resolvedReferences: { [key: string]: TargetCounterReference[] } =
     Object.create(null);
+  private targetsMovedEarlierAfterPageBreak = new Set<string>();
   pageControlledCounterNames: { [key: string]: boolean } = Object.assign(
     Object.create(null),
     { page: true },
@@ -1348,7 +1349,15 @@ export class CounterStore {
         }
 
         const oldPageIndex = this.pageIndicesById[id];
-        if (oldPageIndex && oldPageIndex.pageIndex < pageIndex) {
+        const movedLater = oldPageIndex && oldPageIndex.pageIndex < pageIndex;
+        const movedEarlierAfterPageBreak =
+          oldPageIndex &&
+          oldPageIndex.pageIndex > pageIndex &&
+          !this.targetsMovedEarlierAfterPageBreak.has(id);
+        if (movedEarlierAfterPageBreak) {
+          this.targetsMovedEarlierAfterPageBreak.add(id);
+        }
+        if (movedLater || movedEarlierAfterPageBreak) {
           const resolvedRefs = this.resolvedReferences[id];
           if (resolvedRefs) {
             let unresolvedRefs = this.unresolvedReferences[id];
@@ -1497,6 +1506,56 @@ export class CounterStore {
         snap.counters["page"] = snap.counters["page"].map((v) => v + pageDelta);
       }
     }
+  }
+
+  /**
+   * Drop references whose source page belongs to spine items that are about to
+   * be rebuilt. Target snapshots are deliberately retained until the rebuilt
+   * pages overwrite them: invalidating a still-resolved target here would
+   * unnecessarily rerender earlier source pages and can restart the
+   * page-break oscillation that triggered the suffix rebuild.
+   */
+  discardReferencesFromSpine(firstSpineIndex: number): void {
+    const targetIds = new Set([
+      ...Object.keys(this.resolvedReferences),
+      ...Object.keys(this.unresolvedReferences),
+    ]);
+
+    for (const id of targetIds) {
+      const resolved = (this.resolvedReferences[id] || []).filter(
+        (ref) => ref.spineIndex < firstSpineIndex,
+      );
+      const unresolved = (this.unresolvedReferences[id] || []).filter(
+        (ref) => ref.spineIndex < firstSpineIndex,
+      );
+
+      if (resolved.length) {
+        this.resolvedReferences[id] = resolved;
+      } else {
+        delete this.resolvedReferences[id];
+      }
+      if (unresolved.length) {
+        this.unresolvedReferences[id] = unresolved;
+      } else {
+        delete this.unresolvedReferences[id];
+      }
+    }
+
+    for (const key of Object.keys(this.namedStringPageSnapshots)) {
+      const snapshot = this.namedStringPageSnapshots[parseInt(key, 10)];
+      if (snapshot.spineIndex >= firstSpineIndex) {
+        delete this.namedStringPageSnapshots[parseInt(key, 10)];
+      }
+    }
+
+    const keepEarlierSource = (ref: TargetCounterReference) =>
+      ref.spineIndex < firstSpineIndex;
+    this.newReferencesOfCurrentPage =
+      this.newReferencesOfCurrentPage.filter(keepEarlierSource);
+    this.referencesToSolve = this.referencesToSolve.filter(keepEarlierSource);
+    this.referencesToSolveStack = this.referencesToSolveStack.map((refs) =>
+      refs.filter(keepEarlierSource),
+    );
   }
 
   /**
@@ -1899,6 +1958,16 @@ export class CounterStore {
   createLayoutConstraint(pageIndex: number): Layout.LayoutConstraint {
     return new LayoutConstraint(this, pageIndex);
   }
+
+  canTargetMoveEarlierAfterPageBreak(id: string): boolean {
+    // Keep the anti-oscillation guarantee introduced by b0288a35: a target
+    // gets one exception for a page break that has already been satisfied,
+    // but cannot repeatedly alternate between earlier and later pages.
+    if (this.targetsMovedEarlierAfterPageBreak.has(id)) {
+      return false;
+    }
+    return true;
+  }
 }
 
 export const PAGES_COUNTER_ATTR = "data-vivliostyle-pages-counter";
@@ -1923,25 +1992,17 @@ class LayoutConstraint implements Layout.LayoutConstraint {
   ) {}
 
   /** @override */
+  allowLayoutAfterPageBreak(nodeContext: Vtree.NodeContext): boolean {
+    if (this.allowLayout(nodeContext)) {
+      return true;
+    }
+    const id = this.getReferencedTargetId(nodeContext);
+    return !!id && this.counterStore.canTargetMoveEarlierAfterPageBreak(id);
+  }
+
   allowLayout(nodeContext: Vtree.NodeContext): boolean {
-    if (!nodeContext || nodeContext.after) {
-      return true;
-    }
-    const viewNode = nodeContext.viewNode;
-    if (!viewNode || viewNode.nodeType !== 1) {
-      return true;
-    }
-    const id =
-      (viewNode as Element).getAttribute("data-vivliostyle-id") ||
-      (viewNode as Element).getAttribute("id") ||
-      (viewNode as Element).getAttribute("name");
+    const id = this.getReferencedTargetId(nodeContext);
     if (!id) {
-      return true;
-    }
-    if (
-      !this.counterStore.resolvedReferences[id] &&
-      !this.counterStore.unresolvedReferences[id]
-    ) {
       return true;
     }
     const pageIndex = this.counterStore.pageIndicesById[id];
@@ -1949,5 +2010,29 @@ class LayoutConstraint implements Layout.LayoutConstraint {
       return true;
     }
     return this.pageIndex >= pageIndex.pageIndex;
+  }
+
+  private getReferencedTargetId(nodeContext: Vtree.NodeContext): string | null {
+    if (!nodeContext || nodeContext.after) {
+      return null;
+    }
+    const viewNode = nodeContext.viewNode;
+    if (!viewNode || viewNode.nodeType !== 1) {
+      return null;
+    }
+    const id =
+      (viewNode as Element).getAttribute("data-vivliostyle-id") ||
+      (viewNode as Element).getAttribute("id") ||
+      (viewNode as Element).getAttribute("name");
+    if (!id) {
+      return null;
+    }
+    if (
+      !this.counterStore.resolvedReferences[id] &&
+      !this.counterStore.unresolvedReferences[id]
+    ) {
+      return null;
+    }
+    return id;
   }
 }

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1444,30 +1444,6 @@ export class CounterStore {
     );
   }
 
-  getRebuildStartForReferences(firstSpineIndex: number): number {
-    let rebuildStart = firstSpineIndex;
-    let changed = true;
-    while (changed) {
-      changed = false;
-      for (const id of Object.keys(this.pageIndicesById)) {
-        if (this.pageIndicesById[id].spineIndex < rebuildStart) {
-          continue;
-        }
-        const refs = [
-          ...(this.resolvedReferences[id] || []),
-          ...(this.unresolvedReferences[id] || []),
-        ];
-        for (const ref of refs) {
-          if (ref.spineIndex >= 0 && ref.spineIndex < rebuildStart) {
-            rebuildStart = ref.spineIndex;
-            changed = true;
-          }
-        }
-      }
-    }
-    return rebuildStart;
-  }
-
   /**
    * Record a snapshot of the current page counters keyed by the page's element
    * offset range, so page-based counters in named strings (string-set) can be

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1584,11 +1584,6 @@ export class CounterStore {
 
     for (const id of Object.keys(this.pageIndicesById)) {
       if (this.pageIndicesById[id].spineIndex >= firstSpineIndex) {
-        // Targets in the rebuilt suffix can keep the same spine-local page
-        // index while their absolute page counter changes. Mark retained
-        // source references unresolved so the normal target-resolution path
-        // re-lays out those source pages instead of only patching their DOM.
-        this.unresolveReferences(id);
         delete this.pageCountersById[id];
         delete this.pageDocCountersById[id];
         delete this.pageTextById[id];

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1584,6 +1584,11 @@ export class CounterStore {
 
     for (const id of Object.keys(this.pageIndicesById)) {
       if (this.pageIndicesById[id].spineIndex >= firstSpineIndex) {
+        // Targets in the rebuilt suffix can keep the same spine-local page
+        // index while their absolute page counter changes. Mark retained
+        // source references unresolved so the normal target-resolution path
+        // re-lays out those source pages instead of only patching their DOM.
+        this.unresolveReferences(id);
         delete this.pageCountersById[id];
         delete this.pageDocCountersById[id];
         delete this.pageTextById[id];

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1552,11 +1552,15 @@ export class CounterStore {
 
   /**
    * Drop references whose source page belongs to spine items that are about to
-   * be rebuilt, and invalidate target snapshots owned by that suffix. Retain
-   * pageIndicesById so unresolved forward references can still locate and
-   * render their targets while the suffix is reconstructed.
+   * be rebuilt. Target snapshots owned by that suffix are normally invalidated,
+   * but a fixed-point pagination pass can retain them as the starting estimate
+   * for the next pass. Retain pageIndicesById so unresolved forward references
+   * can still locate and render their targets while the suffix is reconstructed.
    */
-  discardReferencesFromSpine(firstSpineIndex: number): void {
+  discardReferencesFromSpine(
+    firstSpineIndex: number,
+    preserveTargetSnapshots: boolean = false,
+  ): void {
     const targetIds = new Set([
       ...Object.keys(this.resolvedReferences),
       ...Object.keys(this.unresolvedReferences),
@@ -1582,11 +1586,13 @@ export class CounterStore {
       }
     }
 
-    for (const id of Object.keys(this.pageIndicesById)) {
-      if (this.pageIndicesById[id].spineIndex >= firstSpineIndex) {
-        delete this.pageCountersById[id];
-        delete this.pageDocCountersById[id];
-        delete this.pageTextById[id];
+    if (!preserveTargetSnapshots) {
+      for (const id of Object.keys(this.pageIndicesById)) {
+        if (this.pageIndicesById[id].spineIndex >= firstSpineIndex) {
+          delete this.pageCountersById[id];
+          delete this.pageDocCountersById[id];
+          delete this.pageTextById[id];
+        }
       }
     }
 

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1552,15 +1552,11 @@ export class CounterStore {
 
   /**
    * Drop references whose source page belongs to spine items that are about to
-   * be rebuilt. Target snapshots owned by that suffix are normally invalidated,
-   * but a fixed-point pagination pass can retain them as the starting estimate
-   * for the next pass. Retain pageIndicesById so unresolved forward references
-   * can still locate and render their targets while the suffix is reconstructed.
+   * be rebuilt, and invalidate target snapshots owned by that suffix. Retain
+   * pageIndicesById so unresolved forward references can still locate and
+   * render their targets while the suffix is reconstructed.
    */
-  discardReferencesFromSpine(
-    firstSpineIndex: number,
-    preserveTargetSnapshots: boolean = false,
-  ): void {
+  discardReferencesFromSpine(firstSpineIndex: number): void {
     const targetIds = new Set([
       ...Object.keys(this.resolvedReferences),
       ...Object.keys(this.unresolvedReferences),
@@ -1586,13 +1582,11 @@ export class CounterStore {
       }
     }
 
-    if (!preserveTargetSnapshots) {
-      for (const id of Object.keys(this.pageIndicesById)) {
-        if (this.pageIndicesById[id].spineIndex >= firstSpineIndex) {
-          delete this.pageCountersById[id];
-          delete this.pageDocCountersById[id];
-          delete this.pageTextById[id];
-        }
+    for (const id of Object.keys(this.pageIndicesById)) {
+      if (this.pageIndicesById[id].spineIndex >= firstSpineIndex) {
+        delete this.pageCountersById[id];
+        delete this.pageDocCountersById[id];
+        delete this.pageTextById[id];
       }
     }
 
@@ -1623,7 +1617,10 @@ export class CounterStore {
    * Walk through target-counter DOM nodes in the given page containers and
    * update their text content from the current pageCountersById snapshots.
    */
-  updateTargetCounterNodesInPages(pages: Vtree.Page[]): Set<Vtree.Page> {
+  updateTargetCounterNodesInPages(
+    pages: Vtree.Page[],
+    changedTargetIds?: Set<string>,
+  ): Set<Vtree.Page> {
     const changedPages = new Set<Vtree.Page>();
     for (const page of pages) {
       if (!page || !page.container) continue;
@@ -1640,6 +1637,7 @@ export class CounterStore {
               if (node.textContent !== value) {
                 node.textContent = value;
                 changedPages.add(page);
+                changedTargetIds?.add(expr.transformedId);
               }
             }
           }
@@ -1652,7 +1650,10 @@ export class CounterStore {
   /**
    * Update target-text() nodes retained outside a rebuilt spine suffix.
    */
-  updateTargetTextNodesInPages(pages: Vtree.Page[]): Set<Vtree.Page> {
+  updateTargetTextNodesInPages(
+    pages: Vtree.Page[],
+    changedTargetIds?: Set<string>,
+  ): Set<Vtree.Page> {
     const changedPages = new Set<Vtree.Page>();
     for (const page of pages) {
       if (!page || !page.container) continue;
@@ -1674,6 +1675,7 @@ export class CounterStore {
             if (node.textContent !== value) {
               node.textContent = value;
               changedPages.add(page);
+              changedTargetIds?.add(expr.transformedId);
             }
           }
         }
@@ -2076,6 +2078,12 @@ export class CounterStore {
     this.pageIndicesById[id] = { ...oldPageIndex, pageIndex };
     this.unresolveReferences(id);
     return true;
+  }
+
+  unresolveReferencesForTargets(targetIds: Iterable<string>): void {
+    for (const id of targetIds) {
+      this.unresolveReferences(id);
+    }
   }
 
   private unresolveReferences(id: string): void {

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1545,10 +1545,9 @@ export class CounterStore {
 
   /**
    * Drop references whose source page belongs to spine items that are about to
-   * be rebuilt. Target snapshots are deliberately retained until the rebuilt
-   * pages overwrite them: invalidating a still-resolved target here would
-   * unnecessarily rerender earlier source pages and can restart the
-   * page-break oscillation that triggered the suffix rebuild.
+   * be rebuilt, and invalidate target snapshots owned by that suffix. Retain
+   * pageIndicesById so unresolved forward references can still locate and
+   * render their targets while the suffix is reconstructed.
    */
   discardReferencesFromSpine(firstSpineIndex: number): void {
     const targetIds = new Set([
@@ -1573,6 +1572,14 @@ export class CounterStore {
         this.unresolvedReferences[id] = unresolved;
       } else {
         delete this.unresolvedReferences[id];
+      }
+    }
+
+    for (const id of Object.keys(this.pageIndicesById)) {
+      if (this.pageIndicesById[id].spineIndex >= firstSpineIndex) {
+        delete this.pageCountersById[id];
+        delete this.pageDocCountersById[id];
+        delete this.pageTextById[id];
       }
     }
 

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1283,7 +1283,6 @@ export class CounterStore {
     if (!resolvedRefs) {
       resolvedRefs = this.resolvedReferences[id] = [];
     }
-    let pushed = false;
     for (let i = 0; i < this.referencesToSolve.length;) {
       const ref = this.referencesToSolve[i];
       if (ref.targetId === id) {
@@ -1296,14 +1295,15 @@ export class CounterStore {
           }
         }
         resolvedRefs.push(ref);
-        pushed = true;
       } else {
         i++;
       }
     }
-    if (!pushed) {
-      this.saveReferenceOfCurrentPage(id, true);
-    }
+    // Record the reference at its current source page as well as resolving
+    // the old record. A rerender can move generated target-counter()/
+    // target-text() content to another page; finishPage replaces the old
+    // page's records with these newly observed references.
+    this.saveReferenceOfCurrentPage(id, true);
   }
 
   /**
@@ -1355,6 +1355,7 @@ export class CounterStore {
         this.pageIndicesById[id] = { spineIndex, pageIndex };
       });
     }
+    this.discardReferencesFromPage(spineIndex, pageIndex);
     const prevPageCounters = this.previousPageCounters;
     let ref: TargetCounterReference | undefined;
     while ((ref = this.newReferencesOfCurrentPage.shift())) {
@@ -1381,6 +1382,36 @@ export class CounterStore {
       this.recordNamedStringPageSnapshot(spineIndex);
     }
     this.currentPage = null;
+  }
+
+  private discardReferencesFromPage(
+    spineIndex: number,
+    pageIndex: number,
+  ): void {
+    const targetIds = new Set([
+      ...Object.keys(this.resolvedReferences),
+      ...Object.keys(this.unresolvedReferences),
+    ]);
+    for (const id of targetIds) {
+      const keepOtherPage = (ref: TargetCounterReference) =>
+        ref.spineIndex !== spineIndex || ref.pageIndex !== pageIndex;
+      const resolved = (this.resolvedReferences[id] || []).filter(
+        keepOtherPage,
+      );
+      const unresolved = (this.unresolvedReferences[id] || []).filter(
+        keepOtherPage,
+      );
+      if (resolved.length) {
+        this.resolvedReferences[id] = resolved;
+      } else {
+        delete this.resolvedReferences[id];
+      }
+      if (unresolved.length) {
+        this.unresolvedReferences[id] = unresolved;
+      } else {
+        delete this.unresolvedReferences[id];
+      }
+    }
   }
 
   /**

--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1437,6 +1437,13 @@ export class CounterStore {
     }
   }
 
+  isReferenceTracked(ref: TargetCounterReference): boolean {
+    return (
+      (this.resolvedReferences[ref.targetId] || []).includes(ref) ||
+      (this.unresolvedReferences[ref.targetId] || []).includes(ref)
+    );
+  }
+
   /**
    * Record a snapshot of the current page counters keyed by the page's element
    * offset range, so page-based counters in named strings (string-set) can be

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2915,6 +2915,34 @@ export class OPFView implements Vgen.CustomRendererFactory {
         firstInvalidSpine != null &&
         firstInvalidSpine <= position.spineIndex
       ) {
+        if (this.renderingAllPages) {
+          if (sync) {
+            frame.finish(null);
+            return;
+          }
+          // Full pagination owns the shared StyleInstance and will consume
+          // the suffix marker. Do not let navigation return a cached page
+          // from that invalid suffix while the rebuild is still pending.
+          frame
+            .loopWithFrame((loopFrame) => {
+              const pendingSpine = this.deferredFollowingSpineRelayoutStart;
+              if (
+                this.renderingAllPages &&
+                pendingSpine != null &&
+                pendingSpine <= position.spineIndex
+              ) {
+                frame.sleep(100).then(() => loopFrame.continueLoop());
+              } else {
+                loopFrame.breakLoop();
+              }
+            })
+            .then(() => {
+              this.findPage(position, sync).then((result) =>
+                frame.finish(result),
+              );
+            });
+          return;
+        }
         // A cached page in the invalid suffix must not bypass the deferred
         // rebuild. renderPage() consumes the marker before returning it.
         this.renderPage(position).then((result) => frame.finish(result));

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1619,10 +1619,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
   tocView?: Toc.TOCView;
   private deferredReferencePages: DeferredReferencePage[] = [];
   private resolvingDeferredReferences: boolean = false;
-  private drainingDeferredReferencePage: {
-    viewItem: OPFViewItem;
-    pageIndex: number;
-  } | null = null;
+  private processedDeferredReferencePages: Map<
+    OPFViewItem,
+    Set<number>
+  > | null = null;
   private deferredFollowingSpineRelayoutStart: number | null = null;
   private deferredPageReplacements = new Map<number, Vtree.Page[]>();
   private relayoutingFollowingSpines: boolean = false;
@@ -1649,6 +1649,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
       p4: number,
     ) => any,
     cmykReserveMap?: CmykStore.CmykReserveMapEntry[],
+    public readonly pageSheetSizeTruncator: (
+      pageCount: number,
+    ) => void = () => {},
   ) {
     this.pref = Exprs.clonePreferences(pref);
     this.clientLayout = new Vgen.DefaultClientLayout(viewport);
@@ -2209,7 +2212,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
           return;
         }
         const refs = unresolvedRefs[unresolvedRefIndex - 1];
-        refs.refs = refs.refs.filter((ref) => !ref.isResolved());
+        refs.refs = refs.refs.filter(
+          (ref) =>
+            !ref.isResolved() && this.counterStore.isReferenceTracked(ref),
+        );
         if (refs.refs.length === 0) {
           loopFrame.continueLoop();
           return;
@@ -2496,9 +2502,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
       "resolveDeferredReferencesAfterCounterScope",
     );
     this.resolvingDeferredReferences = true;
+    this.processedDeferredReferencePages = new Map();
     frame.handler = (handlerFrame, err) => {
       this.resolvingDeferredReferences = false;
-      this.drainingDeferredReferencePage = null;
+      this.processedDeferredReferencePages = null;
       handlerFrame.task.raise(err, handlerFrame.parent);
     };
     frame
@@ -2514,23 +2521,27 @@ export class OPFView implements Vgen.CustomRendererFactory {
           loopFrame.continueLoop();
           return;
         }
-        this.drainingDeferredReferencePage = {
-          viewItem: entry.viewItem,
-          pageIndex: entry.pageIndex,
-        };
+        let processedPageIndices = this.processedDeferredReferencePages!.get(
+          entry.viewItem,
+        );
+        if (!processedPageIndices) {
+          processedPageIndices = new Set();
+          this.processedDeferredReferencePages!.set(
+            entry.viewItem,
+            processedPageIndices,
+          );
+        }
+        processedPageIndices.add(entry.pageIndex);
         this.resolveUnresolvedReferencesForPage(
           entry.viewItem,
           currentPage,
           entry.pageIndex,
           entry.nextLayoutPosition,
-        ).then(() => {
-          this.drainingDeferredReferencePage = null;
-          loopFrame.continueLoop();
-        });
+        ).then(() => loopFrame.continueLoop());
       })
       .then(() => {
         this.resolvingDeferredReferences = false;
-        this.drainingDeferredReferencePage = null;
+        this.processedDeferredReferencePages = null;
         frame.finish(page);
       });
     return frame.result();
@@ -2551,10 +2562,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     // The deferred drain is the single retry allowed after the outermost
     // counter scope. Do not let the entry currently being retried enqueue
     // itself again; cascaded pages must still join the active queue.
-    if (
-      this.drainingDeferredReferencePage?.viewItem === viewItem &&
-      this.drainingDeferredReferencePage.pageIndex === pageIndex
-    ) {
+    if (this.processedDeferredReferencePages?.get(viewItem)?.has(pageIndex)) {
       return;
     }
     const latestPage = viewItem.pages?.[pageIndex] || page;
@@ -2602,6 +2610,28 @@ export class OPFView implements Vgen.CustomRendererFactory {
         this.deferredReferencePages.splice(deferredIndex, 1);
       }
     }
+  }
+
+  private updateEPageRangesAfterShrink(
+    viewItem: OPFViewItem,
+    finalLength: number,
+  ): void {
+    if (!this.opf.epageIsRenderedPage) {
+      return;
+    }
+    const spineIndex = viewItem.item.spineIndex;
+    viewItem.item.epageCount = finalLength;
+    let nextEPage = viewItem.item.epage + finalLength;
+    for (let index = spineIndex + 1; index < this.opf.spine.length; index++) {
+      const item = this.opf.spine[index];
+      item.epage = nextEPage;
+      nextEPage += item.epageCount;
+    }
+    this.opf.epageCount = this.opf.spine.reduce(
+      (count, item) => count + item.epageCount,
+      0,
+    );
+    this.opf.epageCountCallback?.(this.opf.epageCount);
   }
 
   private rememberDeferredPageReplacement(
@@ -2782,6 +2812,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
         // final page in the requested slot.
         const finalLength = pageIndexToRender + 1;
         const pageCountChanged = viewItem.pages.length > finalLength;
+        if (pageCountChanged) {
+          this.updateEPageRangesAfterShrink(viewItem, finalLength);
+          this.pageSheetSizeTruncator(
+            viewItem.instance.pageNumberOffset + finalLength,
+          );
+        }
         this.removeDeferredReferencePages(
           (entry) =>
             entry.viewItem === viewItem && entry.pageIndex >= finalLength,

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2814,9 +2814,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
         const pageCountChanged = viewItem.pages.length > finalLength;
         if (pageCountChanged) {
           this.updateEPageRangesAfterShrink(viewItem, finalLength);
-          this.pageSheetSizeTruncator(
-            viewItem.instance.pageNumberOffset + finalLength,
-          );
         }
         this.removeDeferredReferencePages(
           (entry) =>
@@ -3101,16 +3098,21 @@ export class OPFView implements Vgen.CustomRendererFactory {
                   frame.finish(requestedResult);
                 };
                 if (rerenderPosition === position) {
+                  this.pageSheetSizeTruncator(this.getRenderedPageCount());
                   finishRerender(rerenderedResult);
                 } else {
                   // Return the originally requested page after rebuilding the
                   // farthest invalidated spine and refreshing retained refs.
-                  this.renderPageTracked(position).then(finishRerender);
+                  this.renderPageTracked(position).then((requestedResult) => {
+                    this.pageSheetSizeTruncator(this.getRenderedPageCount());
+                    finishRerender(requestedResult);
+                  });
                 }
               },
             );
             return;
           }
+          this.pageSheetSizeTruncator(this.getRenderedPageCount());
           endRendering();
           frame.finish(result);
         });
@@ -3263,6 +3265,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             }
           })
           .then(() => {
+            this.pageSheetSizeTruncator(this.getRenderedPageCount());
             this.renderingAllPages = false;
             frame.finish(result);
           });

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1620,6 +1620,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
   private deferredReferencePages: DeferredReferencePage[] = [];
   private resolvingDeferredReferences: boolean = false;
   private deferredFollowingSpineRelayoutStart: number | null = null;
+  private deferredPageReplacements = new Map<number, Map<number, Vtree.Page>>();
   private relayoutingFollowingSpines: boolean = false;
   private renderingAllPages: boolean = false;
   private paginationProgress = {
@@ -1727,6 +1728,11 @@ export class OPFView implements Vgen.CustomRendererFactory {
       page.side as string,
     );
     const oldPage = viewItem.pages[pageIndex];
+    const deferredOldPage = this.takeDeferredPageReplacement(
+      viewItem.item.spineIndex,
+      pageIndex,
+    );
+    const replacedPage = oldPage || deferredOldPage;
     page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
     viewItem.pages[pageIndex] = page;
 
@@ -1751,13 +1757,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
         page.container,
         oldPage.container,
       );
-      oldPage.dispatchEvent({
-        type: "replaced",
-        target: null,
-        currentTarget: null,
-        preventDefault: null,
-        newPage: page,
-      });
     } else {
       // Find insert position in contentContainer.
       let insertPos: Element | null = null;
@@ -1780,6 +1779,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
         page.container,
         insertPos,
       );
+    }
+    if (replacedPage) {
+      replacedPage.dispatchEvent({
+        type: "replaced",
+        target: null,
+        currentTarget: null,
+        preventDefault: null,
+        newPage: page,
+      });
     }
     this.pageSheetSizeReporter(
       {
@@ -2568,6 +2576,47 @@ export class OPFView implements Vgen.CustomRendererFactory {
           );
   }
 
+  private rememberDeferredPageReplacement(
+    spineIndex: number,
+    pageIndex: number,
+    page: Vtree.Page,
+  ): void {
+    const replacements = (this.deferredPageReplacements ??= new Map());
+    let replacementsByPage = replacements.get(spineIndex);
+    if (!replacementsByPage) {
+      replacementsByPage = new Map();
+      replacements.set(spineIndex, replacementsByPage);
+    }
+    replacementsByPage.set(pageIndex, page);
+  }
+
+  private takeDeferredPageReplacement(
+    spineIndex: number,
+    pageIndex: number,
+  ): Vtree.Page | null {
+    const replacementsByPage = this.deferredPageReplacements?.get(spineIndex);
+    const page = replacementsByPage?.get(pageIndex) || null;
+    if (!page) {
+      return null;
+    }
+    replacementsByPage.delete(pageIndex);
+    if (replacementsByPage.size === 0) {
+      this.deferredPageReplacements.delete(spineIndex);
+    }
+    return page;
+  }
+
+  private updateRetainedTargetCounters(firstSpineIndex: number): void {
+    const pages: Vtree.Page[] = [];
+    for (let spineIndex = 0; spineIndex < firstSpineIndex; spineIndex++) {
+      const viewItem = this.spineItems[spineIndex];
+      if (viewItem) {
+        pages.push(...viewItem.pages);
+      }
+    }
+    this.counterStore.updateTargetCounterNodesInPages(pages);
+  }
+
   private relayoutDeferredFollowingSpines(): void {
     const firstSpine = this.deferredFollowingSpineRelayoutStart;
     if (firstSpine == null) {
@@ -2587,7 +2636,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
       if (!viewItem) {
         continue;
       }
-      viewItem.pages.forEach((renderedPage) => {
+      viewItem.pages.forEach((renderedPage, pageIndex) => {
+        this.rememberDeferredPageReplacement(
+          spineIndex,
+          pageIndex,
+          renderedPage,
+        );
         renderedPage.container.remove();
       });
       this.spineItems[spineIndex] = null;
@@ -2866,6 +2920,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             this.relayoutDeferredFollowingSpines();
             this.relayoutingFollowingSpines = true;
             this.renderPagesUpto(position, false).then((rerenderedResult) => {
+              this.updateRetainedTargetCounters(firstSpine);
               this.relayoutingFollowingSpines = false;
               endRendering();
               frame.finish(rerenderedResult);
@@ -3028,13 +3083,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
             frame.finish(result);
           });
       };
-      if (this.deferredFollowingSpineRelayoutStart == null) {
+      const firstSpine = this.deferredFollowingSpineRelayoutStart;
+      if (firstSpine == null) {
         finishAfterImages();
         return;
       }
       this.relayoutDeferredFollowingSpines();
       this.relayoutingFollowingSpines = true;
       this.renderPagesUpto(finalPosition, false).then((rerenderedResult) => {
+        this.updateRetainedTargetCounters(firstSpine);
         this.relayoutingFollowingSpines = false;
         result = rerenderedResult;
         finishAfterImages();

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2589,6 +2589,21 @@ export class OPFView implements Vgen.CustomRendererFactory {
           );
   }
 
+  private removeDeferredReferencePages(
+    shouldRemove: (entry: DeferredReferencePage) => boolean,
+  ): void {
+    // Keep the queue object stable because an active drain holds this array.
+    for (
+      let deferredIndex = this.deferredReferencePages.length - 1;
+      deferredIndex >= 0;
+      deferredIndex--
+    ) {
+      if (shouldRemove(this.deferredReferencePages[deferredIndex])) {
+        this.deferredReferencePages.splice(deferredIndex, 1);
+      }
+    }
+  }
+
   private rememberDeferredPageReplacement(
     spineIndex: number,
     page: Vtree.Page,
@@ -2687,8 +2702,8 @@ export class OPFView implements Vgen.CustomRendererFactory {
       return null;
     }
     this.deferredFollowingSpineRelayoutStart = null;
-    this.deferredReferencePages = this.deferredReferencePages.filter(
-      (entry) => entry.viewItem.item.spineIndex < firstSpine,
+    this.removeDeferredReferencePages(
+      (entry) => entry.viewItem.item.spineIndex >= firstSpine,
     );
     this.counterStore.discardReferencesFromSpine(firstSpine);
     let lastInvalidatedSpine: number | null = null;
@@ -2765,16 +2780,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
         // final page in the requested slot.
         const finalLength = pageIndexToRender + 1;
         const pageCountChanged = viewItem.pages.length > finalLength;
-        for (
-          let deferredIndex = this.deferredReferencePages.length - 1;
-          deferredIndex >= 0;
-          deferredIndex--
-        ) {
-          const entry = this.deferredReferencePages[deferredIndex];
-          if (entry.viewItem === viewItem && entry.pageIndex >= finalLength) {
-            this.deferredReferencePages.splice(deferredIndex, 1);
-          }
-        }
+        this.removeDeferredReferencePages(
+          (entry) =>
+            entry.viewItem === viewItem && entry.pageIndex >= finalLength,
+        );
         for (
           let stalePageIndex = finalLength;
           stalePageIndex < viewItem.pages.length;

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1619,6 +1619,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
   tocView?: Toc.TOCView;
   private deferredReferencePages: DeferredReferencePage[] = [];
   private resolvingDeferredReferences: boolean = false;
+  private drainingDeferredReferencePage: {
+    viewItem: OPFViewItem;
+    pageIndex: number;
+  } | null = null;
   private deferredFollowingSpineRelayoutStart: number | null = null;
   private deferredPageReplacements = new Map<number, Vtree.Page[]>();
   private relayoutingFollowingSpines: boolean = false;
@@ -2494,6 +2498,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.resolvingDeferredReferences = true;
     frame.handler = (handlerFrame, err) => {
       this.resolvingDeferredReferences = false;
+      this.drainingDeferredReferencePage = null;
       handlerFrame.task.raise(err, handlerFrame.parent);
     };
     frame
@@ -2509,15 +2514,23 @@ export class OPFView implements Vgen.CustomRendererFactory {
           loopFrame.continueLoop();
           return;
         }
+        this.drainingDeferredReferencePage = {
+          viewItem: entry.viewItem,
+          pageIndex: entry.pageIndex,
+        };
         this.resolveUnresolvedReferencesForPage(
           entry.viewItem,
           currentPage,
           entry.pageIndex,
           entry.nextLayoutPosition,
-        ).then(() => loopFrame.continueLoop());
+        ).then(() => {
+          this.drainingDeferredReferencePage = null;
+          loopFrame.continueLoop();
+        });
       })
       .then(() => {
         this.resolvingDeferredReferences = false;
+        this.drainingDeferredReferencePage = null;
         frame.finish(page);
       });
     return frame.result();
@@ -2536,9 +2549,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
     nextLayoutPosition: Vtree.LayoutPosition | null,
   ): void {
     // The deferred drain is the single retry allowed after the outermost
-    // counter scope. Do not let that retry enqueue itself again; doing so
-    // bypasses the #1686 recursion guard and creates an infinite loop.
-    if (this.resolvingDeferredReferences) {
+    // counter scope. Do not let the entry currently being retried enqueue
+    // itself again; cascaded pages must still join the active queue.
+    if (
+      this.drainingDeferredReferencePage?.viewItem === viewItem &&
+      this.drainingDeferredReferencePage.pageIndex === pageIndex
+    ) {
       return;
     }
     const latestPage = viewItem.pages?.[pageIndex] || page;
@@ -2630,19 +2646,20 @@ export class OPFView implements Vgen.CustomRendererFactory {
     }
     const newPages = viewItem.pages;
     for (const oldPage of oldPages) {
-      const sameKindPages = newPages.filter(
-        (page) => !!page.isBlankPage === !!oldPage.isBlankPage,
-      );
-      const candidates = sameKindPages.length ? sameKindPages : newPages;
-      const replacement = candidates.reduce<Vtree.Page | null>(
+      const replacement = newPages.reduce<Vtree.Page | null>(
         (closest, page) => {
           if (!closest) {
             return page;
           }
-          return Math.abs(page.offset - oldPage.offset) <
-            Math.abs(closest.offset - oldPage.offset)
-            ? page
-            : closest;
+          const distance = Math.abs(page.offset - oldPage.offset);
+          const closestDistance = Math.abs(closest.offset - oldPage.offset);
+          if (distance !== closestDistance) {
+            return distance < closestDistance ? page : closest;
+          }
+          const sameKind = !!page.isBlankPage === !!oldPage.isBlankPage;
+          const closestSameKind =
+            !!closest.isBlankPage === !!oldPage.isBlankPage;
+          return sameKind && !closestSameKind ? page : closest;
         },
         null,
       );
@@ -2748,6 +2765,16 @@ export class OPFView implements Vgen.CustomRendererFactory {
         // final page in the requested slot.
         const finalLength = pageIndexToRender + 1;
         const pageCountChanged = viewItem.pages.length > finalLength;
+        for (
+          let deferredIndex = this.deferredReferencePages.length - 1;
+          deferredIndex >= 0;
+          deferredIndex--
+        ) {
+          const entry = this.deferredReferencePages[deferredIndex];
+          if (entry.viewItem === viewItem && entry.pageIndex >= finalLength) {
+            this.deferredReferencePages.splice(deferredIndex, 1);
+          }
+        }
         for (
           let stalePageIndex = finalLength;
           stalePageIndex < viewItem.pages.length;

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2614,7 +2614,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
       pages = [];
       replacements.set(spineIndex, pages);
     }
-    pages.push(page);
+    if (!pages.includes(page)) {
+      pages.push(page);
+    }
   }
 
   private takeDeferredPageReplacement(
@@ -2794,9 +2796,13 @@ export class OPFView implements Vgen.CustomRendererFactory {
             stalePageIndex,
           );
         }
-        viewItem.pages
-          .slice(finalLength)
-          .forEach((stalePage) => stalePage.container.remove());
+        viewItem.pages.slice(finalLength).forEach((stalePage) => {
+          this.rememberDeferredPageReplacement(
+            viewItem.item.spineIndex,
+            stalePage,
+          );
+          stalePage.container.remove();
+        });
         viewItem.pages.splice(finalLength);
         viewItem.layoutPositions.splice(finalLength);
         viewItem.pageCounterStarts.splice(finalLength);

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1626,6 +1626,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
   private deferredFollowingSpineRelayoutStart: number | null = null;
   private deferredPageReplacements = new Map<number, Vtree.Page[]>();
   private relayoutingFollowingSpines: boolean = false;
+  private relayoutingFollowingSpineStart: number | null = null;
   private renderingAllPages: boolean = false;
   private paginationProgress = {
     totalOffsetsBySpine: [] as number[],
@@ -2954,53 +2955,41 @@ export class OPFView implements Vgen.CustomRendererFactory {
     sync: boolean,
   ): Task.Result<PageAndPosition | null> {
     const frame: Task.Frame<PageAndPosition | null> = Task.newFrame("findPage");
+    const waitForSuffixRelayout = (): void => {
+      if (sync) {
+        frame.finish(null);
+        return;
+      }
+      frame.sleep(100).then(() => {
+        this.findPage(position, sync).then((result) => frame.finish(result));
+      });
+    };
 
     this.waitForPreviousSpines(position.spineIndex, sync).then(() => {
+      const relayoutingSpine = this.relayoutingFollowingSpineStart;
+      if (relayoutingSpine != null && relayoutingSpine <= position.spineIndex) {
+        // relayoutDeferredFollowingSpines clears the pending marker before it
+        // rebuilds the suffix. Keep navigation behind the in-progress boundary
+        // so it cannot observe or concurrently lay out the partial suffix.
+        waitForSuffixRelayout();
+        return;
+      }
       const firstInvalidSpine = this.deferredFollowingSpineRelayoutStart;
       if (
         firstInvalidSpine != null &&
         firstInvalidSpine <= position.spineIndex
       ) {
         if (this.renderingAllPages) {
-          if (sync) {
-            frame.finish(null);
-            return;
-          }
           // Full pagination owns the shared StyleInstance and will consume
           // the suffix marker. Do not let navigation return a cached page
           // from that invalid suffix while the rebuild is still pending.
-          frame
-            .loopWithFrame((loopFrame) => {
-              const pendingSpine = this.deferredFollowingSpineRelayoutStart;
-              if (
-                this.renderingAllPages &&
-                pendingSpine != null &&
-                pendingSpine <= position.spineIndex
-              ) {
-                frame.sleep(100).then(() => loopFrame.continueLoop());
-              } else {
-                loopFrame.breakLoop();
-              }
-            })
-            .then(() => {
-              this.findPage(position, sync).then((result) =>
-                frame.finish(result),
-              );
-            });
+          waitForSuffixRelayout();
           return;
         }
         if (this.isRenderingPageInAnotherTask()) {
-          if (sync) {
-            frame.finish(null);
-            return;
-          }
           // Another navigation task is already rebuilding the invalid suffix.
           // Retry after it has released the shared layout and counter state.
-          frame.sleep(100).then(() => {
-            this.findPage(position, sync).then((result) =>
-              frame.finish(result),
-            );
-          });
+          waitForSuffixRelayout();
           return;
         }
         // A cached page in the invalid suffix must not bypass the deferred
@@ -3103,6 +3092,8 @@ export class OPFView implements Vgen.CustomRendererFactory {
             // In on-demand pagination there is no final renderAllPages pass.
             // Rebuild the invalid suffix only after the current page render
             // has unwound, and suppress nested requests while doing so.
+            this.relayoutingFollowingSpines = true;
+            this.relayoutingFollowingSpineStart = firstSpine;
             const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
             const rerenderPosition =
               lastInvalidatedSpine != null &&
@@ -3113,7 +3104,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
                     offsetInItem: -1,
                   }
                 : position;
-            this.relayoutingFollowingSpines = true;
             this.renderPagesUpto(rerenderPosition, false).then(
               (rerenderedResult) => {
                 this.updateRetainedTargetCounters();
@@ -3121,6 +3111,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
                   requestedResult: PageAndPosition | null,
                 ): void => {
                   this.relayoutingFollowingSpines = false;
+                  this.relayoutingFollowingSpineStart = null;
                   endRendering();
                   frame.finish(requestedResult);
                 };
@@ -3148,6 +3139,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       },
       (frame, err) => {
         this.relayoutingFollowingSpines = false;
+        this.relayoutingFollowingSpineStart = null;
         endRendering();
         frame.task.raise(err, frame.parent);
       },
@@ -3270,6 +3262,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.renderingAllPages = true;
     frame.handler = (handlerFrame, err) => {
       this.relayoutingFollowingSpines = false;
+      this.relayoutingFollowingSpineStart = null;
       this.renderingAllPages = false;
       handlerFrame.task.raise(err, handlerFrame.parent);
     };
@@ -3304,11 +3297,13 @@ export class OPFView implements Vgen.CustomRendererFactory {
         finishAfterImages();
         return;
       }
-      this.relayoutDeferredFollowingSpines();
       this.relayoutingFollowingSpines = true;
+      this.relayoutingFollowingSpineStart = firstSpine;
+      this.relayoutDeferredFollowingSpines();
       this.renderPagesUpto(finalPosition, false).then((rerenderedResult) => {
         this.updateRetainedTargetCounters();
         this.relayoutingFollowingSpines = false;
+        this.relayoutingFollowingSpineStart = null;
         result = rerenderedResult;
         finishAfterImages();
       });

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2648,6 +2648,16 @@ export class OPFView implements Vgen.CustomRendererFactory {
         // final page in the requested slot.
         const finalLength = pageIndexToRender + 1;
         const pageCountChanged = viewItem.pages.length > finalLength;
+        for (
+          let stalePageIndex = finalLength;
+          stalePageIndex < viewItem.pages.length;
+          stalePageIndex++
+        ) {
+          this.counterStore.discardReferencesFromPage(
+            viewItem.item.spineIndex,
+            stalePageIndex,
+          );
+        }
         viewItem.pages
           .slice(finalLength)
           .forEach((stalePage) => stalePage.container.remove());

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1600,6 +1600,13 @@ export type OPFViewItem = {
   pageCounterStarts: CssCascade.CounterValues[];
 };
 
+type DeferredReferencePage = {
+  viewItem: OPFViewItem;
+  page: Vtree.Page;
+  pageIndex: number;
+  nextLayoutPosition: Vtree.LayoutPosition | null;
+};
+
 export class OPFView implements Vgen.CustomRendererFactory {
   spineItems: (OPFViewItem | null)[] = [];
   spineItemLoadingContinuations: (Task.Continuation<any>[] | null)[] = [];
@@ -1610,6 +1617,11 @@ export class OPFView implements Vgen.CustomRendererFactory {
   tocAutohide: boolean = false;
   tocVisible: boolean = false;
   tocView?: Toc.TOCView;
+  private deferredReferencePages: DeferredReferencePage[] = [];
+  private resolvingDeferredReferences: boolean = false;
+  private deferredFollowingSpineRelayoutStart: number | null = null;
+  private relayoutingFollowingSpines: boolean = false;
+  private renderingAllPages: boolean = false;
   private paginationProgress = {
     totalOffsetsBySpine: [] as number[],
     renderedOffsetsBySpine: [] as number[],
@@ -2162,6 +2174,18 @@ export class OPFView implements Vgen.CustomRendererFactory {
     // target pages are rendered in the normal (non-cascade) flow.
     // (fix for issue #1686)
     const inCounterResolveScope = this.isInCounterResolveScope();
+    if (inCounterResolveScope) {
+      // A cascaded page can invalidate references even when it is not the
+      // page that started the current counter-resolution scope. Remember the
+      // actual page at the point where #1686 defers it, so the outermost pop
+      // can revisit it later.
+      this.deferReferencesForPage(
+        viewItem,
+        page,
+        pageIndex,
+        nextLayoutPosition,
+      );
+    }
     const unresolvedRefs = inCounterResolveScope
       ? []
       : this.counterStore.getUnresolvedRefsToPage(page);
@@ -2279,6 +2303,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
             );
             this.counterStore.popPageCounters();
             this.counterStore.popReferencesToSolve();
+            const continueLoopAfterDeferredReferences = () => {
+              const rerenderedTargetPage = result.pageAndPosition.page;
+              this.resolveDeferredReferencesAfterCounterScope(
+                targetViewItem,
+                rerenderedTargetPage,
+                result.pageAndPosition.position.pageIndex,
+                result.nextLayoutPosition,
+              ).then(() => loopFrame.continueLoop());
+            };
             if (
               result.pageAndPosition.position.spineIndex ===
                 currentPage.spineIndex &&
@@ -2388,7 +2421,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
                     this.counterStore.currentPageCounters =
                       savedCountersBeforePending;
                   }
-                  loopFrame.continueLoop();
+                  continueLoopAfterDeferredReferences();
                 },
               );
               return;
@@ -2400,7 +2433,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             if (isCrossSpine) {
               this.markSpineItemCompleteIfReady(targetViewItem);
             }
-            loopFrame.continueLoop();
+            continueLoopAfterDeferredReferences();
           });
         });
       })
@@ -2428,6 +2461,133 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return frame.result();
   }
 
+  private resolveDeferredReferencesAfterCounterScope(
+    viewItem: OPFViewItem,
+    page: Vtree.Page,
+    pageIndex: number,
+    nextLayoutPosition: Vtree.LayoutPosition | null,
+  ): Task.Result<Vtree.Page> {
+    // A target page may be rerendered several scopes deep. Processing its
+    // newly invalidated references immediately after the innermost pop still
+    // hits the #1686 recursion guard because an outer counter scope remains.
+    // Keep the page until the outermost scope is restored, then drain all
+    // deferred pages in order.
+    this.deferReferencesForPage(viewItem, page, pageIndex, nextLayoutPosition);
+    const deferredReferencePages = (this.deferredReferencePages ??= []);
+
+    if (
+      this.isInCounterResolveScope() ||
+      this.resolvingDeferredReferences ||
+      deferredReferencePages.length === 0
+    ) {
+      return Task.newResult(page);
+    }
+
+    const frame: Task.Frame<Vtree.Page> = Task.newFrame(
+      "resolveDeferredReferencesAfterCounterScope",
+    );
+    this.resolvingDeferredReferences = true;
+    frame.handler = (handlerFrame, err) => {
+      this.resolvingDeferredReferences = false;
+      handlerFrame.task.raise(err, handlerFrame.parent);
+    };
+    frame
+      .loopWithFrame((loopFrame) => {
+        const entry = deferredReferencePages.shift();
+        if (!entry) {
+          loopFrame.breakLoop();
+          return;
+        }
+        const currentPage =
+          entry.viewItem.pages?.[entry.pageIndex] || entry.page;
+        if (!this.hasUnresolvedReferencesToPage(currentPage)) {
+          loopFrame.continueLoop();
+          return;
+        }
+        this.resolveUnresolvedReferencesForPage(
+          entry.viewItem,
+          currentPage,
+          entry.pageIndex,
+          entry.nextLayoutPosition,
+        ).then(() => loopFrame.continueLoop());
+      })
+      .then(() => {
+        this.resolvingDeferredReferences = false;
+        frame.finish(page);
+      });
+    return frame.result();
+  }
+
+  private hasUnresolvedReferencesToPage(page: Vtree.Page): boolean {
+    return this.counterStore
+      .getUnresolvedRefsToPage(page)
+      .some((group) => group.refs.some((ref) => !ref.isResolved()));
+  }
+
+  private deferReferencesForPage(
+    viewItem: OPFViewItem,
+    page: Vtree.Page,
+    pageIndex: number,
+    nextLayoutPosition: Vtree.LayoutPosition | null,
+  ): void {
+    const latestPage = viewItem.pages?.[pageIndex] || page;
+    if (!this.hasUnresolvedReferencesToPage(latestPage)) {
+      return;
+    }
+    const deferredReferencePages = (this.deferredReferencePages ??= []);
+    const queued = deferredReferencePages.find(
+      (entry) => entry.viewItem === viewItem && entry.pageIndex === pageIndex,
+    );
+    if (queued) {
+      queued.page = latestPage;
+      queued.nextLayoutPosition = nextLayoutPosition;
+    } else {
+      deferredReferencePages.push({
+        viewItem,
+        page: latestPage,
+        pageIndex,
+        nextLayoutPosition,
+      });
+    }
+  }
+
+  private deferFollowingSpinesForRelayout(spineIndex: number): void {
+    const firstFollowingSpine = spineIndex + 1;
+    this.deferredFollowingSpineRelayoutStart =
+      this.deferredFollowingSpineRelayoutStart == null
+        ? firstFollowingSpine
+        : Math.min(
+            this.deferredFollowingSpineRelayoutStart,
+            firstFollowingSpine,
+          );
+  }
+
+  private relayoutDeferredFollowingSpines(): void {
+    const firstSpine = this.deferredFollowingSpineRelayoutStart;
+    if (firstSpine == null) {
+      return;
+    }
+    this.deferredFollowingSpineRelayoutStart = null;
+    this.deferredReferencePages = (this.deferredReferencePages || []).filter(
+      (entry) => entry.viewItem.item.spineIndex < firstSpine,
+    );
+    this.counterStore.discardReferencesFromSpine(firstSpine);
+    for (
+      let spineIndex = firstSpine;
+      spineIndex < this.spineItems.length;
+      spineIndex++
+    ) {
+      const viewItem = this.spineItems[spineIndex];
+      if (!viewItem) {
+        continue;
+      }
+      viewItem.pages.forEach((renderedPage) => {
+        renderedPage.container.remove();
+      });
+      this.spineItems[spineIndex] = null;
+      this.spineItemLoadingContinuations[spineIndex] = null;
+    }
+  }
   /**
    * Render a single page. If the new page contains elements with ids that are
    * referenced from other pages by 'target-counter()', those pages are rendered
@@ -2476,9 +2636,23 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
     viewItem.instance.layoutNextPage(page, pos).then((posParam) => {
       pos = posParam;
-      const pageIndex = pos
-        ? pos.page - 1
-        : viewItem.layoutPositions.length - 1;
+      if (!pos) {
+        // A rerender can make the final page move to an earlier slot. Remove
+        // stale following pages and their saved starts before storing the new
+        // final page in the requested slot.
+        const finalLength = pageIndexToRender + 1;
+        const pageCountChanged = viewItem.pages.length > finalLength;
+        viewItem.pages
+          .slice(finalLength)
+          .forEach((stalePage) => stalePage.container.remove());
+        viewItem.pages.splice(finalLength);
+        viewItem.layoutPositions.splice(finalLength);
+        viewItem.pageCounterStarts.splice(finalLength);
+        if (pageCountChanged && !this.relayoutingFollowingSpines) {
+          this.deferFollowingSpinesForRelayout(viewItem.item.spineIndex);
+        }
+      }
+      const pageIndex = pos ? pos.page - 1 : pageIndexToRender;
       this.finishPageContainer(viewItem, page, pageIndex);
       this.counterStore.finishPage(page.spineIndex, pageIndex);
 
@@ -2657,11 +2831,31 @@ export class OPFView implements Vgen.CustomRendererFactory {
       "renderPage",
       (frame) => {
         this.renderPageTracked(position).then((result) => {
+          const firstSpine = this.deferredFollowingSpineRelayoutStart;
+          if (
+            !this.renderingAllPages &&
+            !this.relayoutingFollowingSpines &&
+            firstSpine != null &&
+            firstSpine <= position.spineIndex
+          ) {
+            // In on-demand pagination there is no final renderAllPages pass.
+            // Rebuild the invalid suffix only after the current page render
+            // has unwound, and suppress nested requests while doing so.
+            this.relayoutDeferredFollowingSpines();
+            this.relayoutingFollowingSpines = true;
+            this.renderPagesUpto(position, false).then((rerenderedResult) => {
+              this.relayoutingFollowingSpines = false;
+              endRendering();
+              frame.finish(rerenderedResult);
+            });
+            return;
+          }
           endRendering();
           frame.finish(result);
         });
       },
       (frame, err) => {
+        this.relayoutingFollowingSpines = false;
         endRendering();
         frame.task.raise(err, frame.parent);
       },
@@ -2775,34 +2969,54 @@ export class OPFView implements Vgen.CustomRendererFactory {
   renderAllPages(): Task.Result<PageAndPosition | null> {
     const frame: Task.Frame<PageAndPosition | null> =
       Task.newFrame("renderAllPages");
-    this.renderPagesUpto(
-      {
-        spineIndex: this.opf.spine.length - 1,
-        pageIndex: Number.POSITIVE_INFINITY,
-        offsetInItem: -1,
-      },
-      false,
-    ).then((result) => {
-      // Wait until all images are loaded (Issue #1321)
-      frame
-        .loopWithFrame((loopFrame) => {
-          if (
-            this.spineItems.some((viewItem) =>
-              viewItem?.pages.some((page) =>
-                page?.fetchers.some((fetcher) => !fetcher.arrived),
-              ),
-            )
-          ) {
-            frame.sleep(100).then(() => {
-              loopFrame.continueLoop();
-            });
-          } else {
-            loopFrame.breakLoop();
-          }
-        })
-        .then(() => {
-          frame.finish(result);
-        });
+    const finalPosition = {
+      spineIndex: this.opf.spine.length - 1,
+      pageIndex: Number.POSITIVE_INFINITY,
+      offsetInItem: -1,
+    };
+    let result: PageAndPosition | null = null;
+    this.renderingAllPages = true;
+    frame.handler = (handlerFrame, err) => {
+      this.relayoutingFollowingSpines = false;
+      this.renderingAllPages = false;
+      handlerFrame.task.raise(err, handlerFrame.parent);
+    };
+    this.renderPagesUpto(finalPosition, false).then((initialResult) => {
+      result = initialResult;
+      const finishAfterImages = () => {
+        // Wait until all images are loaded (Issue #1321)
+        frame
+          .loopWithFrame((loopFrame) => {
+            if (
+              this.spineItems.some((viewItem) =>
+                viewItem?.pages.some((page) =>
+                  page?.fetchers.some((fetcher) => !fetcher.arrived),
+                ),
+              )
+            ) {
+              frame.sleep(100).then(() => {
+                loopFrame.continueLoop();
+              });
+            } else {
+              loopFrame.breakLoop();
+            }
+          })
+          .then(() => {
+            this.renderingAllPages = false;
+            frame.finish(result);
+          });
+      };
+      if (this.deferredFollowingSpineRelayoutStart == null) {
+        finishAfterImages();
+        return;
+      }
+      this.relayoutDeferredFollowingSpines();
+      this.relayoutingFollowingSpines = true;
+      this.renderPagesUpto(finalPosition, false).then((rerenderedResult) => {
+        this.relayoutingFollowingSpines = false;
+        result = rerenderedResult;
+        finishAfterImages();
+      });
     });
     return frame.result();
   }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1620,7 +1620,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
   private deferredReferencePages: DeferredReferencePage[] = [];
   private resolvingDeferredReferences: boolean = false;
   private deferredFollowingSpineRelayoutStart: number | null = null;
-  private deferredPageReplacements = new Map<number, Map<number, Vtree.Page>>();
+  private deferredPageReplacements = new Map<number, Vtree.Page[]>();
   private relayoutingFollowingSpines: boolean = false;
   private renderingAllPages: boolean = false;
   private paginationProgress = {
@@ -1730,7 +1730,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const oldPage = viewItem.pages[pageIndex];
     const deferredOldPage = this.takeDeferredPageReplacement(
       viewItem.item.spineIndex,
-      pageIndex,
+      page,
     );
     const replacedPage = oldPage || deferredOldPage;
     page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
@@ -1781,13 +1781,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       );
     }
     if (replacedPage) {
-      replacedPage.dispatchEvent({
-        type: "replaced",
-        target: null,
-        currentTarget: null,
-        preventDefault: null,
-        newPage: page,
-      });
+      this.dispatchPageReplacement(replacedPage, page);
     }
     this.pageSheetSizeReporter(
       {
@@ -1822,6 +1816,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       viewItem.layoutPositions.length === viewItem.pages.length;
     if (viewItem.complete) {
       viewItem.instance.viewport.layoutBox.removeAttribute("style");
+      this.flushDeferredPageReplacements(viewItem);
     }
   }
 
@@ -2578,32 +2573,82 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
   private rememberDeferredPageReplacement(
     spineIndex: number,
-    pageIndex: number,
     page: Vtree.Page,
   ): void {
     const replacements = (this.deferredPageReplacements ??= new Map());
-    let replacementsByPage = replacements.get(spineIndex);
-    if (!replacementsByPage) {
-      replacementsByPage = new Map();
-      replacements.set(spineIndex, replacementsByPage);
+    let pages = replacements.get(spineIndex);
+    if (!pages) {
+      pages = [];
+      replacements.set(spineIndex, pages);
     }
-    replacementsByPage.set(pageIndex, page);
+    pages.push(page);
   }
 
   private takeDeferredPageReplacement(
     spineIndex: number,
-    pageIndex: number,
+    newPage: Vtree.Page,
   ): Vtree.Page | null {
-    const replacementsByPage = this.deferredPageReplacements?.get(spineIndex);
-    const page = replacementsByPage?.get(pageIndex) || null;
-    if (!page) {
+    const pages = this.deferredPageReplacements?.get(spineIndex);
+    if (!pages) {
       return null;
     }
-    replacementsByPage.delete(pageIndex);
-    if (replacementsByPage.size === 0) {
+    const pageIndex = pages.findIndex(
+      (page) =>
+        page.offset === newPage.offset &&
+        !!page.isBlankPage === !!newPage.isBlankPage,
+    );
+    if (pageIndex < 0) {
+      return null;
+    }
+    const [page] = pages.splice(pageIndex, 1);
+    if (pages.length === 0) {
       this.deferredPageReplacements.delete(spineIndex);
     }
     return page;
+  }
+
+  private dispatchPageReplacement(
+    oldPage: Vtree.Page,
+    newPage: Vtree.Page,
+  ): void {
+    oldPage.dispatchEvent({
+      type: "replaced",
+      target: null,
+      currentTarget: null,
+      preventDefault: null,
+      newPage,
+    });
+  }
+
+  private flushDeferredPageReplacements(viewItem: OPFViewItem): void {
+    const spineIndex = viewItem.item.spineIndex;
+    const oldPages = this.deferredPageReplacements?.get(spineIndex);
+    if (!oldPages) {
+      return;
+    }
+    const newPages = viewItem.pages;
+    for (const oldPage of oldPages) {
+      const sameKindPages = newPages.filter(
+        (page) => !!page.isBlankPage === !!oldPage.isBlankPage,
+      );
+      const candidates = sameKindPages.length ? sameKindPages : newPages;
+      const replacement = candidates.reduce<Vtree.Page | null>(
+        (closest, page) => {
+          if (!closest) {
+            return page;
+          }
+          return Math.abs(page.offset - oldPage.offset) <
+            Math.abs(closest.offset - oldPage.offset)
+            ? page
+            : closest;
+        },
+        null,
+      );
+      if (replacement) {
+        this.dispatchPageReplacement(oldPage, replacement);
+      }
+    }
+    this.deferredPageReplacements.delete(spineIndex);
   }
 
   private updateRetainedTargetCounters(firstSpineIndex: number): void {
@@ -2615,6 +2660,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       }
     }
     this.counterStore.updateTargetCounterNodesInPages(pages);
+    this.counterStore.updateTargetTextNodesInPages(pages);
   }
 
   private relayoutDeferredFollowingSpines(): void {
@@ -2636,12 +2682,8 @@ export class OPFView implements Vgen.CustomRendererFactory {
       if (!viewItem) {
         continue;
       }
-      viewItem.pages.forEach((renderedPage, pageIndex) => {
-        this.rememberDeferredPageReplacement(
-          spineIndex,
-          pageIndex,
-          renderedPage,
-        );
+      viewItem.pages.forEach((renderedPage) => {
+        this.rememberDeferredPageReplacement(spineIndex, renderedPage);
         renderedPage.container.remove();
       });
       this.spineItems[spineIndex] = null;

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2989,6 +2989,20 @@ export class OPFView implements Vgen.CustomRendererFactory {
             });
           return;
         }
+        if (this.isRenderingPageInAnotherTask()) {
+          if (sync) {
+            frame.finish(null);
+            return;
+          }
+          // Another navigation task is already rebuilding the invalid suffix.
+          // Retry after it has released the shared layout and counter state.
+          frame.sleep(100).then(() => {
+            this.findPage(position, sync).then((result) =>
+              frame.finish(result),
+            );
+          });
+          return;
+        }
         // A cached page in the invalid suffix must not bypass the deferred
         // rebuild. renderPage() consumes the marker before returning it.
         this.renderPage(position).then((result) => frame.finish(result));

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2731,33 +2731,68 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.deferredPageReplacements.delete(spineIndex);
   }
 
-  private updateRetainedTargetCounters(): number | null {
+  private updateRetainedTargetCounters(): Set<string> {
     const pages: Vtree.Page[] = [];
     for (const viewItem of this.spineItems) {
       if (viewItem) {
         pages.push(...viewItem.pages);
       }
     }
-    const changedPages = new Set<Vtree.Page>([
-      ...(this.counterStore.updateTargetCounterNodesInPages(pages) || []),
-      ...(this.counterStore.updateTargetTextNodesInPages(pages) || []),
-    ]);
-    let firstChangedSpine: number | null = null;
-    for (const viewItem of this.spineItems) {
-      if (
-        viewItem?.pages.some((page) => changedPages.has(page)) &&
-        (firstChangedSpine == null ||
-          viewItem.item.spineIndex < firstChangedSpine)
-      ) {
-        firstChangedSpine = viewItem.item.spineIndex;
-      }
-    }
-    return firstChangedSpine;
+    const changedTargetIds = new Set<string>();
+    this.counterStore.updateTargetCounterNodesInPages(pages, changedTargetIds);
+    this.counterStore.updateTargetTextNodesInPages(pages, changedTargetIds);
+    this.counterStore.unresolveReferencesForTargets(changedTargetIds);
+    return changedTargetIds;
   }
 
-  private relayoutDeferredFollowingSpines(
-    preserveTargetSnapshots: boolean = false,
-  ): number | null {
+  private resolveChangedRetainedTargetReferences(
+    targetIds: Set<string>,
+  ): Task.Result<any> {
+    const targetPages = new Map<
+      string,
+      {
+        viewItem: OPFViewItem;
+        page: Vtree.Page;
+        pageIndex: number;
+        nextLayoutPosition: Vtree.LayoutPosition | null;
+      }
+    >();
+    for (const id of targetIds) {
+      const position = this.counterStore.pageIndicesById[id];
+      if (!position) continue;
+      const viewItem = this.spineItems[position.spineIndex];
+      const page = viewItem?.pages[position.pageIndex];
+      if (!viewItem || !page) continue;
+      const key = `${position.spineIndex}:${position.pageIndex}`;
+      targetPages.set(key, {
+        viewItem,
+        page,
+        pageIndex: position.pageIndex,
+        nextLayoutPosition:
+          viewItem.layoutPositions[position.pageIndex + 1] || null,
+      });
+    }
+    const pages = Array.from(targetPages.values());
+    for (const target of pages) {
+      this.deferReferencesForPage(
+        target.viewItem,
+        target.page,
+        target.pageIndex,
+        target.nextLayoutPosition,
+      );
+    }
+    const first = pages[0];
+    return first
+      ? this.resolveDeferredReferencesAfterCounterScope(
+          first.viewItem,
+          first.page,
+          first.pageIndex,
+          first.nextLayoutPosition,
+        )
+      : Task.newResult(true);
+  }
+
+  private relayoutDeferredFollowingSpines(): number | null {
     const firstSpine = this.deferredFollowingSpineRelayoutStart;
     if (firstSpine == null) {
       return null;
@@ -2766,10 +2801,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.removeDeferredReferencePages(
       (entry) => entry.viewItem.item.spineIndex >= firstSpine,
     );
-    this.counterStore.discardReferencesFromSpine(
-      firstSpine,
-      preserveTargetSnapshots,
-    );
+    this.counterStore.discardReferencesFromSpine(firstSpine);
     let lastInvalidatedSpine: number | null = null;
     for (
       let spineIndex = firstSpine;
@@ -2801,7 +2833,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const maxPasses = Math.max(3, spineCount * 2 + 2);
     let passCount = 0;
     let result: PageAndPosition | null = null;
-    let preserveTargetSnapshots = false;
 
     const clearRelayoutState = (): void => {
       this.relayoutingFollowingSpines = false;
@@ -2831,10 +2862,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
       this.relayoutingFollowingSpines = true;
       this.relayoutingFollowingSpineStart = firstSpine;
-      const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines(
-        preserveTargetSnapshots,
-      );
-      preserveTargetSnapshots = false;
+      const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
       const rerenderPosition =
         lastInvalidatedSpine != null
           ? {
@@ -2845,20 +2873,16 @@ export class OPFView implements Vgen.CustomRendererFactory {
           : position;
       this.renderPagesUpto(rerenderPosition, false).then((rerenderedResult) => {
         result = rerenderedResult;
-        const firstChangedSourceSpine = this.updateRetainedTargetCounters();
-        if (firstChangedSourceSpine != null) {
-          // Updating generated reference text after layout is insufficient:
-          // a width change (for example page 10 to 9) can alter line and page
-          // breaks. Rebuild from the earliest page whose value actually
-          // changed, and repeat until no rendered reference changes.
-          this.deferSpinesForRelayoutFrom(firstChangedSourceSpine);
-          // Seed the next fixed-point pass with the target values produced by
-          // this pass. Clearing them would lay out the source with the
-          // unresolved fallback again, causing an oscillation such as
-          // "??" -> "9" -> "??" instead of converging to "8".
-          preserveTargetSnapshots = true;
-        }
-        runNextPass();
+        const changedTargetIds = this.updateRetainedTargetCounters();
+        // Patching generated reference text is insufficient when its width
+        // changes. Feed the changed targets back through the existing
+        // page-level reference resolver so only retained source pages are
+        // re-laid out. If one of those pages shrinks, it queues the following
+        // spine suffix for the next pass without discarding the target that
+        // supplied the resolved value.
+        this.resolveChangedRetainedTargetReferences(changedTargetIds).then(() =>
+          runNextPass(),
+        );
       });
     };
 

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -3096,8 +3096,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             this.relayoutingFollowingSpineStart = firstSpine;
             const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
             const rerenderPosition =
-              lastInvalidatedSpine != null &&
-              lastInvalidatedSpine > position.spineIndex
+              lastInvalidatedSpine != null
                 ? {
                     spineIndex: lastInvalidatedSpine,
                     pageIndex: Number.POSITIVE_INFINITY,

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2767,13 +2767,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
       const pageIndex = pos ? pos.page - 1 : pageIndexToRender;
       this.finishPageContainer(viewItem, page, pageIndex);
       this.counterStore.finishPage(page.spineIndex, pageIndex);
-      if (!pos) {
-        // A final page can be produced by a nested relayout while resolving a
-        // target reference. Mark the spine complete here as well as in the
-        // outer render loop, otherwise that loop requests the final page again.
-        this.markSpineItemCompleteIfReady(viewItem);
-      }
-
       const collectResult = Plugin.getHooksForName(
         Plugin.HOOKS.PAGINATION_PROGRESS,
       ).length
@@ -2794,6 +2787,13 @@ export class OPFView implements Vgen.CustomRendererFactory {
             ),
           )
           .then((resolvedPage) => {
+            if (!pos) {
+              // A final page can be produced by a nested relayout while
+              // resolving a target reference. Mark the spine complete only
+              // after that asynchronous work settles, otherwise navigation
+              // can start the next spine against counter state still in use.
+              this.markSpineItemCompleteIfReady(viewItem);
+            }
             restorePageNumberContext();
             frame.finish({
               pageAndPosition: makePageAndPosition(resolvedPage, pageIndex),

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1624,6 +1624,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     Set<number>
   > | null = null;
   private deferredFollowingSpineRelayoutStart: number | null = null;
+  private activeFollowingSpineRelayoutStart: number | null = null;
   private deferredPageReplacements = new Map<number, Vtree.Page[]>();
   private relayoutingFollowingSpines: boolean = false;
   private renderingAllPages: boolean = false;
@@ -2734,6 +2735,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       return null;
     }
     this.deferredFollowingSpineRelayoutStart = null;
+    this.activeFollowingSpineRelayoutStart = firstSpine;
     this.removeDeferredReferencePages(
       (entry) => entry.viewItem.item.spineIndex >= firstSpine,
     );
@@ -2757,6 +2759,64 @@ export class OPFView implements Vgen.CustomRendererFactory {
       this.spineItemLoadingContinuations[spineIndex] = null;
     }
     return lastInvalidatedSpine;
+  }
+
+  private rerenderDeferredFollowingSpines(
+    position: Position,
+  ): Task.Result<PageAndPosition | null> {
+    const frame: Task.Frame<PageAndPosition | null> = Task.newFrame(
+      "rerenderDeferredFollowingSpines",
+    );
+    const maxPasses = Math.max(2, this.opf.spine.length * 2 + 2);
+    let passCount = 0;
+    let result: PageAndPosition | null = null;
+
+    frame.handler = (handlerFrame, err) => {
+      this.relayoutingFollowingSpines = false;
+      this.activeFollowingSpineRelayoutStart = null;
+      handlerFrame.task.raise(err, handlerFrame.parent);
+    };
+
+    const runNextPass = (): void => {
+      if (this.deferredFollowingSpineRelayoutStart == null) {
+        this.relayoutingFollowingSpines = false;
+        this.activeFollowingSpineRelayoutStart = null;
+        frame.finish(result);
+        return;
+      }
+      passCount++;
+      if (passCount > maxPasses) {
+        this.relayoutingFollowingSpines = false;
+        this.activeFollowingSpineRelayoutStart = null;
+        frame.task.raise(
+          new Error("Cross-reference pagination did not stabilize"),
+          frame.parent,
+        );
+        return;
+      }
+
+      const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
+      const rerenderPosition =
+        lastInvalidatedSpine != null &&
+        lastInvalidatedSpine > position.spineIndex
+          ? {
+              spineIndex: lastInvalidatedSpine,
+              pageIndex: Number.POSITIVE_INFINITY,
+              offsetInItem: -1,
+            }
+          : position;
+      this.relayoutingFollowingSpines = true;
+      this.renderPagesUpto(rerenderPosition, false).then((rerenderedResult) => {
+        this.updateRetainedTargetCounters();
+        this.relayoutingFollowingSpines = false;
+        this.activeFollowingSpineRelayoutStart = null;
+        result = rerenderedResult;
+        runNextPass();
+      });
+    };
+
+    runNextPass();
+    return frame.result();
   }
   /**
    * Render a single page. If the new page contains elements with ids that are
@@ -2842,7 +2902,13 @@ export class OPFView implements Vgen.CustomRendererFactory {
         viewItem.pages.splice(finalLength);
         viewItem.layoutPositions.splice(finalLength);
         viewItem.pageCounterStarts.splice(finalLength);
-        if (pageCountChanged && !this.relayoutingFollowingSpines) {
+        if (
+          pageCountChanged &&
+          (!this.relayoutingFollowingSpines ||
+            (this.activeFollowingSpineRelayoutStart != null &&
+              viewItem.item.spineIndex <
+                this.activeFollowingSpineRelayoutStart))
+        ) {
           this.deferFollowingSpinesForRelayout(viewItem.item.spineIndex);
         }
       }
@@ -3077,38 +3143,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
             firstSpine <= position.spineIndex
           ) {
             // In on-demand pagination there is no final renderAllPages pass.
-            // Rebuild the invalid suffix only after the current page render
-            // has unwound, and suppress nested requests while doing so.
-            const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
-            const rerenderPosition =
-              lastInvalidatedSpine != null &&
-              lastInvalidatedSpine > position.spineIndex
-                ? {
-                    spineIndex: lastInvalidatedSpine,
-                    pageIndex: Number.POSITIVE_INFINITY,
-                    offsetInItem: -1,
-                  }
-                : position;
-            this.relayoutingFollowingSpines = true;
-            this.renderPagesUpto(rerenderPosition, false).then(
-              (rerenderedResult) => {
-                this.updateRetainedTargetCounters();
-                const finishRerender = (
-                  requestedResult: PageAndPosition | null,
-                ): void => {
-                  this.relayoutingFollowingSpines = false;
-                  endRendering();
-                  frame.finish(requestedResult);
-                };
-                if (rerenderPosition === position) {
-                  finishRerender(rerenderedResult);
-                } else {
-                  // Return the originally requested page after rebuilding the
-                  // farthest invalidated spine and refreshing retained refs.
-                  this.renderPageTracked(position).then(finishRerender);
-                }
-              },
-            );
+            // Stabilize the invalid suffix only after the current page render
+            // has unwound. Retained reference-source pages can themselves
+            // change an earlier page count, which schedules another pass.
+            this.rerenderDeferredFollowingSpines(position).then(() => {
+              this.renderPageTracked(position).then((requestedResult) => {
+                endRendering();
+                frame.finish(requestedResult);
+              });
+            });
             return;
           }
           endRendering();
@@ -3117,6 +3160,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       },
       (frame, err) => {
         this.relayoutingFollowingSpines = false;
+        this.activeFollowingSpineRelayoutStart = null;
         endRendering();
         frame.task.raise(err, frame.parent);
       },
@@ -3239,6 +3283,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.renderingAllPages = true;
     frame.handler = (handlerFrame, err) => {
       this.relayoutingFollowingSpines = false;
+      this.activeFollowingSpineRelayoutStart = null;
       this.renderingAllPages = false;
       handlerFrame.task.raise(err, handlerFrame.parent);
     };
@@ -3272,14 +3317,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
         finishAfterImages();
         return;
       }
-      this.relayoutDeferredFollowingSpines();
-      this.relayoutingFollowingSpines = true;
-      this.renderPagesUpto(finalPosition, false).then((rerenderedResult) => {
-        this.updateRetainedTargetCounters();
-        this.relayoutingFollowingSpines = false;
-        result = rerenderedResult;
-        finishAfterImages();
-      });
+      this.rerenderDeferredFollowingSpines(finalPosition).then(
+        (rerenderedResult) => {
+          result = rerenderedResult;
+          finishAfterImages();
+        },
+      );
     });
     return frame.result();
   }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2729,18 +2729,11 @@ export class OPFView implements Vgen.CustomRendererFactory {
   }
 
   private relayoutDeferredFollowingSpines(): number | null {
-    const firstDeferredSpine = this.deferredFollowingSpineRelayoutStart;
-    if (firstDeferredSpine == null) {
+    const firstSpine = this.deferredFollowingSpineRelayoutStart;
+    if (firstSpine == null) {
       return null;
     }
     this.deferredFollowingSpineRelayoutStart = null;
-    // If retained pages reference targets in the invalid suffix, merely
-    // patching their text after reconstruction cannot update line or page
-    // breaks. Expand the rebuild backwards to every such source page. The
-    // lookup is a transitive closure because expanding the suffix can expose
-    // an earlier source that references a newly included target spine.
-    const firstSpine =
-      this.counterStore.getRebuildStartForReferences(firstDeferredSpine);
     this.removeDeferredReferencePages(
       (entry) => entry.viewItem.item.spineIndex >= firstSpine,
     );

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2755,7 +2755,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return firstChangedSpine;
   }
 
-  private relayoutDeferredFollowingSpines(): number | null {
+  private relayoutDeferredFollowingSpines(
+    preserveTargetSnapshots: boolean = false,
+  ): number | null {
     const firstSpine = this.deferredFollowingSpineRelayoutStart;
     if (firstSpine == null) {
       return null;
@@ -2764,7 +2766,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.removeDeferredReferencePages(
       (entry) => entry.viewItem.item.spineIndex >= firstSpine,
     );
-    this.counterStore.discardReferencesFromSpine(firstSpine);
+    this.counterStore.discardReferencesFromSpine(
+      firstSpine,
+      preserveTargetSnapshots,
+    );
     let lastInvalidatedSpine: number | null = null;
     for (
       let spineIndex = firstSpine;
@@ -2796,6 +2801,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const maxPasses = Math.max(3, spineCount * 2 + 2);
     let passCount = 0;
     let result: PageAndPosition | null = null;
+    let preserveTargetSnapshots = false;
 
     const clearRelayoutState = (): void => {
       this.relayoutingFollowingSpines = false;
@@ -2825,7 +2831,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
       this.relayoutingFollowingSpines = true;
       this.relayoutingFollowingSpineStart = firstSpine;
-      const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
+      const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines(
+        preserveTargetSnapshots,
+      );
+      preserveTargetSnapshots = false;
       const rerenderPosition =
         lastInvalidatedSpine != null
           ? {
@@ -2843,6 +2852,11 @@ export class OPFView implements Vgen.CustomRendererFactory {
           // breaks. Rebuild from the earliest page whose value actually
           // changed, and repeat until no rendered reference changes.
           this.deferSpinesForRelayoutFrom(firstChangedSourceSpine);
+          // Seed the next fixed-point pass with the target values produced by
+          // this pass. Clearing them would lay out the source with the
+          // unresolved fallback again, causing an oscillation such as
+          // "??" -> "9" -> "??" instead of converging to "8".
+          preserveTargetSnapshots = true;
         }
         runNextPass();
       });

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2530,6 +2530,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
     pageIndex: number,
     nextLayoutPosition: Vtree.LayoutPosition | null,
   ): void {
+    // The deferred drain is the single retry allowed after the outermost
+    // counter scope. Do not let that retry enqueue itself again; doing so
+    // bypasses the #1686 recursion guard and creates an infinite loop.
+    if (this.resolvingDeferredReferences) {
+      return;
+    }
     const latestPage = viewItem.pages?.[pageIndex] || page;
     if (!this.hasUnresolvedReferencesToPage(latestPage)) {
       return;
@@ -2655,6 +2661,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
       const pageIndex = pos ? pos.page - 1 : pageIndexToRender;
       this.finishPageContainer(viewItem, page, pageIndex);
       this.counterStore.finishPage(page.spineIndex, pageIndex);
+      if (!pos) {
+        // A final page can be produced by a nested relayout while resolving a
+        // target reference. Mark the spine complete here as well as in the
+        // outer render loop, otherwise that loop requests the final page again.
+        this.markSpineItemCompleteIfReady(viewItem);
+      }
 
       const collectResult = Plugin.getHooksForName(
         Plugin.HOOKS.PAGINATION_PROGRESS,

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2663,16 +2663,17 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.counterStore.updateTargetTextNodesInPages(pages);
   }
 
-  private relayoutDeferredFollowingSpines(): void {
+  private relayoutDeferredFollowingSpines(): number | null {
     const firstSpine = this.deferredFollowingSpineRelayoutStart;
     if (firstSpine == null) {
-      return;
+      return null;
     }
     this.deferredFollowingSpineRelayoutStart = null;
     this.deferredReferencePages = (this.deferredReferencePages || []).filter(
       (entry) => entry.viewItem.item.spineIndex < firstSpine,
     );
     this.counterStore.discardReferencesFromSpine(firstSpine);
+    let lastInvalidatedSpine: number | null = null;
     for (
       let spineIndex = firstSpine;
       spineIndex < this.spineItems.length;
@@ -2682,6 +2683,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       if (!viewItem) {
         continue;
       }
+      lastInvalidatedSpine = spineIndex;
       viewItem.pages.forEach((renderedPage) => {
         this.rememberDeferredPageReplacement(spineIndex, renderedPage);
         renderedPage.container.remove();
@@ -2689,6 +2691,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       this.spineItems[spineIndex] = null;
       this.spineItemLoadingContinuations[spineIndex] = null;
     }
+    return lastInvalidatedSpine;
   }
   /**
    * Render a single page. If the new page contains elements with ids that are
@@ -2959,14 +2962,36 @@ export class OPFView implements Vgen.CustomRendererFactory {
             // In on-demand pagination there is no final renderAllPages pass.
             // Rebuild the invalid suffix only after the current page render
             // has unwound, and suppress nested requests while doing so.
-            this.relayoutDeferredFollowingSpines();
+            const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
+            const rerenderPosition =
+              lastInvalidatedSpine != null &&
+              lastInvalidatedSpine > position.spineIndex
+                ? {
+                    spineIndex: lastInvalidatedSpine,
+                    pageIndex: Number.POSITIVE_INFINITY,
+                    offsetInItem: -1,
+                  }
+                : position;
             this.relayoutingFollowingSpines = true;
-            this.renderPagesUpto(position, false).then((rerenderedResult) => {
-              this.updateRetainedTargetCounters(firstSpine);
-              this.relayoutingFollowingSpines = false;
-              endRendering();
-              frame.finish(rerenderedResult);
-            });
+            this.renderPagesUpto(rerenderPosition, false).then(
+              (rerenderedResult) => {
+                this.updateRetainedTargetCounters(firstSpine);
+                const finishRerender = (
+                  requestedResult: PageAndPosition | null,
+                ): void => {
+                  this.relayoutingFollowingSpines = false;
+                  endRendering();
+                  frame.finish(requestedResult);
+                };
+                if (rerenderPosition === position) {
+                  finishRerender(rerenderedResult);
+                } else {
+                  // Return the originally requested page after rebuilding the
+                  // farthest invalidated spine and refreshing retained refs.
+                  this.renderPageTracked(position).then(finishRerender);
+                }
+              },
+            );
             return;
           }
           endRendering();

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1732,7 +1732,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
       viewItem.item.spineIndex,
       page,
     );
-    const replacedPage = oldPage || deferredOldPage;
     page.isFirstPage = viewItem.item.spineIndex == 0 && pageIndex == 0;
     viewItem.pages[pageIndex] = page;
 
@@ -1780,8 +1779,11 @@ export class OPFView implements Vgen.CustomRendererFactory {
         insertPos,
       );
     }
-    if (replacedPage) {
-      this.dispatchPageReplacement(replacedPage, page);
+    if (oldPage) {
+      this.dispatchPageReplacement(oldPage, page);
+    }
+    if (deferredOldPage && deferredOldPage !== oldPage) {
+      this.dispatchPageReplacement(deferredOldPage, page);
     }
     this.pageSheetSizeReporter(
       {
@@ -2651,10 +2653,9 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.deferredPageReplacements.delete(spineIndex);
   }
 
-  private updateRetainedTargetCounters(firstSpineIndex: number): void {
+  private updateRetainedTargetCounters(): void {
     const pages: Vtree.Page[] = [];
-    for (let spineIndex = 0; spineIndex < firstSpineIndex; spineIndex++) {
-      const viewItem = this.spineItems[spineIndex];
+    for (const viewItem of this.spineItems) {
       if (viewItem) {
         pages.push(...viewItem.pages);
       }
@@ -2867,6 +2868,16 @@ export class OPFView implements Vgen.CustomRendererFactory {
     const frame: Task.Frame<PageAndPosition | null> = Task.newFrame("findPage");
 
     this.waitForPreviousSpines(position.spineIndex, sync).then(() => {
+      const firstInvalidSpine = this.deferredFollowingSpineRelayoutStart;
+      if (
+        firstInvalidSpine != null &&
+        firstInvalidSpine <= position.spineIndex
+      ) {
+        // A cached page in the invalid suffix must not bypass the deferred
+        // rebuild. renderPage() consumes the marker before returning it.
+        this.renderPage(position).then((result) => frame.finish(result));
+        return;
+      }
       this.getPageViewItem(position.spineIndex).then((viewItem) => {
         if (!viewItem) {
           frame.finish(null);
@@ -2975,7 +2986,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             this.relayoutingFollowingSpines = true;
             this.renderPagesUpto(rerenderPosition, false).then(
               (rerenderedResult) => {
-                this.updateRetainedTargetCounters(firstSpine);
+                this.updateRetainedTargetCounters();
                 const finishRerender = (
                   requestedResult: PageAndPosition | null,
                 ): void => {
@@ -3158,7 +3169,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       this.relayoutDeferredFollowingSpines();
       this.relayoutingFollowingSpines = true;
       this.renderPagesUpto(finalPosition, false).then((rerenderedResult) => {
-        this.updateRetainedTargetCounters(firstSpine);
+        this.updateRetainedTargetCounters();
         this.relayoutingFollowingSpines = false;
         result = rerenderedResult;
         finishAfterImages();

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2601,14 +2601,14 @@ export class OPFView implements Vgen.CustomRendererFactory {
   }
 
   private deferFollowingSpinesForRelayout(spineIndex: number): void {
-    const firstFollowingSpine = spineIndex + 1;
+    this.deferSpinesForRelayoutFrom(spineIndex + 1);
+  }
+
+  private deferSpinesForRelayoutFrom(firstSpineIndex: number): void {
     this.deferredFollowingSpineRelayoutStart =
       this.deferredFollowingSpineRelayoutStart == null
-        ? firstFollowingSpine
-        : Math.min(
-            this.deferredFollowingSpineRelayoutStart,
-            firstFollowingSpine,
-          );
+        ? firstSpineIndex
+        : Math.min(this.deferredFollowingSpineRelayoutStart, firstSpineIndex);
   }
 
   private removeDeferredReferencePages(
@@ -2731,15 +2731,28 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.deferredPageReplacements.delete(spineIndex);
   }
 
-  private updateRetainedTargetCounters(): void {
+  private updateRetainedTargetCounters(): number | null {
     const pages: Vtree.Page[] = [];
     for (const viewItem of this.spineItems) {
       if (viewItem) {
         pages.push(...viewItem.pages);
       }
     }
-    this.counterStore.updateTargetCounterNodesInPages(pages);
-    this.counterStore.updateTargetTextNodesInPages(pages);
+    const changedPages = new Set<Vtree.Page>([
+      ...(this.counterStore.updateTargetCounterNodesInPages(pages) || []),
+      ...(this.counterStore.updateTargetTextNodesInPages(pages) || []),
+    ]);
+    let firstChangedSpine: number | null = null;
+    for (const viewItem of this.spineItems) {
+      if (
+        viewItem?.pages.some((page) => changedPages.has(page)) &&
+        (firstChangedSpine == null ||
+          viewItem.item.spineIndex < firstChangedSpine)
+      ) {
+        firstChangedSpine = viewItem.item.spineIndex;
+      }
+    }
+    return firstChangedSpine;
   }
 
   private relayoutDeferredFollowingSpines(): number | null {
@@ -2771,6 +2784,72 @@ export class OPFView implements Vgen.CustomRendererFactory {
       this.spineItemLoadingContinuations[spineIndex] = null;
     }
     return lastInvalidatedSpine;
+  }
+
+  private rerenderDeferredFollowingSpines(
+    position: Position,
+  ): Task.Result<PageAndPosition | null> {
+    const frame: Task.Frame<PageAndPosition | null> = Task.newFrame(
+      "rerenderDeferredFollowingSpines",
+    );
+    const spineCount = this.opf?.spine?.length || this.spineItems.length;
+    const maxPasses = Math.max(3, spineCount * 2 + 2);
+    let passCount = 0;
+    let result: PageAndPosition | null = null;
+
+    const clearRelayoutState = (): void => {
+      this.relayoutingFollowingSpines = false;
+      this.relayoutingFollowingSpineStart = null;
+    };
+    frame.handler = (handlerFrame, err) => {
+      clearRelayoutState();
+      handlerFrame.task.raise(err, handlerFrame.parent);
+    };
+
+    const runNextPass = (): void => {
+      const firstSpine = this.deferredFollowingSpineRelayoutStart;
+      if (firstSpine == null) {
+        clearRelayoutState();
+        frame.finish(result);
+        return;
+      }
+      passCount++;
+      if (passCount > maxPasses) {
+        clearRelayoutState();
+        frame.task.raise(
+          new Error("Cross-reference pagination did not stabilize"),
+          frame.parent,
+        );
+        return;
+      }
+
+      this.relayoutingFollowingSpines = true;
+      this.relayoutingFollowingSpineStart = firstSpine;
+      const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
+      const rerenderPosition =
+        lastInvalidatedSpine != null
+          ? {
+              spineIndex: lastInvalidatedSpine,
+              pageIndex: Number.POSITIVE_INFINITY,
+              offsetInItem: -1,
+            }
+          : position;
+      this.renderPagesUpto(rerenderPosition, false).then((rerenderedResult) => {
+        result = rerenderedResult;
+        const firstChangedSourceSpine = this.updateRetainedTargetCounters();
+        if (firstChangedSourceSpine != null) {
+          // Updating generated reference text after layout is insufficient:
+          // a width change (for example page 10 to 9) can alter line and page
+          // breaks. Rebuild from the earliest page whose value actually
+          // changed, and repeat until no rendered reference changes.
+          this.deferSpinesForRelayoutFrom(firstChangedSourceSpine);
+        }
+        runNextPass();
+      });
+    };
+
+    runNextPass();
+    return frame.result();
   }
   /**
    * Render a single page. If the new page contains elements with ids that are
@@ -2853,7 +2932,11 @@ export class OPFView implements Vgen.CustomRendererFactory {
         viewItem.pages.splice(finalLength);
         viewItem.layoutPositions.splice(finalLength);
         viewItem.pageCounterStarts.splice(finalLength);
-        if (pageCountChanged && !this.relayoutingFollowingSpines) {
+        if (pageCountChanged) {
+          // A page can shrink while it is recursively rerendered for a target
+          // in a later spine. Even during a suffix rebuild, already-rendered
+          // following spines then have stale absolute counters and starts, so
+          // queue them for the next stabilization pass.
           this.deferFollowingSpinesForRelayout(viewItem.item.spineIndex);
         }
       }
@@ -3091,44 +3174,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
           ) {
             // In on-demand pagination there is no final renderAllPages pass.
             // Rebuild the invalid suffix only after the current page render
-            // has unwound, and suppress nested requests while doing so.
-            this.relayoutingFollowingSpines = true;
-            this.relayoutingFollowingSpineStart = firstSpine;
-            const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
-            const rerenderPosition =
-              lastInvalidatedSpine != null
-                ? {
-                    spineIndex: lastInvalidatedSpine,
-                    pageIndex: Number.POSITIVE_INFINITY,
-                    offsetInItem: -1,
-                  }
-                : position;
-            this.renderPagesUpto(rerenderPosition, false).then(
-              (rerenderedResult) => {
-                this.updateRetainedTargetCounters();
-                const finishRerender = (
-                  requestedResult: PageAndPosition | null,
-                ): void => {
-                  this.relayoutingFollowingSpines = false;
-                  this.relayoutingFollowingSpineStart = null;
-                  endRendering();
-                  frame.finish(requestedResult);
-                };
-                if (rerenderPosition === position) {
-                  this.pageSheetSizeTruncator(this.getRenderedPageSizeCount());
-                  finishRerender(rerenderedResult);
-                } else {
-                  // Return the originally requested page after rebuilding the
-                  // farthest invalidated spine and refreshing retained refs.
-                  this.renderPageTracked(position).then((requestedResult) => {
-                    this.pageSheetSizeTruncator(
-                      this.getRenderedPageSizeCount(),
-                    );
-                    finishRerender(requestedResult);
-                  });
-                }
-              },
-            );
+            // has unwound. A changed retained reference can move its source
+            // page too, so keep rebuilding the affected suffix until stable.
+            this.rerenderDeferredFollowingSpines(position).then(() => {
+              this.renderPageTracked(position).then((requestedResult) => {
+                this.pageSheetSizeTruncator(this.getRenderedPageSizeCount());
+                endRendering();
+                frame.finish(requestedResult);
+              });
+            });
             return;
           }
           this.pageSheetSizeTruncator(this.getRenderedPageSizeCount());
@@ -3296,16 +3350,12 @@ export class OPFView implements Vgen.CustomRendererFactory {
         finishAfterImages();
         return;
       }
-      this.relayoutingFollowingSpines = true;
-      this.relayoutingFollowingSpineStart = firstSpine;
-      this.relayoutDeferredFollowingSpines();
-      this.renderPagesUpto(finalPosition, false).then((rerenderedResult) => {
-        this.updateRetainedTargetCounters();
-        this.relayoutingFollowingSpines = false;
-        this.relayoutingFollowingSpineStart = null;
-        result = rerenderedResult;
-        finishAfterImages();
-      });
+      this.rerenderDeferredFollowingSpines(finalPosition).then(
+        (rerenderedResult) => {
+          result = rerenderedResult;
+          finishAfterImages();
+        },
+      );
     });
     return frame.result();
   }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2729,11 +2729,18 @@ export class OPFView implements Vgen.CustomRendererFactory {
   }
 
   private relayoutDeferredFollowingSpines(): number | null {
-    const firstSpine = this.deferredFollowingSpineRelayoutStart;
-    if (firstSpine == null) {
+    const firstDeferredSpine = this.deferredFollowingSpineRelayoutStart;
+    if (firstDeferredSpine == null) {
       return null;
     }
     this.deferredFollowingSpineRelayoutStart = null;
+    // If retained pages reference targets in the invalid suffix, merely
+    // patching their text after reconstruction cannot update line or page
+    // breaks. Expand the rebuild backwards to every such source page. The
+    // lookup is a transitive closure because expanding the suffix can expose
+    // an earlier source that references a newly included target spine.
+    const firstSpine =
+      this.counterStore.getRebuildStartForReferences(firstDeferredSpine);
     this.removeDeferredReferencePages(
       (entry) => entry.viewItem.item.spineIndex >= firstSpine,
     );

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1624,7 +1624,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
     Set<number>
   > | null = null;
   private deferredFollowingSpineRelayoutStart: number | null = null;
-  private activeFollowingSpineRelayoutStart: number | null = null;
   private deferredPageReplacements = new Map<number, Vtree.Page[]>();
   private relayoutingFollowingSpines: boolean = false;
   private renderingAllPages: boolean = false;
@@ -2735,7 +2734,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
       return null;
     }
     this.deferredFollowingSpineRelayoutStart = null;
-    this.activeFollowingSpineRelayoutStart = firstSpine;
     this.removeDeferredReferencePages(
       (entry) => entry.viewItem.item.spineIndex >= firstSpine,
     );
@@ -2759,64 +2757,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
       this.spineItemLoadingContinuations[spineIndex] = null;
     }
     return lastInvalidatedSpine;
-  }
-
-  private rerenderDeferredFollowingSpines(
-    position: Position,
-  ): Task.Result<PageAndPosition | null> {
-    const frame: Task.Frame<PageAndPosition | null> = Task.newFrame(
-      "rerenderDeferredFollowingSpines",
-    );
-    const maxPasses = Math.max(2, this.opf.spine.length * 2 + 2);
-    let passCount = 0;
-    let result: PageAndPosition | null = null;
-
-    frame.handler = (handlerFrame, err) => {
-      this.relayoutingFollowingSpines = false;
-      this.activeFollowingSpineRelayoutStart = null;
-      handlerFrame.task.raise(err, handlerFrame.parent);
-    };
-
-    const runNextPass = (): void => {
-      if (this.deferredFollowingSpineRelayoutStart == null) {
-        this.relayoutingFollowingSpines = false;
-        this.activeFollowingSpineRelayoutStart = null;
-        frame.finish(result);
-        return;
-      }
-      passCount++;
-      if (passCount > maxPasses) {
-        this.relayoutingFollowingSpines = false;
-        this.activeFollowingSpineRelayoutStart = null;
-        frame.task.raise(
-          new Error("Cross-reference pagination did not stabilize"),
-          frame.parent,
-        );
-        return;
-      }
-
-      const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
-      const rerenderPosition =
-        lastInvalidatedSpine != null &&
-        lastInvalidatedSpine > position.spineIndex
-          ? {
-              spineIndex: lastInvalidatedSpine,
-              pageIndex: Number.POSITIVE_INFINITY,
-              offsetInItem: -1,
-            }
-          : position;
-      this.relayoutingFollowingSpines = true;
-      this.renderPagesUpto(rerenderPosition, false).then((rerenderedResult) => {
-        this.updateRetainedTargetCounters();
-        this.relayoutingFollowingSpines = false;
-        this.activeFollowingSpineRelayoutStart = null;
-        result = rerenderedResult;
-        runNextPass();
-      });
-    };
-
-    runNextPass();
-    return frame.result();
   }
   /**
    * Render a single page. If the new page contains elements with ids that are
@@ -2902,13 +2842,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         viewItem.pages.splice(finalLength);
         viewItem.layoutPositions.splice(finalLength);
         viewItem.pageCounterStarts.splice(finalLength);
-        if (
-          pageCountChanged &&
-          (!this.relayoutingFollowingSpines ||
-            (this.activeFollowingSpineRelayoutStart != null &&
-              viewItem.item.spineIndex <
-                this.activeFollowingSpineRelayoutStart))
-        ) {
+        if (pageCountChanged && !this.relayoutingFollowingSpines) {
           this.deferFollowingSpinesForRelayout(viewItem.item.spineIndex);
         }
       }
@@ -3143,15 +3077,38 @@ export class OPFView implements Vgen.CustomRendererFactory {
             firstSpine <= position.spineIndex
           ) {
             // In on-demand pagination there is no final renderAllPages pass.
-            // Stabilize the invalid suffix only after the current page render
-            // has unwound. Retained reference-source pages can themselves
-            // change an earlier page count, which schedules another pass.
-            this.rerenderDeferredFollowingSpines(position).then(() => {
-              this.renderPageTracked(position).then((requestedResult) => {
-                endRendering();
-                frame.finish(requestedResult);
-              });
-            });
+            // Rebuild the invalid suffix only after the current page render
+            // has unwound, and suppress nested requests while doing so.
+            const lastInvalidatedSpine = this.relayoutDeferredFollowingSpines();
+            const rerenderPosition =
+              lastInvalidatedSpine != null &&
+              lastInvalidatedSpine > position.spineIndex
+                ? {
+                    spineIndex: lastInvalidatedSpine,
+                    pageIndex: Number.POSITIVE_INFINITY,
+                    offsetInItem: -1,
+                  }
+                : position;
+            this.relayoutingFollowingSpines = true;
+            this.renderPagesUpto(rerenderPosition, false).then(
+              (rerenderedResult) => {
+                this.updateRetainedTargetCounters();
+                const finishRerender = (
+                  requestedResult: PageAndPosition | null,
+                ): void => {
+                  this.relayoutingFollowingSpines = false;
+                  endRendering();
+                  frame.finish(requestedResult);
+                };
+                if (rerenderPosition === position) {
+                  finishRerender(rerenderedResult);
+                } else {
+                  // Return the originally requested page after rebuilding the
+                  // farthest invalidated spine and refreshing retained refs.
+                  this.renderPageTracked(position).then(finishRerender);
+                }
+              },
+            );
             return;
           }
           endRendering();
@@ -3160,7 +3117,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
       },
       (frame, err) => {
         this.relayoutingFollowingSpines = false;
-        this.activeFollowingSpineRelayoutStart = null;
         endRendering();
         frame.task.raise(err, frame.parent);
       },
@@ -3283,7 +3239,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
     this.renderingAllPages = true;
     frame.handler = (handlerFrame, err) => {
       this.relayoutingFollowingSpines = false;
-      this.activeFollowingSpineRelayoutStart = null;
       this.renderingAllPages = false;
       handlerFrame.task.raise(err, handlerFrame.parent);
     };
@@ -3317,12 +3272,14 @@ export class OPFView implements Vgen.CustomRendererFactory {
         finishAfterImages();
         return;
       }
-      this.rerenderDeferredFollowingSpines(finalPosition).then(
-        (rerenderedResult) => {
-          result = rerenderedResult;
-          finishAfterImages();
-        },
-      );
+      this.relayoutDeferredFollowingSpines();
+      this.relayoutingFollowingSpines = true;
+      this.renderPagesUpto(finalPosition, false).then((rerenderedResult) => {
+        this.updateRetainedTargetCounters();
+        this.relayoutingFollowingSpines = false;
+        result = rerenderedResult;
+        finishAfterImages();
+      });
     });
     return frame.result();
   }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -1813,6 +1813,19 @@ export class OPFView implements Vgen.CustomRendererFactory {
     return count;
   }
 
+  private getRenderedPageSizeCount(): number {
+    let count = 0;
+    for (const item of this.spineItems) {
+      if (item) {
+        count = Math.max(
+          count,
+          item.instance.pageNumberOffset + item.pages.length,
+        );
+      }
+    }
+    return count;
+  }
+
   /**
    * Mark a spine item as complete if all layout positions have corresponding
    * rendered pages (Issue #1498).  When the item becomes complete, clean up
@@ -2866,7 +2879,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             ),
           )
           .then((resolvedPage) => {
-            if (!pos) {
+            if (!pos && !inCounterResolveScopeAtStart) {
               // A final page can be produced by a nested relayout while
               // resolving a target reference. Mark the spine complete only
               // after that asynchronous work settles, otherwise navigation
@@ -3098,13 +3111,15 @@ export class OPFView implements Vgen.CustomRendererFactory {
                   frame.finish(requestedResult);
                 };
                 if (rerenderPosition === position) {
-                  this.pageSheetSizeTruncator(this.getRenderedPageCount());
+                  this.pageSheetSizeTruncator(this.getRenderedPageSizeCount());
                   finishRerender(rerenderedResult);
                 } else {
                   // Return the originally requested page after rebuilding the
                   // farthest invalidated spine and refreshing retained refs.
                   this.renderPageTracked(position).then((requestedResult) => {
-                    this.pageSheetSizeTruncator(this.getRenderedPageCount());
+                    this.pageSheetSizeTruncator(
+                      this.getRenderedPageSizeCount(),
+                    );
                     finishRerender(requestedResult);
                   });
                 }
@@ -3112,7 +3127,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             );
             return;
           }
-          this.pageSheetSizeTruncator(this.getRenderedPageCount());
+          this.pageSheetSizeTruncator(this.getRenderedPageSizeCount());
           endRendering();
           frame.finish(result);
         });
@@ -3265,7 +3280,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
             }
           })
           .then(() => {
-            this.pageSheetSizeTruncator(this.getRenderedPageCount());
+            this.pageSheetSizeTruncator(this.getRenderedPageSizeCount());
             this.renderingAllPages = false;
             frame.finish(result);
           });

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2478,7 +2478,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     // Keep the page until the outermost scope is restored, then drain all
     // deferred pages in order.
     this.deferReferencesForPage(viewItem, page, pageIndex, nextLayoutPosition);
-    const deferredReferencePages = (this.deferredReferencePages ??= []);
+    const deferredReferencePages = this.deferredReferencePages;
 
     if (
       this.isInCounterResolveScope() ||
@@ -2545,7 +2545,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     if (!this.hasUnresolvedReferencesToPage(latestPage)) {
       return;
     }
-    const deferredReferencePages = (this.deferredReferencePages ??= []);
+    const deferredReferencePages = this.deferredReferencePages;
     const queued = deferredReferencePages.find(
       (entry) => entry.viewItem === viewItem && entry.pageIndex === pageIndex,
     );
@@ -2577,7 +2577,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     spineIndex: number,
     page: Vtree.Page,
   ): void {
-    const replacements = (this.deferredPageReplacements ??= new Map());
+    const replacements = this.deferredPageReplacements;
     let pages = replacements.get(spineIndex);
     if (!pages) {
       pages = [];
@@ -2590,7 +2590,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     spineIndex: number,
     newPage: Vtree.Page,
   ): Vtree.Page | null {
-    const pages = this.deferredPageReplacements?.get(spineIndex);
+    const pages = this.deferredPageReplacements.get(spineIndex);
     if (!pages) {
       return null;
     }
@@ -2624,7 +2624,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
 
   private flushDeferredPageReplacements(viewItem: OPFViewItem): void {
     const spineIndex = viewItem.item.spineIndex;
-    const oldPages = this.deferredPageReplacements?.get(spineIndex);
+    const oldPages = this.deferredPageReplacements.get(spineIndex);
     if (!oldPages) {
       return;
     }
@@ -2670,7 +2670,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
       return null;
     }
     this.deferredFollowingSpineRelayoutStart = null;
-    this.deferredReferencePages = (this.deferredReferencePages || []).filter(
+    this.deferredReferencePages = this.deferredReferencePages.filter(
       (entry) => entry.viewItem.item.spineIndex < firstSpine,
     );
     this.counterStore.discardReferencesFromSpine(firstSpine);

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -336,6 +336,14 @@ export class AllLayoutConstraint implements LayoutConstraint {
   allowLayout(nodeContext: Vtree.NodeContext): boolean {
     return this.constraints.every((c) => c.allowLayout(nodeContext));
   }
+
+  allowLayoutAfterPageBreak(nodeContext: Vtree.NodeContext): boolean {
+    return this.constraints.every(
+      (c) =>
+        c.allowLayoutAfterPageBreak?.(nodeContext) ??
+        c.allowLayout(nodeContext),
+    );
+  }
 }
 
 /**
@@ -3776,6 +3784,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let leadingEdgeContexts: Vtree.RenderedNodeContext[] = [];
     let trailingEdgeContexts: Vtree.NodeContext[] = [];
     let onStartEdges = false;
+    let hasSatisfiedLeadingPageBreak = false;
 
     // Issue #1842: if a stronger page/spread break wins at the page's first
     // column, drop weaker ancestor column breaks so they do not fire again
@@ -3839,6 +3848,23 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       breakAtTheEdge = null;
     }
 
+    // A page-level break at the start of the page's first column has already
+    // been satisfied by entering this page. Consume the accumulated edge
+    // value, but keep the break on the node context so continuation positions
+    // still point at the forced-break target.
+    function consumeSatisfiedLeadingPageBreak(): void {
+      if (
+        !leadingEdge ||
+        column.isNonFirstColumn ||
+        forcedBreakValue ||
+        !Break.isPageLevelForcedBreak(breakAtTheEdge)
+      ) {
+        return;
+      }
+      hasSatisfiedLeadingPageBreak = true;
+      breakAtTheEdge = null;
+    }
+
     function suppressWeakerTrailingColumnBreaks(
       currentNodeContext: Vtree.NodeContext,
     ): void {
@@ -3866,6 +3892,16 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       breakAtTheEdge = Break.resolveEffectiveBreakValue(
         breakAtTheEdge,
         nextBreakValue,
+      );
+    }
+
+    function allowLayout(nodeContext: Vtree.NodeContext): boolean {
+      if (!hasSatisfiedLeadingPageBreak) {
+        return column.layoutConstraint.allowLayout(nodeContext);
+      }
+      return (
+        column.layoutConstraint.allowLayoutAfterPageBreak?.(nodeContext) ??
+        column.layoutConstraint.allowLayout(nodeContext)
       );
     }
 
@@ -4013,6 +4049,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 setBreakAtTheEdge(nodeContext.breakBefore);
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
+                consumeSatisfiedLeadingPageBreak();
                 // Leading edge of non-empty block -> finished going through
                 // all starting edges of the box
                 if (needForcedBreak()) {
@@ -4138,6 +4175,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 setBreakAtTheEdge(nodeContext.breakBefore);
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
+                consumeSatisfiedLeadingPageBreak();
 
                 // check if a forced break must occur before the block.
                 if (needForcedBreak()) {
@@ -4149,7 +4187,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                     true,
                     breakAtTheEdge,
                   ) ||
-                  !this.layoutConstraint.allowLayout(nodeContext)
+                  !allowLayout(nodeContext)
                 ) {
                   // overflow
                   nodeContext = (
@@ -4280,6 +4318,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               setBreakAtTheEdge(nodeContext.breakBefore);
               suppressWeakerLeadingColumnBreaks(nodeContext);
               consumeSatisfiedLeadingColumnBreak(nodeContext);
+              consumeSatisfiedLeadingPageBreak();
 
               // Prevent unnecessary blank pages by removing unnecessary forced column breaks
               if (
@@ -4295,7 +4334,7 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               if (
                 (nodeContext.pageType != nodeContext.parent?.pageType || // Fix for issue #771
                   !Break.isForcedBreakValue(breakAtTheEdge)) && // Fix for issue #722
-                !this.layoutConstraint.allowLayout(nodeContext)
+                !allowLayout(nodeContext)
               ) {
                 this.checkOverflowAndSaveEdgeAndBreakPosition(
                   lastAfterNodeContext,

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -3784,7 +3784,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     let leadingEdgeContexts: Vtree.RenderedNodeContext[] = [];
     let trailingEdgeContexts: Vtree.NodeContext[] = [];
     let onStartEdges = false;
-    let hasSatisfiedLeadingPageBreak = false;
 
     // Issue #1842: if a stronger page/spread break wins at the page's first
     // column, drop weaker ancestor column breaks so they do not fire again
@@ -3848,23 +3847,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
       breakAtTheEdge = null;
     }
 
-    // A page-level break at the start of the page's first column has already
-    // been satisfied by entering this page. Consume the accumulated edge
-    // value, but keep the break on the node context so continuation positions
-    // still point at the forced-break target.
-    function consumeSatisfiedLeadingPageBreak(): void {
-      if (
-        !leadingEdge ||
-        column.isNonFirstColumn ||
-        forcedBreakValue ||
-        !Break.isPageLevelForcedBreak(breakAtTheEdge)
-      ) {
-        return;
-      }
-      hasSatisfiedLeadingPageBreak = true;
-      breakAtTheEdge = null;
-    }
-
     function suppressWeakerTrailingColumnBreaks(
       currentNodeContext: Vtree.NodeContext,
     ): void {
@@ -3896,13 +3878,28 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
     }
 
     function allowLayout(nodeContext: Vtree.NodeContext): boolean {
-      if (!hasSatisfiedLeadingPageBreak) {
-        return column.layoutConstraint.allowLayout(nodeContext);
+      if (column.layoutConstraint.allowLayout(nodeContext)) {
+        return true;
       }
-      return (
+      if (
+        !leadingEdge ||
+        column.isNonFirstColumn ||
+        forcedBreakValue ||
+        !Break.isPageLevelForcedBreak(breakAtTheEdge)
+      ) {
+        return false;
+      }
+      const allowedAfterPageBreak =
         column.layoutConstraint.allowLayoutAfterPageBreak?.(nodeContext) ??
-        column.layoutConstraint.allowLayout(nodeContext)
-      );
+        false;
+      if (allowedAfterPageBreak) {
+        // The page-level break has already been satisfied by entering this
+        // page. Consume it only when it is what allows this exact node to move
+        // earlier; keeping a broader flag here changes later, unrelated break
+        // combinations on the same leading edge.
+        breakAtTheEdge = null;
+      }
+      return allowedAfterPageBreak;
     }
 
     function needForcedBreak(): boolean {
@@ -4049,7 +4046,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 setBreakAtTheEdge(nodeContext.breakBefore);
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
-                consumeSatisfiedLeadingPageBreak();
                 // Leading edge of non-empty block -> finished going through
                 // all starting edges of the box
                 if (needForcedBreak()) {
@@ -4175,7 +4171,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
                 setBreakAtTheEdge(nodeContext.breakBefore);
                 suppressWeakerLeadingColumnBreaks(nodeContext);
                 consumeSatisfiedLeadingColumnBreak(nodeContext);
-                consumeSatisfiedLeadingPageBreak();
 
                 // check if a forced break must occur before the block.
                 if (needForcedBreak()) {
@@ -4318,7 +4313,6 @@ export class Column extends VtreeImpl.Container implements Layout.Column {
               setBreakAtTheEdge(nodeContext.breakBefore);
               suppressWeakerLeadingColumnBreaks(nodeContext);
               consumeSatisfiedLeadingColumnBreak(nodeContext);
-              consumeSatisfiedLeadingPageBreak();
 
               // Prevent unnecessary blank pages by removing unnecessary forced column breaks
               if (

--- a/packages/core/src/vivliostyle/layout.ts
+++ b/packages/core/src/vivliostyle/layout.ts
@@ -338,11 +338,26 @@ export class AllLayoutConstraint implements LayoutConstraint {
   }
 
   allowLayoutAfterPageBreak(nodeContext: Vtree.NodeContext): boolean {
-    return this.constraints.every(
-      (c) =>
-        c.allowLayoutAfterPageBreak?.(nodeContext) ??
-        c.allowLayout(nodeContext),
-    );
+    // Hooks may update retained layout state (the counter constraint does).
+    // Reject on ordinary constraints first so a later failure cannot leave a
+    // one-shot page-break allowance consumed by an otherwise rejected node.
+    for (const constraint of this.constraints) {
+      if (
+        !constraint.allowLayoutAfterPageBreak &&
+        !constraint.allowLayout(nodeContext)
+      ) {
+        return false;
+      }
+    }
+    for (const constraint of this.constraints) {
+      if (
+        constraint.allowLayoutAfterPageBreak &&
+        !constraint.allowLayoutAfterPageBreak(nodeContext)
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 }
 

--- a/packages/core/src/vivliostyle/types.ts
+++ b/packages/core/src/vivliostyle/types.ts
@@ -70,6 +70,11 @@ export namespace Layout {
      * current position.
      */
     allowLayout(nodeContext: Vtree.NodeContext): boolean;
+    /**
+     * Returns if this constraint allows the node context immediately after a
+     * page-level break has already been satisfied.
+     */
+    allowLayoutAfterPageBreak?(nodeContext: Vtree.NodeContext): boolean;
   }
   /**
    * Represents constraints on laying out fragments

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -450,6 +450,10 @@ module.exports = [
           "target-text() reflow across WebPub spine navigation (Issue #1856)",
       },
       {
+        file: "target-text-shrinking-spine/publication.json",
+        title: "target-text() reflow that shrinks an earlier WebPub spine",
+      },
+      {
         file: "target-text-vs-named-strings.html",
         title: "target-text() vs Named Strings",
       },
@@ -766,6 +770,10 @@ module.exports = [
       {
         file: "page_breaks/combine_breaks_2.html",
         title: "Combine break value regressions (Issue #1842)",
+      },
+      {
+        file: "page_breaks/break-before-flex-at-page-start.html",
+        title: "Consumed break-before on a flex box at page start",
       },
       {
         file: "page_breaks/break_left_right.html",

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -454,6 +454,10 @@ module.exports = [
         title: "target-text() reflow that shrinks an earlier WebPub spine",
       },
       {
+        file: "target-counter-retained-source/publication.json",
+        title: "target-counter() reflow after a retained source value changes",
+      },
+      {
         file: "target-text-vs-named-strings.html",
         title: "target-text() vs Named Strings",
       },

--- a/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html
+++ b/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html
@@ -16,7 +16,8 @@
       }
       .trigger {
         font: 10px/20px monospace;
-        inline-size: 10ch;
+        /* Leave room for subpixel rounding at the generated-text boundary. */
+        inline-size: 10.1ch;
         margin: 0;
         word-break: break-all;
       }
@@ -40,7 +41,7 @@
       on page 1. The forced break must then put the target on page 2 without
       retaining the now-stale page 3 position.
     -->
-    <p class="trigger">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx<a href="#target"></a></p>
+    <p class="trigger">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx<a href="#target"></a></p>
     <section>
       <h2 id="target">This heading should be on page 2.</h2>
       <p>There must not be a blank page before this heading.</p>

--- a/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html
+++ b/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Consumed break-before on a flex box at page start</title>
+    <style>
+      @page {
+        size: 200px 200px;
+        margin: 20px;
+        @bottom-center {
+          content: counter(page);
+        }
+      }
+      body {
+        margin: 0;
+      }
+      .trigger {
+        font: 10px/20px monospace;
+        inline-size: 10ch;
+        margin: 0;
+        word-break: break-all;
+      }
+      h2 {
+        display: flex;
+        margin: 0;
+      }
+      section {
+        break-before: page;
+        break-inside: avoid;
+      }
+      a::after {
+        content: " (page " target-counter(attr(href url), page) ")";
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      The unresolved "??" target counter makes this paragraph 9 lines high.
+      Once it resolves to "2", the paragraph becomes exactly 8 lines and fits
+      on page 1. The forced break must then put the target on page 2 without
+      retaining the now-stale page 3 position.
+    -->
+    <p class="trigger">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx<a href="#target"></a></p>
+    <section>
+      <h2 id="target">This heading should be on page 2.</h2>
+      <p>There must not be a blank page before this heading.</p>
+    </section>
+  </body>
+</html>

--- a/packages/core/test/files/target-counter-retained-source/filler.html
+++ b/packages/core/test/files/target-counter-retained-source/filler.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Fixed filler pages</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <section class="filler">Filler page 1</section>
+    <section class="filler">Filler page 2</section>
+    <section class="filler">Filler page 3</section>
+    <section class="filler">Filler page 4</section>
+    <section class="filler">Filler page 5</section>
+  </body>
+</html>

--- a/packages/core/test/files/target-counter-retained-source/publication.json
+++ b/packages/core/test/files/target-counter-retained-source/publication.json
@@ -1,0 +1,11 @@
+{
+  "@context": ["https://schema.org", "https://www.w3.org/ns/pub-context"],
+  "type": "Book",
+  "name": "target-counter reflow in a retained source spine",
+  "readingOrder": [
+    { "url": "source.html", "name": "Retained reference source" },
+    { "url": "shrinker.html", "name": "Shrinking spine" },
+    { "url": "filler.html", "name": "Fixed filler pages" },
+    { "url": "target.html", "name": "Referenced target" }
+  ]
+}

--- a/packages/core/test/files/target-counter-retained-source/shrinker.html
+++ b/packages/core/test/files/target-counter-retained-source/shrinker.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Shrinking spine</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- "??" produces nine lines; the resolved one-character text fits in eight. -->
+    <p class="line-box">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx<a class="target-text" href="target.html#target"></a></p>
+  </body>
+</html>

--- a/packages/core/test/files/target-counter-retained-source/source.html
+++ b/packages/core/test/files/target-counter-retained-source/source.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Retained reference source</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!--
+      The unresolved value and page 10 both occupy two characters, so this
+      source initially takes two pages. After the next spine shrinks, the
+      target moves to a single-digit page and this source must be repaginated
+      to one page rather than having only its generated text patched.
+    -->
+    <p class="line-box">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx<a class="page-number" href="target.html#target"></a></p>
+  </body>
+</html>

--- a/packages/core/test/files/target-counter-retained-source/style.css
+++ b/packages/core/test/files/target-counter-retained-source/style.css
@@ -1,0 +1,37 @@
+@page {
+  size: 200px 200px;
+  margin: 20px;
+
+  @bottom-center {
+    content: counter(page);
+  }
+}
+
+html {
+  font: 10px/20px monospace;
+  widows: 1;
+  orphans: 1;
+}
+
+body,
+p,
+section {
+  margin: 0;
+}
+
+.line-box {
+  inline-size: 10.1ch;
+  word-break: break-all;
+}
+
+.page-number::after {
+  content: " (page " target-counter(attr(href url), page) ")";
+}
+
+.target-text::after {
+  content: target-text(attr(href url), content);
+}
+
+.filler + .filler {
+  break-before: page;
+}

--- a/packages/core/test/files/target-counter-retained-source/target.html
+++ b/packages/core/test/files/target-counter-retained-source/target.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Referenced target</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <p id="target">T</p>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-shrinking-spine/chapter-one.html
+++ b/packages/core/test/files/target-text-shrinking-spine/chapter-one.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chapter one</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>Chapter one</h1>
+    <p>
+      This paragraph and the table make the unresolved cross-references occupy
+      more lines than their resolved single-digit chapter numbers.
+    </p>
+    <div class="filler"></div>
+    <table>
+      <tbody>
+        <tr>
+          <td><a class="xref" href="targets.html#chapter-4"></a></td>
+          <td><a class="xref" href="targets.html#chapter-5"></a></td>
+        </tr>
+        <tr>
+          <td><a class="xref" href="targets.html#chapter-6"></a></td>
+          <td><a class="xref" href="targets.html#chapter-7"></a></td>
+        </tr>
+        <tr>
+          <td><a class="xref" href="targets.html#chapter-8"></a></td>
+          <td><a class="xref" href="targets.html#chapter-9"></a></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="tail">This paragraph must stay on page 1 after resolution.</p>
+    <h2 class="summary">Chapter one summary</h2>
+    <p>The summary must start on page 2 without an empty page.</p>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-shrinking-spine/chapter-two.html
+++ b/packages/core/test/files/target-text-shrinking-spine/chapter-two.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chapter two</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1 id="chapter-two">Chapter two must start on page 3</h1>
+    <p>
+      The preceding spine shrinks by one page after target-text() resolution,
+      so this right-page chapter must not retain its stale blank page.
+    </p>
+  </body>
+</html>

--- a/packages/core/test/files/target-text-shrinking-spine/publication.json
+++ b/packages/core/test/files/target-text-shrinking-spine/publication.json
@@ -1,0 +1,19 @@
+{
+  "@context": ["https://schema.org", "https://www.w3.org/ns/pub-context"],
+  "type": "Book",
+  "name": "target-text reflow that shrinks an earlier spine",
+  "readingOrder": [
+    {
+      "url": "chapter-one.html",
+      "name": "Chapter one"
+    },
+    {
+      "url": "chapter-two.html",
+      "name": "Chapter two"
+    },
+    {
+      "url": "targets.html",
+      "name": "Referenced chapters"
+    }
+  ]
+}

--- a/packages/core/test/files/target-text-shrinking-spine/style.css
+++ b/packages/core/test/files/target-text-shrinking-spine/style.css
@@ -1,0 +1,58 @@
+@page {
+  size: 80mm 100mm;
+  margin: 8mm;
+
+  @bottom-center {
+    content: counter(page);
+    font: 8px sans-serif;
+  }
+}
+
+html {
+  font: 12px/1.3 sans-serif;
+  widows: 1;
+  orphans: 1;
+}
+
+body {
+  margin: 0;
+}
+
+h1,
+h2,
+p,
+table {
+  margin: 0 0 6px;
+}
+
+h1 {
+  break-before: right;
+}
+
+.summary {
+  break-before: page;
+}
+
+.xref::before {
+  content: "Chapter " target-text(attr(href url), before);
+}
+
+.chapter-number::before {
+  content: attr(data-number);
+}
+
+table {
+  border-collapse: collapse;
+  font: 10px/1.2 monospace;
+  table-layout: fixed;
+  width: 126px;
+}
+
+.filler {
+  height: 110px;
+}
+
+td {
+  border: 1px solid;
+  padding: 2px;
+}

--- a/packages/core/test/files/target-text-shrinking-spine/targets.html
+++ b/packages/core/test/files/target-text-shrinking-spine/targets.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Referenced chapters</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <p id="chapter-4" class="chapter-number" data-number="4">Four</p>
+    <p id="chapter-5" class="chapter-number" data-number="5">Five</p>
+    <p id="chapter-6" class="chapter-number" data-number="6">Six</p>
+    <p id="chapter-7" class="chapter-number" data-number="7">Seven</p>
+    <p id="chapter-8" class="chapter-number" data-number="8">Eight</p>
+    <p id="chapter-9" class="chapter-number" data-number="9">Nine</p>
+  </body>
+</html>

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -285,12 +285,8 @@ describe("cross-reference layout constraint", function () {
 
     store.discardReferencesFromSpine(2);
 
-    expect(store.resolvedReferences.target).toBeUndefined();
-    expect(store.unresolvedReferences.target).toEqual([
-      earlierUnresolved,
-      earlierResolved,
-    ]);
-    expect(earlierResolved.isResolved()).toBe(false);
+    expect(store.resolvedReferences.target).toEqual([earlierResolved]);
+    expect(store.unresolvedReferences.target).toEqual([earlierUnresolved]);
     expect(store.pageIndicesById.target).toEqual({
       spineIndex: 2,
       pageIndex: 0,

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -38,6 +38,32 @@ function createNodeContext(id) {
 }
 
 describe("cross-reference layout constraint", function () {
+  it("refreshes retained target-text first-letter nodes", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const container = document.createElement("div");
+    const node = document.createElement("span");
+    node.setAttribute(Counters.TARGET_TEXT_ATTR, "first-letter-key");
+    container.appendChild(node);
+    const page = new Vtree.Page(container, container);
+    store.targetTextExprs = [
+      {
+        expr: { key: "first-letter-key" },
+        transformedId: "target",
+        pseudoElement: "first-letter",
+      },
+    ];
+    store.pageTextById.target = {
+      before: "",
+      content: "Alpha",
+      after: "",
+      marker: "",
+    };
+
+    store.updateTargetTextNodesInPages([page]);
+
+    expect(node.textContent).toBe("A");
+  });
+
   it("allows a target to move earlier after a satisfied page break", function () {
     const store = new Counters.CounterStore(documentURLTransformer);
     const reference = new Counters.TargetCounterReference("target", true);

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -107,6 +107,30 @@ describe("cross-reference layout constraint", function () {
     expect(store.resolvedReferences.target[0].pageIndex).toBe(0);
   });
 
+  it("drops references owned by a truncated source page", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const retained = new Counters.TargetCounterReference("target", false);
+    const discarded = new Counters.TargetCounterReference("target", false);
+
+    const page0Container = document.createElement("div");
+    store.setCurrentPage(new Vtree.Page(page0Container, page0Container));
+    store.newReferencesOfCurrentPage = [retained];
+    store.finishPage(0, 0);
+
+    const page1Container = document.createElement("div");
+    store.setCurrentPage(new Vtree.Page(page1Container, page1Container));
+    store.newReferencesOfCurrentPage = [discarded];
+    store.finishPage(0, 1);
+    store.referencesToSolve = [retained, discarded];
+    store.referencesToSolveStack = [[retained, discarded]];
+
+    store.discardReferencesFromPage(0, 1);
+
+    expect(store.unresolvedReferences.target).toEqual([retained]);
+    expect(store.referencesToSolve).toEqual([retained]);
+    expect(store.referencesToSolveStack).toEqual([[retained]]);
+  });
+
   it("re-resolves references when a target moves to an earlier page", function () {
     const store = new Counters.CounterStore(documentURLTransformer);
     const reference = new Counters.TargetCounterReference("target", true);
@@ -150,7 +174,19 @@ describe("cross-reference layout constraint", function () {
     );
     staleFollowingPageRef.spineIndex = 0;
     staleFollowingPageRef.pageIndex = 1;
-    store.unresolvedReferences.target = [earlierPageRef, staleFollowingPageRef];
+    const initialPage0Container = document.createElement("div");
+    store.setCurrentPage(
+      new Vtree.Page(initialPage0Container, initialPage0Container),
+    );
+    store.newReferencesOfCurrentPage = [earlierPageRef];
+    store.finishPage(0, 0);
+
+    const initialPage1Container = document.createElement("div");
+    store.setCurrentPage(
+      new Vtree.Page(initialPage1Container, initialPage1Container),
+    );
+    store.newReferencesOfCurrentPage = [staleFollowingPageRef];
+    store.finishPage(0, 1);
     store.referencesToSolve = [earlierPageRef];
 
     const page0Container = document.createElement("div");

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -129,6 +129,8 @@ describe("cross-reference layout constraint", function () {
     expect(store.unresolvedReferences.target).toEqual([retained]);
     expect(store.referencesToSolve).toEqual([retained]);
     expect(store.referencesToSolveStack).toEqual([[retained]]);
+    expect(store.isReferenceTracked(retained)).toBe(true);
+    expect(store.isReferenceTracked(discarded)).toBe(false);
   });
 
   it("re-resolves references when a target moves to an earlier page", function () {

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -207,7 +207,7 @@ describe("cross-reference layout constraint", function () {
     expect(store.resolvedReferences.target[0].pageIndex).toBe(0);
   });
 
-  it("drops only references whose source spine will be rebuilt", function () {
+  it("invalidates references and target snapshots in a rebuilt suffix", function () {
     const store = new Counters.CounterStore(documentURLTransformer);
     const earlierResolved = new Counters.TargetCounterReference("target", true);
     earlierResolved.spineIndex = 0;
@@ -227,7 +227,10 @@ describe("cross-reference layout constraint", function () {
     );
     discardedUnresolved.spineIndex = 3;
     const targetCounters = { page: [9] };
+    const targetDocCounters = { chapter: [2] };
     const targetText = { content: "target" };
+    const retainedCounters = { page: [4] };
+    const retainedText = { content: "retained" };
 
     store.resolvedReferences.target = [earlierResolved, discardedResolved];
     store.unresolvedReferences.target = [
@@ -236,7 +239,11 @@ describe("cross-reference layout constraint", function () {
     ];
     store.pageIndicesById.target = { spineIndex: 2, pageIndex: 0 };
     store.pageCountersById.target = targetCounters;
+    store.pageDocCountersById.target = targetDocCounters;
     store.pageTextById.target = targetText;
+    store.pageIndicesById.retained = { spineIndex: 1, pageIndex: 0 };
+    store.pageCountersById.retained = retainedCounters;
+    store.pageTextById.retained = retainedText;
     store.namedStringPageSnapshots[10] = {
       lastOffset: 19,
       spineIndex: 1,
@@ -256,8 +263,11 @@ describe("cross-reference layout constraint", function () {
       spineIndex: 2,
       pageIndex: 0,
     });
-    expect(store.pageCountersById.target).toBe(targetCounters);
-    expect(store.pageTextById.target).toBe(targetText);
+    expect(store.pageCountersById.target).toBeUndefined();
+    expect(store.pageDocCountersById.target).toBeUndefined();
+    expect(store.pageTextById.target).toBeUndefined();
+    expect(store.pageCountersById.retained).toBe(retainedCounters);
+    expect(store.pageTextById.retained).toBe(retainedText);
     expect(store.namedStringPageSnapshots[10]).toBeDefined();
     expect(store.namedStringPageSnapshots[20]).toBeUndefined();
   });

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -299,18 +299,4 @@ describe("cross-reference layout constraint", function () {
     expect(store.namedStringPageSnapshots[10]).toBeDefined();
     expect(store.namedStringPageSnapshots[20]).toBeUndefined();
   });
-
-  it("expands a suffix rebuild transitively to retained reference sources", function () {
-    const store = new Counters.CounterStore(documentURLTransformer);
-    const source0 = new Counters.TargetCounterReference("target-1", true);
-    source0.spineIndex = 0;
-    const source1 = new Counters.TargetCounterReference("target-2", true);
-    source1.spineIndex = 1;
-    store.pageIndicesById["target-1"] = { spineIndex: 1, pageIndex: 0 };
-    store.pageIndicesById["target-2"] = { spineIndex: 2, pageIndex: 0 };
-    store.resolvedReferences["target-1"] = [source0];
-    store.resolvedReferences["target-2"] = [source1];
-
-    expect(store.getRebuildStartForReferences(2)).toBe(0);
-  });
 });

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -110,6 +110,38 @@ describe("cross-reference layout constraint", function () {
     );
   });
 
+  it("replaces stale source-page references after content moves earlier", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const earlierPageRef = new Counters.TargetCounterReference("target", false);
+    earlierPageRef.spineIndex = 0;
+    earlierPageRef.pageIndex = 0;
+    const staleFollowingPageRef = new Counters.TargetCounterReference(
+      "target",
+      false,
+    );
+    staleFollowingPageRef.spineIndex = 0;
+    staleFollowingPageRef.pageIndex = 1;
+    store.unresolvedReferences.target = [earlierPageRef, staleFollowingPageRef];
+    store.referencesToSolve = [earlierPageRef];
+
+    const page0Container = document.createElement("div");
+    store.setCurrentPage(new Vtree.Page(page0Container, page0Container));
+    store.resolveReference("target");
+    store.finishPage(0, 0);
+
+    expect(store.resolvedReferences.target.length).toBe(1);
+    expect(store.resolvedReferences.target[0].pageIndex).toBe(0);
+    expect(store.unresolvedReferences.target).toEqual([staleFollowingPageRef]);
+
+    const page1Container = document.createElement("div");
+    store.setCurrentPage(new Vtree.Page(page1Container, page1Container));
+    store.finishPage(0, 1);
+
+    expect(store.unresolvedReferences.target).toBeUndefined();
+    expect(store.resolvedReferences.target.length).toBe(1);
+    expect(store.resolvedReferences.target[0].pageIndex).toBe(0);
+  });
+
   it("drops only references whose source spine will be rebuilt", function () {
     const store = new Counters.CounterStore(documentURLTransformer);
     const earlierResolved = new Counters.TargetCounterReference("target", true);

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -49,8 +49,10 @@ describe("cross-reference layout constraint", function () {
 
     expect(constraint.allowLayout(nodeContext)).toBe(false);
     expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
-
-    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
+    expect(store.pageIndicesById.target.pageIndex).toBe(1);
+    expect(reference.isResolved()).toBe(false);
+    expect(store.unresolvedReferences.target).toEqual([reference]);
+    expect(constraint.allowLayout(nodeContext)).toBe(true);
   });
 
   it("keeps non-counter constraints after a satisfied page break", function () {
@@ -92,14 +94,16 @@ describe("cross-reference layout constraint", function () {
     const constraint = store.createLayoutConstraint(1);
     const nodeContext = createNodeContext("target");
     expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
-
-    store.finishPage(0, 1);
-
     expect(reference.isResolved()).toBe(false);
     expect(store.resolvedReferences.target).toEqual([]);
     expect(store.unresolvedReferences.target).toEqual([reference]);
+    expect(store.pageIndicesById.target).toEqual({
+      spineIndex: 0,
+      pageIndex: 1,
+    });
 
-    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 1 };
+    store.finishPage(0, 1);
+
     const earlierConstraint = store.createLayoutConstraint(0);
     expect(earlierConstraint.allowLayoutAfterPageBreak(nodeContext)).toBe(
       false,

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -285,8 +285,12 @@ describe("cross-reference layout constraint", function () {
 
     store.discardReferencesFromSpine(2);
 
-    expect(store.resolvedReferences.target).toEqual([earlierResolved]);
-    expect(store.unresolvedReferences.target).toEqual([earlierUnresolved]);
+    expect(store.resolvedReferences.target).toBeUndefined();
+    expect(store.unresolvedReferences.target).toEqual([
+      earlierUnresolved,
+      earlierResolved,
+    ]);
+    expect(earlierResolved.isResolved()).toBe(false);
     expect(store.pageIndicesById.target).toEqual({
       spineIndex: 2,
       pageIndex: 0,

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -301,4 +301,29 @@ describe("cross-reference layout constraint", function () {
     expect(store.namedStringPageSnapshots[10]).toBeDefined();
     expect(store.namedStringPageSnapshots[20]).toBeUndefined();
   });
+
+  it("can retain target snapshots as the seed for a pagination fixed-point pass", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const discardedReference = new Counters.TargetCounterReference(
+      "target",
+      true,
+    );
+    discardedReference.spineIndex = 0;
+    const targetCounters = { page: [9] };
+    const targetDocCounters = { chapter: [2] };
+    const targetText = { content: "target" };
+
+    store.resolvedReferences.target = [discardedReference];
+    store.pageIndicesById.target = { spineIndex: 2, pageIndex: 0 };
+    store.pageCountersById.target = targetCounters;
+    store.pageDocCountersById.target = targetDocCounters;
+    store.pageTextById.target = targetText;
+
+    store.discardReferencesFromSpine(0, true);
+
+    expect(store.resolvedReferences.target).toBeUndefined();
+    expect(store.pageCountersById.target).toBe(targetCounters);
+    expect(store.pageDocCountersById.target).toBe(targetDocCounters);
+    expect(store.pageTextById.target).toBe(targetText);
+  });
 });

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -299,4 +299,18 @@ describe("cross-reference layout constraint", function () {
     expect(store.namedStringPageSnapshots[10]).toBeDefined();
     expect(store.namedStringPageSnapshots[20]).toBeUndefined();
   });
+
+  it("expands a suffix rebuild transitively to retained reference sources", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const source0 = new Counters.TargetCounterReference("target-1", true);
+    source0.spineIndex = 0;
+    const source1 = new Counters.TargetCounterReference("target-2", true);
+    source1.spineIndex = 1;
+    store.pageIndicesById["target-1"] = { spineIndex: 1, pageIndex: 0 };
+    store.pageIndicesById["target-2"] = { spineIndex: 2, pageIndex: 0 };
+    store.resolvedReferences["target-1"] = [source0];
+    store.resolvedReferences["target-2"] = [source1];
+
+    expect(store.getRebuildStartForReferences(2)).toBe(0);
+  });
 });

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -59,10 +59,15 @@ describe("cross-reference layout constraint", function () {
       marker: "",
     };
 
-    const changedPages = store.updateTargetTextNodesInPages([page]);
+    const changedTargetIds = new Set();
+    const changedPages = store.updateTargetTextNodesInPages(
+      [page],
+      changedTargetIds,
+    );
 
     expect(node.textContent).toBe("A");
     expect(changedPages).toEqual(new Set([page]));
+    expect(changedTargetIds).toEqual(new Set(["target"]));
     expect(store.updateTargetTextNodesInPages([page])).toEqual(new Set());
   });
 
@@ -300,30 +305,5 @@ describe("cross-reference layout constraint", function () {
     expect(store.pageTextById.retained).toBe(retainedText);
     expect(store.namedStringPageSnapshots[10]).toBeDefined();
     expect(store.namedStringPageSnapshots[20]).toBeUndefined();
-  });
-
-  it("can retain target snapshots as the seed for a pagination fixed-point pass", function () {
-    const store = new Counters.CounterStore(documentURLTransformer);
-    const discardedReference = new Counters.TargetCounterReference(
-      "target",
-      true,
-    );
-    discardedReference.spineIndex = 0;
-    const targetCounters = { page: [9] };
-    const targetDocCounters = { chapter: [2] };
-    const targetText = { content: "target" };
-
-    store.resolvedReferences.target = [discardedReference];
-    store.pageIndicesById.target = { spineIndex: 2, pageIndex: 0 };
-    store.pageCountersById.target = targetCounters;
-    store.pageDocCountersById.target = targetDocCounters;
-    store.pageTextById.target = targetText;
-
-    store.discardReferencesFromSpine(0, true);
-
-    expect(store.resolvedReferences.target).toBeUndefined();
-    expect(store.pageCountersById.target).toBe(targetCounters);
-    expect(store.pageDocCountersById.target).toBe(targetDocCounters);
-    expect(store.pageTextById.target).toBe(targetText);
   });
 });

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -56,15 +56,12 @@ describe("cross-reference layout constraint", function () {
   });
 
   it("keeps non-counter constraints after a satisfied page break", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const reference = new Counters.TargetCounterReference("target", true);
+    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 2 };
+    store.resolvedReferences.target = [reference];
     const nodeContext = createNodeContext("target");
-    const counterConstraint = {
-      allowLayout() {
-        return false;
-      },
-      allowLayoutAfterPageBreak() {
-        return true;
-      },
-    };
+    const counterConstraint = store.createLayoutConstraint(1);
     const rejectingConstraint = {
       allowLayout() {
         return false;
@@ -76,6 +73,38 @@ describe("cross-reference layout constraint", function () {
     ]);
 
     expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(false);
+    expect(store.pageIndicesById.target).toEqual({
+      spineIndex: 0,
+      pageIndex: 2,
+    });
+    expect(reference.isResolved()).toBe(true);
+    expect(store.unresolvedReferences.target).toBeUndefined();
+  });
+
+  it("does not scan unrelated reference buckets when finishing a page", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const page0Container = document.createElement("div");
+    store.setCurrentPage(new Vtree.Page(page0Container, page0Container));
+    store.saveReferenceOfCurrentPage("target", true);
+    store.finishPage(0, 0);
+
+    const ownKeys = jasmine
+      .createSpy("ownKeys")
+      .and.callFake((target) => Reflect.ownKeys(target));
+    store.resolvedReferences = new Proxy(store.resolvedReferences, {
+      ownKeys,
+    });
+    store.unresolvedReferences = new Proxy(store.unresolvedReferences, {
+      ownKeys,
+    });
+
+    const page1Container = document.createElement("div");
+    store.setCurrentPage(new Vtree.Page(page1Container, page1Container));
+    store.finishPage(0, 1);
+
+    expect(ownKeys).not.toHaveBeenCalled();
+    expect(store.resolvedReferences.target.length).toBe(1);
+    expect(store.resolvedReferences.target[0].pageIndex).toBe(0);
   });
 
   it("re-resolves references when a target moves to an earlier page", function () {

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2026 Vivliostyle Foundation
+ *
+ * Vivliostyle.js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import * as Counters from "../../../src/vivliostyle/counters";
+import * as Layout from "../../../src/vivliostyle/layout";
+import * as LayoutProcessor from "../../../src/vivliostyle/layout-processor";
+import * as Vtree from "../../../src/vivliostyle/vtree";
+
+const documentURLTransformer = {
+  transformFragment(fragment) {
+    return fragment;
+  },
+  transformURL(url) {
+    return url;
+  },
+  restoreURL(url) {
+    return [url];
+  },
+};
+
+function createNodeContext(id) {
+  const element = document.createElement("h2");
+  element.id = id;
+  const nodeContext = new Vtree.NodeContext(
+    element,
+    null,
+    0,
+    new LayoutProcessor.BlockFormattingContext(null),
+  );
+  nodeContext.viewNode = element;
+  return nodeContext;
+}
+
+describe("cross-reference layout constraint", function () {
+  it("allows a target to move earlier after a satisfied page break", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const reference = new Counters.TargetCounterReference("target", true);
+    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 2 };
+    store.resolvedReferences.target = [reference];
+
+    const constraint = store.createLayoutConstraint(1);
+    const nodeContext = createNodeContext("target");
+
+    expect(constraint.allowLayout(nodeContext)).toBe(false);
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
+
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
+  });
+
+  it("keeps non-counter constraints after a satisfied page break", function () {
+    const nodeContext = createNodeContext("target");
+    const counterConstraint = {
+      allowLayout() {
+        return false;
+      },
+      allowLayoutAfterPageBreak() {
+        return true;
+      },
+    };
+    const rejectingConstraint = {
+      allowLayout() {
+        return false;
+      },
+    };
+    const constraint = new Layout.AllLayoutConstraint([
+      counterConstraint,
+      rejectingConstraint,
+    ]);
+
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(false);
+  });
+
+  it("re-resolves references when a target moves to an earlier page", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const reference = new Counters.TargetCounterReference("target", true);
+    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 2 };
+    store.resolvedReferences.target = [reference];
+
+    const container = document.createElement("div");
+    const page = new Vtree.Page(container, container);
+    const target = document.createElement("h2");
+    target.id = "target";
+    page.elementsById.target = [target];
+    store.currentPage = page;
+
+    const constraint = store.createLayoutConstraint(1);
+    const nodeContext = createNodeContext("target");
+    expect(constraint.allowLayoutAfterPageBreak(nodeContext)).toBe(true);
+
+    store.finishPage(0, 1);
+
+    expect(reference.isResolved()).toBe(false);
+    expect(store.resolvedReferences.target).toEqual([]);
+    expect(store.unresolvedReferences.target).toEqual([reference]);
+
+    store.pageIndicesById.target = { spineIndex: 0, pageIndex: 1 };
+    const earlierConstraint = store.createLayoutConstraint(0);
+    expect(earlierConstraint.allowLayoutAfterPageBreak(nodeContext)).toBe(
+      false,
+    );
+  });
+
+  it("drops only references whose source spine will be rebuilt", function () {
+    const store = new Counters.CounterStore(documentURLTransformer);
+    const earlierResolved = new Counters.TargetCounterReference("target", true);
+    earlierResolved.spineIndex = 0;
+    const discardedResolved = new Counters.TargetCounterReference(
+      "target",
+      true,
+    );
+    discardedResolved.spineIndex = 2;
+    const earlierUnresolved = new Counters.TargetCounterReference(
+      "target",
+      false,
+    );
+    earlierUnresolved.spineIndex = 1;
+    const discardedUnresolved = new Counters.TargetCounterReference(
+      "target",
+      false,
+    );
+    discardedUnresolved.spineIndex = 3;
+    const targetCounters = { page: [9] };
+    const targetText = { content: "target" };
+
+    store.resolvedReferences.target = [earlierResolved, discardedResolved];
+    store.unresolvedReferences.target = [
+      earlierUnresolved,
+      discardedUnresolved,
+    ];
+    store.pageIndicesById.target = { spineIndex: 2, pageIndex: 0 };
+    store.pageCountersById.target = targetCounters;
+    store.pageTextById.target = targetText;
+    store.namedStringPageSnapshots[10] = {
+      lastOffset: 19,
+      spineIndex: 1,
+      counters: { page: [3] },
+    };
+    store.namedStringPageSnapshots[20] = {
+      lastOffset: 29,
+      spineIndex: 2,
+      counters: { page: [4] },
+    };
+
+    store.discardReferencesFromSpine(2);
+
+    expect(store.resolvedReferences.target).toEqual([earlierResolved]);
+    expect(store.unresolvedReferences.target).toEqual([earlierUnresolved]);
+    expect(store.pageIndicesById.target).toEqual({
+      spineIndex: 2,
+      pageIndex: 0,
+    });
+    expect(store.pageCountersById.target).toBe(targetCounters);
+    expect(store.pageTextById.target).toBe(targetText);
+    expect(store.namedStringPageSnapshots[10]).toBeDefined();
+    expect(store.namedStringPageSnapshots[20]).toBeUndefined();
+  });
+});

--- a/packages/core/test/spec/vivliostyle/counters-spec.js
+++ b/packages/core/test/spec/vivliostyle/counters-spec.js
@@ -59,9 +59,11 @@ describe("cross-reference layout constraint", function () {
       marker: "",
     };
 
-    store.updateTargetTextNodesInPages([page]);
+    const changedPages = store.updateTargetTextNodesInPages([page]);
 
     expect(node.textContent).toBe("A");
+    expect(changedPages).toEqual(new Set([page]));
+    expect(store.updateTargetTextNodesInPages([page])).toEqual(new Set());
   });
 
   it("allows a target to move earlier after a satisfied page break", function () {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -627,6 +627,65 @@ describe("epub", function () {
       });
     });
 
+    it("waits for another navigation task to rebuild an invalid suffix", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = { spineIndex: 1, pageIndex: 0, offsetInItem: -1 };
+        var rebuiltPage = {};
+        var viewItem = { pages: [rebuiltPage], complete: true };
+        view.deferredFollowingSpineRelayoutStart = 1;
+        view.renderingAllPages = false;
+        view.renderingPageTasks = new Map([[{}, 1]]);
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "getPageViewItem").and.returnValue(
+          adapt_task.newResult(viewItem),
+        );
+        spyOn(view, "renderPage");
+        var scheduler = adapt_task.currentTask().getScheduler();
+        var rebuildTask = scheduler.run(function () {
+          var rebuildFrame = adapt_task.newFrame("finishNavigationRebuild");
+          rebuildFrame.sleep(50).then(function () {
+            view.renderingPageTasks.clear();
+            view.deferredFollowingSpineRelayoutStart = null;
+            rebuildFrame.finish(true);
+          });
+          return rebuildFrame.result();
+        });
+
+        view.findPage(position, false).then(function (result) {
+          expect(result.page).toBe(rebuiltPage);
+          expect(view.renderPage).not.toHaveBeenCalled();
+          rebuildTask.join().then(function () {
+            done();
+          });
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("does not start a synchronous invalid-suffix rebuild in parallel", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = { spineIndex: 1, pageIndex: 0, offsetInItem: -1 };
+        view.deferredFollowingSpineRelayoutStart = 1;
+        view.renderingAllPages = false;
+        view.renderingPageTasks = new Map([[{}, 1]]);
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "renderPage");
+
+        view.findPage(position, true).then(function (result) {
+          expect(result).toBeNull();
+          expect(view.renderPage).not.toHaveBeenCalled();
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
     it("reuses the requested slot when a final-page rerender shrinks the spine", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -1122,13 +1122,20 @@ describe("epub", function () {
       var view = Object.create(adapt_epub.OPFView.prototype);
       var prefixPage = { id: "prefix" };
       var rebuiltPage = { id: "rebuilt" };
-      view.spineItems = [{ pages: [prefixPage] }, { pages: [rebuiltPage] }];
+      view.spineItems = [
+        { item: { spineIndex: 0 }, pages: [prefixPage] },
+        { item: { spineIndex: 1 }, pages: [rebuiltPage] },
+      ];
       view.counterStore = {
-        updateTargetCounterNodesInPages: jasmine.createSpy(),
-        updateTargetTextNodesInPages: jasmine.createSpy(),
+        updateTargetCounterNodesInPages: jasmine
+          .createSpy()
+          .and.returnValue(new Set([prefixPage])),
+        updateTargetTextNodesInPages: jasmine
+          .createSpy()
+          .and.returnValue(new Set([rebuiltPage])),
       };
 
-      view.updateRetainedTargetCounters();
+      var firstChangedSpine = view.updateRetainedTargetCounters();
 
       expect(
         view.counterStore.updateTargetCounterNodesInPages,
@@ -1136,6 +1143,50 @@ describe("epub", function () {
       expect(
         view.counterStore.updateTargetTextNodesInPages,
       ).toHaveBeenCalledOnceWith([prefixPage, rebuiltPage]);
+      expect(firstChangedSpine).toBe(0);
+    });
+
+    it("rebuilds from a changed retained reference until stable", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = {
+          spineIndex: 2,
+          pageIndex: Number.POSITIVE_INFINITY,
+          offsetInItem: -1,
+        };
+        var passStarts = [];
+        view.opf = { spine: [{}, {}, {}] };
+        view.spineItems = [];
+        view.deferredFollowingSpineRelayoutStart = 1;
+        view.relayoutingFollowingSpines = false;
+        view.relayoutingFollowingSpineStart = null;
+        spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
+          function () {
+            passStarts.push(view.deferredFollowingSpineRelayoutStart);
+            view.deferredFollowingSpineRelayoutStart = null;
+            return 2;
+          },
+        );
+        spyOn(view, "renderPagesUpto").and.returnValues(
+          adapt_task.newResult({ id: "first" }),
+          adapt_task.newResult({ id: "stable" }),
+        );
+        spyOn(view, "updateRetainedTargetCounters").and.returnValues(0, null);
+
+        view.rerenderDeferredFollowingSpines(position).then(function (result) {
+          expect(passStarts).toEqual([1, 0]);
+          expect(view.renderPagesUpto.calls.count()).toBe(2);
+          expect(view.renderPagesUpto.calls.allArgs()).toEqual([
+            [position, false],
+            [position, false],
+          ]);
+          expect(result).toEqual({ id: "stable" });
+          expect(view.relayoutingFollowingSpines).toBe(false);
+          expect(view.relayoutingFollowingSpineStart).toBeNull();
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
     });
 
     it("rerenders a deferred suffix once after full pagination", function (done) {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -1193,15 +1193,16 @@ describe("epub", function () {
       });
     });
 
-    it("rerenders a deferred suffix after on-demand pagination", function (done) {
+    it("rerenders an invalidated spine through its end after on-demand pagination", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
         var position = {
           spineIndex: 2,
-          pageIndex: Number.POSITIVE_INFINITY,
+          pageIndex: 1,
           offsetInItem: -1,
         };
         var initialResult = { id: "initial" };
+        var requestedResult = { id: "requested" };
         var rerenderedResult = { id: "rerendered" };
         var sourcePage = { id: "source", fetchers: [] };
         view.renderingPageTasks = new Map();
@@ -1218,12 +1219,14 @@ describe("epub", function () {
           "pageSheetSizeTruncator",
         );
         view.deferredFollowingSpineRelayoutStart = 1;
-        spyOn(view, "renderPageTracked").and.returnValue(
+        spyOn(view, "renderPageTracked").and.returnValues(
           adapt_task.newResult(initialResult),
+          adapt_task.newResult(requestedResult),
         );
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
           function () {
             view.deferredFollowingSpineRelayoutStart = null;
+            return 2;
           },
         );
         spyOn(view, "renderPagesUpto").and.returnValue(
@@ -1232,8 +1235,16 @@ describe("epub", function () {
 
         view.renderPage(position).then(function (result) {
           expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
-          expect(view.renderPagesUpto).toHaveBeenCalledWith(position, false);
-          expect(result).toBe(rerenderedResult);
+          expect(view.renderPagesUpto).toHaveBeenCalledWith(
+            {
+              spineIndex: 2,
+              pageIndex: Number.POSITIVE_INFINITY,
+              offsetInItem: -1,
+            },
+            false,
+          );
+          expect(view.renderPageTracked.calls.count()).toBe(2);
+          expect(result).toBe(requestedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
           ).toHaveBeenCalledOnceWith([sourcePage]);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -501,12 +501,18 @@ describe("epub", function () {
     it("reuses the requested slot when a final-page rerender shrinks the spine", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
-        var page = { spineIndex: 0, offset: 0, fetchers: [] };
+        var page = { spineIndex: 0, offset: 15, fetchers: [] };
+        var stalePageReplaced = jasmine.createSpy("stalePageReplaced");
         var viewItem = {
           item: { spineIndex: 0 },
           layoutPositions: new Array(17).fill(null),
-          pages: Array.from({ length: 17 }, function () {
-            return { container: { remove: function () {} } };
+          pages: Array.from({ length: 17 }, function (_, pageIndex) {
+            return {
+              offset: pageIndex,
+              container: { remove: function () {} },
+              dispatchEvent:
+                pageIndex === 16 ? stalePageReplaced : function () {},
+            };
           }),
           pageCounterStarts: new Array(17).fill(null),
           instance: {
@@ -570,6 +576,10 @@ describe("epub", function () {
           expect(view.deferredReferencePages).toEqual([
             { viewItem: viewItem, pageIndex: 15 },
           ]);
+          expect(stalePageReplaced).toHaveBeenCalled();
+          expect(stalePageReplaced.calls.mostRecent().args[0].newPage).toBe(
+            page,
+          );
           expect(viewItem.complete).toBe(true);
           done();
         });

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -1282,6 +1282,7 @@ describe("epub", function () {
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
+          unresolveReferencesForTargets: function () {},
         };
         view.pageSheetSizeTruncator = jasmine.createSpy(
           "pageSheetSizeTruncator",
@@ -1340,6 +1341,7 @@ describe("epub", function () {
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
+          unresolveReferencesForTargets: function () {},
         };
         view.pageSheetSizeTruncator = jasmine.createSpy(
           "pageSheetSizeTruncator",
@@ -1407,6 +1409,7 @@ describe("epub", function () {
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
+          unresolveReferencesForTargets: function () {},
         };
         view.pageSheetSizeTruncator = jasmine.createSpy(
           "pageSheetSizeTruncator",

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -582,12 +582,28 @@ describe("epub", function () {
     it("notifies a displayed page when its rebuilt replacement is ready", function () {
       var view = Object.create(adapt_epub.OPFView.prototype);
       var contentContainer = document.createElement("div");
-      var oldContainer = document.createElement("div");
-      contentContainer.appendChild(oldContainer);
-      var oldPage = new adapt_vtree.Page(oldContainer, oldContainer);
-      oldPage.spineIndex = 1;
+      var oldBlankContainer = document.createElement("div");
+      var oldContentContainer = document.createElement("div");
+      contentContainer.appendChild(oldBlankContainer);
+      contentContainer.appendChild(oldContentContainer);
+      var oldBlankPage = new adapt_vtree.Page(
+        oldBlankContainer,
+        oldBlankContainer,
+      );
+      oldBlankPage.spineIndex = 1;
+      oldBlankPage.offset = 10;
+      oldBlankPage.isBlankPage = true;
+      var oldContentPage = new adapt_vtree.Page(
+        oldContentContainer,
+        oldContentContainer,
+      );
+      oldContentPage.spineIndex = 1;
+      oldContentPage.offset = 10;
       var sourceItem = { item: { spineIndex: 0 }, pages: [] };
-      var oldViewItem = { item: { spineIndex: 1 }, pages: [oldPage] };
+      var oldViewItem = {
+        item: { spineIndex: 1 },
+        pages: [oldBlankPage, oldContentPage],
+      };
       view.opf = { epageIsRenderedPage: false };
       view.pageSheetSizeReporter = function () {};
       view.spineItems = [sourceItem, oldViewItem];
@@ -596,7 +612,9 @@ describe("epub", function () {
         discardReferencesFromSpine: function () {},
       };
       var replacedListener = jasmine.createSpy("replacedListener");
-      oldPage.addEventListener("replaced", replacedListener, false);
+      var blankReplacedListener = jasmine.createSpy("blankReplacedListener");
+      oldContentPage.addEventListener("replaced", replacedListener, false);
+      oldBlankPage.addEventListener("replaced", blankReplacedListener, false);
 
       view.deferFollowingSpinesForRelayout(0);
       view.relayoutDeferredFollowingSpines();
@@ -604,11 +622,16 @@ describe("epub", function () {
       var newContainer = document.createElement("div");
       var newPage = new adapt_vtree.Page(newContainer, newContainer);
       newPage.side = "right";
+      newPage.offset = 10;
       var newViewItem = {
         item: { spineIndex: 1 },
         pages: [],
+        layoutPositions: [null],
         instance: {
-          viewport: { contentContainer: contentContainer },
+          viewport: {
+            contentContainer: contentContainer,
+            layoutBox: { removeAttribute: function () {} },
+          },
           pageSheetWidth: 0,
           pageSheetHeight: 0,
           pageSheetSize: {},
@@ -621,6 +644,12 @@ describe("epub", function () {
       expect(replacedListener).toHaveBeenCalled();
       expect(replacedListener.calls.mostRecent().args[0].newPage).toBe(newPage);
       expect(newContainer.parentElement).toBe(contentContainer);
+      view.markSpineItemCompleteIfReady(newViewItem);
+      expect(blankReplacedListener).toHaveBeenCalled();
+      expect(blankReplacedListener.calls.mostRecent().args[0].newPage).toBe(
+        newPage,
+      );
+      expect(view.deferredPageReplacements.size).toBe(0);
     });
 
     it("keeps the earliest following spine queued for relayout", function () {
@@ -649,6 +678,7 @@ describe("epub", function () {
         view.spineItems = [{ pages: [sourcePage] }];
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
+          updateTargetTextNodesInPages: jasmine.createSpy(),
         };
         view.deferredFollowingSpineRelayoutStart = 1;
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
@@ -671,6 +701,9 @@ describe("epub", function () {
           expect(result).toBe(rerenderedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
+          ).toHaveBeenCalledOnceWith([sourcePage]);
+          expect(
+            view.counterStore.updateTargetTextNodesInPages,
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.renderingAllPages).toBe(false);
           done();
@@ -696,6 +729,7 @@ describe("epub", function () {
         view.spineItems = [{ pages: [sourcePage] }];
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
+          updateTargetTextNodesInPages: jasmine.createSpy(),
         };
         view.deferredFollowingSpineRelayoutStart = 1;
         spyOn(view, "renderPageTracked").and.returnValue(
@@ -716,6 +750,9 @@ describe("epub", function () {
           expect(result).toBe(rerenderedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
+          ).toHaveBeenCalledOnceWith([sourcePage]);
+          expect(
+            view.counterStore.updateTargetTextNodesInPages,
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -48,6 +48,26 @@ describe("epub", function () {
       );
       expect(viewer.pageRuleStyleElement.textContent).not.toContain("750pt");
     });
+
+    it("keeps a live sparse page-size slot created by startPage", function () {
+      var viewer = Object.create(adapt_viewer.AdaptiveViewer.prototype);
+      viewer.pageSizes = [];
+      viewer.pageSizes[4] = { width: 120, height: 110 };
+      viewer.pageSizes[5] = { width: 1000, height: 1000 };
+      viewer.pageRuleStyleElement = document.createElement("style");
+      viewer.pageRuleStyleElement.textContent = "stale";
+      viewer.pageSheetSizeAlreadySet = true;
+      viewer.pixelRatio = 1;
+
+      viewer.truncatePageSizes(5);
+
+      expect(viewer.pageSizes.length).toBe(5);
+      expect(viewer.pageSizes[4]).toEqual({ width: 120, height: 110 });
+      expect(viewer.pageRuleStyleElement.textContent).toContain(
+        "size: 90pt 83pt",
+      );
+      expect(viewer.pageRuleStyleElement.textContent).not.toContain("750pt");
+    });
   });
 
   describe("EPUBDocStore", function () {
@@ -705,6 +725,69 @@ describe("epub", function () {
       });
     });
 
+    it("defers final-page completion while a counter scope is still pushed", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = { spineIndex: 0, offset: 0, fetchers: [] };
+        var removeLayoutStyle = jasmine.createSpy("removeLayoutStyle");
+        var restorePageNumberContext = jasmine.createSpy(
+          "restorePageNumberContext",
+        );
+        var viewItem = {
+          item: { spineIndex: 0 },
+          layoutPositions: [null],
+          pages: [],
+          pageCounterStarts: [null],
+          instance: {
+            pageNumberOffset: 0,
+            viewport: {
+              layoutBox: { removeAttribute: removeLayoutStyle },
+            },
+            getPageNumberContextDepth: function () {
+              return 0;
+            },
+            pushPageNumberContext: function () {},
+            restorePageNumberContextDepth: restorePageNumberContext,
+            layoutNextPage: function () {
+              return adapt_task.newResult(null);
+            },
+          },
+        };
+        view.counterStore = {
+          finishPage: function () {},
+        };
+        view.isInCounterResolveScope = function () {
+          return true;
+        };
+        view.preparePageCountersForRender = function () {
+          return null;
+        };
+        view.makePage = function () {
+          return page;
+        };
+        view.resolvePageTypeForRenderSlot = function () {};
+        view.finishPageContainer = function (item, renderedPage, pageIndex) {
+          item.pages[pageIndex] = renderedPage;
+        };
+        view.reportPaginationProgress = function () {};
+        view.maybeRelayoutFollowingPage = function () {
+          return adapt_task.newResult(true);
+        };
+        view.resolveUnresolvedReferencesForPage = function () {
+          return adapt_task.newResult(page);
+        };
+
+        view.renderSinglePage(viewItem, { page: 0 }).then(function () {
+          expect(viewItem.pages).toEqual([page]);
+          expect(viewItem.complete).not.toBe(true);
+          expect(removeLayoutStyle).not.toHaveBeenCalled();
+          expect(restorePageNumberContext).toHaveBeenCalledOnceWith(0);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
     it("discards following spines after an earlier spine shrinks", function () {
       var view = Object.create(adapt_epub.OPFView.prototype);
       var sourcePage = { container: { remove: jasmine.createSpy() } };
@@ -931,7 +1014,9 @@ describe("epub", function () {
         var rerenderedResult = { id: "rerendered" };
         var sourcePage = { id: "source", fetchers: [] };
         view.opf = { spine: [{}, {}, {}] };
-        view.spineItems = [{ pages: [sourcePage] }];
+        view.spineItems = [
+          { pages: [sourcePage], instance: { pageNumberOffset: 4 } },
+        ];
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
@@ -965,7 +1050,7 @@ describe("epub", function () {
             view.counterStore.updateTargetTextNodesInPages,
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.renderingAllPages).toBe(false);
-          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(1);
+          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(5);
           done();
         });
         return adapt_task.newResult(true);
@@ -986,7 +1071,9 @@ describe("epub", function () {
         view.renderingPageTasks = new Map();
         view.renderingAllPages = false;
         view.relayoutingFollowingSpines = false;
-        view.spineItems = [{ pages: [sourcePage] }];
+        view.spineItems = [
+          { pages: [sourcePage], instance: { pageNumberOffset: 4 } },
+        ];
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
@@ -1019,7 +1106,7 @@ describe("epub", function () {
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);
-          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(1);
+          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(5);
           done();
         });
         return adapt_task.newResult(true);
@@ -1041,7 +1128,9 @@ describe("epub", function () {
         view.renderingPageTasks = new Map();
         view.renderingAllPages = false;
         view.relayoutingFollowingSpines = false;
-        view.spineItems = [{ pages: [sourcePage] }];
+        view.spineItems = [
+          { pages: [sourcePage], instance: { pageNumberOffset: 4 } },
+        ];
         view.counterStore = {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
@@ -1083,7 +1172,7 @@ describe("epub", function () {
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);
-          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(1);
+          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(5);
           done();
         });
         return adapt_task.newResult(true);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -544,6 +544,7 @@ describe("epub", function () {
         var cachedPage = {};
         var rebuiltPage = {};
         view.deferredFollowingSpineRelayoutStart = 1;
+        view.renderingPageTasks = new Map();
         spyOn(view, "waitForPreviousSpines").and.returnValue(
           adapt_task.newResult(true),
         );

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -526,6 +526,10 @@ describe("epub", function () {
         view.spineItems = [viewItem];
         view.spineItemLoadingContinuations = [null];
         view.deferredPageReplacements = new Map();
+        view.deferredReferencePages = [
+          { viewItem: viewItem, pageIndex: 15 },
+          { viewItem: viewItem, pageIndex: 16 },
+        ];
         view.counterStore = {
           finishPage: function () {},
           discardReferencesFromPage: jasmine.createSpy(),
@@ -563,6 +567,9 @@ describe("epub", function () {
           expect(
             view.counterStore.discardReferencesFromPage,
           ).toHaveBeenCalledOnceWith(0, 16);
+          expect(view.deferredReferencePages).toEqual([
+            { viewItem: viewItem, pageIndex: 15 },
+          ]);
           expect(viewItem.complete).toBe(true);
           done();
         });
@@ -679,6 +686,15 @@ describe("epub", function () {
       expect(replacedListener).toHaveBeenCalled();
       expect(replacedListener.calls.mostRecent().args[0].newPage).toBe(newPage);
       expect(newContainer.parentElement).toBe(contentContainer);
+      var laterBlankContainer = document.createElement("div");
+      var laterBlankPage = new adapt_vtree.Page(
+        laterBlankContainer,
+        laterBlankContainer,
+      );
+      laterBlankPage.offset = 100;
+      laterBlankPage.isBlankPage = true;
+      newViewItem.pages.push(laterBlankPage);
+      newViewItem.layoutPositions.push(null);
       view.markSpineItemCompleteIfReady(newViewItem);
       expect(blankReplacedListener).toHaveBeenCalled();
       expect(blankReplacedListener.calls.mostRecent().args[0].newPage).toBe(
@@ -1086,6 +1102,11 @@ describe("epub", function () {
           },
         };
         view.resolvingDeferredReferences = true;
+        view.deferredReferencePages = [];
+        view.drainingDeferredReferencePage = {
+          viewItem: viewItem,
+          pageIndex: 0,
+        };
         view.counterStore = {
           getUnresolvedRefsToPage: function () {
             return [{ spineIndex: 0, refs: [ref] }];
@@ -1093,8 +1114,66 @@ describe("epub", function () {
         };
 
         view.deferReferencesForPage(viewItem, page, 0, null);
-        expect(view.deferredReferencePages || []).toEqual([]);
+        expect(view.deferredReferencePages).toEqual([]);
         done();
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("drains references cascaded from another deferred page", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var pages = [{ id: "a" }, { id: "b" }, { id: "c" }];
+        var viewItem = { pages: pages };
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.deferredReferencePages = [];
+        view.resolvingDeferredReferences = false;
+        view.drainingDeferredReferencePage = null;
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return false;
+        };
+        spyOn(view, "resolveUnresolvedReferencesForPage").and.callFake(
+          function (item, page, pageIndex) {
+            if (pageIndex < pages.length - 1) {
+              return view.resolveDeferredReferencesAfterCounterScope(
+                item,
+                pages[pageIndex + 1],
+                pageIndex + 1,
+                null,
+              );
+            }
+            return adapt_task.newResult(page);
+          },
+        );
+
+        view
+          .resolveDeferredReferencesAfterCounterScope(
+            viewItem,
+            pages[0],
+            0,
+            null,
+          )
+          .then(function () {
+            expect(
+              view.resolveUnresolvedReferencesForPage.calls
+                .allArgs()
+                .map(function (args) {
+                  return args[2];
+                }),
+            ).toEqual([0, 1, 2]);
+            expect(view.deferredReferencePages).toEqual([]);
+            expect(view.drainingDeferredReferencePage).toBeNull();
+            done();
+          });
         return adapt_task.newResult(true);
       });
     });

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -525,6 +525,7 @@ describe("epub", function () {
         };
         view.spineItems = [viewItem];
         view.spineItemLoadingContinuations = [null];
+        view.deferredPageReplacements = new Map();
         view.counterStore = {
           finishPage: function () {},
           discardReferencesFromPage: jasmine.createSpy(),
@@ -641,6 +642,7 @@ describe("epub", function () {
       view.spineItems = [sourceItem, oldViewItem];
       view.spineItemLoadingContinuations = [[], []];
       view.deferredPageReplacements = new Map();
+      view.deferredReferencePages = [];
       view.counterStore = {
         discardReferencesFromSpine: function () {},
       };

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -480,6 +480,9 @@ describe("epub", function () {
           }),
           pageCounterStarts: new Array(17).fill(null),
           instance: {
+            viewport: {
+              layoutBox: { removeAttribute: function () {} },
+            },
             getPageNumberContextDepth: function () {
               return 0;
             },
@@ -521,6 +524,7 @@ describe("epub", function () {
           expect(viewItem.pages.length).toBe(16);
           expect(viewItem.layoutPositions.length).toBe(16);
           expect(viewItem.pageCounterStarts.length).toBe(16);
+          expect(viewItem.complete).toBe(true);
           done();
         });
         return adapt_task.newResult(true);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -965,6 +965,7 @@ describe("epub", function () {
       expect(view.deferredReferencePages).toEqual([{ viewItem: sourceItem }]);
       expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
         1,
+        false,
       );
     });
 
@@ -1161,8 +1162,9 @@ describe("epub", function () {
         view.relayoutingFollowingSpines = false;
         view.relayoutingFollowingSpineStart = null;
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
-          function () {
+          function (preserveTargetSnapshots) {
             passStarts.push(view.deferredFollowingSpineRelayoutStart);
+            expect(preserveTargetSnapshots).toBe(passStarts.length > 1);
             view.deferredFollowingSpineRelayoutStart = null;
             return 2;
           },

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -611,7 +611,11 @@ describe("epub", function () {
           return page;
         };
         view.resolvePageTypeForRenderSlot = function () {};
-        spyOn(view, "finishPageContainer");
+        spyOn(view, "finishPageContainer").and.callFake(
+          function (item, renderedPage, pageIndex) {
+            item.pages[pageIndex] = renderedPage;
+          },
+        );
         view.reportPaginationProgress = function () {};
         view.maybeRelayoutFollowingPage = function () {
           expect(viewItem.complete).not.toBe(true);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -615,6 +615,7 @@ describe("epub", function () {
           }),
           pageCounterStarts: new Array(17).fill(null),
           instance: {
+            pageNumberOffset: 0,
             viewport: {
               layoutBox: { removeAttribute: function () {} },
             },
@@ -727,9 +728,6 @@ describe("epub", function () {
       ];
       view.deferredReferencePages = deferredReferencePages;
       view.counterStore = {
-        getRebuildStartForReferences: function (firstSpine) {
-          return firstSpine;
-        },
         discardReferencesFromSpine: jasmine.createSpy(),
       };
 
@@ -749,41 +747,6 @@ describe("epub", function () {
       expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
         1,
       );
-    });
-
-    it("rebuilds retained source pages whose target is in the invalid suffix", function () {
-      var view = Object.create(adapt_epub.OPFView.prototype);
-      var sourcePage = { container: { remove: jasmine.createSpy() } };
-      var targetPage = { container: { remove: jasmine.createSpy() } };
-      var sourceItem = {
-        item: { spineIndex: 0 },
-        pages: [sourcePage],
-      };
-      var targetItem = {
-        item: { spineIndex: 1 },
-        pages: [targetPage],
-      };
-      view.spineItems = [sourceItem, targetItem];
-      view.spineItemLoadingContinuations = [[], []];
-      view.deferredPageReplacements = new Map();
-      view.deferredReferencePages = [];
-      view.counterStore = {
-        getRebuildStartForReferences: jasmine.createSpy().and.returnValue(0),
-        discardReferencesFromSpine: jasmine.createSpy(),
-      };
-
-      view.deferFollowingSpinesForRelayout(0);
-      view.relayoutDeferredFollowingSpines();
-
-      expect(
-        view.counterStore.getRebuildStartForReferences,
-      ).toHaveBeenCalledOnceWith(1);
-      expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
-        0,
-      );
-      expect(sourcePage.container.remove).toHaveBeenCalled();
-      expect(targetPage.container.remove).toHaveBeenCalled();
-      expect(view.spineItems).toEqual([null, null]);
     });
 
     it("notifies a displayed page when its rebuilt replacement is ready", function () {
@@ -818,9 +781,6 @@ describe("epub", function () {
       view.deferredPageReplacements = new Map();
       view.deferredReferencePages = [];
       view.counterStore = {
-        getRebuildStartForReferences: function (firstSpine) {
-          return firstSpine;
-        },
         discardReferencesFromSpine: function () {},
       };
       var replacedListener = jasmine.createSpy("replacedListener");

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -965,7 +965,6 @@ describe("epub", function () {
       expect(view.deferredReferencePages).toEqual([{ viewItem: sourceItem }]);
       expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
         1,
-        false,
       );
     });
 
@@ -1130,24 +1129,84 @@ describe("epub", function () {
       view.counterStore = {
         updateTargetCounterNodesInPages: jasmine
           .createSpy()
-          .and.returnValue(new Set([prefixPage])),
+          .and.callFake(function (pages, changedTargetIds) {
+            changedTargetIds.add("counter-target");
+            return new Set([prefixPage]);
+          }),
         updateTargetTextNodesInPages: jasmine
           .createSpy()
-          .and.returnValue(new Set([rebuiltPage])),
+          .and.callFake(function (pages, changedTargetIds) {
+            changedTargetIds.add("text-target");
+            return new Set([rebuiltPage]);
+          }),
+        unresolveReferencesForTargets: jasmine.createSpy(),
       };
 
-      var firstChangedSpine = view.updateRetainedTargetCounters();
+      var changedTargetIds = view.updateRetainedTargetCounters();
 
       expect(
         view.counterStore.updateTargetCounterNodesInPages,
-      ).toHaveBeenCalledOnceWith([prefixPage, rebuiltPage]);
+      ).toHaveBeenCalledWith([prefixPage, rebuiltPage], jasmine.any(Set));
       expect(
         view.counterStore.updateTargetTextNodesInPages,
-      ).toHaveBeenCalledOnceWith([prefixPage, rebuiltPage]);
-      expect(firstChangedSpine).toBe(0);
+      ).toHaveBeenCalledWith([prefixPage, rebuiltPage], jasmine.any(Set));
+      expect(changedTargetIds).toEqual(
+        new Set(["counter-target", "text-target"]),
+      );
+      expect(
+        view.counterStore.unresolveReferencesForTargets,
+      ).toHaveBeenCalledOnceWith(changedTargetIds);
     });
 
-    it("rebuilds from a changed retained reference until stable", function (done) {
+    it("routes changed retained references through the target page resolver", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var targetPage = { id: "target-page" };
+        var nextPosition = { page: 1 };
+        var targetViewItem = {
+          item: { spineIndex: 1 },
+          pages: [targetPage],
+          layoutPositions: [{ page: 0 }, nextPosition],
+        };
+        view.spineItems = [null, targetViewItem];
+        view.counterStore = {
+          pageIndicesById: {
+            target1: { spineIndex: 1, pageIndex: 0 },
+            target2: { spineIndex: 1, pageIndex: 0 },
+          },
+        };
+        spyOn(view, "deferReferencesForPage");
+        spyOn(
+          view,
+          "resolveDeferredReferencesAfterCounterScope",
+        ).and.returnValue(adapt_task.newResult(targetPage));
+
+        view
+          .resolveChangedRetainedTargetReferences(
+            new Set(["target1", "target2"]),
+          )
+          .then(function () {
+            expect(view.deferReferencesForPage).toHaveBeenCalledOnceWith(
+              targetViewItem,
+              targetPage,
+              0,
+              nextPosition,
+            );
+            expect(
+              view.resolveDeferredReferencesAfterCounterScope,
+            ).toHaveBeenCalledOnceWith(
+              targetViewItem,
+              targetPage,
+              0,
+              nextPosition,
+            );
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("rerenders changed retained references before rebuilding the suffix", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
         var position = {
@@ -1162,9 +1221,8 @@ describe("epub", function () {
         view.relayoutingFollowingSpines = false;
         view.relayoutingFollowingSpineStart = null;
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
-          function (preserveTargetSnapshots) {
+          function () {
             passStarts.push(view.deferredFollowingSpineRelayoutStart);
-            expect(preserveTargetSnapshots).toBe(passStarts.length > 1);
             view.deferredFollowingSpineRelayoutStart = null;
             return 2;
           },
@@ -1173,16 +1231,31 @@ describe("epub", function () {
           adapt_task.newResult({ id: "first" }),
           adapt_task.newResult({ id: "stable" }),
         );
-        spyOn(view, "updateRetainedTargetCounters").and.returnValues(0, null);
+        var changedTargetIds = new Set(["target"]);
+        spyOn(view, "updateRetainedTargetCounters").and.returnValues(
+          changedTargetIds,
+          new Set(),
+        );
+        spyOn(view, "resolveChangedRetainedTargetReferences").and.callFake(
+          function (targetIds) {
+            if (targetIds.size) {
+              view.deferredFollowingSpineRelayoutStart = 1;
+            }
+            return adapt_task.newResult(true);
+          },
+        );
 
         view.rerenderDeferredFollowingSpines(position).then(function (result) {
-          expect(passStarts).toEqual([1, 0]);
+          expect(passStarts).toEqual([1, 1]);
           expect(view.renderPagesUpto.calls.count()).toBe(2);
           expect(view.renderPagesUpto.calls.allArgs()).toEqual([
             [position, false],
             [position, false],
           ]);
           expect(result).toEqual({ id: "stable" });
+          expect(
+            view.resolveChangedRetainedTargetReferences.calls.allArgs(),
+          ).toEqual([[changedTargetIds], [new Set()]]);
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.relayoutingFollowingSpineStart).toBeNull();
           done();

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -1308,10 +1308,10 @@ describe("epub", function () {
           expect(result).toBe(rerenderedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledOnceWith([sourcePage], jasmine.any(Set));
           expect(
             view.counterStore.updateTargetTextNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledOnceWith([sourcePage], jasmine.any(Set));
           expect(view.renderingAllPages).toBe(false);
           expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(5);
           done();
@@ -1375,10 +1375,10 @@ describe("epub", function () {
           expect(result).toBe(requestedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledOnceWith([sourcePage], jasmine.any(Set));
           expect(
             view.counterStore.updateTargetTextNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledOnceWith([sourcePage], jasmine.any(Set));
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);
           expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(5);
@@ -1442,10 +1442,10 @@ describe("epub", function () {
           expect(result).toBe(requestedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledOnceWith([sourcePage], jasmine.any(Set));
           expect(
             view.counterStore.updateTargetTextNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledOnceWith([sourcePage], jasmine.any(Set));
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);
           expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(5);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -589,6 +589,7 @@ describe("epub", function () {
       var sourceItem = { item: { spineIndex: 0 }, pages: [] };
       var oldViewItem = { item: { spineIndex: 1 }, pages: [oldPage] };
       view.opf = { epageIsRenderedPage: false };
+      view.pageSheetSizeReporter = function () {};
       view.spineItems = [sourceItem, oldViewItem];
       view.spineItemLoadingContinuations = [[], []];
       view.counterStore = {
@@ -606,7 +607,13 @@ describe("epub", function () {
       var newViewItem = {
         item: { spineIndex: 1 },
         pages: [],
-        instance: { viewport: { contentContainer: contentContainer } },
+        instance: {
+          viewport: { contentContainer: contentContainer },
+          pageSheetWidth: 0,
+          pageSheetHeight: 0,
+          pageSheetSize: {},
+          pageNumberOffset: 0,
+        },
       };
       view.spineItems[1] = newViewItem;
       view.finishPageContainer(newViewItem, newPage, 0);
@@ -682,9 +689,14 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
+        var sourcePage = { id: "source" };
         view.renderingPageTasks = new Map();
         view.renderingAllPages = false;
         view.relayoutingFollowingSpines = false;
+        view.spineItems = [{ pages: [sourcePage] }];
+        view.counterStore = {
+          updateTargetCounterNodesInPages: jasmine.createSpy(),
+        };
         view.deferredFollowingSpineRelayoutStart = 1;
         spyOn(view, "renderPageTracked").and.returnValue(
           adapt_task.newResult(initialResult),
@@ -702,6 +714,9 @@ describe("epub", function () {
           expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
           expect(view.renderPagesUpto).toHaveBeenCalledWith(position, false);
           expect(result).toBe(rerenderedResult);
+          expect(
+            view.counterStore.updateTargetCounterNodesInPages,
+          ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);
           done();

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -498,6 +498,67 @@ describe("epub", function () {
       });
     });
 
+    it("waits for background pagination to rebuild a cached suffix page", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = { spineIndex: 1, pageIndex: 0, offsetInItem: -1 };
+        var stalePage = {};
+        var rebuiltPage = {};
+        var viewItem = { pages: [stalePage], complete: true };
+        view.deferredFollowingSpineRelayoutStart = 1;
+        view.renderingAllPages = true;
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "getPageViewItem").and.callFake(function () {
+          return adapt_task.newResult(viewItem);
+        });
+        spyOn(view, "renderPage").and.returnValue(
+          adapt_task.newResult({ page: stalePage, position: position }),
+        );
+        var scheduler = adapt_task.currentTask().getScheduler();
+        var backgroundTask = scheduler.run(function () {
+          var backgroundFrame = adapt_task.newFrame("finishSuffixRebuild");
+          backgroundFrame.sleep(50).then(function () {
+            viewItem.pages[0] = rebuiltPage;
+            view.deferredFollowingSpineRelayoutStart = null;
+            view.renderingAllPages = false;
+            backgroundFrame.finish(true);
+          });
+          return backgroundFrame.result();
+        });
+
+        view.findPage(position, false).then(function (result) {
+          expect(result.page).toBe(rebuiltPage);
+          expect(view.renderPage).not.toHaveBeenCalled();
+          backgroundTask.join().then(function () {
+            done();
+          });
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("does not return an invalid cached suffix page synchronously", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = { spineIndex: 1, pageIndex: 0, offsetInItem: -1 };
+        view.deferredFollowingSpineRelayoutStart = 1;
+        view.renderingAllPages = true;
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "renderPage");
+
+        view.findPage(position, true).then(function (result) {
+          expect(result).toBeNull();
+          expect(view.renderPage).not.toHaveBeenCalled();
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
     it("reuses the requested slot when a final-page rerender shrinks the spine", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -763,6 +763,67 @@ describe("epub", function () {
         return adapt_task.newResult(true);
       });
     });
+
+    it("rerenders every previously rendered spine after on-demand invalidation", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = {
+          spineIndex: 2,
+          pageIndex: Number.POSITIVE_INFINITY,
+          offsetInItem: -1,
+        };
+        var initialResult = { id: "initial" };
+        var requestedResult = { id: "requested" };
+        var farthestResult = { id: "farthest" };
+        var sourcePage = { id: "source", fetchers: [] };
+        view.renderingPageTasks = new Map();
+        view.renderingAllPages = false;
+        view.relayoutingFollowingSpines = false;
+        view.spineItems = [{ pages: [sourcePage] }];
+        view.counterStore = {
+          updateTargetCounterNodesInPages: jasmine.createSpy(),
+          updateTargetTextNodesInPages: jasmine.createSpy(),
+        };
+        view.deferredFollowingSpineRelayoutStart = 1;
+        spyOn(view, "renderPageTracked").and.returnValues(
+          adapt_task.newResult(initialResult),
+          adapt_task.newResult(requestedResult),
+        );
+        spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
+          function () {
+            view.deferredFollowingSpineRelayoutStart = null;
+            return 4;
+          },
+        );
+        spyOn(view, "renderPagesUpto").and.returnValue(
+          adapt_task.newResult(farthestResult),
+        );
+
+        view.renderPage(position).then(function (result) {
+          expect(view.renderPagesUpto).toHaveBeenCalledOnceWith(
+            {
+              spineIndex: 4,
+              pageIndex: Number.POSITIVE_INFINITY,
+              offsetInItem: -1,
+            },
+            false,
+          );
+          expect(view.renderPageTracked.calls.count()).toBe(2);
+          expect(result).toBe(requestedResult);
+          expect(
+            view.counterStore.updateTargetCounterNodesInPages,
+          ).toHaveBeenCalledOnceWith([sourcePage]);
+          expect(
+            view.counterStore.updateTargetTextNodesInPages,
+          ).toHaveBeenCalledOnceWith([sourcePage]);
+          expect(view.relayoutingFollowingSpines).toBe(false);
+          expect(view.renderingPageTasks.size).toBe(0);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
     it("resolves references deferred by a nested counter scope", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -495,7 +495,10 @@ describe("epub", function () {
         };
         view.spineItems = [viewItem];
         view.spineItemLoadingContinuations = [null];
-        view.counterStore = { finishPage: function () {} };
+        view.counterStore = {
+          finishPage: function () {},
+          discardReferencesFromPage: jasmine.createSpy(),
+        };
         view.isInCounterResolveScope = function () {
           return false;
         };
@@ -524,6 +527,9 @@ describe("epub", function () {
           expect(viewItem.pages.length).toBe(16);
           expect(viewItem.layoutPositions.length).toBe(16);
           expect(viewItem.pageCounterStarts.length).toBe(16);
+          expect(
+            view.counterStore.discardReferencesFromPage,
+          ).toHaveBeenCalledOnceWith(0, 16);
           expect(viewItem.complete).toBe(true);
           done();
         });

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -687,6 +687,57 @@ describe("epub", function () {
       });
     });
 
+    it("waits until an in-progress suffix rebuild has completed", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = { spineIndex: 1, pageIndex: 0, offsetInItem: -1 };
+        var rebuiltPage = {};
+        view.relayoutingFollowingSpineStart = 1;
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "getPageViewItem").and.returnValue(
+          adapt_task.newResult({ pages: [rebuiltPage], complete: true }),
+        );
+        var scheduler = adapt_task.currentTask().getScheduler();
+        var rebuildTask = scheduler.run(function () {
+          var rebuildFrame = adapt_task.newFrame("finishSuffixRelayout");
+          rebuildFrame.sleep(50).then(function () {
+            view.relayoutingFollowingSpineStart = null;
+            rebuildFrame.finish(true);
+          });
+          return rebuildFrame.result();
+        });
+
+        view.findPage(position, false).then(function (result) {
+          expect(result.page).toBe(rebuiltPage);
+          rebuildTask.join().then(function () {
+            done();
+          });
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("does not expose an in-progress suffix rebuild synchronously", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = { spineIndex: 1, pageIndex: 0, offsetInItem: -1 };
+        view.relayoutingFollowingSpineStart = 1;
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "getPageViewItem");
+
+        view.findPage(position, true).then(function (result) {
+          expect(result).toBeNull();
+          expect(view.getPageViewItem).not.toHaveBeenCalled();
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
     it("reuses the requested slot when a final-page rerender shrinks the spine", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -467,6 +467,332 @@ describe("epub", function () {
         return testFrame.result();
       });
     });
+
+    it("reuses the requested slot when a final-page rerender shrinks the spine", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = { spineIndex: 0, offset: 0, fetchers: [] };
+        var viewItem = {
+          item: { spineIndex: 0 },
+          layoutPositions: new Array(17).fill(null),
+          pages: Array.from({ length: 17 }, function () {
+            return { container: { remove: function () {} } };
+          }),
+          pageCounterStarts: new Array(17).fill(null),
+          instance: {
+            getPageNumberContextDepth: function () {
+              return 0;
+            },
+            pushPageNumberContext: function () {},
+            restorePageNumberContextDepth: function () {},
+            layoutNextPage: function () {
+              return adapt_task.newResult(null);
+            },
+          },
+        };
+        view.spineItems = [viewItem];
+        view.spineItemLoadingContinuations = [null];
+        view.counterStore = { finishPage: function () {} };
+        view.isInCounterResolveScope = function () {
+          return false;
+        };
+        view.preparePageCountersForRender = function () {
+          return null;
+        };
+        view.makePage = function () {
+          return page;
+        };
+        view.resolvePageTypeForRenderSlot = function () {};
+        spyOn(view, "finishPageContainer");
+        view.reportPaginationProgress = function () {};
+        view.maybeRelayoutFollowingPage = function () {
+          return adapt_task.newResult(true);
+        };
+        view.resolveUnresolvedReferencesForPage = function () {
+          return adapt_task.newResult(page);
+        };
+
+        view.renderSinglePage(viewItem, { page: 15 }).then(function () {
+          expect(view.finishPageContainer).toHaveBeenCalledWith(
+            viewItem,
+            page,
+            15,
+          );
+          expect(viewItem.pages.length).toBe(16);
+          expect(viewItem.layoutPositions.length).toBe(16);
+          expect(viewItem.pageCounterStarts.length).toBe(16);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("discards following spines after an earlier spine shrinks", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      var sourcePage = { container: { remove: jasmine.createSpy() } };
+      var followingPage1 = { container: { remove: jasmine.createSpy() } };
+      var followingPage2 = { container: { remove: jasmine.createSpy() } };
+      var sourceItem = { item: { spineIndex: 0 }, pages: [sourcePage] };
+      var followingItem1 = {
+        item: { spineIndex: 1 },
+        pages: [followingPage1],
+      };
+      var followingItem2 = {
+        item: { spineIndex: 2 },
+        pages: [followingPage2],
+      };
+      view.spineItems = [sourceItem, followingItem1, followingItem2];
+      view.spineItemLoadingContinuations = [[], [], []];
+      view.deferredReferencePages = [
+        { viewItem: sourceItem },
+        { viewItem: followingItem1 },
+      ];
+      view.counterStore = {
+        discardReferencesFromSpine: jasmine.createSpy(),
+      };
+
+      view.deferFollowingSpinesForRelayout(0);
+      view.relayoutDeferredFollowingSpines();
+
+      expect(view.spineItems[0]).toBe(sourceItem);
+      expect(view.spineItems[1]).toBeNull();
+      expect(view.spineItems[2]).toBeNull();
+      expect(sourcePage.container.remove).not.toHaveBeenCalled();
+      expect(followingPage1.container.remove).toHaveBeenCalled();
+      expect(followingPage2.container.remove).toHaveBeenCalled();
+      expect(view.spineItemLoadingContinuations[1]).toBeNull();
+      expect(view.spineItemLoadingContinuations[2]).toBeNull();
+      expect(view.deferredReferencePages).toEqual([{ viewItem: sourceItem }]);
+      expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
+        1,
+      );
+    });
+
+    it("keeps the earliest following spine queued for relayout", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      view.spineItems = [];
+      view.spineItemLoadingContinuations = [];
+
+      view.deferFollowingSpinesForRelayout(3);
+      view.deferFollowingSpinesForRelayout(1);
+
+      expect(view.deferredFollowingSpineRelayoutStart).toBe(2);
+    });
+
+    it("rerenders a deferred suffix once after full pagination", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var finalPosition = {
+          spineIndex: 2,
+          pageIndex: Number.POSITIVE_INFINITY,
+          offsetInItem: -1,
+        };
+        var initialResult = { id: "initial" };
+        var rerenderedResult = { id: "rerendered" };
+        view.opf = { spine: [{}, {}, {}] };
+        view.spineItems = [];
+        view.deferredFollowingSpineRelayoutStart = 1;
+        spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
+          function () {
+            view.deferredFollowingSpineRelayoutStart = null;
+          },
+        );
+        spyOn(view, "renderPagesUpto").and.returnValues(
+          adapt_task.newResult(initialResult),
+          adapt_task.newResult(rerenderedResult),
+        );
+
+        view.renderAllPages().then(function (result) {
+          expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
+          expect(view.renderPagesUpto.calls.count()).toBe(2);
+          expect(view.renderPagesUpto.calls.allArgs()).toEqual([
+            [finalPosition, false],
+            [finalPosition, false],
+          ]);
+          expect(result).toBe(rerenderedResult);
+          expect(view.renderingAllPages).toBe(false);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("rerenders a deferred suffix after on-demand pagination", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = {
+          spineIndex: 2,
+          pageIndex: Number.POSITIVE_INFINITY,
+          offsetInItem: -1,
+        };
+        var initialResult = { id: "initial" };
+        var rerenderedResult = { id: "rerendered" };
+        view.renderingPageTasks = new Map();
+        view.renderingAllPages = false;
+        view.relayoutingFollowingSpines = false;
+        view.deferredFollowingSpineRelayoutStart = 1;
+        spyOn(view, "renderPageTracked").and.returnValue(
+          adapt_task.newResult(initialResult),
+        );
+        spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
+          function () {
+            view.deferredFollowingSpineRelayoutStart = null;
+          },
+        );
+        spyOn(view, "renderPagesUpto").and.returnValue(
+          adapt_task.newResult(rerenderedResult),
+        );
+
+        view.renderPage(position).then(function (result) {
+          expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
+          expect(view.renderPagesUpto).toHaveBeenCalledWith(position, false);
+          expect(result).toBe(rerenderedResult);
+          expect(view.relayoutingFollowingSpines).toBe(false);
+          expect(view.renderingPageTasks.size).toBe(0);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+    it("resolves references deferred by a nested counter scope", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = {};
+        var viewItem = {};
+        var nextLayoutPosition = { page: 16 };
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return false;
+        };
+        spyOn(view, "resolveUnresolvedReferencesForPage").and.returnValue(
+          adapt_task.newResult(page),
+        );
+
+        view
+          .resolveDeferredReferencesAfterCounterScope(
+            viewItem,
+            page,
+            15,
+            nextLayoutPosition,
+          )
+          .then(function (result) {
+            expect(
+              view.resolveUnresolvedReferencesForPage,
+            ).toHaveBeenCalledWith(viewItem, page, 15, nextLayoutPosition);
+            expect(result).toBe(page);
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("remembers the cascaded page where a counter scope defers references", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = {
+          container: {
+            parentElement: {},
+            setAttribute: function () {},
+          },
+          spineIndex: 0,
+        };
+        var viewItem = { pages: [page], item: { spineIndex: 0 } };
+        var nextLayoutPosition = { page: 1 };
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.opf = { spine: [{}, {}] };
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return true;
+        };
+        spyOn(view, "deferReferencesForPage").and.callThrough();
+
+        view
+          .resolveUnresolvedReferencesForPage(
+            viewItem,
+            page,
+            0,
+            nextLayoutPosition,
+          )
+          .then(function () {
+            expect(view.deferReferencesForPage).toHaveBeenCalledWith(
+              viewItem,
+              page,
+              0,
+              nextLayoutPosition,
+            );
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("queues deferred references until the outermost counter scope is restored", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = {};
+        var viewItem = { pages: [page] };
+        var inCounterScope = true;
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return inCounterScope;
+        };
+        spyOn(view, "resolveUnresolvedReferencesForPage").and.returnValue(
+          adapt_task.newResult(page),
+        );
+
+        view
+          .resolveDeferredReferencesAfterCounterScope(viewItem, page, 0, null)
+          .then(function () {
+            expect(
+              view.resolveUnresolvedReferencesForPage,
+            ).not.toHaveBeenCalled();
+            inCounterScope = false;
+            view
+              .resolveDeferredReferencesAfterCounterScope(
+                viewItem,
+                page,
+                0,
+                null,
+              )
+              .then(function () {
+                expect(
+                  view.resolveUnresolvedReferencesForPage,
+                ).toHaveBeenCalledWith(viewItem, page, 0, null);
+                expect(
+                  view.resolveUnresolvedReferencesForPage.calls.count(),
+                ).toBe(1);
+                done();
+              });
+          });
+        return adapt_task.newResult(true);
+      });
+    });
   });
   describe("OPFView pagination progress", function () {
     function createFakeView(totalOffsets) {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -594,10 +594,11 @@ describe("epub", function () {
       view.spineItems = [sourceItem, followingItem1, followingItem2];
       view.spineItemLoadingContinuations = [[], [], []];
       view.deferredPageReplacements = new Map();
-      view.deferredReferencePages = [
+      var deferredReferencePages = [
         { viewItem: sourceItem },
         { viewItem: followingItem1 },
       ];
+      view.deferredReferencePages = deferredReferencePages;
       view.counterStore = {
         discardReferencesFromSpine: jasmine.createSpy(),
       };
@@ -613,6 +614,7 @@ describe("epub", function () {
       expect(followingPage2.container.remove).toHaveBeenCalled();
       expect(view.spineItemLoadingContinuations[1]).toBeNull();
       expect(view.spineItemLoadingContinuations[2]).toBeNull();
+      expect(view.deferredReferencePages).toBe(deferredReferencePages);
       expect(view.deferredReferencePages).toEqual([{ viewItem: sourceItem }]);
       expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
         1,

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -919,7 +919,7 @@ describe("epub", function () {
       ).toHaveBeenCalledOnceWith([prefixPage, rebuiltPage]);
     });
 
-    it("rerenders a deferred suffix once after full pagination", function (done) {
+    it("rerenders a deferred suffix until page counts stabilize", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
         var finalPosition = {
@@ -929,6 +929,8 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
+        var stabilizedResult = { id: "stabilized" };
+        var renderCount = 0;
         var sourcePage = { id: "source", fetchers: [] };
         view.opf = { spine: [{}, {}, {}] };
         view.spineItems = [{ pages: [sourcePage] }];
@@ -942,25 +944,33 @@ describe("epub", function () {
             view.deferredFollowingSpineRelayoutStart = null;
           },
         );
-        spyOn(view, "renderPagesUpto").and.returnValues(
-          adapt_task.newResult(initialResult),
-          adapt_task.newResult(rerenderedResult),
-        );
+        spyOn(view, "renderPagesUpto").and.callFake(function () {
+          renderCount++;
+          if (renderCount === 2) {
+            view.deferredFollowingSpineRelayoutStart = 1;
+            return adapt_task.newResult(rerenderedResult);
+          }
+          return adapt_task.newResult(
+            renderCount === 1 ? initialResult : stabilizedResult,
+          );
+        });
 
         view.renderAllPages().then(function (result) {
           expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
-          expect(view.renderPagesUpto.calls.count()).toBe(2);
+          expect(view.relayoutDeferredFollowingSpines.calls.count()).toBe(2);
+          expect(view.renderPagesUpto.calls.count()).toBe(3);
           expect(view.renderPagesUpto.calls.allArgs()).toEqual([
             [finalPosition, false],
             [finalPosition, false],
+            [finalPosition, false],
           ]);
-          expect(result).toBe(rerenderedResult);
+          expect(result).toBe(stabilizedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledTimes(2);
           expect(
             view.counterStore.updateTargetTextNodesInPages,
-          ).toHaveBeenCalledOnceWith([sourcePage]);
+          ).toHaveBeenCalledTimes(2);
           expect(view.renderingAllPages).toBe(false);
           done();
         });
@@ -978,6 +988,7 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
+        var requestedResult = { id: "requested" };
         var sourcePage = { id: "source", fetchers: [] };
         view.renderingPageTasks = new Map();
         view.renderingAllPages = false;
@@ -988,8 +999,9 @@ describe("epub", function () {
           updateTargetTextNodesInPages: jasmine.createSpy(),
         };
         view.deferredFollowingSpineRelayoutStart = 1;
-        spyOn(view, "renderPageTracked").and.returnValue(
+        spyOn(view, "renderPageTracked").and.returnValues(
           adapt_task.newResult(initialResult),
+          adapt_task.newResult(requestedResult),
         );
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
           function () {
@@ -1003,7 +1015,8 @@ describe("epub", function () {
         view.renderPage(position).then(function (result) {
           expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
           expect(view.renderPagesUpto).toHaveBeenCalledWith(position, false);
-          expect(result).toBe(rerenderedResult);
+          expect(result).toBe(requestedResult);
+          expect(view.renderPageTracked.calls.count()).toBe(2);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
           ).toHaveBeenCalledOnceWith([sourcePage]);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -644,7 +644,7 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
-        var sourcePage = { id: "source" };
+        var sourcePage = { id: "source", fetchers: [] };
         view.opf = { spine: [{}, {}, {}] };
         view.spineItems = [{ pages: [sourcePage] }];
         view.counterStore = {
@@ -689,7 +689,7 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
-        var sourcePage = { id: "source" };
+        var sourcePage = { id: "source", fetchers: [] };
         view.renderingPageTasks = new Map();
         view.renderingAllPages = false;
         view.relayoutingFollowingSpines = false;

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -68,6 +68,27 @@ describe("epub", function () {
       );
       expect(viewer.pageRuleStyleElement.textContent).not.toContain("750pt");
     });
+
+    it("refreshes page rules after a same-length page-size rebuild", function () {
+      var viewer = Object.create(adapt_viewer.AdaptiveViewer.prototype);
+      viewer.pageSizes = [
+        { width: 100, height: 100 },
+        { width: 100, height: 100 },
+      ];
+      viewer.pageRuleStyleElement = document.createElement("style");
+      viewer.pageRuleStyleElement.textContent =
+        "@page {size: 750pt 750pt; margin: 0;}";
+      viewer.pageSheetSizeAlreadySet = true;
+      viewer.pixelRatio = 1;
+
+      viewer.truncatePageSizes(2);
+
+      expect(viewer.pageSizes.length).toBe(2);
+      expect(viewer.pageRuleStyleElement.textContent).toContain(
+        "size: 75pt 75pt",
+      );
+      expect(viewer.pageRuleStyleElement.textContent).not.toContain("750pt");
+    });
   });
 
   describe("EPUBDocStore", function () {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -18,6 +18,7 @@
 
 import * as adapt_epub from "../../../src/vivliostyle/epub";
 import * as adapt_task from "../../../src/vivliostyle/task";
+import * as adapt_vtree from "../../../src/vivliostyle/vtree";
 import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
 import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
 
@@ -578,6 +579,43 @@ describe("epub", function () {
       );
     });
 
+    it("notifies a displayed page when its rebuilt replacement is ready", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      var contentContainer = document.createElement("div");
+      var oldContainer = document.createElement("div");
+      contentContainer.appendChild(oldContainer);
+      var oldPage = new adapt_vtree.Page(oldContainer, oldContainer);
+      oldPage.spineIndex = 1;
+      var sourceItem = { item: { spineIndex: 0 }, pages: [] };
+      var oldViewItem = { item: { spineIndex: 1 }, pages: [oldPage] };
+      view.opf = { epageIsRenderedPage: false };
+      view.spineItems = [sourceItem, oldViewItem];
+      view.spineItemLoadingContinuations = [[], []];
+      view.counterStore = {
+        discardReferencesFromSpine: function () {},
+      };
+      var replacedListener = jasmine.createSpy("replacedListener");
+      oldPage.addEventListener("replaced", replacedListener, false);
+
+      view.deferFollowingSpinesForRelayout(0);
+      view.relayoutDeferredFollowingSpines();
+
+      var newContainer = document.createElement("div");
+      var newPage = new adapt_vtree.Page(newContainer, newContainer);
+      newPage.side = "right";
+      var newViewItem = {
+        item: { spineIndex: 1 },
+        pages: [],
+        instance: { viewport: { contentContainer: contentContainer } },
+      };
+      view.spineItems[1] = newViewItem;
+      view.finishPageContainer(newViewItem, newPage, 0);
+
+      expect(replacedListener).toHaveBeenCalled();
+      expect(replacedListener.calls.mostRecent().args[0].newPage).toBe(newPage);
+      expect(newContainer.parentElement).toBe(contentContainer);
+    });
+
     it("keeps the earliest following spine queued for relayout", function () {
       var view = Object.create(adapt_epub.OPFView.prototype);
       view.spineItems = [];
@@ -599,8 +637,12 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
+        var sourcePage = { id: "source" };
         view.opf = { spine: [{}, {}, {}] };
-        view.spineItems = [];
+        view.spineItems = [{ pages: [sourcePage] }];
+        view.counterStore = {
+          updateTargetCounterNodesInPages: jasmine.createSpy(),
+        };
         view.deferredFollowingSpineRelayoutStart = 1;
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
           function () {
@@ -620,6 +662,9 @@ describe("epub", function () {
             [finalPosition, false],
           ]);
           expect(result).toBe(rerenderedResult);
+          expect(
+            view.counterStore.updateTargetCounterNodesInPages,
+          ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.renderingAllPages).toBe(false);
           done();
         });

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -919,7 +919,7 @@ describe("epub", function () {
       ).toHaveBeenCalledOnceWith([prefixPage, rebuiltPage]);
     });
 
-    it("rerenders a deferred suffix until page counts stabilize", function (done) {
+    it("rerenders a deferred suffix once after full pagination", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
         var finalPosition = {
@@ -929,8 +929,6 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
-        var stabilizedResult = { id: "stabilized" };
-        var renderCount = 0;
         var sourcePage = { id: "source", fetchers: [] };
         view.opf = { spine: [{}, {}, {}] };
         view.spineItems = [{ pages: [sourcePage] }];
@@ -944,33 +942,25 @@ describe("epub", function () {
             view.deferredFollowingSpineRelayoutStart = null;
           },
         );
-        spyOn(view, "renderPagesUpto").and.callFake(function () {
-          renderCount++;
-          if (renderCount === 2) {
-            view.deferredFollowingSpineRelayoutStart = 1;
-            return adapt_task.newResult(rerenderedResult);
-          }
-          return adapt_task.newResult(
-            renderCount === 1 ? initialResult : stabilizedResult,
-          );
-        });
+        spyOn(view, "renderPagesUpto").and.returnValues(
+          adapt_task.newResult(initialResult),
+          adapt_task.newResult(rerenderedResult),
+        );
 
         view.renderAllPages().then(function (result) {
           expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
-          expect(view.relayoutDeferredFollowingSpines.calls.count()).toBe(2);
-          expect(view.renderPagesUpto.calls.count()).toBe(3);
+          expect(view.renderPagesUpto.calls.count()).toBe(2);
           expect(view.renderPagesUpto.calls.allArgs()).toEqual([
             [finalPosition, false],
             [finalPosition, false],
-            [finalPosition, false],
           ]);
-          expect(result).toBe(stabilizedResult);
+          expect(result).toBe(rerenderedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
-          ).toHaveBeenCalledTimes(2);
+          ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(
             view.counterStore.updateTargetTextNodesInPages,
-          ).toHaveBeenCalledTimes(2);
+          ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.renderingAllPages).toBe(false);
           done();
         });
@@ -988,7 +978,6 @@ describe("epub", function () {
         };
         var initialResult = { id: "initial" };
         var rerenderedResult = { id: "rerendered" };
-        var requestedResult = { id: "requested" };
         var sourcePage = { id: "source", fetchers: [] };
         view.renderingPageTasks = new Map();
         view.renderingAllPages = false;
@@ -999,9 +988,8 @@ describe("epub", function () {
           updateTargetTextNodesInPages: jasmine.createSpy(),
         };
         view.deferredFollowingSpineRelayoutStart = 1;
-        spyOn(view, "renderPageTracked").and.returnValues(
+        spyOn(view, "renderPageTracked").and.returnValue(
           adapt_task.newResult(initialResult),
-          adapt_task.newResult(requestedResult),
         );
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
           function () {
@@ -1015,8 +1003,7 @@ describe("epub", function () {
         view.renderPage(position).then(function (result) {
           expect(view.relayoutDeferredFollowingSpines).toHaveBeenCalled();
           expect(view.renderPagesUpto).toHaveBeenCalledWith(position, false);
-          expect(result).toBe(requestedResult);
-          expect(view.renderPageTracked.calls.count()).toBe(2);
+          expect(result).toBe(rerenderedResult);
           expect(
             view.counterStore.updateTargetCounterNodesInPages,
           ).toHaveBeenCalledOnceWith([sourcePage]);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -727,6 +727,9 @@ describe("epub", function () {
       ];
       view.deferredReferencePages = deferredReferencePages;
       view.counterStore = {
+        getRebuildStartForReferences: function (firstSpine) {
+          return firstSpine;
+        },
         discardReferencesFromSpine: jasmine.createSpy(),
       };
 
@@ -746,6 +749,41 @@ describe("epub", function () {
       expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
         1,
       );
+    });
+
+    it("rebuilds retained source pages whose target is in the invalid suffix", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      var sourcePage = { container: { remove: jasmine.createSpy() } };
+      var targetPage = { container: { remove: jasmine.createSpy() } };
+      var sourceItem = {
+        item: { spineIndex: 0 },
+        pages: [sourcePage],
+      };
+      var targetItem = {
+        item: { spineIndex: 1 },
+        pages: [targetPage],
+      };
+      view.spineItems = [sourceItem, targetItem];
+      view.spineItemLoadingContinuations = [[], []];
+      view.deferredPageReplacements = new Map();
+      view.deferredReferencePages = [];
+      view.counterStore = {
+        getRebuildStartForReferences: jasmine.createSpy().and.returnValue(0),
+        discardReferencesFromSpine: jasmine.createSpy(),
+      };
+
+      view.deferFollowingSpinesForRelayout(0);
+      view.relayoutDeferredFollowingSpines();
+
+      expect(
+        view.counterStore.getRebuildStartForReferences,
+      ).toHaveBeenCalledOnceWith(1);
+      expect(view.counterStore.discardReferencesFromSpine).toHaveBeenCalledWith(
+        0,
+      );
+      expect(sourcePage.container.remove).toHaveBeenCalled();
+      expect(targetPage.container.remove).toHaveBeenCalled();
+      expect(view.spineItems).toEqual([null, null]);
     });
 
     it("notifies a displayed page when its rebuilt replacement is ready", function () {
@@ -780,6 +818,9 @@ describe("epub", function () {
       view.deferredPageReplacements = new Map();
       view.deferredReferencePages = [];
       view.counterStore = {
+        getRebuildStartForReferences: function (firstSpine) {
+          return firstSpine;
+        },
         discardReferencesFromSpine: function () {},
       };
       var replacedListener = jasmine.createSpy("replacedListener");

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -469,6 +469,35 @@ describe("epub", function () {
       });
     });
 
+    it("processes a pending suffix rebuild before returning a cached page", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var position = { spineIndex: 1, pageIndex: 0, offsetInItem: -1 };
+        var cachedPage = {};
+        var rebuiltPage = {};
+        view.deferredFollowingSpineRelayoutStart = 1;
+        spyOn(view, "waitForPreviousSpines").and.returnValue(
+          adapt_task.newResult(true),
+        );
+        spyOn(view, "getPageViewItem").and.returnValue(
+          adapt_task.newResult({ pages: [cachedPage], complete: true }),
+        );
+        spyOn(view, "renderPage").and.returnValue(
+          adapt_task.newResult({
+            page: rebuiltPage,
+            position: position,
+          }),
+        );
+
+        view.findPage(position, false).then(function (result) {
+          expect(view.renderPage).toHaveBeenCalledOnceWith(position);
+          expect(result.page).toBe(rebuiltPage);
+          done();
+        });
+        return adapt_task.newResult(true);
+      });
+    });
+
     it("reuses the requested slot when a final-page rerender shrinks the spine", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
@@ -654,6 +683,61 @@ describe("epub", function () {
       expect(view.deferredPageReplacements.size).toBe(0);
     });
 
+    it("notifies both intermediate and original pages after recursive replacement", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      var contentContainer = document.createElement("div");
+      var originalContainer = document.createElement("div");
+      var intermediateContainer = document.createElement("div");
+      contentContainer.appendChild(intermediateContainer);
+      var originalPage = new adapt_vtree.Page(
+        originalContainer,
+        originalContainer,
+      );
+      originalPage.offset = 10;
+      var intermediatePage = new adapt_vtree.Page(
+        intermediateContainer,
+        intermediateContainer,
+      );
+      intermediatePage.offset = 20;
+      var newContainer = document.createElement("div");
+      var newPage = new adapt_vtree.Page(newContainer, newContainer);
+      newPage.offset = 10;
+      newPage.side = "right";
+      var viewItem = {
+        item: { spineIndex: 1 },
+        pages: [intermediatePage],
+        instance: {
+          viewport: { contentContainer: contentContainer },
+          pageSheetWidth: 0,
+          pageSheetHeight: 0,
+          pageSheetSize: {},
+          pageNumberOffset: 0,
+        },
+      };
+      view.opf = { epageIsRenderedPage: false };
+      view.spineItems = [null, viewItem];
+      view.pageSheetSizeReporter = function () {};
+      view.deferredPageReplacements = new Map([[1, [originalPage]]]);
+      var originalListener = jasmine.createSpy("originalListener");
+      var intermediateListener = jasmine.createSpy("intermediateListener");
+      originalPage.addEventListener("replaced", originalListener, false);
+      intermediatePage.addEventListener(
+        "replaced",
+        intermediateListener,
+        false,
+      );
+
+      view.finishPageContainer(viewItem, newPage, 0);
+
+      expect(originalListener).toHaveBeenCalled();
+      expect(intermediateListener).toHaveBeenCalled();
+      expect(originalListener.calls.mostRecent().args[0].newPage).toBe(newPage);
+      expect(intermediateListener.calls.mostRecent().args[0].newPage).toBe(
+        newPage,
+      );
+      expect(view.deferredPageReplacements.size).toBe(0);
+    });
+
     it("keeps the earliest following spine queued for relayout", function () {
       var view = Object.create(adapt_epub.OPFView.prototype);
       view.spineItems = [];
@@ -663,6 +747,29 @@ describe("epub", function () {
       view.deferFollowingSpinesForRelayout(1);
 
       expect(view.deferredFollowingSpineRelayoutStart).toBe(2);
+    });
+
+    it("refreshes target references in rebuilt suffix pages", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      var prefixPage = { id: "prefix" };
+      var rebuiltPage = { id: "rebuilt" };
+      view.spineItems = [
+        { pages: [prefixPage] },
+        { pages: [rebuiltPage] },
+      ];
+      view.counterStore = {
+        updateTargetCounterNodesInPages: jasmine.createSpy(),
+        updateTargetTextNodesInPages: jasmine.createSpy(),
+      };
+
+      view.updateRetainedTargetCounters(1);
+
+      expect(
+        view.counterStore.updateTargetCounterNodesInPages,
+      ).toHaveBeenCalledOnceWith([prefixPage, rebuiltPage]);
+      expect(
+        view.counterStore.updateTargetTextNodesInPages,
+      ).toHaveBeenCalledOnceWith([prefixPage, rebuiltPage]);
     });
 
     it("rerenders a deferred suffix once after full pagination", function (done) {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -769,6 +769,9 @@ describe("epub", function () {
         view.finishPageContainer = function (item, renderedPage, pageIndex) {
           item.pages[pageIndex] = renderedPage;
         };
+        view.collectTotalOffsets = function () {
+          return adapt_task.newResult(true);
+        };
         view.reportPaginationProgress = function () {};
         view.maybeRelayoutFollowingPage = function () {
           return adapt_task.newResult(true);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -585,6 +585,7 @@ describe("epub", function () {
       };
       view.spineItems = [sourceItem, followingItem1, followingItem2];
       view.spineItemLoadingContinuations = [[], [], []];
+      view.deferredPageReplacements = new Map();
       view.deferredReferencePages = [
         { viewItem: sourceItem },
         { viewItem: followingItem1 },
@@ -639,6 +640,7 @@ describe("epub", function () {
       view.pageSheetSizeReporter = function () {};
       view.spineItems = [sourceItem, oldViewItem];
       view.spineItemLoadingContinuations = [[], []];
+      view.deferredPageReplacements = new Map();
       view.counterStore = {
         discardReferencesFromSpine: function () {},
       };
@@ -753,16 +755,13 @@ describe("epub", function () {
       var view = Object.create(adapt_epub.OPFView.prototype);
       var prefixPage = { id: "prefix" };
       var rebuiltPage = { id: "rebuilt" };
-      view.spineItems = [
-        { pages: [prefixPage] },
-        { pages: [rebuiltPage] },
-      ];
+      view.spineItems = [{ pages: [prefixPage] }, { pages: [rebuiltPage] }];
       view.counterStore = {
         updateTargetCounterNodesInPages: jasmine.createSpy(),
         updateTargetTextNodesInPages: jasmine.createSpy(),
       };
 
-      view.updateRetainedTargetCounters(1);
+      view.updateRetainedTargetCounters();
 
       expect(
         view.counterStore.updateTargetCounterNodesInPages,
@@ -936,6 +935,7 @@ describe("epub", function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
         var page = {};
         var viewItem = {};
+        view.deferredReferencePages = [];
         var nextLayoutPosition = { page: 16 };
         var ref = {
           isResolved: function () {
@@ -983,6 +983,7 @@ describe("epub", function () {
           spineIndex: 0,
         };
         var viewItem = { pages: [page], item: { spineIndex: 0 } };
+        view.deferredReferencePages = [];
         var nextLayoutPosition = { page: 1 };
         var ref = {
           isResolved: function () {
@@ -1025,6 +1026,7 @@ describe("epub", function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
         var page = {};
         var viewItem = { pages: [page] };
+        view.deferredReferencePages = [];
         var inCounterScope = true;
         var ref = {
           isResolved: function () {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -513,9 +513,11 @@ describe("epub", function () {
         spyOn(view, "finishPageContainer");
         view.reportPaginationProgress = function () {};
         view.maybeRelayoutFollowingPage = function () {
+          expect(viewItem.complete).not.toBe(true);
           return adapt_task.newResult(true);
         };
         view.resolveUnresolvedReferencesForPage = function () {
+          expect(viewItem.complete).not.toBe(true);
           return adapt_task.newResult(page);
         };
 

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -693,7 +693,7 @@ describe("epub", function () {
           expect(followingItem.epage).toBe(16);
           expect(view.opf.epageCount).toBe(19);
           expect(epageCountCallback).toHaveBeenCalledOnceWith(19);
-          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(16);
+          expect(view.pageSheetSizeTruncator).not.toHaveBeenCalled();
           expect(stalePageReplaced).toHaveBeenCalled();
           expect(stalePageReplaced.calls.mostRecent().args[0].newPage).toBe(
             page,
@@ -936,6 +936,9 @@ describe("epub", function () {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
         };
+        view.pageSheetSizeTruncator = jasmine.createSpy(
+          "pageSheetSizeTruncator",
+        );
         view.deferredFollowingSpineRelayoutStart = 1;
         spyOn(view, "relayoutDeferredFollowingSpines").and.callFake(
           function () {
@@ -962,6 +965,7 @@ describe("epub", function () {
             view.counterStore.updateTargetTextNodesInPages,
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.renderingAllPages).toBe(false);
+          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(1);
           done();
         });
         return adapt_task.newResult(true);
@@ -987,6 +991,9 @@ describe("epub", function () {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
         };
+        view.pageSheetSizeTruncator = jasmine.createSpy(
+          "pageSheetSizeTruncator",
+        );
         view.deferredFollowingSpineRelayoutStart = 1;
         spyOn(view, "renderPageTracked").and.returnValue(
           adapt_task.newResult(initialResult),
@@ -1012,6 +1019,7 @@ describe("epub", function () {
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);
+          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(1);
           done();
         });
         return adapt_task.newResult(true);
@@ -1038,6 +1046,9 @@ describe("epub", function () {
           updateTargetCounterNodesInPages: jasmine.createSpy(),
           updateTargetTextNodesInPages: jasmine.createSpy(),
         };
+        view.pageSheetSizeTruncator = jasmine.createSpy(
+          "pageSheetSizeTruncator",
+        );
         view.deferredFollowingSpineRelayoutStart = 1;
         spyOn(view, "renderPageTracked").and.returnValues(
           adapt_task.newResult(initialResult),
@@ -1072,6 +1083,7 @@ describe("epub", function () {
           ).toHaveBeenCalledOnceWith([sourcePage]);
           expect(view.relayoutingFollowingSpines).toBe(false);
           expect(view.renderingPageTasks.size).toBe(0);
+          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(1);
           done();
         });
         return adapt_task.newResult(true);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -17,12 +17,39 @@
  */
 
 import * as adapt_epub from "../../../src/vivliostyle/epub";
+import * as adapt_viewer from "../../../src/vivliostyle/adaptive-viewer";
 import * as adapt_task from "../../../src/vivliostyle/task";
 import * as adapt_vtree from "../../../src/vivliostyle/vtree";
 import * as adapt_xmldoc from "../../../src/vivliostyle/xml-doc";
 import * as vivliostyle_plugin from "../../../src/vivliostyle/plugin";
 
 describe("epub", function () {
+  describe("AdaptiveViewer page sizes", function () {
+    it("removes stale page sizes after pagination shrinks", function () {
+      var viewer = Object.create(adapt_viewer.AdaptiveViewer.prototype);
+      viewer.pageSizes = [
+        { width: 100, height: 100 },
+        { width: 120, height: 110 },
+        { width: 1000, height: 1000 },
+      ];
+      viewer.pageRuleStyleElement = document.createElement("style");
+      viewer.pageRuleStyleElement.textContent = "stale";
+      viewer.pageSheetSizeAlreadySet = true;
+      viewer.pixelRatio = 1;
+
+      viewer.truncatePageSizes(2);
+
+      expect(viewer.pageSizes).toEqual([
+        { width: 100, height: 100 },
+        { width: 120, height: 110 },
+      ]);
+      expect(viewer.pageRuleStyleElement.textContent).toContain(
+        "size: 90pt 83pt",
+      );
+      expect(viewer.pageRuleStyleElement.textContent).not.toContain("750pt");
+    });
+  });
+
   describe("EPUBDocStore", function () {
     describe("loadPubDoc", function () {
       it("skips HEAD and treats data: URLs as a Web Publication primary entry", function (done) {
@@ -564,8 +591,19 @@ describe("epub", function () {
         var view = Object.create(adapt_epub.OPFView.prototype);
         var page = { spineIndex: 0, offset: 15, fetchers: [] };
         var stalePageReplaced = jasmine.createSpy("stalePageReplaced");
+        var currentItem = {
+          spineIndex: 0,
+          epage: 0,
+          epageCount: 17,
+        };
+        var followingItem = {
+          spineIndex: 1,
+          epage: 17,
+          epageCount: 3,
+        };
+        var epageCountCallback = jasmine.createSpy("epageCountCallback");
         var viewItem = {
-          item: { spineIndex: 0 },
+          item: currentItem,
           layoutPositions: new Array(17).fill(null),
           pages: Array.from({ length: 17 }, function (_, pageIndex) {
             return {
@@ -590,9 +628,18 @@ describe("epub", function () {
             },
           },
         };
+        view.opf = {
+          epageIsRenderedPage: true,
+          spine: [currentItem, followingItem],
+          epageCount: 20,
+          epageCountCallback: epageCountCallback,
+        };
         view.spineItems = [viewItem];
         view.spineItemLoadingContinuations = [null];
         view.deferredPageReplacements = new Map();
+        view.pageSheetSizeTruncator = jasmine.createSpy(
+          "pageSheetSizeTruncator",
+        );
         view.deferredReferencePages = [
           { viewItem: viewItem, pageIndex: 15 },
           { viewItem: viewItem, pageIndex: 16 },
@@ -641,6 +688,11 @@ describe("epub", function () {
           expect(view.deferredReferencePages).toEqual([
             { viewItem: viewItem, pageIndex: 15 },
           ]);
+          expect(currentItem.epageCount).toBe(16);
+          expect(followingItem.epage).toBe(16);
+          expect(view.opf.epageCount).toBe(19);
+          expect(epageCountCallback).toHaveBeenCalledOnceWith(19);
+          expect(view.pageSheetSizeTruncator).toHaveBeenCalledOnceWith(16);
           expect(stalePageReplaced).toHaveBeenCalled();
           expect(stalePageReplaced.calls.mostRecent().args[0].newPage).toBe(
             page,
@@ -1180,10 +1232,9 @@ describe("epub", function () {
         };
         view.resolvingDeferredReferences = true;
         view.deferredReferencePages = [];
-        view.drainingDeferredReferencePage = {
-          viewItem: viewItem,
-          pageIndex: 0,
-        };
+        view.processedDeferredReferencePages = new Map([
+          [viewItem, new Set([0])],
+        ]);
         view.counterStore = {
           getUnresolvedRefsToPage: function () {
             return [{ spineIndex: 0, refs: [ref] }];
@@ -1209,7 +1260,7 @@ describe("epub", function () {
         };
         view.deferredReferencePages = [];
         view.resolvingDeferredReferences = false;
-        view.drainingDeferredReferencePage = null;
+        view.processedDeferredReferencePages = null;
         view.counterStore = {
           getUnresolvedRefsToPage: function () {
             return [{ refs: [ref] }];
@@ -1248,7 +1299,101 @@ describe("epub", function () {
                 }),
             ).toEqual([0, 1, 2]);
             expect(view.deferredReferencePages).toEqual([]);
-            expect(view.drainingDeferredReferencePage).toBeNull();
+            expect(view.processedDeferredReferencePages).toBeNull();
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("does not revisit pages already processed by a deferred drain", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var pages = [{ id: "a" }, { id: "b" }];
+        var viewItem = { pages: pages };
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.deferredReferencePages = [];
+        view.resolvingDeferredReferences = false;
+        view.processedDeferredReferencePages = null;
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ refs: [ref] }];
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return false;
+        };
+        spyOn(view, "resolveUnresolvedReferencesForPage").and.callFake(
+          function (item, page, pageIndex) {
+            return view.resolveDeferredReferencesAfterCounterScope(
+              item,
+              pages[pageIndex === 0 ? 1 : 0],
+              pageIndex === 0 ? 1 : 0,
+              null,
+            );
+          },
+        );
+
+        view
+          .resolveDeferredReferencesAfterCounterScope(
+            viewItem,
+            pages[0],
+            0,
+            null,
+          )
+          .then(function () {
+            expect(
+              view.resolveUnresolvedReferencesForPage.calls
+                .allArgs()
+                .map(function (args) {
+                  return args[2];
+                }),
+            ).toEqual([0, 1]);
+            expect(view.deferredReferencePages).toEqual([]);
+            expect(view.processedDeferredReferencePages).toBeNull();
+            done();
+          });
+        return adapt_task.newResult(true);
+      });
+    });
+
+    it("skips references discarded after the resolution worklist was captured", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var container = document.createElement("div");
+        document.body.appendChild(container);
+        var page = new adapt_vtree.Page(container, container);
+        page.spineIndex = 0;
+        var viewItem = { item: { spineIndex: 0 }, pages: [page] };
+        var discardedRef = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.opf = { spine: [{}, {}] };
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ spineIndex: 1, pageIndex: 5, refs: [discardedRef] }];
+          },
+          isReferenceTracked: function () {
+            return false;
+          },
+        };
+        view.isInCounterResolveScope = function () {
+          return false;
+        };
+        spyOn(view, "getPageViewItem");
+
+        view
+          .resolveUnresolvedReferencesForPage(viewItem, page, 0, { page: 1 })
+          .then(function (result) {
+            expect(result).toBe(page);
+            expect(view.getPageViewItem).not.toHaveBeenCalled();
+            container.remove();
             done();
           });
         return adapt_task.newResult(true);

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -793,6 +793,30 @@ describe("epub", function () {
         return adapt_task.newResult(true);
       });
     });
+
+    it("does not requeue a deferred page while draining it", function (done) {
+      adapt_task.start(function () {
+        var view = Object.create(adapt_epub.OPFView.prototype);
+        var page = {};
+        var viewItem = { pages: [page] };
+        var ref = {
+          isResolved: function () {
+            return false;
+          },
+        };
+        view.resolvingDeferredReferences = true;
+        view.counterStore = {
+          getUnresolvedRefsToPage: function () {
+            return [{ spineIndex: 0, refs: [ref] }];
+          },
+        };
+
+        view.deferReferencesForPage(viewItem, page, 0, null);
+        expect(view.deferredReferencePages || []).toEqual([]);
+        done();
+        return adapt_task.newResult(true);
+      });
+    });
   });
   describe("OPFView pagination progress", function () {
     function createFakeView(totalOffsets) {

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -756,6 +756,7 @@ describe("epub", function () {
         view.counterStore = {
           finishPage: function () {},
         };
+        view.deferredReferencePages = [];
         view.isInCounterResolveScope = function () {
           return true;
         };


### PR DESCRIPTION
## Summary

- consume page-level forced breaks that have already been satisfied at the start of a fresh page
- allow one stable earlier-page correction for referenced targets while preserving the existing anti-oscillation guard
- truncate stale trailing pages when reference resolution shortens a spine, then rebuild the affected following spine suffix once
- replace stale source-page reference records and prevent deferred-reference draining from re-enqueueing itself
- mark a spine complete when its final page is produced inside nested reference resolution

## Root cause

A referenced target with `break-before: page` can move to an earlier page when `target-text()` or `target-counter()` is resolved. Five pieces of retained layout state made that correction unstable:

1. the page-level forced break had already been satisfied by entering the fresh page, but its accumulated edge value was applied again;
2. the reference-target constraint introduced in `b0288a356d78d6d92b0d256e6233b7044e07cde5` rejected the target's corrected earlier placement;
3. when the corrected rerender shortened a spine, stale trailing pages and already-rendered following spines retained their old page offsets, sides, and counters;
4. references invalidated on a cascaded page inside a nested counter-resolution scope were skipped by the #1686 recursion guard and were not revisited after the outermost scope was restored; and
5. when nested reference resolution produced the final page, the spine was not marked complete, leaving the viewer waiting even though layout had reached the end.

The fix consumes a page break that is already satisfied without discarding the target continuation, permits one earlier correction for that specific condition, removes stale page and source-reference state, and rebuilds only the invalid following spine suffix. Deferred pages are drained only by the outermost reference-resolution scope, and a final page produced by nested resolution now completes its spine.

## Regression boundary

The first observable bad commit in the production publication is `2bacf4bd455dcec41ef06c0f339a38422bf4e1b8` (`fix: Make text-spacing filler widths independent of installed fonts (#2035)`):

- parent `88418bc25a68cbefec8bcc129d644ca807831a3d`: 309 pages; chapter summary on page 37, intentional parity blank on page 38, next chapter on page 39
- `2bacf4bd455dcec41ef06c0f339a38422bf4e1b8`: 299 pages; unwanted folio-only page 34, chapter summary on page 35, blank page 36, next chapter on page 37

Commit `2bacf4bd` does not introduce the faulty pagination logic. Its font-independent text-spacing metrics change the page geometry and expose the older retained-state bug. The anti-backward constraint itself dates to `b0288a356d78d6d92b0d256e6233b7044e07cde5`; this change preserves its anti-oscillation purpose by allowing only one earlier correction after an already-satisfied page break.

I also tested `2a0f1a41529f7a6971ef0eb05abf73027b3e84b8` (`Restore target-counter references for redirected chapter URLs`) and its parent; both are unaffected.

## Validation

- all 762 core tests pass on macOS Chrome, macOS Firefox, Ubuntu Chrome, and Windows Chrome ([CI run](https://github.com/minorun365/vivliostyle.js/actions/runs/32974472661))
- added unit coverage for satisfied page breaks, the one-time earlier move, stale source-reference replacement, suffix invalidation, full and on-demand pagination, nested deferred-reference draining, and final-spine completion
- corrected `break-before-flex-at-page-start.html` to use 71 `x` characters and `inline-size: 10.1ch`:
  - stable reproduces the blank second page and finishes in 4 pages
  - this PR removes the blank page, finishes in 3 pages, and allows every page to be captured
- `page_breaks/combine_breaks_2.html` is unchanged from stable; “This should be on the 6th page.” remains on page 6
- `target-text-shrinking-spine/publication.json` finishes in 4 pages instead of stable's 6 pages and completed 5 consecutive measured runs after a separate viewer warm-up ([repeat run](https://github.com/minorun365/vivliostyle.js/actions/runs/32975358685))
- the three focused layout cases complete with zero render errors and zero timeouts ([layout validation](https://github.com/minorun365/vivliostyle.js/actions/runs/32975605707))
- built the 299-page production Japanese publication against exact commit `f908d1a542304a7041372b0208e4820b722307f5` with production fonts:
  - the chapter summary is on page 34 and the next chapter starts on page 35
  - folio numbering and left/right page assignment are correct across all 299 pages
  - a full-document scan finds only the intentional parity blank on page 58
  - all 11 chapter openers are on odd pages

Supersedes #2131.

Related: #722, #1686, #1842, #2035

Assisted-by: Codex:gpt-5.6-sol

<details>
<summary>How the AI was used</summary>

- The human contributor identified the regression in the production publication, defined the expected pagination behavior, requested root-cause and regression-boundary analysis, and decided to submit the upstream fix.
- Codex traced the retained layout state and regression boundary, drafted the implementation and regression tests, ran the automated and production-publication validation, and assisted with the pull request documentation.
- The human contributor reviewed the validation evidence and submission. The project maintainers independently reviewed the implementation, identified gaps in the initial tests, and verified the corrected result before merging.

</details>
