### PR TITLE
refactor: unify cross-reference relayout cleanup and epage updates

### DIFF
--- a/packages/core/src/vivliostyle/counters.ts
+++ b/packages/core/src/vivliostyle/counters.ts
@@ -1405,28 +1405,11 @@ export class CounterStore {
     if (!targetIds) {
       return;
     }
-    for (const id of targetIds) {
-      const keepOtherPage = (ref: TargetCounterReference) =>
-        ref.spineIndex !== spineIndex || ref.pageIndex !== pageIndex;
-      const resolved = (this.resolvedReferences[id] || []).filter(
-        keepOtherPage,
-      );
-      const unresolved = (this.unresolvedReferences[id] || []).filter(
-        keepOtherPage,
-      );
-      if (resolved.length) {
-        this.resolvedReferences[id] = resolved;
-      } else {
-        delete this.resolvedReferences[id];
-      }
-      if (unresolved.length) {
-        this.unresolvedReferences[id] = unresolved;
-      } else {
-        delete this.unresolvedReferences[id];
-      }
-    }
     const keepOtherPage = (ref: TargetCounterReference) =>
       ref.spineIndex !== spineIndex || ref.pageIndex !== pageIndex;
+    for (const id of targetIds) {
+      this.retainReferences(id, keepOtherPage);
+    }
     this.referencesToSolve = this.referencesToSolve.filter(keepOtherPage);
     this.referencesToSolveStack = this.referencesToSolveStack.map((refs) =>
       refs.filter(keepOtherPage),
@@ -1434,6 +1417,28 @@ export class CounterStore {
     targetIdsByPage.delete(pageIndex);
     if (targetIdsByPage.size === 0) {
       this.referenceTargetIdsBySourcePage.delete(spineIndex);
+    }
+  }
+
+  /**
+   * Keep only the resolved/unresolved references of the target that satisfy
+   * the given predicate, removing the arrays entirely when they become empty.
+   */
+  private retainReferences(
+    id: string,
+    keep: (ref: TargetCounterReference) => boolean,
+  ): void {
+    const resolved = (this.resolvedReferences[id] || []).filter(keep);
+    const unresolved = (this.unresolvedReferences[id] || []).filter(keep);
+    if (resolved.length) {
+      this.resolvedReferences[id] = resolved;
+    } else {
+      delete this.resolvedReferences[id];
+    }
+    if (unresolved.length) {
+      this.unresolvedReferences[id] = unresolved;
+    } else {
+      delete this.unresolvedReferences[id];
     }
   }
 
@@ -1562,24 +1567,10 @@ export class CounterStore {
       ...Object.keys(this.unresolvedReferences),
     ]);
 
+    const keepEarlierSource = (ref: TargetCounterReference) =>
+      ref.spineIndex < firstSpineIndex;
     for (const id of targetIds) {
-      const resolved = (this.resolvedReferences[id] || []).filter(
-        (ref) => ref.spineIndex < firstSpineIndex,
-      );
-      const unresolved = (this.unresolvedReferences[id] || []).filter(
-        (ref) => ref.spineIndex < firstSpineIndex,
-      );
-
-      if (resolved.length) {
-        this.resolvedReferences[id] = resolved;
-      } else {
-        delete this.resolvedReferences[id];
-      }
-      if (unresolved.length) {
-        this.unresolvedReferences[id] = unresolved;
-      } else {
-        delete this.unresolvedReferences[id];
-      }
+      this.retainReferences(id, keepEarlierSource);
     }
 
     for (const id of Object.keys(this.pageIndicesById)) {
@@ -1603,8 +1594,6 @@ export class CounterStore {
       }
     }
 
-    const keepEarlierSource = (ref: TargetCounterReference) =>
-      ref.spineIndex < firstSpineIndex;
     this.newReferencesOfCurrentPage =
       this.newReferencesOfCurrentPage.filter(keepEarlierSource);
     this.referencesToSolve = this.referencesToSolve.filter(keepEarlierSource);
@@ -1621,30 +1610,26 @@ export class CounterStore {
     pages: Vtree.Page[],
     changedTargetIds?: Set<string>,
   ): Set<Vtree.Page> {
-    const changedPages = new Set<Vtree.Page>();
-    for (const page of pages) {
-      if (!page || !page.container) continue;
-      const nodes = page.container.querySelectorAll(`[${TARGET_COUNTER_ATTR}]`);
-      for (const node of nodes) {
-        const key = node.getAttribute(TARGET_COUNTER_ATTR);
+    return this.updateGeneratedContentNodesInPages(
+      pages,
+      TARGET_COUNTER_ATTR,
+      (key) => {
         const expr = this.targetCounterExprs.find((o) => o.expr.key === key);
-        if (expr && expr.transformedId) {
-          const counterValue = this.pageCountersById[expr.transformedId];
-          if (counterValue) {
-            const arr: number[] = counterValue[expr.name];
-            if (arr) {
-              const value = expr.format(arr[arr.length - 1]);
-              if (node.textContent !== value) {
-                node.textContent = value;
-                changedPages.add(page);
-                changedTargetIds?.add(expr.transformedId);
-              }
-            }
-          }
+        if (!expr || !expr.transformedId) {
+          return null;
         }
-      }
-    }
-    return changedPages;
+        const arr: number[] | undefined =
+          this.pageCountersById[expr.transformedId]?.[expr.name];
+        if (!arr) {
+          return null;
+        }
+        return {
+          id: expr.transformedId,
+          value: expr.format(arr[arr.length - 1]),
+        };
+      },
+      changedTargetIds,
+    );
   }
 
   /**
@@ -1654,30 +1639,52 @@ export class CounterStore {
     pages: Vtree.Page[],
     changedTargetIds?: Set<string>,
   ): Set<Vtree.Page> {
+    return this.updateGeneratedContentNodesInPages(
+      pages,
+      TARGET_TEXT_ATTR,
+      (key) => {
+        const expr = this.targetTextExprs.find((o) => o.expr.key === key);
+        if (!expr || !expr.transformedId) {
+          return null;
+        }
+        const text = this.pageTextById[expr.transformedId];
+        if (!text) {
+          return null;
+        }
+        let value: string;
+        if (expr.pseudoElement === "first-letter") {
+          const fullText =
+            (text.before ?? "") + (text.content ?? "") + (text.after ?? "");
+          value = fullText.match(Base.firstLetterPattern)?.[0] ?? "";
+        } else {
+          value = text[expr.pseudoElement] ?? "";
+        }
+        return { id: expr.transformedId, value };
+      },
+      changedTargetIds,
+    );
+  }
+
+  /**
+   * Shared walker for patching generated-content nodes (target-counter/
+   * target-text) in retained pages from the current target snapshots.
+   */
+  private updateGeneratedContentNodesInPages(
+    pages: Vtree.Page[],
+    attrName: string,
+    resolveValue: (key: string | null) => { id: string; value: string } | null,
+    changedTargetIds?: Set<string>,
+  ): Set<Vtree.Page> {
     const changedPages = new Set<Vtree.Page>();
     for (const page of pages) {
       if (!page || !page.container) continue;
-      const nodes = page.container.querySelectorAll(`[${TARGET_TEXT_ATTR}]`);
+      const nodes = page.container.querySelectorAll(`[${attrName}]`);
       for (const node of nodes) {
-        const key = node.getAttribute(TARGET_TEXT_ATTR);
-        const expr = this.targetTextExprs.find((o) => o.expr.key === key);
-        if (expr && expr.transformedId) {
-          const text = this.pageTextById[expr.transformedId];
-          if (text) {
-            let value: string;
-            if (expr.pseudoElement === "first-letter") {
-              const fullText =
-                (text.before ?? "") + (text.content ?? "") + (text.after ?? "");
-              value = fullText.match(Base.firstLetterPattern)?.[0] ?? "";
-            } else {
-              value = text[expr.pseudoElement] ?? "";
-            }
-            if (node.textContent !== value) {
-              node.textContent = value;
-              changedPages.add(page);
-              changedTargetIds?.add(expr.transformedId);
-            }
-          }
+        const resolved = resolveValue(node.getAttribute(attrName));
+        if (resolved && node.textContent !== resolved.value) {
+          node.textContent = resolved.value;
+          changedPages.add(page);
+          changedTargetIds?.add(resolved.id);
         }
       }
     }

--- a/packages/core/src/vivliostyle/epub.ts
+++ b/packages/core/src/vivliostyle/epub.ts
@@ -2411,6 +2411,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
                     this.counterStore.updateTargetCounterNodesInPages(
                       targetViewItem.pages,
                     );
+                    this.updateEPageRangesAfterPageCountChange(
+                      targetViewItem,
+                      targetViewItem.pages.length,
+                    );
                     // Adjust pageCounterStarts and page-counter DOM nodes
                     // for all already-rendered later-spine viewItems so
                     // their counter(page) margins show the corrected value
@@ -2423,7 +2427,6 @@ export class OPFView implements Vgen.CustomRendererFactory {
                     ) {
                       const laterItem = this.spineItems[si];
                       if (!laterItem) continue;
-                      laterItem.item.epage += pageDelta;
                       for (const pcs of laterItem.pageCounterStarts) {
                         if (pcs?.["page"]) {
                           pcs["page"] = pcs["page"].map((v) => v + pageDelta);
@@ -2626,16 +2629,16 @@ export class OPFView implements Vgen.CustomRendererFactory {
     }
   }
 
-  private updateEPageRangesAfterShrink(
+  private updateEPageRangesAfterPageCountChange(
     viewItem: OPFViewItem,
-    finalLength: number,
+    pageCount: number,
   ): void {
     if (!this.opf.epageIsRenderedPage) {
       return;
     }
     const spineIndex = viewItem.item.spineIndex;
-    viewItem.item.epageCount = finalLength;
-    let nextEPage = viewItem.item.epage + finalLength;
+    viewItem.item.epageCount = pageCount;
+    let nextEPage = viewItem.item.epage + pageCount;
     for (let index = spineIndex + 1; index < this.opf.spine.length; index++) {
       const item = this.opf.spine[index];
       item.epage = nextEPage;
@@ -2697,6 +2700,22 @@ export class OPFView implements Vgen.CustomRendererFactory {
       preventDefault: null,
       newPage,
     });
+  }
+
+  /**
+   * Detach stale rendered pages, remembering them so a later rebuilt page can
+   * dispatch the `replaced` event to any viewer still displaying them.
+   */
+  private retireStalePages(spineIndex: number, pages: Vtree.Page[]): void {
+    for (const stalePage of pages) {
+      this.rememberDeferredPageReplacement(spineIndex, stalePage);
+      stalePage.container.remove();
+    }
+  }
+
+  private clearFollowingSpineRelayoutState(): void {
+    this.relayoutingFollowingSpines = false;
+    this.relayoutingFollowingSpineStart = null;
   }
 
   private flushDeferredPageReplacements(viewItem: OPFViewItem): void {
@@ -2813,10 +2832,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         continue;
       }
       lastInvalidatedSpine = spineIndex;
-      viewItem.pages.forEach((renderedPage) => {
-        this.rememberDeferredPageReplacement(spineIndex, renderedPage);
-        renderedPage.container.remove();
-      });
+      this.retireStalePages(spineIndex, viewItem.pages);
       this.spineItems[spineIndex] = null;
       this.spineItemLoadingContinuations[spineIndex] = null;
     }
@@ -2834,25 +2850,21 @@ export class OPFView implements Vgen.CustomRendererFactory {
     let passCount = 0;
     let result: PageAndPosition | null = null;
 
-    const clearRelayoutState = (): void => {
-      this.relayoutingFollowingSpines = false;
-      this.relayoutingFollowingSpineStart = null;
-    };
     frame.handler = (handlerFrame, err) => {
-      clearRelayoutState();
+      this.clearFollowingSpineRelayoutState();
       handlerFrame.task.raise(err, handlerFrame.parent);
     };
 
     const runNextPass = (): void => {
       const firstSpine = this.deferredFollowingSpineRelayoutStart;
       if (firstSpine == null) {
-        clearRelayoutState();
+        this.clearFollowingSpineRelayoutState();
         frame.finish(result);
         return;
       }
       passCount++;
       if (passCount > maxPasses) {
-        clearRelayoutState();
+        this.clearFollowingSpineRelayoutState();
         frame.task.raise(
           new Error("Cross-reference pagination did not stabilize"),
           frame.parent,
@@ -2944,7 +2956,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         const finalLength = pageIndexToRender + 1;
         const pageCountChanged = viewItem.pages.length > finalLength;
         if (pageCountChanged) {
-          this.updateEPageRangesAfterShrink(viewItem, finalLength);
+          this.updateEPageRangesAfterPageCountChange(viewItem, finalLength);
         }
         this.removeDeferredReferencePages(
           (entry) =>
@@ -2960,13 +2972,10 @@ export class OPFView implements Vgen.CustomRendererFactory {
             stalePageIndex,
           );
         }
-        viewItem.pages.slice(finalLength).forEach((stalePage) => {
-          this.rememberDeferredPageReplacement(
-            viewItem.item.spineIndex,
-            stalePage,
-          );
-          stalePage.container.remove();
-        });
+        this.retireStalePages(
+          viewItem.item.spineIndex,
+          viewItem.pages.slice(finalLength),
+        );
         viewItem.pages.splice(finalLength);
         viewItem.layoutPositions.splice(finalLength);
         viewItem.pageCounterStarts.splice(finalLength);
@@ -3229,8 +3238,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
         });
       },
       (frame, err) => {
-        this.relayoutingFollowingSpines = false;
-        this.relayoutingFollowingSpineStart = null;
+        this.clearFollowingSpineRelayoutState();
         endRendering();
         frame.task.raise(err, frame.parent);
       },
@@ -3352,8 +3360,7 @@ export class OPFView implements Vgen.CustomRendererFactory {
     let result: PageAndPosition | null = null;
     this.renderingAllPages = true;
     frame.handler = (handlerFrame, err) => {
-      this.relayoutingFollowingSpines = false;
-      this.relayoutingFollowingSpineStart = null;
+      this.clearFollowingSpineRelayoutState();
       this.renderingAllPages = false;
       handlerFrame.task.raise(err, handlerFrame.parent);
     };

--- a/packages/core/test/spec/vivliostyle/epub-spec.js
+++ b/packages/core/test/spec/vivliostyle/epub-spec.js
@@ -857,6 +857,62 @@ describe("epub", function () {
       });
     });
 
+    it("recomputes following epage ranges when a spine grows", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      var precedingItem = { spineIndex: 0, epage: 0, epageCount: 10 };
+      var grownItem = { spineIndex: 1, epage: 10, epageCount: 5 };
+      var loadedFollowingItem = { spineIndex: 2, epage: 15, epageCount: 3 };
+      var unloadedFollowingItem = { spineIndex: 3, epage: 18, epageCount: 4 };
+      var epageCountCallback = jasmine.createSpy("epageCountCallback");
+      view.opf = {
+        epageIsRenderedPage: true,
+        spine: [
+          precedingItem,
+          grownItem,
+          loadedFollowingItem,
+          unloadedFollowingItem,
+        ],
+        epageCount: 22,
+        epageCountCallback: epageCountCallback,
+      };
+      // Only the loaded following spine has a view item; the last one is
+      // not yet rendered and must still get its epage start recomputed.
+      view.spineItems = [
+        null,
+        { item: grownItem },
+        { item: loadedFollowingItem },
+        null,
+      ];
+
+      view.updateEPageRangesAfterPageCountChange({ item: grownItem }, 7);
+
+      expect(grownItem.epageCount).toBe(7);
+      expect(loadedFollowingItem.epage).toBe(17);
+      expect(unloadedFollowingItem.epage).toBe(20);
+      expect(view.opf.epageCount).toBe(24);
+      expect(epageCountCallback).toHaveBeenCalledOnceWith(24);
+    });
+
+    it("keeps epage ranges when epage is not the rendered page", function () {
+      var view = Object.create(adapt_epub.OPFView.prototype);
+      var changedItem = { spineIndex: 0, epage: 0, epageCount: 10 };
+      var followingItem = { spineIndex: 1, epage: 10, epageCount: 3 };
+      var epageCountCallback = jasmine.createSpy("epageCountCallback");
+      view.opf = {
+        epageIsRenderedPage: false,
+        spine: [changedItem, followingItem],
+        epageCount: 13,
+        epageCountCallback: epageCountCallback,
+      };
+
+      view.updateEPageRangesAfterPageCountChange({ item: changedItem }, 12);
+
+      expect(changedItem.epageCount).toBe(10);
+      expect(followingItem.epage).toBe(10);
+      expect(view.opf.epageCount).toBe(13);
+      expect(epageCountCallback).not.toHaveBeenCalled();
+    });
+
     it("defers final-page completion while a counter scope is still pushed", function (done) {
       adapt_task.start(function () {
         var view = Object.create(adapt_epub.OPFView.prototype);

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -1,1 +1,36 @@
-[]
+- category: Cross-references
+  title: target-text() reflow that shrinks an earlier WebPub spine
+  file: target-text-shrinking-spine/publication.json
+  decision: expected  # regression / expected / skip
+  notes: "New test case for PR #2132"
+  approvedViewer: git-fork-minorun365-fix-referenc-2ffc35  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: canary
+  actualUrl: >-
+    https://vivliostyle.vercel.app/#src=https://raw.githubusercontent.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/target-text-shrinking-spine/publication.json&zoom=1&spread=false
+  baselineLabel: stable
+  baselineUrl: >-
+    https://vivliostyle.org/viewer/#src=https://raw.githubusercontent.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/target-text-shrinking-spine/publication.json&zoom=1&spread=false
+- category: Cross-references
+  title: target-counter() reflow after a retained source value changes
+  file: target-counter-retained-source/publication.json
+  decision: expected  # regression / expected / skip
+  notes: "New test case for PR #2132"
+  approvedViewer: git-fork-minorun365-fix-referenc-2ffc35  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: canary
+  actualUrl: >-
+    https://vivliostyle.vercel.app/#src=https://raw.githubusercontent.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/target-counter-retained-source/publication.json&zoom=1&spread=false
+  baselineLabel: stable
+  baselineUrl: >-
+    https://vivliostyle.org/viewer/#src=https://raw.githubusercontent.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/target-counter-retained-source/publication.json&zoom=1&spread=false
+- category: Page breaks
+  title: Consumed break-before on a flex box at page start
+  file: page_breaks/break-before-flex-at-page-start.html
+  decision: expected  # regression / expected / skip
+  notes: "New test case for PR #2132"
+  approvedViewer: git-fork-minorun365-fix-referenc-2ffc35  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: canary
+  actualUrl: >-
+    https://vivliostyle.vercel.app/#src=https://raw.githubusercontent.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html&zoom=1&spread=false
+  baselineLabel: stable
+  baselineUrl: >-
+    https://vivliostyle.org/viewer/#src=https://raw.githubusercontent.com/vivliostyle/vivliostyle.js/master/packages/core/test/files/page_breaks/break-before-flex-at-page-start.html&zoom=1&spread=false


### PR DESCRIPTION
## Summary

Follow-up to #2132, reducing duplicated mechanisms accumulated across cross-reference (`target-counter()`/`target-text()`) relayout fixes (#1649, #1689, #1714, #1715, #1716, #1857, #1967, #1995, #2014, #2027, #2132):

- share the epage range recomputation between spine growth and shrinkage via `updateEPageRangesAfterPageCountChange()`; the growth path now also respects `epageIsRenderedPage`, recomputes the epage starts of not-yet-loaded spine items, and keeps `epageCount` and its callback consistent
- extract `retainReferences()` for the repeated resolved/unresolved reference filtering in `CounterStore`
- extract a shared generated-content DOM patch walker (`updateGeneratedContentNodesInPages()`) used by both target-counter and target-text node updates
- extract `retireStalePages()` and `clearFollowingSpineRelayoutState()` for the stale-page removal and relayout-state cleanup repeated across render paths

Also records the layout regression triage for the three test cases added in #2132.

## Validation

- `yarn build`, `yarn lint`, and `yarn test:core` (785/785) pass
- visual check of both #2132 test publications in the viewer:
  - `target-text-shrinking-spine` finishes in 4 pages with the cross-references resolved to single-digit chapter numbers
  - `target-counter-retained-source` resolves “(page 8)” and epubcfi navigation reaches the target on page 8, exercising the unified epage recomputation

Assisted-by: GitHub Copilot Chat:claude-fable-5

<details>
<summary>How the AI was used</summary>

- The human maintainer reviewed #2132, identified the duplication/complexity concerns during that review, decided the refactoring scope, and requested this follow-up.
- The AI (GitHub Copilot Chat, Claude Fable 5) located the duplicated code paths, implemented the extractions and the epage unification, ran build/lint/unit tests, and performed the visual verification in the integrated browser.
- The human maintainer reviewed the diff and the verification results before opening this PR.

</details>