### PR TITLE
fix: Keep table caption before repeated header in the view tree

### DIFF
--- a/packages/core/src/vivliostyle/repetitive-element.ts
+++ b/packages/core/src/vivliostyle/repetitive-element.ts
@@ -1017,6 +1017,61 @@ export function appendHeaderToAncestors(
   );
 }
 
+/**
+ * Check whether the view node is a table caption or a table column group
+ * (or column), which must precede the table header in the view tree.
+ */
+function isTableCaptionOrColumnGroup(node: Node): boolean {
+  if (node.nodeType !== 1) {
+    return false;
+  }
+  const element = node as Element;
+  switch (element.localName) {
+    case "caption":
+    case "colgroup":
+    case "col":
+      return true;
+    case "thead":
+    case "tbody":
+    case "tfoot":
+    case "tr":
+      return false;
+  }
+  const display =
+    element.ownerDocument.defaultView?.getComputedStyle(element).display;
+  return (
+    display === "table-caption" ||
+    display === "table-column-group" ||
+    display === "table-column"
+  );
+}
+
+/**
+ * Find the node before which the repeated header is to be inserted into the
+ * fragment root view node. The header is normally inserted at the beginning,
+ * but in a table it must come after the caption and the column groups, which
+ * are inserted into each fragment before the header. (Issue #2137)
+ */
+function findHeaderInsertionPoint(
+  formattingContext: RepetitiveElement.RepetitiveElementsOwnerFormattingContext,
+  rootViewNode: Element,
+): Node | null {
+  let insertionPoint = rootViewNode.firstChild;
+  if (!Table.isInstanceOfTableFormattingContext(formattingContext)) {
+    return insertionPoint;
+  }
+  let child = insertionPoint;
+  while (child) {
+    if (isTableCaptionOrColumnGroup(child)) {
+      insertionPoint = child.nextSibling;
+    } else if (!VtreeImpl.canIgnore(child)) {
+      break;
+    }
+    child = child.nextSibling;
+  }
+  return insertionPoint;
+}
+
 export function appendHeader(
   formattingContext: RepetitiveElement.RepetitiveElementsOwnerFormattingContext,
   nodeContext: Vtree.NodeContext,
@@ -1028,7 +1083,10 @@ export function appendHeader(
     const rootElementContext =
       rootNodeContext && VtreeImpl.asElementNodeContext(rootNodeContext);
     if (rootElementContext) {
-      const firstChild = rootElementContext.viewNode.firstChild;
+      const firstChild = findHeaderInsertionPoint(
+        formattingContext,
+        rootElementContext.viewNode,
+      );
       return repetitiveElements.appendHeaderToFragment(
         rootElementContext,
         firstChild,

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -940,6 +940,11 @@ module.exports = [
         file: "table/table-header-repeat-nested-rowspan.html",
         title: "Table header repeat with nested rowspans (Issue #1980)",
       },
+      {
+        file: "table/table-caption-order.html",
+        title:
+          "Table caption order when table breaks across pages (Issue #2137)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/table/table-caption-order.html
+++ b/packages/core/test/files/table/table-caption-order.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2137: table <caption> must stay before <thead> in the
+     view tree (output DOM order) even when the table fragments across pages. -->
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>Test: Table caption order when table breaks across pages</title>
+<style>
+@page {
+  size: 150mm 100mm;
+  margin: 10mm;
+}
+body {
+  font: 10pt/1.4 sans-serif;
+  margin: 0;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+th, td {
+  border: 1px solid #888;
+  padding: 2px 4px;
+}
+thead th {
+  background: #ccc;
+}
+caption {
+  font-weight: bold;
+  padding: 2px;
+}
+table.bottom-caption > caption {
+  caption-side: bottom;
+}
+</style>
+</head>
+<body>
+<h1>Table caption order (Issue #2137)</h1>
+
+<table id="tab-1">
+  <caption>Caption 1 (caption-side: top)</caption>
+  <colgroup>
+    <col style="width: 20%"/>
+    <col/>
+  </colgroup>
+  <thead>
+    <tr><th>No.</th><th>Header cell</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>1</td><td>Row 1</td></tr>
+    <tr><td>2</td><td>Row 2</td></tr>
+    <tr><td>3</td><td>Row 3</td></tr>
+    <tr><td>4</td><td>Row 4</td></tr>
+    <tr><td>5</td><td>Row 5</td></tr>
+    <tr><td>6</td><td>Row 6</td></tr>
+    <tr><td>7</td><td>Row 7</td></tr>
+    <tr><td>8</td><td>Row 8</td></tr>
+    <tr><td>9</td><td>Row 9</td></tr>
+    <tr><td>10</td><td>Row 10</td></tr>
+    <tr><td>11</td><td>Row 11</td></tr>
+    <tr><td>12</td><td>Row 12</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><th>No.</th><th>Footer cell</th></tr>
+  </tfoot>
+</table>
+
+<table id="tab-2" class="bottom-caption">
+  <caption>Caption 2 (caption-side: bottom)</caption>
+  <thead>
+    <tr><th>No.</th><th>Header cell</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>1</td><td>Row 1</td></tr>
+    <tr><td>2</td><td>Row 2</td></tr>
+    <tr><td>3</td><td>Row 3</td></tr>
+    <tr><td>4</td><td>Row 4</td></tr>
+    <tr><td>5</td><td>Row 5</td></tr>
+    <tr><td>6</td><td>Row 6</td></tr>
+    <tr><td>7</td><td>Row 7</td></tr>
+    <tr><td>8</td><td>Row 8</td></tr>
+    <tr><td>9</td><td>Row 9</td></tr>
+    <tr><td>10</td><td>Row 10</td></tr>
+    <tr><td>11</td><td>Row 11</td></tr>
+    <tr><td>12</td><td>Row 12</td></tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Fixes the table `<caption>` being placed after the `<thead>` in the view tree when a table is fragmented across pages.

## Problem

The repeated `<thead>` of a fragmented table is not laid out in the normal flow; it is inserted into each fragment by `appendHeader()` in `repetitive-element.ts`. The insertion point was unconditionally `rootViewNode.firstChild`, so the header ended up before the `<caption>` and `<colgroup>` elements that `TableLayoutProcessor.doLayout()` had already inserted into the fragment. The rendered view tree order became `thead, caption, colgroup, tbody`, which breaks the document order that accessibility tools and PDF tagging rely on. Tables that fit on a single page were unaffected, because their header is generated in the normal flow — which is why the problem showed up only on some tables, as reported.

## Fix

`findHeaderInsertionPoint()` skips any leading caption and column groups when the fragment root belongs to a table formatting context, so the repeated header is inserted after them. Element types are recognized by tag name for HTML tables, with a fallback to the computed `display` value (`table-caption`, `table-column-group`, `table-column`) so that tables built from other elements (e.g. `<div style="display: table">`) work too. Non-table `repeat-on-break` elements keep the previous behavior.

## Test

New test case `packages/core/test/files/table/table-caption-order.html` (registered in `file-list.js`) covers `caption-side: top` with `<colgroup>`, `<thead>` and `<tfoot>`, plus a `caption-side: bottom` table, both fragmented across pages.

## Verification

- View tree order before the fix: `thead, caption, colgroup, tbody, tfoot`; after: `caption, colgroup, thead, tbody, tfoot` on every fragment. Rendered output (screenshots) is identical before and after — this is a view tree order fix only.
- The real-world document from the issue report (the `table.longtable#tab-3` in the https://fiduswriter.github.io/vivliostyle-pdf/ demo) was extracted and rendered locally: its caption is now emitted before the header.
- A `display: table` / `display: table-caption` version built from `<div>` elements was checked to confirm the computed-`display` fallback path.
- `yarn lint` passes; `yarn test:core` passes (803/803).
- `yarn test:layout-regression --actual-viewer dev --baseline-viewer canary`: 371 entries compared, 0 differences.

Closes #2137

Assisted-by: Claude Code:claude-opus-5

<details>
<summary>How the AI was used</summary>

- The human author reported the issue from a user report on Slack, and asked the AI to resolve it end to end in this repository.
- The AI reproduced the bug with a new minimal test case, located the root cause in `appendHeader()`, wrote the fix and the test file, and ran the unit tests and the layout regression suite. It also verified the view tree order with a headless browser, both on the new test case and on the document from the original report.
- The human author reviews the diff and verifies the rendering before merging, and remains responsible for the change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
