### PR TITLE
test: resolve the real Vercel preview URL for long PR branch names

### DIFF
--- a/.github/workflows/layout-regression.yml
+++ b/.github/workflows/layout-regression.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write # needed to post/update PR comments
+      pull-requests: write # needed to post/update PR comments, and to read the Vercel bot's preview-URL comment
     # For pull_request events, only run on internal PRs (same repo).
     # Fork PRs don't have a Vercel preview until a maintainer authorizes it.
     # In that case, a maintainer can manually trigger via workflow_dispatch
@@ -70,22 +70,65 @@ jobs:
             fi
           fi
 
-      # ── For PR runs: derive the Vercel preview URL from the branch name ───
-      - name: Derive PR Vercel preview spec
+      # ── For PR runs: derive (or resolve) the Vercel preview URL ────────────
+      # Deriving the URL from the sanitized branch name works as long as the
+      # resulting host is at most 63 characters. Beyond that, Vercel truncates
+      # the host and appends a short content hash to keep it unique, and that
+      # hash can't be predicted here — so for long branch names, look up the
+      # real URL from the Vercel bot's PR comment (which always has the exact
+      # branch-alias URL) instead of guessing.
+      - name: Resolve PR Vercel preview URL
         if: github.event_name == 'pull_request'
         id: pr_viewer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
-          # Replicate Vercel's branch name sanitization
           SANITIZED=$(echo "$BRANCH" \
             | tr '[:upper:]' '[:lower:]' \
-            | sed 's/[^a-z0-9]\+/-/g' \
-            | sed 's/^-\|-$//g')
-          echo "spec=git-${SANITIZED}" >> "$GITHUB_OUTPUT"
-          echo "label=git-${SANITIZED}" >> "$GITHUB_OUTPUT"
-          echo "url=https://vivliostyle-git-${SANITIZED}-vivliostyle.vercel.app/" >> "$GITHUB_OUTPUT"
+            | sed -E 's/[^a-z0-9]+/-/g' \
+            | sed -E 's/^-|-$//g')
+          HOST="vivliostyle-git-${SANITIZED}-vivliostyle"
 
-      # ── Wait for Vercel preview to become ready (PR runs only) ────────────
+          if [ "${#HOST}" -le 63 ]; then
+            URL="https://${HOST}.vercel.app/"
+            echo "Branch-derived URL: $URL"
+          else
+            echo "Branch-derived host is ${#HOST} chars (over the 63-char Vercel limit)."
+            echo "Looking up the real preview URL from the Vercel bot's PR comment..."
+            URL=""
+            for i in $(seq 1 20); do
+              BODY=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+                --jq '[.[] | select(.user.login == "vercel[bot]")] | last | .body // empty')
+              if echo "$BODY" | grep -q 'ready\.svg'; then
+                CANDIDATE_URL=$(echo "$BODY" | grep -oE '\[Preview\]\(https://[^)]+\)' | grep -oE 'https://[^)]+' | head -1)
+                if [ -n "$CANDIDATE_URL" ]; then
+                  URL="$CANDIDATE_URL"
+                  echo "Preview is ready (attempt $i): $URL"
+                  break
+                fi
+              fi
+              echo "  attempt $i: not ready yet — waiting 15s..."
+              sleep 15
+            done
+            if [ -z "$URL" ]; then
+              # Best-effort fallback: likely wrong for this branch name, since
+              # Vercel's truncation hash can't be predicted here.
+              echo "Warning: could not resolve the real Vercel preview URL in time; falling back to a branch-derived guess."
+              URL="https://${HOST}.vercel.app/"
+            fi
+          fi
+
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "label=git-${SANITIZED}" >> "$GITHUB_OUTPUT"
+
+      # ── Wait for the Vercel preview to become ready (PR runs only) ────────
+      # Needed for the fast (short branch name) path above, which derives the
+      # URL without confirming the deployment has finished. The bot-comment
+      # lookup path already confirms readiness itself, so this is a quick
+      # no-op there.
       - name: Wait for Vercel preview
         if: github.event_name == 'pull_request'
         run: |
@@ -106,7 +149,8 @@ jobs:
       - name: Run regression compare
         id: compare
         env:
