### PR TITLE
fix: Fix text overflowing outside the page area after text-spacing

### DIFF
--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -326,8 +326,8 @@ function findBlockContainer(node: Node): HTMLElement | null {
 /**
  * Force the block to be laid out from scratch.
  *
- * After the `viv-ts-*` elements are inserted, Chromium reuses cached shaping
- * results and can break lines differently than it does on a fresh layout,
+ * After the `viv-ts-*` elements are inserted, the browser may reuse cached
+ * shaping results and break lines differently than it does on a fresh layout,
  * so measuring the block as-is would paginate against a layout that changes
  * later. (Issue #2142)
  */
@@ -336,9 +336,8 @@ function reshapeBlockContainer(element: HTMLElement): void {
   const { fontKerning } =
     element.ownerDocument.defaultView.getComputedStyle(element);
   element.style.fontKerning = fontKerning === "none" ? "normal" : "none";
-  element.offsetHeight; // force layout
+  element.offsetHeight; // force layout so that restoring the value re-shapes
   element.style.fontKerning = savedFontKerning;
-  element.offsetHeight; // force layout
 }
 
 const CHROMIUM_VO_TR_FALLBACK_PATTERN = /^[‘’“”〰﹙﹚﹛﹜﹝﹞〚〛]\p{M}*$/u;

--- a/packages/core/src/vivliostyle/text-polyfill.ts
+++ b/packages/core/src/vivliostyle/text-polyfill.ts
@@ -298,6 +298,49 @@ function normalizeLang(lang: string | null | undefined): string | null {
   return null;
 }
 
+/**
+ * Find the block container establishing the inline formatting context that
+ * the node participates in.
+ */
+function findBlockContainer(node: Node): HTMLElement | null {
+  const window = node.ownerDocument?.defaultView;
+  if (!window) {
+    return null;
+  }
+  for (let elem = node.parentElement; elem; elem = elem.parentElement) {
+    if (elem.hasAttribute("data-vivliostyle-column")) {
+      return elem;
+    }
+    const { display } = window.getComputedStyle(elem);
+    if (
+      display !== "inline" &&
+      display !== "contents" &&
+      !/^ruby/.test(display)
+    ) {
+      return elem;
+    }
+  }
+  return null;
+}
+
+/**
+ * Force the block to be laid out from scratch.
+ *
+ * After the `viv-ts-*` elements are inserted, Chromium reuses cached shaping
+ * results and can break lines differently than it does on a fresh layout,
+ * so measuring the block as-is would paginate against a layout that changes
+ * later. (Issue #2142)
+ */
+function reshapeBlockContainer(element: HTMLElement): void {
+  const savedFontKerning = element.style.fontKerning;
+  const { fontKerning } =
+    element.ownerDocument.defaultView.getComputedStyle(element);
+  element.style.fontKerning = fontKerning === "none" ? "normal" : "none";
+  element.offsetHeight; // force layout
+  element.style.fontKerning = savedFontKerning;
+  element.offsetHeight; // force layout
+}
+
 const CHROMIUM_VO_TR_FALLBACK_PATTERN = /^[‘’“”〰﹙﹚﹛﹜﹝﹞〚〛]\p{M}*$/u;
 const CHROMIUM_VO_TR_FALLBACK_OPEN_PATTERN = /^[‘“﹙﹛﹝〚]\p{M}*$/u;
 
@@ -548,6 +591,7 @@ class TextSpacingPolyfill {
     }
 
     let iFirst = -1;
+    const reshapeTargets = new Set<HTMLElement>();
     for (let i = 0; i < checkPoints.length; i++) {
       const p = checkPoints[i];
       const textP =
@@ -774,12 +818,21 @@ class TextSpacingPolyfill {
           lang,
           textP.vertical,
         );
+        const blockContainer = findBlockContainer(textP.viewNode);
+        if (blockContainer) {
+          reshapeTargets.add(blockContainer);
+        }
         if (columnOver > 0) {
           // Stop processing if the node is moved to next column
           // because it will be processed again in the next column.
           // (Issue #1256)
           break;
         }
+      }
+    }
+    for (const target of reshapeTargets) {
+      if (target.querySelector("viv-ts-open, viv-ts-close, viv-ts-thin-sp")) {
+        reshapeBlockContainer(target);
       }
     }
   }

