### PR TITLE
fix: Keep rules with valid but unsupported selectors like `:host`

### DIFF
--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5336,7 +5336,7 @@ export class CascadeParserHandler
         ? !functionalPseudoClasses.has(name.toLowerCase())
         : functionalPseudoClasses.has(name.toLowerCase())
     ) {
-      this.unsupportedPseudoclassSelector(name, !!params);
+      this.unsupportedPseudoclassSelector(name, params);
       return;
     }
     switch (name.toLowerCase()) {
@@ -5458,7 +5458,7 @@ export class CascadeParserHandler
         this.pseudoelementSelector(name, params);
         return;
       default:
-        this.unsupportedPseudoclassSelector(name, !!params);
+        this.unsupportedPseudoclassSelector(name, params);
         return;
     }
     this.specificity += 256;
@@ -5466,12 +5466,10 @@ export class CascadeParserHandler
 
   private unsupportedPseudoclassSelector(
     name: string,
-    functional: boolean,
+    params: (number | string)[] | null,
   ): void {
     if (
-      functional
-        ? unsupportedFunctionalPseudoClasses.has(name.toLowerCase())
-        : CSS.supports(`selector(:${name})`)
+      CSS.supports(`selector(${unsupportedSelectorText(":", name, params)})`)
     ) {
       this.chain.push(new CheckConditionAction("")); // always fails
       this.specificity += 256;
@@ -5532,7 +5530,7 @@ export class CascadeParserHandler
         }
         break;
       default:
-        this.unsupportedPseudoelementSelector(name, !!params);
+        this.unsupportedPseudoelementSelector(name, params);
         return;
     }
     this.specificity += 1;
@@ -5540,12 +5538,10 @@ export class CascadeParserHandler
 
   private unsupportedPseudoelementSelector(
     name: string,
-    functional: boolean,
+    params: (number | string)[] | null,
   ): void {
     if (
-      functional
-        ? unsupportedFunctionalPseudoElements.has(name.toLowerCase())
-        : CSS.supports(`selector(::${name})`)
+      CSS.supports(`selector(${unsupportedSelectorText("::", name, params)})`)
     ) {
       this.chain.push(new CheckConditionAction("")); // always fails
       this.specificity += 1;
@@ -5978,28 +5974,21 @@ const functionalPseudoClasses: ReadonlySet<string> = new Set([
   "nth-of-type",
 ]);
 
-// Functional selectors that browsers parse but that never match anything this
-// engine lays out, such as the shadow-DOM ones. Their arguments are not
-// validated; a browser would reject e.g. `:host(a b)`, this engine keeps it as
-// never matching.
-const unsupportedFunctionalPseudoClasses: ReadonlySet<string> = new Set([
-  "active-view-transition-type",
-  "host",
-  "host-context",
-  "state",
-]);
-
-const unsupportedFunctionalPseudoElements: ReadonlySet<string> = new Set([
-  "cue",
-  "highlight",
-  "part",
-  "picker",
-  "slotted",
-  "view-transition-group",
-  "view-transition-image-pair",
-  "view-transition-new",
-  "view-transition-old",
-]);
+/**
+ * Source text of a pseudo-class or pseudo-element this engine does not
+ * implement, for probing with `CSS.supports`. `params` holds the raw argument
+ * text of a functional form, as the parser hands it over, and is null for the
+ * plain form. The name is escaped again because the tokenizer has decoded the
+ * escapes it was written with.
+ */
+function unsupportedSelectorText(
+  colons: string,
+  name: string,
+  params: (number | string)[] | null,
+): string {
+  const ident = Base.escapeCSSIdent(name);
+  return params ? `${colons}${ident}(${params[0]})` : `${colons}${ident}`;
+}
 
 export let conditionCount: number = 0;
 

--- a/packages/core/src/vivliostyle/css-cascade.ts
+++ b/packages/core/src/vivliostyle/css-cascade.ts
@@ -5336,7 +5336,7 @@ export class CascadeParserHandler
         ? !functionalPseudoClasses.has(name.toLowerCase())
         : functionalPseudoClasses.has(name.toLowerCase())
     ) {
-      this.invalidSelector(`Unsupported pseudo-class :${name}`);
+      this.unsupportedPseudoclassSelector(name, !!params);
       return;
     }
     switch (name.toLowerCase()) {
@@ -5458,10 +5458,26 @@ export class CascadeParserHandler
         this.pseudoelementSelector(name, params);
         return;
       default:
-        this.invalidSelector(`Unknown pseudo-class :${name}`);
+        this.unsupportedPseudoclassSelector(name, !!params);
         return;
     }
     this.specificity += 256;
+  }
+
+  private unsupportedPseudoclassSelector(
+    name: string,
+    functional: boolean,
+  ): void {
+    if (
+      functional
+        ? unsupportedFunctionalPseudoClasses.has(name.toLowerCase())
+        : CSS.supports(`selector(:${name})`)
+    ) {
+      this.chain.push(new CheckConditionAction("")); // always fails
+      this.specificity += 256;
+    } else {
+      this.invalidSelector(`Unsupported pseudo-class :${name}`);
+    }
   }
 
   override pseudoelementSelector(
@@ -5515,11 +5531,27 @@ export class CascadeParserHandler
           this.chain.push(new CheckConditionAction("")); // always fails
         }
         break;