-          ACTUAL_VIEWER: ${{ github.event_name == 'pull_request' && steps.pr_viewer.outputs.spec || inputs.actual_viewer }}
+          ACTUAL_VIEWER: ${{ github.event_name == 'pull_request' && steps.pr_viewer.outputs.url || inputs.actual_viewer }}
+          ACTUAL_LABEL: ${{ steps.pr_viewer.outputs.label }}
           BASELINE_VIEWER: ${{ inputs.baseline_viewer }}
           INPUT_CATEGORY: ${{ inputs.category }}
           INPUT_LIMIT: ${{ inputs.limit }}
@@ -128,6 +172,7 @@ jobs:
           else
             # PR run: actual = PR preview, baseline = stable (default)
             args+=(--actual-viewer "$ACTUAL_VIEWER")
+            args+=(--actual-label "$ACTUAL_LABEL")
           fi
           yarn test:layout-regression "${args[@]}"
         continue-on-error: true

--- a/.github/workflows/layout-regression.yml
+++ b/.github/workflows/layout-regression.yml
@@ -34,6 +34,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # needed to post/update PR comments, and to read the Vercel bot's preview-URL comment
+      statuses: read # needed to confirm the Vercel deployment for the exact head commit is ready
     # For pull_request events, only run on internal PRs (same repo).
     # Fork PRs don't have a Vercel preview until a maintainer authorizes it.
     # In that case, a maintainer can manually trigger via workflow_dispatch
@@ -84,6 +85,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
           BRANCH: ${{ github.head_ref }}
         run: |
           SANITIZED=$(echo "$BRANCH" \
@@ -97,18 +99,30 @@ jobs:
             echo "Branch-derived URL: $URL"
           else
             echo "Branch-derived host is ${#HOST} chars (over the 63-char Vercel limit)."
-            echo "Looking up the real preview URL from the Vercel bot's PR comment..."
+            echo "Waiting for the Vercel deployment of commit $SHA, then looking up the real preview URL..."
             URL=""
             for i in $(seq 1 20); do
-              BODY=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
-                --jq '[.[] | select(.user.login == "vercel[bot]")] | last | .body // empty')
-              if echo "$BODY" | grep -q 'ready\.svg'; then
+              # Gate on a Vercel status tied to the exact head commit before
+              # trusting the PR comment: Vercel edits a single comment in
+              # place on every push, so right after a new push it can still
+              # show the previous commit's "Ready" state and alias link.
+              COMMIT_STATE=$(gh api "repos/$REPO/commits/$SHA/statuses?per_page=100" \
+                --jq '[.[] | select(.context == "Vercel")] | sort_by(.created_at) | last | .state // empty')
+              if [ "$COMMIT_STATE" = "success" ]; then
+                # Paginate: the bot comment is normally the first comment on
+                # the PR, but fetch every page rather than assume it fits in
+                # the first one.
+                BODY=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+                  | jq -s -r 'add | [.[] | select(.user.login == "vercel[bot]")] | last | .body // empty')
                 CANDIDATE_URL=$(echo "$BODY" | grep -oE '\[Preview\]\(https://[^)]+\)' | grep -oE 'https://[^)]+' | head -1)
                 if [ -n "$CANDIDATE_URL" ]; then
                   URL="$CANDIDATE_URL"
                   echo "Preview is ready (attempt $i): $URL"
                   break
                 fi
+              elif [ "$COMMIT_STATE" = "failure" ] || [ "$COMMIT_STATE" = "error" ]; then
+                echo "Vercel deployment for commit $SHA reported state=$COMMIT_STATE — giving up."
+                break
               fi
               echo "  attempt $i: not ready yet — waiting 15s..."
               sleep 15

--- a/.github/workflows/layout-regression.yml
+++ b/.github/workflows/layout-regression.yml
@@ -114,10 +114,12 @@ jobs:
               sleep 15
             done
             if [ -z "$URL" ]; then
-              # Best-effort fallback: likely wrong for this branch name, since
-              # Vercel's truncation hash can't be predicted here.
-              echo "Warning: could not resolve the real Vercel preview URL in time; falling back to a branch-derived guess."
-              URL="https://${HOST}.vercel.app/"
+              # No safe fallback here: HOST is already known to exceed 63
+              # characters, so guessing it as the URL would be a guaranteed
+              # DNS failure, not a best effort. Fail explicitly instead of
+              # feeding a known-bad URL into the comparison step.
+              echo "::error::Could not resolve the real Vercel preview URL for branch '$BRANCH' from the Vercel bot's PR comment in time."
+              exit 1
             fi
           fi
 