--- a/packages/core/test/files/file-list.js
+++ b/packages/core/test/files/file-list.js
@@ -614,6 +614,10 @@ module.exports = [
         file: "text-spacing/text-decoration.html",
         title: "Continuous text decorations across text-autospace",
       },
+      {
+        file: "text-spacing/line-break-stability.html",
+        title: "Line breaking stability with text-spacing (Issue #2142)",
+      },
     ],
   },
   {

--- a/packages/core/test/files/text-spacing/line-break-stability.html
+++ b/packages/core/test/files/text-spacing/line-break-stability.html
@@ -16,13 +16,14 @@
     <meta charset="UTF-8" />
     <title>Line breaking stability with text-spacing (Issue #2142)</title>
     <style>
+      @import url("https://fonts.googleapis.com/css2?family=Noto+Serif+JP");
       @page {
         size: 210mm 41mm;
         margin: 14mm 15mm 15mm;
         outline: 1pt solid red;
       }
       html {
-        font-family: serif;
+        font-family: "Noto Serif JP", serif;
         font-size: 8pt;
         line-height: 1.3;
         text-align: justify;
@@ -35,7 +36,7 @@
       }
       p {
         margin: 0;
-        width: 323.75px;
+        width: 324.5px;
         text-indent: 1em;
       }
     </style>

--- a/packages/core/test/files/text-spacing/line-break-stability.html
+++ b/packages/core/test/files/text-spacing/line-break-stability.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!-- Test case for Issue #2142: line breaking must not change after the
+     text-spacing polyfill has wrapped the punctuation in its own elements.
+
+     The paragraph ends with a 。 that text-spacing trims to half width, and
+     the width is chosen so that the trimmed 。 lands exactly on the line end.
+     The page area is 3 lines tall, so the expected result is 2 pages, with
+     the last line on page 2.
+
+     When the block is measured before Chromium has re-shaped it, the
+     paragraph is taken to be 3 lines and kept on a single page, then gains a
+     4th line that overflows the page area (in the reported case, into an
+     extra column outside the page). -->
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Line breaking stability with text-spacing (Issue #2142)</title>
+    <style>
+      @page {
+        size: 210mm 41mm;
+        margin: 14mm 15mm 15mm;
+        outline: 1pt solid red;
+      }
+      html {
+        font-family: serif;
+        font-size: 8pt;
+        line-height: 1.3;
+        text-align: justify;
+        text-spacing: auto;
+        orphans: 1;
+        widows: 1;
+      }
+      body {
+        margin: 0;
+      }
+      p {
+        margin: 0;
+        width: 323.75px;
+        text-indent: 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <p>同委員会は、原則として四半期に一度開催し、気候変動、人的資本、人権の尊重、サプライチェーン管理並びに製品の品質及び安全に関する方針の策定、目標の設定及び進捗の管理を行っております。</p>
+  </body>
+</html>

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -7,7 +7,7 @@
   notes: >-
     Fix for Issue #2142: the paragraph no longer gains a line after pagination, so the overflowing line is now broken to
     the next page.
-  approvedViewer: ""  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  approvedViewer: git-fix-issue2142  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
   actualLabel: dev
   actualUrl: >-
     http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/text-spacing/line-break-stability.html&zoom=1&spread=false

--- a/scripts/layout-regression-triage.yaml
+++ b/scripts/layout-regression-triage.yaml
@@ -1,3 +1,23 @@
+- id: "0001"
+  category: Text Spacing
+  title: "Line breaking stability with text-spacing (Issue #2142)"
+  file: text-spacing/line-break-stability.html
+  type: difference
+  decision: expected  # regression / expected / skip
+  notes: >-
+    Fix for Issue #2142: the paragraph no longer gains a line after pagination, so the overflowing line is now broken to
+    the next page.
+  approvedViewer: ""  # viewer spec: git-<branch>, v2.35.0, canary, stable, URL...
+  actualLabel: dev
+  actualUrl: >-
+    http://localhost:3300/viewer/lib/vivliostyle-viewer-dev.html#src=http://localhost:3300/core/test/files/text-spacing/line-break-stability.html&zoom=1&spread=false
+  baselineLabel: canary
+  baselineUrl: >-
+    https://vivliostyle.vercel.app/#src=http://localhost:3300/core/test/files/text-spacing/line-break-stability.html&zoom=1&spread=false
+  pageCountActual: 2
+  pageCountBaseline: 1
+  diffPages:
+    - 1
 - category: Cross-references
   title: target-text() reflow that shrinks an earlier WebPub spine
   file: target-text-shrinking-spine/publication.json


### PR DESCRIPTION
Fixes text overflowing outside the page area — reported as multi-column overflow into the page margin.

The text-spacing polyfill wraps punctuation in `viv-ts-open` / `viv-ts-close` / `viv-ts-inner` elements after a block has been laid out. Chromium reuses cached shaping results for that incremental change, so the line breaking it reports right afterwards can differ from a fresh layout. In the reported document a line whose trailing trimmed `。` sits exactly on the line end was measured as fitting, and the paragraph gained a line only once the page was re-laid out for display.

Because the pagination had already been decided on that stale geometry, the extra line overflowed the page area. With a non-root multi-column box using `column-fill: auto`, whose block size is pinned to the page area, the overflow was pushed into an extra column painted in the page margin — in the viewer and in print/PDF output alike.

`postLayoutBlock()` now re-shapes the block containers it has modified before the layout is measured, so pagination is computed against the final geometry. It runs before `calculateEdge()`, so nothing reflows after the page break has been chosen.

## Test case

`packages/core/test/files/text-spacing/line-break-stability.html` — one paragraph whose trimmed `。` lands on the line-breaking boundary, in a page area three lines tall:

| | pages | page 1 |
| --- | --- | --- |
| before | 1 | 4 lines — the last line hangs below the page area outline |
| after | 2 | 3 lines inside the page area, last line on page 2 |

The failing condition is a sub-pixel one, so the test loads Noto Serif JP from Google Fonts instead of depending on the platform `serif` font, and the paragraph width is set to the line-breaking boundary of that font. This makes it reproduce in any environment rather than only on macOS.

## Verification

- Reported sample renders without margin overflow in the viewer and in headless Chromium `page.pdf()` output; `column-fill: auto` is preserved on every page.
- `yarn lint`, `yarn test:core` (803/803).
- `yarn test:layout-regression --actual-viewer dev --baseline-viewer canary`: 372 entries, the new test case is the only difference (dev=2 pages, canary=1), triaged as `expected`; the other 371 are unchanged and the run time is unaffected.

Closes #2142

Assisted-by: GitHub Copilot Chat:claude-opus-5

<details>
<summary>How the AI was used</summary>

- The human author reported the bug, provided the reproduction sample, and rejected two earlier AI proposals that only treated the symptom: reverting the multi-column box to `column-fill: balance`, and a viewer-only hook that left print/PDF output broken.
- The human author debugged the running viewer with DevTools and pinpointed that hiding and re-showing the page container changes the line breaking of the affected paragraphs, and pointed out that Vivliostyle disables the browser's own text-spacing because it implements it itself.
- Starting from that observation, the AI instrumented the layout pipeline to compare the geometry before and after the reflow, ruled out the font, zoom, transform and `text-spacing-trim` CSS as causes, identified the cached-shaping behaviour as the root cause, implemented the re-shaping in `postLayoutBlock()`, and built the reduced test case.
- The human author reviewed the result, asked for the test case to be reduced to a single page so the overflow is immediately visible, then found that it only reproduced on macOS and switched it to a Google Fonts web font with an adjusted paragraph width; the AI verified that change in both directions.

</details>