-      default: // always fails
-        this.invalidSelector(`Unknown pseudo-element ::${name}`);
+      default:
+        this.unsupportedPseudoelementSelector(name, !!params);
         return;
     }
     this.specificity += 1;
+  }
+
+  private unsupportedPseudoelementSelector(
+    name: string,
+    functional: boolean,
+  ): void {
+    if (
+      functional
+        ? unsupportedFunctionalPseudoElements.has(name.toLowerCase())
+        : CSS.supports(`selector(::${name})`)
+    ) {
+      this.chain.push(new CheckConditionAction("")); // always fails
+      this.specificity += 1;
+    } else {
+      this.invalidSelector(`Unknown pseudo-element ::${name}`);
+    }
   }
 
   override idSelector(id: string): void {
@@ -5944,6 +5976,29 @@ const functionalPseudoClasses: ReadonlySet<string> = new Set([
   "nth-last-child",
   "nth-last-of-type",
   "nth-of-type",
+]);
+
+// Functional selectors that browsers parse but that never match anything this
+// engine lays out, such as the shadow-DOM ones. Their arguments are not
+// validated; a browser would reject e.g. `:host(a b)`, this engine keeps it as
+// never matching.
+const unsupportedFunctionalPseudoClasses: ReadonlySet<string> = new Set([
+  "active-view-transition-type",
+  "host",
+  "host-context",
+  "state",
+]);
+
+const unsupportedFunctionalPseudoElements: ReadonlySet<string> = new Set([
+  "cue",
+  "highlight",
+  "part",
+  "picker",
+  "slotted",
+  "view-transition-group",
+  "view-transition-image-pair",
+  "view-transition-new",
+  "view-transition-old",
 ]);
 
 export let conditionCount: number = 0;

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1943,8 +1943,15 @@ export class Parser {
                 if (params === null) {
                   break;
                 }
-              } else {
+              } else if (text == "first-n-lines") {
                 params = this.readPseudoParams();
+              } else {
+                // A pseudo-element this engine does not implement; its
+                // argument can hold tokens `readPseudoParams` rejects.
+                params = [];
+                if (!this.skipPseudoFunctionContents()) {
+                  break;
+                }
               }
               token = tokenizer.token();
               if (token.type == TokenType.C_PAR) {

--- a/packages/core/src/vivliostyle/css-parser.ts
+++ b/packages/core/src/vivliostyle/css-parser.ts
@@ -1288,6 +1288,21 @@ export class Parser {
     }
   }
 
+  /**
+   * Raw source text of the argument of a functional pseudo-class or
+   * pseudo-element, from `funcPosition` (the position of its name) to the
+   * closing parenthesis the tokenizer is left on by
+   * `skipPseudoFunctionContents`.
+   */
+  rawPseudoFunctionArg(funcPosition: number): string {
+    const tokenizer = this.tokenizer;
+    const text = tokenizer.input.substring(
+      funcPosition,
+      tokenizer.token().position,
+    );
+    return text.substring(text.indexOf("(") + 1);
+  }
+
   skipPseudoFunctionContents(): boolean {
     let depth = 0;
     while (true) {
@@ -1525,6 +1540,7 @@ export class Parser {
     let num: number;
     let val: Css.Val | null = null;
     let params: (number | string)[] | null;
+    let funcPosition = 0;
     let selectorStartPosition: number | null = null;
 
     if (parsingStyleAttr) {
@@ -1772,6 +1788,7 @@ export class Parser {
               continue;
             case TokenType.FUNC:
               text = token.text.toLowerCase();
+              funcPosition = token.position;
               tokenizer.consume();
               switch (text) {
                 case "is":
@@ -1893,12 +1910,21 @@ export class Parser {
                     tokenizer.consume();
                     break;
                   }
-                // fall through
-                default:
+                  // An argument that is not a single identifier is invalid;
+                  // the empty params array tells the handler to void it.
                   params = [];
                   if (!this.skipPseudoFunctionContents()) {
                     break pseudoclassType;
                   }
+                  break;
+                default:
+                  // A pseudo-class this engine does not implement. Its raw
+                  // argument text goes to the handler, which validates the
+                  // whole functional selector with `CSS.supports`.
+                  if (!this.skipPseudoFunctionContents()) {
+                    break pseudoclassType;
+                  }
+                  params = [this.rawPseudoFunctionArg(funcPosition)];
               }
               token = tokenizer.token();
               if (token.type == TokenType.C_PAR) {
@@ -1937,6 +1963,7 @@ export class Parser {
               continue;
             case TokenType.FUNC:
               text = token.text.toLowerCase();
+              funcPosition = token.position;
               tokenizer.consume();
               if (text == "nth-fragment") {
                 params = this.readNthPseudoParams();
@@ -1946,12 +1973,14 @@ export class Parser {
               } else if (text == "first-n-lines") {
                 params = this.readPseudoParams();
               } else {
-                // A pseudo-element this engine does not implement; its
-                // argument can hold tokens `readPseudoParams` rejects.
-                params = [];
+                // A pseudo-element this engine does not implement. Its raw
+                // argument text goes to the handler, which validates the whole
+                // functional selector with `CSS.supports`; `readPseudoParams`
+                // would reject tokens the argument may legitimately contain.
                 if (!this.skipPseudoFunctionContents()) {
                   break;
                 }
+                params = [this.rawPseudoFunctionArg(funcPosition)];
               }
               token = tokenizer.token();
               if (token.type == TokenType.C_PAR) {

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -2322,16 +2322,29 @@ describe("css-cascade", function () {
         expectNeverMatching();
       });
 
-      it("keeps the functional form :host() as a never-matching selector", function () {
-        handler.pseudoclassSelector("host", []);
+      it("keeps the functional form :host(.foo) as a never-matching selector", function () {
+        handler.pseudoclassSelector("host", [".foo"]);
 
         expectNeverMatching();
       });
 
-      it("keeps :host-context() as a never-matching selector", function () {
-        handler.pseudoclassSelector("host-context", []);
+      it("keeps :host-context(.foo) as a never-matching selector", function () {
+        handler.pseudoclassSelector("host-context", [".foo"]);
 
         expectNeverMatching();
+      });
+
+      it("voids the selector list when a functional pseudo-class argument is invalid", function () {
+        handler.pseudoclassSelector("host", ["a b"]);
+
+        expect(handler.selectorListVoided).toBe(true);
+      });
+
+      it("voids the selector list for an escaped name that is not valid CSS", function () {
+        // `:\69s\28 \.foo` is one pseudo-class name, not `:is(.foo)`.
+        handler.pseudoclassSelector("is(.foo", null);
+
+        expect(handler.selectorListVoided).toBe(true);
       });
 
       it("voids the selector list for a pseudo-class that is not valid CSS", function () {
@@ -2346,10 +2359,16 @@ describe("css-cascade", function () {
         expectNeverMatching();
       });
 
-      it("keeps ::slotted() as a never-matching selector", function () {
-        handler.pseudoelementSelector("slotted", []);
+      it("keeps ::slotted(.foo) as a never-matching selector", function () {
+        handler.pseudoelementSelector("slotted", [".foo"]);
 
         expectNeverMatching();
+      });
+
+      it("voids the selector list when a functional pseudo-element argument is invalid", function () {
+        handler.pseudoelementSelector("slotted", ["a b"]);
+
+        expect(handler.selectorListVoided).toBe(true);
       });
 
       it("voids the selector list for a pseudo-element that is not valid CSS", function () {
@@ -2389,6 +2408,36 @@ describe("css-cascade", function () {
         parseAndCheck(
           done,
           "x::slotted(.foo), p { color: red; }",
+          function (handler) {
+            expect(Object.keys(handler.cascade.tags)).toContain("p");
+          },
+        );
+      });
+
+      it("voids the whole selector list when ::slotted() has an invalid argument", function (done) {
+        parseAndCheck(
+          done,
+          "::slotted(a b), p { color: red; }",
+          function (handler) {
+            expect(Object.keys(handler.cascade.tags)).not.toContain("p");
+          },
+        );
+      });
+
+      it("voids the whole selector list when ::part() has an invalid argument", function (done) {
+        parseAndCheck(
+          done,
+          "::part(#x), p { color: red; }",
+          function (handler) {
+            expect(Object.keys(handler.cascade.tags)).not.toContain("p");
+          },
+        );
+      });
+
+      it("keeps a pseudo-class that follows an unsupported pseudo-element", function (done) {
+        parseAndCheck(
+          done,
+          "::part(button):hover, p { color: red; }",
           function (handler) {
             expect(Object.keys(handler.cascade.tags)).toContain("p");
           },

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -1484,7 +1484,14 @@ describe("css-cascade", function () {
           "p:focus-visible { color: red } q { color: blue }",
           done,
           function (cascade) {
-            expect(Object.keys(cascade.tags)).toEqual(["q"]);
+            // The rule survives as valid CSS, but its selector matches
+            // nothing instead of being handed to the native matcher.
+            expect(Object.keys(cascade.tags)).toEqual(["p", "q"]);
+            var action = cascade.tags["p"];
+            expect(action).toEqual(
+              jasmine.any(adapt_csscasc.WiredConditionScope),
+            );
+            expect(action.condition.condition).toBe("");
           },
         );
       });
@@ -2287,6 +2294,115 @@ describe("css-cascade", function () {
 
         expect(handler.chain.actions).toBeUndefined();
         expect(handler.selectorListVoided).toBe(true);
+      });
+    });
+
+    describe("valid but unsupported selectors", function () {
+      var handler;
+
+      beforeEach(function () {
+        handler = cascadeParserHandler(
+          new adapt_exprs.LexicalScope(null),
+          adapt_cssvalid.baseValidatorSet(),
+        );
+        handler.startSelectorRule();
+      });
+
+      function expectNeverMatching() {
+        expect(handler.selectorListVoided).toBe(false);
+        expect(handler.chain.actions.length).toBe(1);
+        var action = handler.chain.actions[0];
+        expect(action).toEqual(jasmine.any(adapt_csscasc.CheckConditionAction));
+        expect(action.condition).toBe("");
+      }
+
+      it("keeps :host as a never-matching selector", function () {
+        handler.pseudoclassSelector("host", null);
+
+        expectNeverMatching();
+      });
+
+      it("keeps the functional form :host() as a never-matching selector", function () {
+        handler.pseudoclassSelector("host", []);
+
+        expectNeverMatching();
+      });
+
+      it("keeps :host-context() as a never-matching selector", function () {
+        handler.pseudoclassSelector("host-context", []);
+
+        expectNeverMatching();
+      });
+
+      it("voids the selector list for a pseudo-class that is not valid CSS", function () {
+        handler.pseudoclassSelector("this-is-not-css", null);
+
+        expect(handler.selectorListVoided).toBe(true);
+      });
+
+      it("keeps ::selection as a never-matching selector", function () {
+        handler.pseudoelementSelector("selection", null);
+
+        expectNeverMatching();
+      });
+
+      it("keeps ::slotted() as a never-matching selector", function () {
+        handler.pseudoelementSelector("slotted", []);
+
+        expectNeverMatching();
+      });
+
+      it("voids the selector list for a pseudo-element that is not valid CSS", function () {
+        handler.pseudoelementSelector("this-is-not-css", null);
+
+        expect(handler.selectorListVoided).toBe(true);
+      });
+    });
+
+    describe("valid but unsupported selectors in a selector list", function () {
+      function parseAndCheck(done, text, fn) {
+        var handler = cascadeParserHandler(
+          new adapt_exprs.LexicalScope(null),
+          adapt_cssvalid.baseValidatorSet(),
+        );
+        var tokenizer = new adapt_csstok.Tokenizer(text, handler.owner);
+
+        adapt_task.start(function () {
+          adapt_cssparse
+            .parseStylesheet(tokenizer, handler.owner, null, null, null)
+            .then(function (result) {
+              expect(result).toBe(true);
+              fn(handler);
+              done();
+            });
+          return adapt_task.newResult(true);
+        });
+      }
+
+      it("keeps the rest of the selector list when it contains :host", function (done) {
+        parseAndCheck(done, ":host, p { color: red; }", function (handler) {
+          expect(Object.keys(handler.cascade.tags)).toContain("p");
+        });
+      });
+
+      it("parses a compound selector argument of ::slotted()", function (done) {
+        parseAndCheck(
+          done,
+          "x::slotted(.foo), p { color: red; }",
+          function (handler) {
+            expect(Object.keys(handler.cascade.tags)).toContain("p");
+          },
+        );
+      });
+
+      it("voids the whole selector list when it contains an invalid selector", function (done) {
+        parseAndCheck(
+          done,
+          ":this-is-not-css, p { color: red; }",
+          function (handler) {
+            expect(Object.keys(handler.cascade.tags)).not.toContain("p");
+          },
+        );
       });
     });
   });

--- a/packages/core/test/spec/vivliostyle/css-cascade-spec.js
+++ b/packages/core/test/spec/vivliostyle/css-cascade-spec.js
@@ -2328,10 +2328,17 @@ describe("css-cascade", function () {
         expectNeverMatching();
       });
 
-      it("keeps :host-context(.foo) as a never-matching selector", function () {
+      it("follows the host browser on :host-context(.foo)", function () {
+        // `:host-context()` is supported by Chrome only; a browser that does
+        // not recognize it treats the selector as invalid, and so does this
+        // handler.
         handler.pseudoclassSelector("host-context", [".foo"]);
 
-        expectNeverMatching();
+        if (CSS.supports("selector(:host-context(.foo))")) {
+          expectNeverMatching();
+        } else {
+          expect(handler.selectorListVoided).toBe(true);
+        }
       });
 
       it("voids the selector list when a functional pseudo-class argument is invalid", function () {


### PR DESCRIPTION
A stylesheet rule whose selector list contained a selector that is valid CSS but not implemented by this engine — `:host`, `:host-context()`, `::slotted()`, `::part()`, `::selection`, `:focus-visible`, etc. — was voided entirely, dropping the styles for every other selector in the same comma-separated list. Browsers parse such selectors as valid and simply never match them, so CSS coming from web component libraries (found while working on vivliostyle-cli) lost unrelated rules.

## Changes

- `CascadeParserHandler` now treats valid-but-unimplemented pseudo-classes/pseudo-elements as never matching (the way `:hover` and `:visited` already are) instead of voiding the whole selector list. Plain forms are probed with `CSS.supports("selector(...)")`, so the judgment follows the host browser with no name list to maintain; functional forms are matched against name lists (`:host()`, `:state()`, `::slotted()`, `::part()`, `::highlight()`, `::cue()`, `::view-transition-*()`, …) because the parser has discarded their arguments. Every listed name was confirmed to parse as valid in Chrome, and deliberately excluded names (`:nth-col()`, `:current()`, …) to parse as invalid, via `CSS.supports`.
- The parser now skips the argument of an unimplemented functional pseudo-element instead of tokenizing it with `readPseudoParams()`, so `::slotted(.foo)` no longer aborts with `E_CSS_PSEUDOELEM_SYNTAX`.
- Genuinely invalid selectors (e.g. `:hoge`) still void the whole rule, per the CSS spec.

Side effects that now match browsers: `:not(:host)` matches everything, and `@supports selector(:host)` evaluates to true.

## Note for reviewers

The test "does not delegate a pseudo-class only because the browser supports it" from #2093 asserted that `p:focus-visible` voids the rule. The decision recorded there — do not hand unimplemented pseudo-classes to the native matcher, `:dir()` excepted — is preserved (no `MatchesNativeSelectorAction` is involved), but the expectation is updated: the rule now survives with a never-matching selector.

## Verification

- All 797 core unit tests pass (10 added), lint passes.
- E2E in the viewer: with `:host, p { … }`, `em::slotted(.foo), h2 { … }`, `::part(button), h3 { … }` the `p`/`h2`/`h3` styles apply, while a rule with an invalid selector is still dropped.

Assisted-by: Claude Code:claude-fable-5

<details>
<summary>How the AI was used</summary>

- The human author found the problem while developing vivliostyle-cli, decided it should be fixed in the core engine, and requested the fix.
- The AI diagnosed the cause in `CascadeParserHandler`, designed and implemented the fix, wrote the unit and integration tests, adjusted the #2093 test expectation (flagging that change to the human for review), and verified the result with the test suite, lint, and an end-to-end check in the viewer. It also grounded the hardcoded functional-selector lists by probing `CSS.supports` in Chrome.
- The human author reviewed the diff and directed refactoring: questioned the rationale of the name lists (which surfaced the missing `::cue()`), required a `unsupportedPseudoelementSelector` helper symmetric to the pseudo-class one, and required a comment documenting the parser/cascade coupling.
- **Maintainer follow-up:** after the review round below, the human maintainer (@MurakamiShinyu) questioned whether the hardcoded name lists were really necessary and had a first revision drafted with an agent; judging that draft too large (a ~110-line specificity calculator plus a new parser-handler API), the maintainer had a second agent (Claude Code, claude-opus-5) review both the Copilot findings and the draft, which produced the much smaller `CSS.supports` version that was pushed. The agent implemented the change, wrote the tests, and ran the suites; the maintainer decided which findings to decline, spotted the Firefox CI failure, and verified the result on Chrome and Firefox.

</details>

---

## Maintainer follow-up

Two commits were pushed on top of the original fix after reviewing the Copilot findings.

**cdaa289 — `refactor: Validate unsupported functional selectors with CSS.supports`**

- The parser no longer discards the argument of an unimplemented functional pseudo-class or pseudo-element: it hands the raw source text of the argument to the cascade handler in the existing `params` array, and the handler probes the complete selector with `CSS.supports`. Both hardcoded name lists are gone, so functional forms follow the host browser exactly like the plain forms, with nothing to maintain as browsers gain selectors.
- Syntactically invalid arguments void the rule again, as browsers do: `::slotted(a b), p { … }` and `::part(#x), p { … }` drop the whole list.
- The plain form is probed with `Base.escapeCSSIdent(name)`, so an escaped name such as `::part\28 foo` is no longer probed as the valid `::part(foo)` and kept.
- No new parser-handler API was needed; the change is +51/−38 lines in `packages/core/src`, and `PageParserHandler` and the `:is()`/`:not()` handlers keep working through their existing overrides.

Three Copilot findings were deliberately not taken; the reasoning is in each thread.

- **Specificity of a `:host()` argument** — only observable when the never-matching selector sits inside `:is()` / `:not()` / `:has()`, and retaining it means a second specificity calculator: a working draft came to ~110 lines and still disagreed with the spec on `:host(*)`, `:host(:where(.a))` and `:host(:not(#a))`.
- **Recording unsupported pseudo-elements in `this.pseudoelement`** — that puts them under `invalidContinuationAfterPseudoelement`, which rejects every continuation, so `::part(button):hover, p { … }` would lose the `p` rule although browsers keep that selector. Enforcing placement properly needs the set of pseudo-classes permitted after a pseudo-element, which is missing for the supported ones too (`::before:hover` is rejected the same way today), so it belongs in its own PR. `::selection.foo` consequently stays accepted as never-matching — the remaining known gap.
- **`:has()` delegating an unsupported selector to `querySelector`** — `MatchesRelationalAction` discards the parsed chain for every alternative, so `:hover`, `:focus`, `:active` and `:visited` have leaked through `:has()` the same way since it was implemented; a fix should cover all of them in its own issue.

**08385e29 — `test: follow the host browser on :host-context() support`**

`:host-context()` is implemented by Chrome only, so its probe is false on Firefox and Safari, which void the selector as those browsers themselves do. The test asserted the Chrome outcome and failed on the Firefox CI job; it now asserts whichever outcome the host browser calls for. Note the consequence of following the host browser: `:host-context(.foo), p { … }` keeps the `p` rule on Chrome and drops the rule on Firefox and Safari, each matching that browser.

Verification: core unit tests 803/803 on Chrome and on Firefox 154, `yarn lint` clean.

Assisted-by: Claude Code:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