--- a/.github/workflows/layout-regression.yml
+++ b/.github/workflows/layout-regression.yml
@@ -114,7 +114,11 @@ jobs:
                 # the first one.
                 BODY=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
                   | jq -s -r 'add | [.[] | select(.user.login == "vercel[bot]")] | last | .body // empty')
-                CANDIDATE_URL=$(echo "$BODY" | grep -oE '\[Preview\]\(https://[^)]+\)' | grep -oE 'https://[^)]+' | head -1)
+                # `|| true`: GitHub Actions runs this with `bash -e -o pipefail`,
+                # so a non-matching grep (expected while the comment hasn't
+                # picked up the new commit's Preview link yet) would otherwise
+                # abort this step outright instead of letting the loop retry.
+                CANDIDATE_URL=$(echo "$BODY" | grep -oE '\[Preview\]\(https://[^)]+\)' | grep -oE 'https://[^)]+' | head -1 || true)
                 if [ -n "$CANDIDATE_URL" ]; then
                   URL="$CANDIDATE_URL"
                   echo "Preview is ready (attempt $i): $URL"

--- a/docs/ja/layout-regression-test.md
+++ b/docs/ja/layout-regression-test.md
@@ -218,6 +218,16 @@ yarn test:reftest-diff \
 | レガシーバージョン | `2019.11.100` | https://vivliostyle.github.io/viewer/2019.11.100/vivliostyle-viewer.html |
 | URL | `https://...` | 任意のビューワー URL（レガシーの `vivliostyle-viewer.html` URL も自動判別） |
 
+`git-<branch>` / `git:<branch>` はサニタイズしたブランチ名から URL を組み立てる
+ため、ホスト名が63文字以内であれば確実に動作する。それを超える場合、Vercel は
+ホスト名を切り詰めた上で一意性のためのハッシュを付加するが、このハッシュは
+本スクリプトからは予測できないため、長いブランチ名では生成した URL が誤った
+ものになる可能性が高い。この場合スクリプトは警告を表示するので、代わりに
+実際のプレビュー URL（PR の Vercel コメントなどから取得）を
+`--actual-viewer <url>` で直接指定すること。CI ワークフローも同じ63文字以内の
+判定を使うが、それを超えるブランチ名の場合は推測する代わりに Vercel bot の
+PR コメントから実際の URL を取得する。
+
 使用例:
 
 ```bash

--- a/docs/ja/layout-regression-test.md
+++ b/docs/ja/layout-regression-test.md
@@ -218,14 +218,16 @@ yarn test:reftest-diff \
 | レガシーバージョン | `2019.11.100` | https://vivliostyle.github.io/viewer/2019.11.100/vivliostyle-viewer.html |
 | URL | `https://...` | 任意のビューワー URL（レガシーの `vivliostyle-viewer.html` URL も自動判別） |
 
-`git-<branch>` / `git:<branch>` はサニタイズしたブランチ名から URL を組み立てる
-ため、ホスト名が63文字以内であれば確実に動作する。それを超える場合、Vercel は
+`git-<branch>` / `git:<branch>` はサニタイズしたブランチ名から URL を組み立てる。
+これが確実に動作するのは、生成されるホスト名
+（`vivliostyle-git-<branch>-vivliostyle`）が63文字以内に収まる場合のみで、
+実質的にブランチ名として使えるのは約35文字である。それを超える場合、Vercel は
 ホスト名を切り詰めた上で一意性のためのハッシュを付加するが、このハッシュは
 本スクリプトからは予測できないため、長いブランチ名では生成した URL が誤った
 ものになる可能性が高い。この場合スクリプトは警告を表示するので、代わりに
 実際のプレビュー URL（PR の Vercel コメントなどから取得）を
-`--actual-viewer <url>` で直接指定すること。CI ワークフローも同じ63文字以内の
-判定を使うが、それを超えるブランチ名の場合は推測する代わりに Vercel bot の
+`--actual-viewer <url>` で直接指定すること。CI ワークフローも同じ短いブランチ名
+向けの組み立て方を使うが、長いブランチ名の場合は推測する代わりに Vercel bot の
 PR コメントから実際の URL を取得する。
 
 使用例:

--- a/docs/layout-regression-test.md
+++ b/docs/layout-regression-test.md
@@ -221,14 +221,15 @@ yarn test:reftest-diff \
 | URL | `https://...` | Any viewer URL (legacy `vivliostyle-viewer.html` URLs are auto-detected) |
 
 `git-<branch>`/`git:<branch>` derives the preview URL from the sanitized branch
-name, which only works reliably up to 63 characters. Beyond that, Vercel
-truncates the hostname and appends a short content hash to keep it unique — a
-hash this script cannot predict — so the derived URL is likely wrong for long
-branch names. The script prints a warning in that case; pass the real preview
-URL directly with `--actual-viewer <url>` instead (e.g. from the PR's Vercel
-comment). The CI workflow uses the same short-name derivation, but for long
-branch names it looks up the real URL from the Vercel bot's PR comment instead
-of guessing.
+name, which only works reliably while the resulting hostname
+(`vivliostyle-git-<branch>-vivliostyle`) stays at most 63 characters — about 35
+characters of actual branch name. Beyond that, Vercel truncates the hostname
+and appends a short content hash to keep it unique — a hash this script cannot
+predict — so the derived URL is likely wrong for long branch names. The script
+prints a warning in that case; pass the real preview URL directly with
+`--actual-viewer <url>` instead (e.g. from the PR's Vercel comment). The CI
+workflow uses the same short-name derivation, but for long branch names it
+looks up the real URL from the Vercel bot's PR comment instead of guessing.
 
 Examples:
 

--- a/docs/layout-regression-test.md
+++ b/docs/layout-regression-test.md
@@ -221,12 +221,12 @@ yarn test:reftest-diff \
 | URL | `https://...` | Any viewer URL (legacy `vivliostyle-viewer.html` URLs are auto-detected) |
 
 `git-<branch>`/`git:<branch>` derives the preview URL from the sanitized branch
-name, which only works reliably while the resulting hostname
+name. This is reliable only while the resulting hostname
 (`vivliostyle-git-<branch>-vivliostyle`) stays at most 63 characters — about 35
 characters of actual branch name. Beyond that, Vercel truncates the hostname
-and appends a short content hash to keep it unique — a hash this script cannot
-predict — so the derived URL is likely wrong for long branch names. The script
-prints a warning in that case; pass the real preview URL directly with
+and appends a short content hash to keep it unique, and that hash cannot be
+predicted here, so the derived URL is likely wrong for long branch names. The
+script prints a warning in that case; pass the real preview URL directly with
 `--actual-viewer <url>` instead (e.g. from the PR's Vercel comment). The CI
 workflow uses the same short-name derivation, but for long branch names it
 looks up the real URL from the Vercel bot's PR comment instead of guessing.

--- a/docs/layout-regression-test.md
+++ b/docs/layout-regression-test.md
@@ -220,6 +220,16 @@ yarn test:reftest-diff \
 | legacy version | `2019.11.100` | https://vivliostyle.github.io/viewer/2019.11.100/vivliostyle-viewer.html |
 | URL | `https://...` | Any viewer URL (legacy `vivliostyle-viewer.html` URLs are auto-detected) |
 
+`git-<branch>`/`git:<branch>` derives the preview URL from the sanitized branch
+name, which only works reliably up to 63 characters. Beyond that, Vercel
+truncates the hostname and appends a short content hash to keep it unique — a
+hash this script cannot predict — so the derived URL is likely wrong for long
+branch names. The script prints a warning in that case; pass the real preview
+URL directly with `--actual-viewer <url>` instead (e.g. from the PR's Vercel
+comment). The CI workflow uses the same short-name derivation, but for long
+branch names it looks up the real URL from the Vercel bot's PR comment instead
+of guessing.
+
 Examples:
 
 ```bash

--- a/scripts/layout-regression.mjs
+++ b/scripts/layout-regression.mjs
@@ -637,8 +637,22 @@ function resolveViewerSpec(spec) {
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-+|-+$/g, "");
     const label = `git-${sanitized}`;
+    const host = `vivliostyle-git-${sanitized}-vivliostyle`;
+    // Vercel truncates a subdomain longer than 63 characters (before
+    // `.vercel.app`) and appends a short content hash to keep it unique.
+    // That hash can't be predicted here, so the derived URL below is only
+    // reliable for short branch names; long ones need the real preview URL
+    // (e.g. from the PR's Vercel comment) passed via --actual-viewer <url>.
+    if (host.length > 63) {
+      console.warn(
+        `Warning: branch name "${branch}" produces a Vercel preview host longer than 63 characters.\n` +
+          `Vercel truncates and hashes such hosts unpredictably, so the derived URL below is likely wrong:\n` +
+          `  https://${host}.vercel.app/\n` +
+          `Pass the actual preview URL directly instead, e.g. --actual-viewer <url>.`,
+      );
+    }
     return {
-      url: `https://vivliostyle-git-${sanitized}-vivliostyle.vercel.app/`,
+      url: `https://${host}.vercel.app/`,
       label,
     };
   }


### PR DESCRIPTION
Long branch names produced a Vercel preview host over 63 characters, which Vercel truncates and appends a short content hash to keep unique. The `layout-regression` workflow's naive branch-name-derived URL didn't account for this, so every test entry on such PRs failed with `ERR_NAME_NOT_RESOLVED` (see the [comment on #2135](https://github.com/vivliostyle/vivliostyle.js/pull/2135#issuecomment-5476112771)).

This PR's own branch name is deliberately long (`fix/layout-regression-vercel-preview-url-for-long-branch-names`, a 90-character derived host) to exercise the new code path live in its own CI run, and it has now passed repeatedly across several revisions.

## Changes

- `.github/workflows/layout-regression.yml`: branch names whose derived host (`vivliostyle-git-<branch>-vivliostyle`) stays within 63 characters keep the existing fast, API-free derivation. Longer ones have the real preview URL looked up from the Vercel bot's PR comment (which always carries the exact branch-alias URL) instead of being guessed. The lookup is gated on the Vercel commit status for the exact PR head SHA, since Vercel edits a single PR comment in place on every push and a `synchronize` event could otherwise read a stale "Ready" state left over from the previous commit. The comment fetch is paginated rather than assuming the bot's comment fits on the first page, and the URL-extracting `grep` pipeline is made pipefail-safe so a temporary non-match during the comment-update race retries instead of aborting the step.
- `scripts/layout-regression.mjs`: the standalone `git-<branch>` viewer spec can't make that API call outside CI, so it now warns instead of silently returning a broken URL when the derived host exceeds 63 characters.
- Docs updated in English and Japanese, kept in sync with each other.

## Verification

- Confirmed against the real `#2135` PR comment from `vercel[bot]` that the regex extraction correctly parses the real preview URL, and that URL returns HTTP 200.
- This PR's own CI runs exercised the new >63-char lookup path live across four pushes (initial implementation, two rounds of Copilot review fixes), each time correctly resolving `https://vivliostyle-git-fix-layout-regression-vercel-3ee30a-vivliostyle.vercel.app` from the PR comment and completing the `compare` job successfully (most recently in 8m0s with all 370 entries compared, no errors).

Assisted-by: Claude Code:claude-sonnet-5

<details>
<summary>How the AI was used</summary>

- The human author reported the layout-regression CI failure on long branch names (linking the failing comment on #2135) and asked for a fix.
- The AI's first proposed fix (simple 63-character truncation) was shown wrong by the human, who supplied the actual Vercel preview URL from the PR comment, revealing Vercel appends a content hash rather than truncating plainly.
- The AI's second proposal (resolving the URL via the GitHub Deployments API) gave a working but commit-scoped URL rather than the branch-scoped one. The human asked whether the branch-scoped URL could be obtained instead, and suggested keeping the cheap branch-name derivation for the common case and only doing extra work past the 63-character threshold. The AI found that the Vercel bot's own PR comment always carries the real branch-alias URL and redesigned the workflow around that split (fast path / comment lookup), which the human then had built and pushed to a deliberately long-named branch to test in CI.
- Two rounds of automated Copilot review followed. The AI investigated each finding before treating it as valid, confirming that: (1) the timeout fallback re-guessed an already-known-broken host, (2) the docs conflated the branch-name length limit with the resulting hostname's limit, (3) the comment fetch didn't paginate, (4) the lookup could read a stale comment after a `synchronize` push (fixed by gating on the commit-specific Vercel status), and (5) `pipefail` could abort the retry loop on a non-matching `grep`. All five were fixed and pushed; the human reviewed each diff, approved pushing and PR/thread management steps explicitly, and verified the resulting CI runs.

</details>
